### PR TITLE
fix(lint): simplify resource path in AuditLogViewer to avoid fmt divergence

### DIFF
--- a/frontend/islands/AuditLogViewer.tsx
+++ b/frontend/islands/AuditLogViewer.tsx
@@ -178,9 +178,11 @@ export default function AuditLogViewer() {
                     </td>
                     <td class="px-3 py-2 text-slate-600 dark:text-slate-400">
                       {e.resourceKind
-                        ? `${e.resourceKind}${
-                          e.resourceNamespace ? "/" + e.resourceNamespace : ""
-                        }${e.resourceName ? "/" + e.resourceName : ""}`
+                        ? [
+                          e.resourceKind,
+                          e.resourceNamespace,
+                          e.resourceName,
+                        ].filter(Boolean).join("/")
                         : "-"}
                     </td>
                     <td class="px-3 py-2">


### PR DESCRIPTION
Replaces nested ternaries inside a template literal with `array.filter.join` to avoid Deno version-dependent formatting. Fixes #25.