### PR TITLE
fix(ratelimit): separate rate limit bucket for YAML endpoints

### DIFF
--- a/backend/cmd/kubecenter/main.go
+++ b/backend/cmd/kubecenter/main.go
@@ -11,6 +11,7 @@ import (
 	"os/signal"
 	"sync/atomic"
 	"syscall"
+	"time"
 
 	"github.com/kubecenter/kubecenter/internal/audit"
 	"github.com/kubecenter/kubecenter/internal/auth"
@@ -107,6 +108,8 @@ func main() {
 	auditLogger := audit.NewSlogLogger(logger)
 	rateLimiter := middleware.NewRateLimiter()
 	rateLimiter.StartCleanup(ctx)
+	yamlRateLimiter := middleware.NewRateLimiterWithRate(30, time.Minute)
+	yamlRateLimiter.StartCleanup(ctx)
 
 	// Ready state: true after informer sync, false during shutdown
 	var ready atomic.Bool
@@ -123,8 +126,9 @@ func main() {
 		Sessions:      sessions,
 		RBACChecker:   rbacChecker,
 		AuditLogger:   auditLogger,
-		RateLimiter:   rateLimiter,
-		Hub:           hub,
+		RateLimiter:     rateLimiter,
+		YAMLRateLimiter: yamlRateLimiter,
+		Hub:             hub,
 		AccessChecker: accessChecker,
 		ReadyFn:       ready.Load,
 	})

--- a/backend/internal/server/middleware/ratelimit.go
+++ b/backend/internal/server/middleware/ratelimit.go
@@ -33,10 +33,15 @@ type RateLimiter struct {
 
 // NewRateLimiter creates a rate limiter with default settings (5 req/min).
 func NewRateLimiter() *RateLimiter {
+	return NewRateLimiterWithRate(defaultRate, defaultWindow)
+}
+
+// NewRateLimiterWithRate creates a rate limiter with the specified rate and window.
+func NewRateLimiterWithRate(rate int, window time.Duration) *RateLimiter {
 	return &RateLimiter{
 		buckets: make(map[string]*bucket),
-		rate:    defaultRate,
-		window:  defaultWindow,
+		rate:    rate,
+		window:  window,
 	}
 }
 

--- a/backend/internal/server/middleware/ratelimit_test.go
+++ b/backend/internal/server/middleware/ratelimit_test.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"testing"
+	"time"
 )
 
 func TestRateLimiter_AllowsWithinLimit(t *testing.T) {
@@ -72,5 +73,26 @@ func TestRateLimiter_RetryAfter_UnknownIP(t *testing.T) {
 	}
 	if retryAfter != 0 {
 		t.Errorf("expected 0 retry after for unknown IP, got %d", retryAfter)
+	}
+}
+
+func TestRateLimiterWithRate_CustomLimit(t *testing.T) {
+	rl := NewRateLimiterWithRate(30, time.Minute)
+
+	// All 30 requests should be allowed
+	for i := 0; i < 30; i++ {
+		allowed, _ := rl.Check("192.168.1.1")
+		if !allowed {
+			t.Errorf("request %d should be allowed with rate 30", i+1)
+		}
+	}
+
+	// 31st request should be blocked
+	allowed, retryAfter := rl.Check("192.168.1.1")
+	if allowed {
+		t.Error("31st request should be rate limited with rate 30")
+	}
+	if retryAfter <= 0 || retryAfter > 61 {
+		t.Errorf("expected retry after between 1 and 61 seconds, got %d", retryAfter)
 	}
 }

--- a/backend/internal/server/routes.go
+++ b/backend/internal/server/routes.go
@@ -70,9 +70,14 @@ func (s *Server) registerResourceRoutes(ar chi.Router) {
 func (s *Server) registerYAMLRoutes(ar chi.Router) {
 	h := s.YAMLHandler
 	ar.Route("/yaml", func(yr chi.Router) {
-		// Rate limit YAML operations — these accept large bodies and
-		// trigger multiple k8s API calls per request.
-		yr.Use(middleware.RateLimit(s.RateLimiter))
+		// Rate limit YAML operations with a dedicated, higher-limit bucket
+		// (30 req/min) so that validate → diff → apply workflows don't
+		// exhaust the stricter auth rate limit (5 req/min).
+		yamlRL := s.YAMLRateLimiter
+		if yamlRL == nil {
+			yamlRL = s.RateLimiter
+		}
+		yr.Use(middleware.RateLimit(yamlRL))
 
 		yr.Post("/validate", h.HandleValidate)
 		yr.Post("/apply", h.HandleApply)

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -31,6 +31,7 @@ type Server struct {
 	RBACChecker     *auth.RBACChecker
 	AuditLogger     audit.Logger
 	RateLimiter     *middleware.RateLimiter
+	YAMLRateLimiter *middleware.RateLimiter
 	ResourceHandler *resources.Handler
 	YAMLHandler     *yamlpkg.Handler
 	Hub             *websocket.Hub
@@ -47,9 +48,10 @@ type Deps struct {
 	LocalAuth     *auth.LocalProvider
 	Sessions      *auth.SessionStore
 	RBACChecker   *auth.RBACChecker
-	AuditLogger   audit.Logger
-	RateLimiter   *middleware.RateLimiter
-	Hub           *websocket.Hub
+	AuditLogger     audit.Logger
+	RateLimiter     *middleware.RateLimiter
+	YAMLRateLimiter *middleware.RateLimiter
+	Hub             *websocket.Hub
 	AccessChecker *resources.AccessChecker
 	ReadyFn       func() bool
 }
@@ -66,9 +68,10 @@ func New(deps Deps) *Server {
 		LocalAuth:    deps.LocalAuth,
 		Sessions:     deps.Sessions,
 		RBACChecker:  deps.RBACChecker,
-		AuditLogger:  deps.AuditLogger,
-		RateLimiter:  deps.RateLimiter,
-		Hub:          deps.Hub,
+		AuditLogger:     deps.AuditLogger,
+		RateLimiter:     deps.RateLimiter,
+		YAMLRateLimiter: deps.YAMLRateLimiter,
+		Hub:             deps.Hub,
 		ready:        deps.ReadyFn,
 	}
 


### PR DESCRIPTION
## Summary
- Adds `NewRateLimiterWithRate(rate, window)` constructor to support configurable rate limits
- Creates a dedicated YAML rate limiter (30 req/min) separate from auth rate limiter (5 req/min)
- Adds `YAMLRateLimiter` field to `Server`/`Deps` structs, used by `registerYAMLRoutes`
- Previously, YAML validate/apply/diff/export shared the same 5 req/min bucket as auth endpoints, making YAML workflows unusable

Closes #10

## Test plan
- [x] `TestRateLimiterWithRate_CustomLimit` added — verifies 30 req rate limit
- [x] `go test ./... -race -count=1` passes
- [x] `go vet ./...` clean
- [ ] Re-smoke-test against homelab: verify YAML validate/apply work without hitting rate limits during normal use

🤖 Generated with [Claude Code](https://claude.com/claude-code)