### PR TITLE
fix(secrets): strip last-applied-configuration annotation to prevent data leak

### DIFF
--- a/backend/internal/k8s/resources/resources_test.go
+++ b/backend/internal/k8s/resources/resources_test.go
@@ -343,6 +343,44 @@ func TestSecretMasking(t *testing.T) {
 	}
 }
 
+func TestSecretMaskingStripsLastAppliedAnnotation(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "db-creds",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"kubectl.kubernetes.io/last-applied-configuration": `{"apiVersion":"v1","kind":"Secret","metadata":{"name":"db-creds"},"stringData":{"password":"supersecret"}}`,
+				"some-other-annotation": "keep-me",
+			},
+		},
+		Data: map[string][]byte{
+			"password": []byte("supersecret"),
+		},
+	}
+
+	masked := maskedSecret(secret)
+
+	// last-applied-configuration must be stripped
+	if _, exists := masked.Annotations["kubectl.kubernetes.io/last-applied-configuration"]; exists {
+		t.Error("maskedSecret did not strip kubectl.kubernetes.io/last-applied-configuration annotation")
+	}
+
+	// Other annotations must be preserved
+	if masked.Annotations["some-other-annotation"] != "keep-me" {
+		t.Error("maskedSecret incorrectly removed non-sensitive annotation")
+	}
+
+	// Data must still be masked
+	if string(masked.Data["password"]) != "****" {
+		t.Errorf("expected password to be masked, got %q", string(masked.Data["password"]))
+	}
+
+	// Original must be untouched
+	if _, exists := secret.Annotations["kubectl.kubernetes.io/last-applied-configuration"]; !exists {
+		t.Error("maskedSecret modified the original secret's annotations")
+	}
+}
+
 func TestListNodes(t *testing.T) {
 	node := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{Name: "worker-1"},

--- a/backend/internal/k8s/resources/secrets.go
+++ b/backend/internal/k8s/resources/secrets.go
@@ -12,7 +12,13 @@ import (
 
 const kindSecret = "secrets"
 
-// maskedSecret returns a copy of a Secret with all data values replaced by "****".
+// lastAppliedConfigAnnotation is the annotation kubectl uses to store the full
+// original manifest, which may contain plaintext secret values (stringData).
+const lastAppliedConfigAnnotation = "kubectl.kubernetes.io/last-applied-configuration"
+
+// maskedSecret returns a copy of a Secret with all data values replaced by "****"
+// and the kubectl.kubernetes.io/last-applied-configuration annotation stripped
+// to prevent leaking plaintext secret values.
 func maskedSecret(s *corev1.Secret) *corev1.Secret {
 	cp := s.DeepCopy()
 	if cp.Data != nil {
@@ -24,6 +30,11 @@ func maskedSecret(s *corev1.Secret) *corev1.Secret {
 		for k := range cp.StringData {
 			cp.StringData[k] = "****"
 		}
+	}
+	// Strip last-applied-configuration annotation which may contain plaintext
+	// secret values (stringData) from the original kubectl apply manifest.
+	if cp.Annotations != nil {
+		delete(cp.Annotations, lastAppliedConfigAnnotation)
 	}
 	return cp
 }


### PR DESCRIPTION
## Summary
- Strips `kubectl.kubernetes.io/last-applied-configuration` annotation from Secret resources in `maskedSecret()` to prevent plaintext secret data from being exposed
- Found during homelab smoke test: real credentials (adguard-exporter-secret) were visible in the annotation even though `.data` values were properly masked

Closes #8

## Test plan
- [x] `TestSecretMaskingStripsLastAppliedAnnotation` added — verifies annotation stripped, other annotations preserved, data masked, original not mutated
- [x] `go test ./... -race -count=1` passes
- [x] `go vet ./...` clean
- [ ] Re-smoke-test against homelab: verify Secret GET no longer returns `last-applied-configuration`

🤖 Generated with [Claude Code](https://claude.com/claude-code)