### PR TITLE
fix(csp): widen esm.sh CSP to allow Monaco transitive dependencies

### DIFF
--- a/frontend/routes/_middleware.ts
+++ b/frontend/routes/_middleware.ts
@@ -15,8 +15,8 @@ export default define.middleware(async (ctx) => {
   res.headers.set(
     "Content-Security-Policy",
     // TODO: replace 'unsafe-inline' on script-src with nonce-based CSP when Fresh supports it
-    // esm.sh is allowed for Monaco editor CDN loading (Step 7), pinned to monaco-editor path
-    "default-src 'self'; script-src 'self' 'unsafe-inline' https://esm.sh/monaco-editor@0.52.2/; style-src 'self' 'unsafe-inline' https://esm.sh/monaco-editor@0.52.2/; img-src 'self' data:; connect-src 'self' https://esm.sh/monaco-editor@0.52.2/; worker-src 'self' blob: https://esm.sh/monaco-editor@0.52.2/; frame-ancestors 'none'",
+    // esm.sh domain is allowed for Monaco editor and its transitive dependencies (e.g. /node/buffer)
+    "default-src 'self'; script-src 'self' 'unsafe-inline' https://esm.sh/; style-src 'self' 'unsafe-inline' https://esm.sh/; img-src 'self' data:; connect-src 'self' https://esm.sh/; worker-src 'self' blob: https://esm.sh/; frame-ancestors 'none'",
   );
   res.headers.set("X-Frame-Options", "DENY");
   res.headers.set("X-Content-Type-Options", "nosniff");


### PR DESCRIPTION
## Summary
- Widens CSP from pinned `https://esm.sh/monaco-editor@0.52.2/` to `https://esm.sh/` in script-src, style-src, connect-src, and worker-src directives
- Monaco loads transitive dependencies from paths like `esm.sh/node/buffer` and `esm.sh/node/process` which were blocked by the too-narrow CSP

Closes #9

## Test plan
- [x] `deno lint && deno fmt --check` passes
- [ ] Re-smoke-test against homelab: verify Monaco YAML editor loads without CSP console errors
- [ ] Verify editor is functional (syntax highlighting, typing, validation markers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)