### PR TITLE
fix: address 10 review findings for permission gating

### DIFF
--- a/backend/internal/auth/rbac.go
+++ b/backend/internal/auth/rbac.go
@@ -35,12 +35,29 @@ type rbacCacheEntry struct {
 var systemNamespacePrefixes = []string{"kube-"}
 
 // trackedResources are the resource types we check permissions for.
+// Must include every kind the frontend renders in RESOURCE_COLUMNS and ACTIONS_BY_KIND.
 var trackedResources = map[string]bool{
-	"pods": true, "deployments": true, "services": true,
-	"configmaps": true, "secrets": true, "ingresses": true,
-	"statefulsets": true, "daemonsets": true, "jobs": true,
-	"networkpolicies": true, "nodes": true, "namespaces": true,
-	"clusterroles": true, "clusterrolebindings": true,
+	// Core
+	"pods": true, "services": true, "configmaps": true, "secrets": true,
+	"namespaces": true, "nodes": true, "persistentvolumeclaims": true,
+	"persistentvolumes": true, "endpoints": true, "events": true,
+	"resourcequotas": true, "limitranges": true, "serviceaccounts": true,
+	// Apps
+	"deployments": true, "statefulsets": true, "daemonsets": true, "replicasets": true,
+	// Batch
+	"jobs": true, "cronjobs": true,
+	// Networking
+	"ingresses": true, "networkpolicies": true,
+	// Policy
+	"poddisruptionbudgets": true,
+	// Autoscaling
+	"horizontalpodautoscalers": true,
+	// Storage
+	"storageclasses": true,
+	// RBAC
+	"roles": true, "clusterroles": true, "rolebindings": true, "clusterrolebindings": true,
+	// Discovery
+	"endpointslices": true,
 }
 
 // RBACChecker queries Kubernetes RBAC permissions for users.
@@ -215,9 +232,26 @@ func rbacCacheKey(username string, groups []string) string {
 
 // GetNamespacePermissions returns permissions for a single namespace plus cluster-scoped.
 // This is more efficient than GetSummary for the common case (frontend requesting permissions
-// for the currently selected namespace). Results are NOT cached separately — the full summary
-// cache may serve this if available.
+// for the currently selected namespace). Checks the full-summary cache first to avoid
+// redundant API calls; falls back to fresh SelfSubjectRulesReview if not cached.
 func (rc *RBACChecker) GetNamespacePermissions(ctx context.Context, user *User, namespace string) (*RBACSummary, error) {
+	// Check existing full-summary cache — if we have a warm entry, extract the subset
+	cacheKey := rbacCacheKey(user.KubernetesUsername, user.KubernetesGroups)
+	rc.mu.Lock()
+	if entry, ok := rc.cache[cacheKey]; ok && time.Now().Before(entry.expiresAt) {
+		rc.mu.Unlock()
+		// Extract requested namespace + cluster-scoped from cached full summary
+		result := &RBACSummary{
+			ClusterScoped: entry.summary.ClusterScoped,
+			Namespaces:    make(map[string]map[string][]string),
+		}
+		if nsPerms, ok := entry.summary.Namespaces[namespace]; ok {
+			result.Namespaces[namespace] = nsPerms
+		}
+		return result, nil
+	}
+	rc.mu.Unlock()
+
 	cs, err := rc.clientFactory.ClientForUser(user.KubernetesUsername, user.KubernetesGroups)
 	if err != nil {
 		return nil, fmt.Errorf("creating client for RBAC check: %w", err)

--- a/backend/internal/auth/rbac_test.go
+++ b/backend/internal/auth/rbac_test.go
@@ -139,6 +139,53 @@ func TestAppendUnique(t *testing.T) {
 	}
 }
 
+func TestGetNamespacePermissions_UsesCacheWhenAvailable(t *testing.T) {
+	factory := &fakeClientFactory{}
+	checker := NewRBACChecker(factory, slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})))
+
+	user := &User{Username: "test-user", KubernetesUsername: "test-user"}
+
+	// Populate the full-summary cache
+	_, err := checker.GetSummary(context.Background(), user, []string{"default"})
+	if err != nil {
+		t.Fatalf("GetSummary failed: %v", err)
+	}
+
+	callsBefore := factory.callCount
+
+	// GetNamespacePermissions should use the cached full summary, not make new API calls
+	result, err := checker.GetNamespacePermissions(context.Background(), user, "default")
+	if err != nil {
+		t.Fatalf("GetNamespacePermissions failed: %v", err)
+	}
+
+	if factory.callCount != callsBefore {
+		t.Errorf("expected cache hit (no new API calls), but callCount went from %d to %d",
+			callsBefore, factory.callCount)
+	}
+
+	if result.ClusterScoped == nil {
+		t.Error("expected non-nil ClusterScoped in result")
+	}
+}
+
+func TestGetNamespacePermissions_SystemNamespaceSkipped(t *testing.T) {
+	factory := &fakeClientFactory{}
+	checker := NewRBACChecker(factory, slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})))
+
+	user := &User{Username: "test-user", KubernetesUsername: "test-user"}
+
+	result, err := checker.GetNamespacePermissions(context.Background(), user, "kube-system")
+	if err != nil {
+		t.Fatalf("GetNamespacePermissions failed: %v", err)
+	}
+
+	// System namespace should be skipped — no namespace permissions returned
+	if len(result.Namespaces) != 0 {
+		t.Errorf("expected no namespace permissions for kube-system, got %v", result.Namespaces)
+	}
+}
+
 // fakeClientFactory returns a fake clientset for testing.
 // The clientset's AuthorizationV1 will fail on actual API calls,
 // but that's fine — we're testing cache behavior, not the API call itself.

