### PR TITLE
fix(lint): add type="button" to AuthSettings tab buttons

### DIFF
--- a/frontend/islands/AuthSettings.tsx
+++ b/frontend/islands/AuthSettings.tsx
@@ -98,6 +98,7 @@ export default function AuthSettings() {
             ] as const
           ).map(([key, label]) => (
             <button
+              type="button"
               key={key}
               onClick={() => {
                 activeTab.value = key;


### PR DESCRIPTION
## Summary

- Add missing `type="button"` attribute to tab buttons in `AuthSettings.tsx`

Fixes #19

## Test plan

- [x] `deno lint` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)