--- a/backend/internal/server/handle_auth.go
+++ b/backend/internal/server/handle_auth.go
@@ -287,6 +287,13 @@ func (s *Server) handleAuthMe(w http.ResponseWriter, r *http.Request) {
 	// This is the fast path for frontend permission gating (2 API calls instead of N).
 	var summary *auth.RBACSummary
 	if ns := r.URL.Query().Get("namespace"); ns != "" {
+		// Validate namespace — prevent arbitrary strings hitting the k8s API
+		if len(ns) > 63 || !isValidDNSLabel(ns) {
+			writeJSON(w, http.StatusBadRequest, api.Response{
+				Error: &api.APIError{Code: 400, Message: "invalid namespace"},
+			})
+			return
+		}
 		var err error
 		summary, err = s.RBACChecker.GetNamespacePermissions(r.Context(), user, ns)
 		if err != nil {

--- a/backend/internal/server/response.go
+++ b/backend/internal/server/response.go
@@ -4,11 +4,20 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"regexp"
 	"time"
 
 	"github.com/kubecenter/kubecenter/internal/audit"
 	"github.com/kubecenter/kubecenter/internal/auth"
 )
+
+// dnsLabelRegex matches valid RFC 1123 DNS labels (used for namespace validation).
+var dnsLabelRegex = regexp.MustCompile(`^[a-z0-9]([a-z0-9\-]{0,61}[a-z0-9])?$`)
+
+// isValidDNSLabel checks whether s is a valid RFC 1123 DNS label.
+func isValidDNSLabel(s string) bool {
+	return dnsLabelRegex.MatchString(s)
+}
 
 func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")

--- a/frontend/islands/ResourceTable.tsx
+++ b/frontend/islands/ResourceTable.tsx
@@ -345,55 +345,55 @@ export default function ResourceTable({
     getVisibleActions(kind, ns.value, rbac.value)
   );
 
-  // Kebab menu renderer for each row
-  const renderActions = actions.value.length > 0
-    ? (resource: K8sResource) => {
-      const isOpen = actionMenuOpen.value === resource.metadata.uid;
-      return (
-        <div class="relative">
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              actionMenuOpen.value = isOpen ? null : resource.metadata.uid;
-            }}
-            class="rounded p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-slate-700 dark:hover:text-slate-300"
-            title="Actions"
+  // Kebab menu renderer for each row — reads actions.value reactively inside the callback
+  const renderActions = (resource: K8sResource) => {
+    const currentActions = actions.value;
+    if (currentActions.length === 0) return null;
+    const isOpen = actionMenuOpen.value === resource.metadata.uid;
+    return (
+      <div class="relative">
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            actionMenuOpen.value = isOpen ? null : resource.metadata.uid;
+          }}
+          class="rounded p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-slate-700 dark:hover:text-slate-300"
+          title="Actions"
+        >
+          <svg class="h-4 w-4" viewBox="0 0 16 16" fill="currentColor">
+            <circle cx="8" cy="3" r="1.5" />
+            <circle cx="8" cy="8" r="1.5" />
+            <circle cx="8" cy="13" r="1.5" />
+          </svg>
+        </button>
+        {isOpen && (
+          <div
+            class="absolute right-0 z-20 mt-1 w-40 rounded-md border border-slate-200 bg-white py-1 shadow-lg dark:border-slate-600 dark:bg-slate-800"
+            onClick={(e) => e.stopPropagation()}
           >
-            <svg class="h-4 w-4" viewBox="0 0 16 16" fill="currentColor">
-              <circle cx="8" cy="3" r="1.5" />
-              <circle cx="8" cy="8" r="1.5" />
-              <circle cx="8" cy="13" r="1.5" />
-            </svg>
-          </button>
-          {isOpen && (
-            <div
-              class="absolute right-0 z-20 mt-1 w-40 rounded-md border border-slate-200 bg-white py-1 shadow-lg dark:border-slate-600 dark:bg-slate-800"
-              onClick={(e) => e.stopPropagation()}
-            >
-              {actions.value.map((actionId: ActionId) => {
-                const meta = getActionMeta(actionId, resource);
-                return (
-                  <button
-                    key={actionId}
-                    type="button"
-                    onClick={() => handleActionClick(actionId, resource)}
-                    class={`w-full px-3 py-1.5 text-left text-sm ${
-                      meta.danger
-                        ? "text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900/20"
-                        : "text-slate-700 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-700"
-                    }`}
-                  >
-                    {meta.label}
-                  </button>
-                );
-              })}
-            </div>
-          )}
-        </div>
-      );
-    }
-    : undefined;
+            {currentActions.map((actionId: ActionId) => {
+              const meta = getActionMeta(actionId, resource);
+              return (
+                <button
+                  key={actionId}
+                  type="button"
+                  onClick={() => handleActionClick(actionId, resource)}
+                  class={`w-full px-3 py-1.5 text-left text-sm ${
+                    meta.danger
+                      ? "text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900/20"
+                      : "text-slate-700 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-700"
+                  }`}
+                >
+                  {meta.label}
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    );
+  };
 
   // Confirmation dialog
   const confirmMeta = confirmAction.value

--- a/frontend/islands/Sidebar.tsx
+++ b/frontend/islands/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useSignal } from "@preact/signals";
+import { useComputed, useSignal } from "@preact/signals";
 import { useEffect } from "preact/hooks";
 import { IS_BROWSER } from "fresh/runtime";
 import { NAV_SECTIONS } from "@/lib/constants.ts";
@@ -13,7 +13,10 @@ interface SidebarProps {
 
 export default function Sidebar({ currentPath }: SidebarProps) {
   const { user } = useAuth();
-  const userIsAdmin = user.value?.roles?.includes("admin") ?? false;
+  // Reactive — re-evaluates when user signal changes (e.g., after login)
+  const userIsAdmin = useComputed(() =>
+    user.value?.roles?.includes("admin") ?? false
+  );
   const collapsed = useSignal<Record<string, boolean>>({});
   const appVersion = useSignal("");
 
@@ -73,7 +76,7 @@ export default function Sidebar({ currentPath }: SidebarProps) {
       <nav class="flex-1 overflow-y-auto py-2">
         {NAV_SECTIONS.filter((section) =>
           // Hide "Settings" section for non-admin users
-          section.title !== "Settings" || userIsAdmin
+          section.title !== "Settings" || userIsAdmin.value
         ).map((section) => (
           <div key={section.title} class="mb-1">
             <button

--- a/frontend/islands/TopBar.tsx
+++ b/frontend/islands/TopBar.tsx
@@ -1,7 +1,7 @@
 import { useComputed, useSignal } from "@preact/signals";
 import { useEffect, useRef } from "preact/hooks";
 import { IS_BROWSER } from "fresh/runtime";
-import { useAuth } from "@/lib/auth.ts";
+import { refreshPermissions, useAuth } from "@/lib/auth.ts";
 import { apiGet } from "@/lib/api.ts";
 import { selectedNamespace } from "@/lib/namespace.ts";
 import ThemeToggle from "@/islands/ThemeToggle.tsx";
@@ -62,7 +62,12 @@ export default function TopBar() {
           id="namespace-select"
           value={selectedNamespace.value}
           onChange={(e) => {
-            selectedNamespace.value = (e.target as HTMLSelectElement).value;
+            const ns = (e.target as HTMLSelectElement).value;
+            selectedNamespace.value = ns;
+            // Refresh RBAC permissions for the new namespace
+            if (ns && ns !== "all") {
+              refreshPermissions(ns);
+            }
           }}
           class="rounded-md border border-slate-300 bg-white px-2.5 py-1.5 text-sm text-slate-700 focus:border-brand focus:ring-1 focus:ring-brand dark:border-slate-600 dark:bg-slate-700 dark:text-slate-200"
         >

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -13,6 +13,14 @@ let accessToken: string | null = null;
 /** Track in-flight refresh to avoid concurrent refresh requests. */
 let refreshPromise: Promise<boolean> | null = null;
 
+/** Optional callback invoked on 403 responses — used by auth.ts to refresh permissions. */
+let on403Callback: (() => void) | null = null;
+
+/** Register a callback for 403 responses (permission denied). */
+export function onForbidden(cb: () => void) {
+  on403Callback = cb;
+}
+
 export function setAccessToken(token: string | null) {
   accessToken = token;
 }
@@ -121,6 +129,10 @@ export async function api<T>(
       errorBody = await res.json();
     } catch {
       // Response wasn't JSON
+    }
+    // On 403, notify auth layer to refresh permissions (self-correcting mechanism)
+    if (res.status === 403 && on403Callback) {
+      on403Callback();
     }
     throw new ApiError(
       res.status,

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -4,8 +4,9 @@
  * this server-side would leak auth state across SSR requests.
  */
 import { computed, signal } from "@preact/signals";
-import { api, getAccessToken, setAccessToken } from "@/lib/api.ts";
+import { api, getAccessToken, onForbidden, setAccessToken } from "@/lib/api.ts";
 import type { RBACSummary, UserInfo } from "@/lib/k8s-types.ts";
+import { selectedNamespace } from "@/lib/namespace.ts";
 
 /** Reactive user state. */
 const userSignal = signal<UserInfo | null>(null);
@@ -16,6 +17,15 @@ const rbacSignal = signal<RBACSummary | null>(null);
 
 /** Whether the user is authenticated. */
 const isAuthenticated = computed(() => userSignal.value !== null);
+
+// Self-correcting: on any 403, refresh RBAC permissions for the current namespace.
+// This handles the case where permissions changed while the user was active.
+onForbidden(() => {
+  const ns = selectedNamespace.value;
+  if (ns && ns !== "all") {
+    refreshPermissions(ns);
+  }
+});
 
 /**
  * Log in with username and password.
@@ -123,7 +133,10 @@ export async function refreshPermissions(namespace: string): Promise<void> {
     );
     rbacSignal.value = res.data.rbac;
   } catch {
-    // Silently fail — existing permissions stay, backend still enforces
+    // Clear stale permissions from previous namespace — prevents showing
+    // actions that were valid for namespace A but not namespace B.
+    // canPerform defaults to true when null, so actions show optimistically.
+    rbacSignal.value = null;
   }
 }
 

--- a/frontend/lib/permissions.ts
+++ b/frontend/lib/permissions.ts
@@ -3,9 +3,7 @@
  * Sources permissions from Kubernetes RBAC via the /auth/me response.
  * This is a UX optimization — the backend still enforces on every request.
  */
-import { computed, type Signal } from "@preact/signals";
 import type { RBACSummary } from "@/lib/k8s-types.ts";
-import type { UserInfo } from "@/lib/k8s-types.ts";
 
 /**
  * Check if the user can perform a verb on a resource kind in a namespace.
@@ -38,19 +36,4 @@ export function canPerform(
   }
 
   return false;
-}
-
-/**
- * Check if the user has the app-level "admin" role.
- * This controls non-k8s features (user management, audit logs, settings).
- */
-export function isAdmin(user: Signal<UserInfo | null>): boolean {
-  return user.value?.roles?.includes("admin") ?? false;
-}
-
-/**
- * Create a computed isAdmin signal from a user signal.
- */
-export function computedIsAdmin(user: Signal<UserInfo | null>) {
-  return computed(() => user.value?.roles?.includes("admin") ?? false);
 }


### PR DESCRIPTION
## Summary

Addresses all P1, P2, and P3 findings from the post-merge security + architecture review of PR #53.

### P1 — Fixed
- **Uncached GetNamespacePermissions**: Now checks full-summary cache first (0 API calls when warm)
- **Sidebar userIsAdmin not reactive**: Changed to `useComputed()` — updates correctly after login
- **Permissions not refreshed on namespace change**: TopBar's onChange now calls `refreshPermissions(ns)`

### P2 — Fixed
- **trackedResources missing 14 kinds**: Expanded from 14 to 28 (cronjobs, pvcs, roles, hpas, etc.)
- **403 → permission re-fetch**: Added `onForbidden()` callback in api.ts, registered in auth.ts
- **renderActions outside reactive context**: Now reads `actions.value` inside the callback
- **Unvalidated namespace param**: Added DNS label regex + 63-char length check

### P3 — Fixed
- **Unused exports**: Removed `isAdmin`/`computedIsAdmin` from permissions.ts
- **Missing tests**: Added 2 tests for GetNamespacePermissions (cache hit, system ns filtering)
- **Stale permissions on failure**: Clear rbacSignal on namespace switch error

## Test Plan
- [x] `go test ./... -race` — all 15 packages pass (including 2 new tests)
- [x] `deno lint` + `deno fmt --check` — pass
- [x] `deno task build` — builds clean

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>