### PR TITLE
feat: real-time WebSocket updates for GitOps & Policy CRDs

### DIFF
--- a/backend/cmd/kubecenter/main.go
+++ b/backend/cmd/kubecenter/main.go
@@ -84,14 +84,17 @@ func main() {
 
 	// Create informer manager and WebSocket hub
 	baseCS := k8sClient.BaseClientset()
-	informerMgr := k8s.NewInformerManager(baseCS, k8sClient.BaseDynamicClient(), k8sClient.DiscoveryClient(), logger)
+	informerMgr := k8s.NewInformerManager(baseCS, k8sClient.BaseDynamicClient(), logger)
 	accessChecker := resources.NewAccessChecker(k8sClient, logger)
 	accessChecker.StartCacheSweeper(ctx)
 	hub := websocket.NewHub(logger, accessChecker)
 
-	// Register dynamic CRD kinds for WebSocket subscriptions (only if CRD detected)
-	if informerMgr.CiliumNetworkPolicies() != nil {
+	// Cilium CRD watch — probe once at startup via discovery, use WatchCRD for lifecycle
+	if _, err := k8sClient.DiscoveryClient().ServerResourcesForGroupVersion("cilium.io/v2"); err == nil {
 		websocket.RegisterAllowedKind("ciliumnetworkpolicies", "cilium.io")
+		informerMgr.WatchCRD(ctx, k8s.CiliumPolicyGVR, "ciliumnetworkpolicies", func(obj *unstructured.Unstructured) (any, error) {
+			return obj.Object, nil // Cilium policies don't need normalization for the existing ResourceTable consumer
+		}, hub.HandleEvent)
 	}
 
 	// Register informer event handlers BEFORE starting informers
@@ -393,8 +396,10 @@ func main() {
 				websocket.RegisterAllowedKind("policyreports", "wgpolicyk8s.io")
 				// PolicyReports are watched but not normalized individually — the frontend
 				// re-fetches the full violation list on any report change.
+				// Send a minimal sentinel (name+namespace) instead of the full CRD object
+				// to avoid broadcasting managedFields and cross-namespace refs over WebSocket.
 				informerMgr.WatchCRD(ctx, policy.PolicyReportGVR, "policyreports", func(obj *unstructured.Unstructured) (any, error) {
-					return obj.Object, nil
+					return map[string]string{"name": obj.GetName(), "namespace": obj.GetNamespace()}, nil
 				}, func(eventType, kind, ns, name string, obj any) {
 					hub.HandleEvent(eventType, kind, ns, name, obj)
 					policyHandler.InvalidateCache()
@@ -402,11 +407,20 @@ func main() {
 
 				websocket.RegisterAllowedKind("clusterpolicyreports", "wgpolicyk8s.io")
 				informerMgr.WatchCRD(ctx, policy.ClusterPolicyReportGVR, "clusterpolicyreports", func(obj *unstructured.Unstructured) (any, error) {
-					return obj.Object, nil
+					return map[string]string{"name": obj.GetName(), "namespace": obj.GetNamespace()}, nil
 				}, func(eventType, kind, ns, name string, obj any) {
 					hub.HandleEvent(eventType, kind, ns, name, obj)
 					policyHandler.InvalidateCache()
 				})
+			} else {
+				informerMgr.StopCRD(policy.KyvernoClusterPolicyGVR)
+				websocket.UnregisterAllowedKind("clusterpolicies")
+				informerMgr.StopCRD(policy.KyvernoPolicyGVR)
+				websocket.UnregisterAllowedKind("policies")
+				informerMgr.StopCRD(policy.PolicyReportGVR)
+				websocket.UnregisterAllowedKind("policyreports")
+				informerMgr.StopCRD(policy.ClusterPolicyReportGVR)
+				websocket.UnregisterAllowedKind("clusterpolicyreports")
 			}
 			if gatekeeperAvailable {
 				websocket.RegisterAllowedKind("constrainttemplates", "templates.gatekeeper.sh")
@@ -414,11 +428,15 @@ func main() {
 					Group: "templates.gatekeeper.sh", Version: "v1", Resource: "constrainttemplates",
 				}
 				informerMgr.WatchCRD(ctx, gkTemplateGVR, "constrainttemplates", func(obj *unstructured.Unstructured) (any, error) {
-					return obj.Object, nil
+					return map[string]string{"name": obj.GetName(), "namespace": obj.GetNamespace()}, nil
 				}, func(eventType, kind, ns, name string, obj any) {
 					hub.HandleEvent(eventType, kind, ns, name, obj)
 					policyHandler.InvalidateCache()
 				})
+			} else {
+				gkTemplateGVR := schema.GroupVersionResource{Group: "templates.gatekeeper.sh", Version: "v1", Resource: "constrainttemplates"}
+				informerMgr.StopCRD(gkTemplateGVR)
+				websocket.UnregisterAllowedKind("constrainttemplates")
 			}
 		})
 		go policyDiscoverer.RunDiscoveryLoop(ctx)
@@ -446,6 +464,9 @@ func main() {
 				hub.HandleEvent(eventType, kind, ns, name, obj)
 				gitopsHandler.InvalidateCache()
 			})
+		} else {
+			informerMgr.StopCRD(gitops.ArgoApplicationGVR)
+			websocket.UnregisterAllowedKind("applications")
 		}
 		if fluxAvailable {
 			websocket.RegisterAllowedKind("kustomizations", "kustomize.toolkit.fluxcd.io")
@@ -463,6 +484,11 @@ func main() {
 				hub.HandleEvent(eventType, kind, ns, name, obj)
 				gitopsHandler.InvalidateCache()
 			})
+		} else {
+			informerMgr.StopCRD(gitops.FluxKustomizationGVR)
+			websocket.UnregisterAllowedKind("kustomizations")
+			informerMgr.StopCRD(gitops.FluxHelmReleaseGVR)
+			websocket.UnregisterAllowedKind("helmreleases")
 		}
 	})
 	go gitopsDiscoverer.RunDiscoveryLoop(ctx)

--- a/backend/cmd/kubecenter/main.go
+++ b/backend/cmd/kubecenter/main.go
@@ -15,6 +15,9 @@ import (
 
 	_ "go.uber.org/automaxprocs" // Automatically set GOMAXPROCS from cgroup CPU quota
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/kubecenter/kubecenter/internal/alerting"
 	"github.com/kubecenter/kubecenter/internal/diagnostics"
 	"github.com/kubecenter/kubecenter/internal/audit"
@@ -88,7 +91,7 @@ func main() {
 
 	// Register dynamic CRD kinds for WebSocket subscriptions (only if CRD detected)
 	if informerMgr.CiliumNetworkPolicies() != nil {
-		websocket.RegisterAllowedKind("ciliumnetworkpolicies")
+		websocket.RegisterAllowedKind("ciliumnetworkpolicies", "cilium.io")
 	}
 
 	// Register informer event handlers BEFORE starting informers
@@ -358,7 +361,6 @@ func main() {
 	var policyHandler *policy.Handler
 	if crdDiscovery != nil {
 		policyDiscoverer := policy.NewDiscoverer(k8sClient, crdDiscovery, logger)
-		go policyDiscoverer.RunDiscoveryLoop(ctx)
 
 		policyHandler = &policy.Handler{
 			K8sClient:     k8sClient,
@@ -368,11 +370,62 @@ func main() {
 			AccessChecker: accessChecker,
 			Logger:        logger,
 		}
+
+		// Wire Policy CRD watches — Kyverno policies and reports, Gatekeeper constraint templates
+		policyDiscoverer.SetOnChange(func(kyvernoAvailable, gatekeeperAvailable bool) {
+			if kyvernoAvailable {
+				websocket.RegisterAllowedKind("clusterpolicies", "kyverno.io")
+				informerMgr.WatchCRD(ctx, policy.KyvernoClusterPolicyGVR, "clusterpolicies", func(obj *unstructured.Unstructured) (any, error) {
+					return policy.NormalizeKyvernoPolicy(obj, true), nil
+				}, func(eventType, kind, ns, name string, obj any) {
+					hub.HandleEvent(eventType, kind, ns, name, obj)
+					policyHandler.InvalidateCache()
+				})
+
+				websocket.RegisterAllowedKind("policies", "kyverno.io")
+				informerMgr.WatchCRD(ctx, policy.KyvernoPolicyGVR, "policies", func(obj *unstructured.Unstructured) (any, error) {
+					return policy.NormalizeKyvernoPolicy(obj, false), nil
+				}, func(eventType, kind, ns, name string, obj any) {
+					hub.HandleEvent(eventType, kind, ns, name, obj)
+					policyHandler.InvalidateCache()
+				})
+
+				websocket.RegisterAllowedKind("policyreports", "wgpolicyk8s.io")
+				// PolicyReports are watched but not normalized individually — the frontend
+				// re-fetches the full violation list on any report change.
+				informerMgr.WatchCRD(ctx, policy.PolicyReportGVR, "policyreports", func(obj *unstructured.Unstructured) (any, error) {
+					return obj.Object, nil
+				}, func(eventType, kind, ns, name string, obj any) {
+					hub.HandleEvent(eventType, kind, ns, name, obj)
+					policyHandler.InvalidateCache()
+				})
+
+				websocket.RegisterAllowedKind("clusterpolicyreports", "wgpolicyk8s.io")
+				informerMgr.WatchCRD(ctx, policy.ClusterPolicyReportGVR, "clusterpolicyreports", func(obj *unstructured.Unstructured) (any, error) {
+					return obj.Object, nil
+				}, func(eventType, kind, ns, name string, obj any) {
+					hub.HandleEvent(eventType, kind, ns, name, obj)
+					policyHandler.InvalidateCache()
+				})
+			}
+			if gatekeeperAvailable {
+				websocket.RegisterAllowedKind("constrainttemplates", "templates.gatekeeper.sh")
+				gkTemplateGVR := schema.GroupVersionResource{
+					Group: "templates.gatekeeper.sh", Version: "v1", Resource: "constrainttemplates",
+				}
+				informerMgr.WatchCRD(ctx, gkTemplateGVR, "constrainttemplates", func(obj *unstructured.Unstructured) (any, error) {
+					return obj.Object, nil
+				}, func(eventType, kind, ns, name string, obj any) {
+					hub.HandleEvent(eventType, kind, ns, name, obj)
+					policyHandler.InvalidateCache()
+				})
+			}
+		})
+		go policyDiscoverer.RunDiscoveryLoop(ctx)
 	}
 
 	// GitOps discovery and handler
 	gitopsDiscoverer := gitops.NewDiscoverer(k8sClient, logger)
-	go gitopsDiscoverer.RunDiscoveryLoop(ctx)
 
 	gitopsHandler := &gitops.Handler{
 		K8sClient:     k8sClient,
@@ -381,6 +434,38 @@ func main() {
 		Logger:        logger,
 		AuditLogger:   auditLogger,
 	}
+
+	// Wire GitOps CRD watches — when tools are discovered, start dynamic informers
+	// and register kinds for WebSocket subscriptions. Events invalidate the REST cache.
+	gitopsDiscoverer.SetOnChange(func(argoAvailable, fluxAvailable bool) {
+		if argoAvailable {
+			websocket.RegisterAllowedKind("applications", "argoproj.io")
+			informerMgr.WatchCRD(ctx, gitops.ArgoApplicationGVR, "applications", func(obj *unstructured.Unstructured) (any, error) {
+				return gitops.NormalizeArgoApp(obj), nil
+			}, func(eventType, kind, ns, name string, obj any) {
+				hub.HandleEvent(eventType, kind, ns, name, obj)
+				gitopsHandler.InvalidateCache()
+			})
+		}
+		if fluxAvailable {
+			websocket.RegisterAllowedKind("kustomizations", "kustomize.toolkit.fluxcd.io")
+			informerMgr.WatchCRD(ctx, gitops.FluxKustomizationGVR, "kustomizations", func(obj *unstructured.Unstructured) (any, error) {
+				return gitops.NormalizeFluxKustomization(obj), nil
+			}, func(eventType, kind, ns, name string, obj any) {
+				hub.HandleEvent(eventType, kind, ns, name, obj)
+				gitopsHandler.InvalidateCache()
+			})
+
+			websocket.RegisterAllowedKind("helmreleases", "helm.toolkit.fluxcd.io")
+			informerMgr.WatchCRD(ctx, gitops.FluxHelmReleaseGVR, "helmreleases", func(obj *unstructured.Unstructured) (any, error) {
+				return gitops.NormalizeFluxHelmRelease(obj), nil
+			}, func(eventType, kind, ns, name string, obj any) {
+				hub.HandleEvent(eventType, kind, ns, name, obj)
+				gitopsHandler.InvalidateCache()
+			})
+		}
+	})
+	go gitopsDiscoverer.RunDiscoveryLoop(ctx)
 
 	// Security scanning discovery and handler
 	scanDiscoverer := scanning.NewDiscoverer(k8sClient, logger)

--- a/backend/internal/gitops/argocd.go
+++ b/backend/internal/gitops/argocd.go
@@ -12,7 +12,8 @@ import (
 	"k8s.io/client-go/dynamic"
 )
 
-var argoApplicationGVR = schema.GroupVersionResource{
+// ArgoApplicationGVR is the GVR for Argo CD Application resources.
+var ArgoApplicationGVR = schema.GroupVersionResource{
 	Group:    "argoproj.io",
 	Version:  "v1alpha1",
 	Resource: "applications",
@@ -21,14 +22,14 @@ var argoApplicationGVR = schema.GroupVersionResource{
 // ListArgoApplications fetches all Argo CD Applications across namespaces
 // and returns them as normalized app objects.
 func ListArgoApplications(ctx context.Context, dynClient dynamic.Interface) ([]NormalizedApp, error) {
-	list, err := dynClient.Resource(argoApplicationGVR).Namespace("").List(ctx, metav1.ListOptions{})
+	list, err := dynClient.Resource(ArgoApplicationGVR).Namespace("").List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("listing argo cd applications: %w", err)
 	}
 
 	apps := make([]NormalizedApp, 0, len(list.Items))
 	for i := range list.Items {
-		apps = append(apps, normalizeArgoApp(&list.Items[i]))
+		apps = append(apps, NormalizeArgoApp(&list.Items[i]))
 	}
 
 	return apps, nil
@@ -37,12 +38,12 @@ func ListArgoApplications(ctx context.Context, dynClient dynamic.Interface) ([]N
 // GetArgoAppDetail fetches a single Argo CD Application and returns its
 // full detail including managed resources and revision history.
 func GetArgoAppDetail(ctx context.Context, dynClient dynamic.Interface, namespace, name string) (*AppDetail, error) {
-	obj, err := dynClient.Resource(argoApplicationGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	obj, err := dynClient.Resource(ArgoApplicationGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("getting argo cd application %s/%s: %w", namespace, name, err)
 	}
 
-	app := normalizeArgoApp(obj)
+	app := NormalizeArgoApp(obj)
 	resources := extractArgoResources(obj)
 	history := extractArgoHistory(obj)
 
@@ -53,7 +54,7 @@ func GetArgoAppDetail(ctx context.Context, dynClient dynamic.Interface, namespac
 	}, nil
 }
 
-func normalizeArgoApp(obj *unstructured.Unstructured) NormalizedApp {
+func NormalizeArgoApp(obj *unstructured.Unstructured) NormalizedApp {
 	name := obj.GetName()
 	ns := obj.GetNamespace()
 
@@ -213,7 +214,7 @@ func extractArgoHistory(obj *unstructured.Unstructured) []RevisionEntry {
 
 // SyncArgoApp triggers a sync operation on an Argo CD Application.
 func SyncArgoApp(ctx context.Context, dynClient dynamic.Interface, ns, name, username string) (*unstructured.Unstructured, error) {
-	obj, err := dynClient.Resource(argoApplicationGVR).Namespace(ns).Get(ctx, name, metav1.GetOptions{})
+	obj, err := dynClient.Resource(ArgoApplicationGVR).Namespace(ns).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("getting argo cd application %s/%s: %w", ns, name, err)
 	}
@@ -242,7 +243,7 @@ func SyncArgoApp(ctx context.Context, dynClient dynamic.Interface, ns, name, use
 		return nil, fmt.Errorf("marshaling sync patch: %w", err)
 	}
 
-	result, err := dynClient.Resource(argoApplicationGVR).Namespace(ns).Patch(ctx, name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	result, err := dynClient.Resource(ArgoApplicationGVR).Namespace(ns).Patch(ctx, name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("patching argo cd application %s/%s for sync: %w", ns, name, err)
 	}
@@ -253,7 +254,7 @@ func SyncArgoApp(ctx context.Context, dynClient dynamic.Interface, ns, name, use
 // SuspendArgoApp disables automated sync on an Argo CD Application,
 // preserving the previous sync policy in an annotation for later restore.
 func SuspendArgoApp(ctx context.Context, dynClient dynamic.Interface, ns, name string) (*unstructured.Unstructured, error) {
-	obj, err := dynClient.Resource(argoApplicationGVR).Namespace(ns).Get(ctx, name, metav1.GetOptions{})
+	obj, err := dynClient.Resource(ArgoApplicationGVR).Namespace(ns).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("getting argo cd application %s/%s: %w", ns, name, err)
 	}
@@ -287,7 +288,7 @@ func SuspendArgoApp(ctx context.Context, dynClient dynamic.Interface, ns, name s
 		return nil, fmt.Errorf("marshaling suspend patch: %w", err)
 	}
 
-	result, err := dynClient.Resource(argoApplicationGVR).Namespace(ns).Patch(ctx, name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	result, err := dynClient.Resource(ArgoApplicationGVR).Namespace(ns).Patch(ctx, name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("patching argo cd application %s/%s for suspend: %w", ns, name, err)
 	}
@@ -298,7 +299,7 @@ func SuspendArgoApp(ctx context.Context, dynClient dynamic.Interface, ns, name s
 // ResumeArgoApp re-enables automated sync on an Argo CD Application,
 // restoring the policy saved by SuspendArgoApp or using sensible defaults.
 func ResumeArgoApp(ctx context.Context, dynClient dynamic.Interface, ns, name string) (*unstructured.Unstructured, error) {
-	obj, err := dynClient.Resource(argoApplicationGVR).Namespace(ns).Get(ctx, name, metav1.GetOptions{})
+	obj, err := dynClient.Resource(ArgoApplicationGVR).Namespace(ns).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("getting argo cd application %s/%s: %w", ns, name, err)
 	}
@@ -335,7 +336,7 @@ func ResumeArgoApp(ctx context.Context, dynClient dynamic.Interface, ns, name st
 		return nil, fmt.Errorf("marshaling resume patch: %w", err)
 	}
 
-	result, err := dynClient.Resource(argoApplicationGVR).Namespace(ns).Patch(ctx, name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	result, err := dynClient.Resource(ArgoApplicationGVR).Namespace(ns).Patch(ctx, name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("patching argo cd application %s/%s for resume: %w", ns, name, err)
 	}
@@ -346,7 +347,7 @@ func ResumeArgoApp(ctx context.Context, dynClient dynamic.Interface, ns, name st
 // RollbackArgoApp triggers a sync to a specific historical revision.
 // Auto-sync must be disabled first, and the revision must exist in history.
 func RollbackArgoApp(ctx context.Context, dynClient dynamic.Interface, ns, name, revision, username string) (*unstructured.Unstructured, error) {
-	obj, err := dynClient.Resource(argoApplicationGVR).Namespace(ns).Get(ctx, name, metav1.GetOptions{})
+	obj, err := dynClient.Resource(ArgoApplicationGVR).Namespace(ns).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("getting argo cd application %s/%s: %w", ns, name, err)
 	}
@@ -393,7 +394,7 @@ func RollbackArgoApp(ctx context.Context, dynClient dynamic.Interface, ns, name,
 		return nil, fmt.Errorf("marshaling rollback patch: %w", err)
 	}
 
-	result, err := dynClient.Resource(argoApplicationGVR).Namespace(ns).Patch(ctx, name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	result, err := dynClient.Resource(ArgoApplicationGVR).Namespace(ns).Patch(ctx, name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("patching argo cd application %s/%s for rollback: %w", ns, name, err)
 	}

--- a/backend/internal/gitops/argocd_test.go
+++ b/backend/internal/gitops/argocd_test.go
@@ -186,7 +186,7 @@ func TestSuspendArgoApp_StashesPolicy(t *testing.T) {
 	}
 
 	// Fetch the patched object
-	patched, err := client.Resource(argoApplicationGVR).Namespace("argocd").Get(context.Background(), "test-app", metav1.GetOptions{})
+	patched, err := client.Resource(ArgoApplicationGVR).Namespace("argocd").Get(context.Background(), "test-app", metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("failed to get patched object: %v", err)
 	}
@@ -231,7 +231,7 @@ func TestResumeArgoApp_RestoresPolicy(t *testing.T) {
 	}
 
 	// Fetch the patched object
-	patched, err := client.Resource(argoApplicationGVR).Namespace("argocd").Get(context.Background(), "test-app", metav1.GetOptions{})
+	patched, err := client.Resource(ArgoApplicationGVR).Namespace("argocd").Get(context.Background(), "test-app", metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("failed to get patched object: %v", err)
 	}

--- a/backend/internal/gitops/discovery.go
+++ b/backend/internal/gitops/discovery.go
@@ -13,14 +13,19 @@ import (
 
 const recheckInterval = 5 * time.Minute
 
+// DiscoveryChangeCallback is called when tool availability changes.
+// argoAvailable and fluxAvailable reflect the current state.
+type DiscoveryChangeCallback func(argoAvailable, fluxAvailable bool)
+
 // GitOpsDiscoverer probes the cluster for ArgoCD and FluxCD GitOps tools
 // and maintains cached discovery state.
 type GitOpsDiscoverer struct {
 	k8sClient *k8s.ClientFactory
 	logger    *slog.Logger
 
-	mu     sync.RWMutex
-	status *GitOpsStatus
+	mu       sync.RWMutex
+	status   *GitOpsStatus
+	onChange DiscoveryChangeCallback
 }
 
 // NewDiscoverer creates a new GitOps tool discoverer.
@@ -32,6 +37,13 @@ func NewDiscoverer(k8sClient *k8s.ClientFactory, logger *slog.Logger) *GitOpsDis
 			LastChecked: time.Now().UTC().Format(time.RFC3339),
 		},
 	}
+}
+
+// SetOnChange registers a callback invoked when tool availability changes.
+func (d *GitOpsDiscoverer) SetOnChange(cb DiscoveryChangeCallback) {
+	d.mu.Lock()
+	d.onChange = cb
+	d.mu.Unlock()
 }
 
 // Status returns a copy of the cached GitOps status.
@@ -145,6 +157,7 @@ func (d *GitOpsDiscoverer) Discover(ctx context.Context) {
 
 	d.mu.Lock()
 	d.status = status
+	cb := d.onChange
 	d.mu.Unlock()
 
 	d.logger.Info("gitops tool discovery complete",
@@ -152,4 +165,8 @@ func (d *GitOpsDiscoverer) Discover(ctx context.Context) {
 		"argoCDAvailable", argoDetail != nil,
 		"fluxCDAvailable", fluxDetail != nil,
 	)
+
+	if cb != nil {
+		cb(argoDetail != nil, fluxDetail != nil)
+	}
 }

--- a/backend/internal/gitops/discovery.go
+++ b/backend/internal/gitops/discovery.go
@@ -23,9 +23,10 @@ type GitOpsDiscoverer struct {
 	k8sClient *k8s.ClientFactory
 	logger    *slog.Logger
 
-	mu       sync.RWMutex
-	status   *GitOpsStatus
-	onChange DiscoveryChangeCallback
+	mu            sync.RWMutex
+	status        *GitOpsStatus
+	onChange      DiscoveryChangeCallback
+	hasDiscovered bool // true after first Discover completes
 }
 
 // NewDiscoverer creates a new GitOps tool discoverer.
@@ -155,18 +156,26 @@ func (d *GitOpsDiscoverer) Discover(ctx context.Context) {
 		LastChecked: now,
 	}
 
+	newArgo := argoDetail != nil
+	newFlux := fluxDetail != nil
+
 	d.mu.Lock()
+	prevArgo := d.status.ArgoCD != nil && d.status.ArgoCD.Available
+	prevFlux := d.status.FluxCD != nil && d.status.FluxCD.Available
+	firstRun := !d.hasDiscovered
+	d.hasDiscovered = true
 	d.status = status
 	cb := d.onChange
 	d.mu.Unlock()
 
 	d.logger.Info("gitops tool discovery complete",
 		"detected", detected,
-		"argoCDAvailable", argoDetail != nil,
-		"fluxCDAvailable", fluxDetail != nil,
+		"argoCDAvailable", newArgo,
+		"fluxCDAvailable", newFlux,
 	)
 
-	if cb != nil {
-		cb(argoDetail != nil, fluxDetail != nil)
+	// Fire callback only on state transitions or the first discovery run.
+	if cb != nil && (firstRun || prevArgo != newArgo || prevFlux != newFlux) {
+		cb(newArgo, newFlux)
 	}
 }

--- a/backend/internal/gitops/flux.go
+++ b/backend/internal/gitops/flux.go
@@ -16,12 +16,14 @@ import (
 )
 
 var (
-	fluxKustomizationGVR = schema.GroupVersionResource{
+	// FluxKustomizationGVR is the GVR for Flux Kustomization resources.
+	FluxKustomizationGVR = schema.GroupVersionResource{
 		Group:    "kustomize.toolkit.fluxcd.io",
 		Version:  "v1",
 		Resource: "kustomizations",
 	}
-	fluxHelmReleaseGVR = schema.GroupVersionResource{
+	// FluxHelmReleaseGVR is the GVR for Flux HelmRelease resources.
+	FluxHelmReleaseGVR = schema.GroupVersionResource{
 		Group:    "helm.toolkit.fluxcd.io",
 		Version:  "v2",
 		Resource: "helmreleases",
@@ -31,14 +33,14 @@ var (
 // ListFluxKustomizations lists all Flux Kustomization resources across namespaces
 // and returns them as normalized GitOps applications.
 func ListFluxKustomizations(ctx context.Context, dynClient dynamic.Interface) ([]NormalizedApp, error) {
-	list, err := dynClient.Resource(fluxKustomizationGVR).Namespace("").List(ctx, metav1.ListOptions{})
+	list, err := dynClient.Resource(FluxKustomizationGVR).Namespace("").List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("listing flux kustomizations: %w", err)
 	}
 
 	apps := make([]NormalizedApp, 0, len(list.Items))
 	for i := range list.Items {
-		apps = append(apps, normalizeFluxKustomization(&list.Items[i]))
+		apps = append(apps, NormalizeFluxKustomization(&list.Items[i]))
 	}
 	return apps, nil
 }
@@ -46,14 +48,14 @@ func ListFluxKustomizations(ctx context.Context, dynClient dynamic.Interface) ([
 // ListFluxHelmReleases lists all Flux HelmRelease resources across namespaces
 // and returns them as normalized GitOps applications.
 func ListFluxHelmReleases(ctx context.Context, dynClient dynamic.Interface) ([]NormalizedApp, error) {
-	list, err := dynClient.Resource(fluxHelmReleaseGVR).Namespace("").List(ctx, metav1.ListOptions{})
+	list, err := dynClient.Resource(FluxHelmReleaseGVR).Namespace("").List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("listing flux helmreleases: %w", err)
 	}
 
 	apps := make([]NormalizedApp, 0, len(list.Items))
 	for i := range list.Items {
-		apps = append(apps, normalizeFluxHelmRelease(&list.Items[i]))
+		apps = append(apps, NormalizeFluxHelmRelease(&list.Items[i]))
 	}
 	return apps, nil
 }
@@ -64,9 +66,9 @@ func GetFluxAppDetail(ctx context.Context, dynClient dynamic.Interface, kind, na
 	var gvr schema.GroupVersionResource
 	switch kind {
 	case "Kustomization":
-		gvr = fluxKustomizationGVR
+		gvr = FluxKustomizationGVR
 	case "HelmRelease":
-		gvr = fluxHelmReleaseGVR
+		gvr = FluxHelmReleaseGVR
 	default:
 		return nil, fmt.Errorf("unsupported flux kind: %s", kind)
 	}
@@ -80,18 +82,18 @@ func GetFluxAppDetail(ctx context.Context, dynClient dynamic.Interface, kind, na
 
 	switch kind {
 	case "Kustomization":
-		detail.App = normalizeFluxKustomization(obj)
+		detail.App = NormalizeFluxKustomization(obj)
 		detail.Resources = extractFluxInventory(obj)
 		// Flux Kustomizations have no CRD-native revision history.
 	case "HelmRelease":
-		detail.App = normalizeFluxHelmRelease(obj)
+		detail.App = NormalizeFluxHelmRelease(obj)
 		detail.History = extractFluxHelmHistory(obj)
 	}
 
 	return detail, nil
 }
 
-func normalizeFluxKustomization(obj *unstructured.Unstructured) NormalizedApp {
+func NormalizeFluxKustomization(obj *unstructured.Unstructured) NormalizedApp {
 	name := obj.GetName()
 	namespace := obj.GetNamespace()
 
@@ -149,7 +151,7 @@ func normalizeFluxKustomization(obj *unstructured.Unstructured) NormalizedApp {
 	}
 }
 
-func normalizeFluxHelmRelease(obj *unstructured.Unstructured) NormalizedApp {
+func NormalizeFluxHelmRelease(obj *unstructured.Unstructured) NormalizedApp {
 	name := obj.GetName()
 	namespace := obj.GetNamespace()
 

--- a/backend/internal/gitops/flux_test.go
+++ b/backend/internal/gitops/flux_test.go
@@ -170,7 +170,7 @@ func TestReconcileFluxResource_Suspended(t *testing.T) {
 	}
 
 	client := newFluxFakeDynClient(ks)
-	_, err := ReconcileFluxResource(context.Background(), client, fluxKustomizationGVR, "flux-system", "test-ks")
+	_, err := ReconcileFluxResource(context.Background(), client, FluxKustomizationGVR, "flux-system", "test-ks")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -195,13 +195,13 @@ func TestReconcileFluxResource_SetsAnnotation(t *testing.T) {
 	}
 
 	client := newFluxFakeDynClient(ks)
-	_, err := ReconcileFluxResource(context.Background(), client, fluxKustomizationGVR, "flux-system", "test-ks")
+	_, err := ReconcileFluxResource(context.Background(), client, FluxKustomizationGVR, "flux-system", "test-ks")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	// Fetch the patched object
-	patched, err := client.Resource(fluxKustomizationGVR).Namespace("flux-system").Get(context.Background(), "test-ks", metav1.GetOptions{})
+	patched, err := client.Resource(FluxKustomizationGVR).Namespace("flux-system").Get(context.Background(), "test-ks", metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("failed to get patched object: %v", err)
 	}
@@ -234,13 +234,13 @@ func TestSuspendFluxResource(t *testing.T) {
 	}
 
 	client := newFluxFakeDynClient(ks)
-	_, err := SuspendFluxResource(context.Background(), client, fluxKustomizationGVR, "flux-system", "test-ks", true)
+	_, err := SuspendFluxResource(context.Background(), client, FluxKustomizationGVR, "flux-system", "test-ks", true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	// Fetch the patched object
-	patched, err := client.Resource(fluxKustomizationGVR).Namespace("flux-system").Get(context.Background(), "test-ks", metav1.GetOptions{})
+	patched, err := client.Resource(FluxKustomizationGVR).Namespace("flux-system").Get(context.Background(), "test-ks", metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("failed to get patched object: %v", err)
 	}

--- a/backend/internal/gitops/handler.go
+++ b/backend/internal/gitops/handler.go
@@ -34,6 +34,7 @@ type Handler struct {
 	fetchGroup singleflight.Group
 	cacheMu    sync.RWMutex
 	cachedData *cachedApps
+	cacheGen   uint64 // incremented on invalidation; prevents stale writes
 }
 
 type cachedApps struct {
@@ -92,6 +93,11 @@ func (h *Handler) fetchApps(ctx context.Context) ([]NormalizedApp, error) {
 
 // doFetch queries both engines based on discovery and merges results.
 func (h *Handler) doFetch(ctx context.Context) (*cachedApps, error) {
+	// Capture current generation to detect concurrent invalidations.
+	h.cacheMu.RLock()
+	gen := h.cacheGen
+	h.cacheMu.RUnlock()
+
 	dynClient := h.K8sClient.BaseDynamicClient()
 	status := h.Discoverer.Status()
 
@@ -173,8 +179,11 @@ func (h *Handler) doFetch(ctx context.Context) (*cachedApps, error) {
 		fetchedAt: time.Now(),
 	}
 
+	// Only write cache if no invalidation occurred during fetch.
 	h.cacheMu.Lock()
-	h.cachedData = data
+	if h.cacheGen == gen {
+		h.cachedData = data
+	}
 	h.cacheMu.Unlock()
 
 	return data, nil
@@ -417,6 +426,7 @@ func computeMetadata(apps []NormalizedApp) AppListMetadata {
 func (h *Handler) invalidateCache() {
 	h.cacheMu.Lock()
 	h.cachedData = nil
+	h.cacheGen++
 	h.cacheMu.Unlock()
 }
 

--- a/backend/internal/gitops/handler.go
+++ b/backend/internal/gitops/handler.go
@@ -409,12 +409,20 @@ func computeMetadata(apps []NormalizedApp) AppListMetadata {
 	return m
 }
 
-// invalidateCache clears the cached application list and cancels any in-flight singleflight fetch.
+// invalidateCache clears the cached application list so the next REST call re-fetches.
+// We intentionally do NOT call fetchGroup.Forget — an in-flight singleflight fetch
+// could repopulate the cache with pre-event data if we start a competing fetch.
+// Setting cachedData to nil is sufficient: the in-flight fetch will complete and
+// cache its result, but the next call after that will see the stale timestamp and re-fetch.
 func (h *Handler) invalidateCache() {
 	h.cacheMu.Lock()
 	h.cachedData = nil
 	h.cacheMu.Unlock()
-	h.fetchGroup.Forget("fetch")
+}
+
+// InvalidateCache is the exported version for use by CRD event handlers.
+func (h *Handler) InvalidateCache() {
+	h.invalidateCache()
 }
 
 // prepareAction extracts the common preamble for action handlers:
@@ -496,10 +504,10 @@ func (h *Handler) HandleSync(w http.ResponseWriter, r *http.Request) {
 		_, err = SyncArgoApp(r.Context(), dynClient, ns, name, user.KubernetesUsername)
 	case "flux-ks":
 		kind = "Kustomization"
-		_, err = ReconcileFluxResource(r.Context(), dynClient, fluxKustomizationGVR, ns, name)
+		_, err = ReconcileFluxResource(r.Context(), dynClient, FluxKustomizationGVR, ns, name)
 	case "flux-hr":
 		kind = "HelmRelease"
-		_, err = ReconcileFluxResource(r.Context(), dynClient, fluxHelmReleaseGVR, ns, name)
+		_, err = ReconcileFluxResource(r.Context(), dynClient, FluxHelmReleaseGVR, ns, name)
 	}
 
 	if err != nil {
@@ -554,10 +562,10 @@ func (h *Handler) HandleSuspend(w http.ResponseWriter, r *http.Request) {
 		}
 	case "flux-ks":
 		kind = "Kustomization"
-		_, err = SuspendFluxResource(r.Context(), dynClient, fluxKustomizationGVR, ns, name, req.Suspend)
+		_, err = SuspendFluxResource(r.Context(), dynClient, FluxKustomizationGVR, ns, name, req.Suspend)
 	case "flux-hr":
 		kind = "HelmRelease"
-		_, err = SuspendFluxResource(r.Context(), dynClient, fluxHelmReleaseGVR, ns, name, req.Suspend)
+		_, err = SuspendFluxResource(r.Context(), dynClient, FluxHelmReleaseGVR, ns, name, req.Suspend)
 	}
 
 	if err != nil {

--- a/backend/internal/k8s/informers.go
+++ b/backend/internal/k8s/informers.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/informers"
@@ -50,10 +49,9 @@ type crdWatch struct {
 
 // InformerManager wraps typed and dynamic informer factories and manages their lifecycle.
 type InformerManager struct {
-	factory    informers.SharedInformerFactory
-	dynFactory dynamicinformer.DynamicSharedInformerFactory // nil if no CRDs detected
-	dynClient  dynamic.Interface
-	logger     *slog.Logger
+	factory   informers.SharedInformerFactory
+	dynClient dynamic.Interface
+	logger    *slog.Logger
 
 	crdMu      sync.RWMutex
 	crdWatches map[schema.GroupVersionResource]*crdWatch
@@ -62,7 +60,7 @@ type InformerManager struct {
 // NewInformerManager creates a new InformerManager with informers for all
 // resource types KubeCenter needs to watch. The dynClient parameter may be nil
 // if the dynamic client failed to initialize.
-func NewInformerManager(clientset kubernetes.Interface, dynClient dynamic.Interface, disco discovery.DiscoveryInterface, logger *slog.Logger) *InformerManager {
+func NewInformerManager(clientset kubernetes.Interface, dynClient dynamic.Interface, logger *slog.Logger) *InformerManager {
 	factory := informers.NewSharedInformerFactory(clientset, defaultResyncPeriod)
 
 	// Pre-register informers so the factory knows what to start.
@@ -127,47 +125,17 @@ func NewInformerManager(clientset kubernetes.Interface, dynClient dynamic.Interf
 		crdWatches: make(map[schema.GroupVersionResource]*crdWatch),
 	}
 
-	// Dynamic informer for CRDs — probe discovery first to avoid reflector
-	// spin on clusters where the CRD is not installed.
-	if dynClient != nil {
-		mgr.dynFactory = probeCRDsAndCreateFactory(dynClient, disco, defaultResyncPeriod, logger)
-	}
-
-	typedCount := 31
-	dynCount := 0
-	if mgr.dynFactory != nil {
-		dynCount = 1
-	}
 	logger.Info("informer manager created",
-		"typedResources", typedCount,
-		"dynamicResources", dynCount,
+		"typedResources", 31,
 		"resyncPeriod", defaultResyncPeriod,
 	)
 
 	return mgr
 }
 
-// probeCRDsAndCreateFactory checks if known CRDs exist via discovery and creates
-// a dynamic informer factory for those that are present. Returns nil if no CRDs found.
-func probeCRDsAndCreateFactory(dynClient dynamic.Interface, disco discovery.DiscoveryInterface, resync time.Duration, logger *slog.Logger) dynamicinformer.DynamicSharedInformerFactory {
-	_, err := disco.ServerResourcesForGroupVersion("cilium.io/v2")
-	if err != nil {
-		logger.Info("cilium.io/v2 CRD not found — skipping dynamic informer", "error", err)
-		return nil
-	}
-
-	logger.Info("cilium.io/v2 CRD detected — registering dynamic informer")
-	dynFactory := dynamicinformer.NewDynamicSharedInformerFactory(dynClient, resync)
-	dynFactory.ForResource(CiliumPolicyGVR)
-	return dynFactory
-}
-
 // Start begins all registered informers. Call this once after creating the manager.
 func (m *InformerManager) Start(ctx context.Context) {
 	m.factory.Start(ctx.Done())
-	if m.dynFactory != nil {
-		m.dynFactory.Start(ctx.Done())
-	}
 	m.logger.Info("informers started")
 }
 
@@ -182,17 +150,6 @@ func (m *InformerManager) WaitForSync(ctx context.Context) error {
 		}
 	}
 
-	if m.dynFactory != nil {
-		dynSynced := m.dynFactory.WaitForCacheSync(ctx.Done())
-		for gvr, ok := range dynSynced {
-			if !ok {
-				m.logger.Warn("dynamic informer sync failed", "gvr", gvr.String())
-				// Don't fail startup — the CRD may have been removed after discovery probe.
-				// Handlers will get errors from the lister and return appropriate HTTP responses.
-			}
-		}
-	}
-
 	m.logger.Info("all informer caches synced")
 	return nil
 }
@@ -203,12 +160,21 @@ func (m *InformerManager) Factory() informers.SharedInformerFactory {
 }
 
 // CiliumNetworkPolicies returns the dynamic lister for CiliumNetworkPolicy CRDs.
-// Returns nil if the Cilium CRD was not detected at startup.
+// Returns nil if the Cilium CRD watch has not been started via WatchCRD.
 func (m *InformerManager) CiliumNetworkPolicies() cache.GenericLister {
-	if m.dynFactory == nil {
+	return m.CRDLister(CiliumPolicyGVR)
+}
+
+// CRDLister returns the GenericLister for a dynamically-watched CRD.
+// Returns nil if no watch exists for the given GVR.
+func (m *InformerManager) CRDLister(gvr schema.GroupVersionResource) cache.GenericLister {
+	m.crdMu.RLock()
+	w, exists := m.crdWatches[gvr]
+	m.crdMu.RUnlock()
+	if !exists {
 		return nil
 	}
-	return m.dynFactory.ForResource(CiliumPolicyGVR).Lister()
+	return w.factory.ForResource(gvr).Lister()
 }
 
 // Typed lister accessors — Core
@@ -401,13 +367,6 @@ func (m *InformerManager) RegisterEventHandlers(cb EventCallback) {
 		{"mutatingwebhookconfigurations", m.factory.Admissionregistration().V1().MutatingWebhookConfigurations().Informer()},
 	}
 
-	// Dynamic CRD informers
-	if m.dynFactory != nil {
-		specs = append(specs, informerSpec{
-			"ciliumnetworkpolicies", m.dynFactory.ForResource(CiliumPolicyGVR).Informer(),
-		})
-	}
-
 	for _, spec := range specs {
 		kind := spec.kind
 		handler := cache.ResourceEventHandlerDetailedFuncs{
@@ -462,6 +421,9 @@ func (m *InformerManager) emitEvent(cb EventCallback, eventType, kind string, ob
 // Each GVR gets its own DynamicSharedInformerFactory for independent lifecycle.
 // Safe to call at runtime when CRDs are discovered.
 func (m *InformerManager) WatchCRD(ctx context.Context, gvr schema.GroupVersionResource, kind string, normalizer CRDNormalizer, cb EventCallback) {
+	if ctx.Err() != nil {
+		return
+	}
 	if m.dynClient == nil {
 		m.logger.Warn("cannot watch CRD: dynamic client not available", "gvr", gvr.String())
 		return

--- a/backend/internal/k8s/informers.go
+++ b/backend/internal/k8s/informers.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
@@ -37,11 +39,24 @@ var CiliumPolicyGVR = schema.GroupVersionResource{
 	Resource: "ciliumnetworkpolicies",
 }
 
+// CRDNormalizer converts an unstructured CRD object into a domain type for WebSocket broadcast.
+type CRDNormalizer func(obj *unstructured.Unstructured) (any, error)
+
+// crdWatch tracks a single CRD dynamic informer with its own lifecycle.
+type crdWatch struct {
+	factory dynamicinformer.DynamicSharedInformerFactory
+	cancel  context.CancelFunc
+}
+
 // InformerManager wraps typed and dynamic informer factories and manages their lifecycle.
 type InformerManager struct {
 	factory    informers.SharedInformerFactory
 	dynFactory dynamicinformer.DynamicSharedInformerFactory // nil if no CRDs detected
+	dynClient  dynamic.Interface
 	logger     *slog.Logger
+
+	crdMu      sync.RWMutex
+	crdWatches map[schema.GroupVersionResource]*crdWatch
 }
 
 // NewInformerManager creates a new InformerManager with informers for all
@@ -106,8 +121,10 @@ func NewInformerManager(clientset kubernetes.Interface, dynClient dynamic.Interf
 	factory.Admissionregistration().V1().MutatingWebhookConfigurations().Informer()
 
 	mgr := &InformerManager{
-		factory: factory,
-		logger:  logger,
+		factory:    factory,
+		dynClient:  dynClient,
+		logger:     logger,
+		crdWatches: make(map[schema.GroupVersionResource]*crdWatch),
 	}
 
 	// Dynamic informer for CRDs — probe discovery first to avoid reflector
@@ -438,4 +455,108 @@ func (m *InformerManager) emitEvent(cb EventCallback, eventType, kind string, ob
 		return
 	}
 	cb(eventType, kind, meta.GetNamespace(), meta.GetName(), obj)
+}
+
+// WatchCRD starts a dynamic informer for a CRD resource. Events are deep-copied,
+// normalized via the provided normalizer, and emitted through the callback.
+// Each GVR gets its own DynamicSharedInformerFactory for independent lifecycle.
+// Safe to call at runtime when CRDs are discovered.
+func (m *InformerManager) WatchCRD(ctx context.Context, gvr schema.GroupVersionResource, kind string, normalizer CRDNormalizer, cb EventCallback) {
+	if m.dynClient == nil {
+		m.logger.Warn("cannot watch CRD: dynamic client not available", "gvr", gvr.String())
+		return
+	}
+
+	m.crdMu.Lock()
+	if _, exists := m.crdWatches[gvr]; exists {
+		m.crdMu.Unlock()
+		m.logger.Debug("CRD already being watched", "gvr", gvr.String())
+		return
+	}
+
+	crdCtx, cancel := context.WithCancel(ctx)
+	factory := dynamicinformer.NewDynamicSharedInformerFactory(m.dynClient, defaultResyncPeriod)
+	informer := factory.ForResource(gvr).Informer()
+
+	handler := cache.ResourceEventHandlerDetailedFuncs{
+		AddFunc: func(obj interface{}, isInInitialList bool) {
+			if isInInitialList {
+				return
+			}
+			m.emitCRDEvent(cb, "ADDED", kind, normalizer, obj)
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			oldMeta, ok1 := oldObj.(metav1.Object)
+			newMeta, ok2 := newObj.(metav1.Object)
+			if ok1 && ok2 && oldMeta.GetResourceVersion() == newMeta.GetResourceVersion() {
+				return
+			}
+			m.emitCRDEvent(cb, "MODIFIED", kind, normalizer, newObj)
+		},
+		DeleteFunc: func(obj interface{}) {
+			if d, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+				obj = d.Obj
+			}
+			m.emitCRDEvent(cb, "DELETED", kind, normalizer, obj)
+		},
+	}
+
+	if _, err := informer.AddEventHandler(handler); err != nil {
+		cancel()
+		m.crdMu.Unlock()
+		m.logger.Error("failed to add CRD event handler", "gvr", gvr.String(), "error", err)
+		return
+	}
+
+	m.crdWatches[gvr] = &crdWatch{factory: factory, cancel: cancel}
+	m.crdMu.Unlock()
+
+	factory.Start(crdCtx.Done())
+
+	// Wait for sync in background — don't block the caller
+	go func() {
+		synced := factory.WaitForCacheSync(crdCtx.Done())
+		for r, ok := range synced {
+			if !ok {
+				m.logger.Warn("CRD informer sync failed", "gvr", r.String())
+			}
+		}
+	}()
+
+	m.logger.Info("CRD watch started", "gvr", gvr.String(), "kind", kind)
+}
+
+// StopCRD stops watching a CRD resource and cleans up the informer.
+func (m *InformerManager) StopCRD(gvr schema.GroupVersionResource) {
+	m.crdMu.Lock()
+	w, exists := m.crdWatches[gvr]
+	if !exists {
+		m.crdMu.Unlock()
+		return
+	}
+	delete(m.crdWatches, gvr)
+	m.crdMu.Unlock()
+
+	w.cancel()
+	m.logger.Info("CRD watch stopped", "gvr", gvr.String())
+}
+
+// emitCRDEvent deep-copies an unstructured object, normalizes it, and emits it.
+func (m *InformerManager) emitCRDEvent(cb EventCallback, eventType, kind string, normalizer CRDNormalizer, obj interface{}) {
+	u, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		m.logger.Warn("CRD event object is not *unstructured.Unstructured", "kind", kind)
+		return
+	}
+
+	// Deep copy to avoid data races with informer cache
+	copied := u.DeepCopy()
+
+	normalized, err := normalizer(copied)
+	if err != nil {
+		m.logger.Warn("CRD normalization failed", "kind", kind, "name", copied.GetName(), "error", err)
+		return
+	}
+
+	cb(eventType, kind, copied.GetNamespace(), copied.GetName(), normalized)
 }

--- a/backend/internal/k8s/informers_test.go
+++ b/backend/internal/k8s/informers_test.go
@@ -4,11 +4,7 @@ import (
 	"log/slog"
 	"os"
 	"testing"
-	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	fakedynamic "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -16,36 +12,10 @@ func testLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 }
 
-func TestProbeCRDs_NoCilium(t *testing.T) {
+func TestCiliumNetworkPolicies_NilWhenNoWatch(t *testing.T) {
 	fakeCS := fake.NewSimpleClientset()
-	result := probeCRDsAndCreateFactory(nil, fakeCS.Discovery(), time.Minute, testLogger())
-	if result != nil {
-		t.Error("expected nil when Cilium CRD is not installed")
-	}
-}
-
-func TestProbeCRDs_WithCilium(t *testing.T) {
-	fakeCS := fake.NewSimpleClientset()
-	fakeCS.Resources = []*metav1.APIResourceList{
-		{
-			GroupVersion: "cilium.io/v2",
-			APIResources: []metav1.APIResource{
-				{Name: "ciliumnetworkpolicies", Kind: "CiliumNetworkPolicy", Namespaced: true},
-			},
-		},
-	}
-
-	fakeDyn := fakedynamic.NewSimpleDynamicClient(runtime.NewScheme())
-	result := probeCRDsAndCreateFactory(fakeDyn, fakeCS.Discovery(), time.Minute, testLogger())
-	if result == nil {
-		t.Fatal("expected non-nil when Cilium CRD is installed")
-	}
-}
-
-func TestCiliumNetworkPolicies_NilWhenNoDynFactory(t *testing.T) {
-	fakeCS := fake.NewSimpleClientset()
-	mgr := NewInformerManager(fakeCS, nil, fakeCS.Discovery(), testLogger())
+	mgr := NewInformerManager(fakeCS, nil, testLogger())
 	if mgr.CiliumNetworkPolicies() != nil {
-		t.Error("expected nil lister when dynClient is nil")
+		t.Error("expected nil lister when no CRD watch started")
 	}
 }

--- a/backend/internal/k8s/resources/resources_test.go
+++ b/backend/internal/k8s/resources/resources_test.go
@@ -35,7 +35,7 @@ func testHandler(t *testing.T, objs ...runtime.Object) (*Handler, *fake.Clientse
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	im := k8s.NewInformerManager(fakeCS, nil, fakeCS.Discovery(), logger)
+	im := k8s.NewInformerManager(fakeCS, nil, logger)
 	im.Start(ctx)
 	if err := im.WaitForSync(ctx); err != nil {
 		t.Fatalf("informer sync failed: %v", err)

--- a/backend/internal/policy/discovery.go
+++ b/backend/internal/policy/discovery.go
@@ -27,6 +27,7 @@ type PolicyDiscoverer struct {
 	status         *EngineStatus
 	gatekeeperCRDs []*k8s.CRDInfo
 	onChange       PolicyChangeCallback
+	hasDiscovered  bool // true after first Discover completes
 }
 
 // NewDiscoverer creates a new policy engine discoverer.
@@ -153,7 +154,14 @@ func (d *PolicyDiscoverer) Discover(ctx context.Context) {
 		LastChecked: now,
 	}
 
+	newKyverno := kyvernoDetail != nil
+	newGatekeeper := gatekeeperDetail != nil
+
 	d.mu.Lock()
+	prevKyverno := d.status.Kyverno != nil && d.status.Kyverno.Available
+	prevGatekeeper := d.status.Gatekeeper != nil && d.status.Gatekeeper.Available
+	firstRun := !d.hasDiscovered
+	d.hasDiscovered = true
 	d.status = status
 	d.gatekeeperCRDs = constraintCRDs
 	cb := d.onChange
@@ -161,13 +169,14 @@ func (d *PolicyDiscoverer) Discover(ctx context.Context) {
 
 	d.logger.Info("policy engine discovery complete",
 		"detected", detected,
-		"kyvernoAvailable", kyvernoDetail != nil,
-		"gatekeeperAvailable", gatekeeperDetail != nil,
+		"kyvernoAvailable", newKyverno,
+		"gatekeeperAvailable", newGatekeeper,
 		"constraintCRDs", len(constraintCRDs),
 	)
 
-	if cb != nil {
-		cb(kyvernoDetail != nil, gatekeeperDetail != nil)
+	// Fire callback only on state transitions or the first discovery run.
+	if cb != nil && (firstRun || prevKyverno != newKyverno || prevGatekeeper != newGatekeeper) {
+		cb(newKyverno, newGatekeeper)
 	}
 }
 

--- a/backend/internal/policy/discovery.go
+++ b/backend/internal/policy/discovery.go
@@ -13,6 +13,9 @@ import (
 
 const recheckInterval = 5 * time.Minute
 
+// PolicyChangeCallback is called when engine availability changes.
+type PolicyChangeCallback func(kyvernoAvailable, gatekeeperAvailable bool)
+
 // PolicyDiscoverer probes the cluster for Kyverno and OPA/Gatekeeper policy
 // engines and maintains cached discovery state.
 type PolicyDiscoverer struct {
@@ -20,9 +23,10 @@ type PolicyDiscoverer struct {
 	crdDiscovery *k8s.CRDDiscovery
 	logger       *slog.Logger
 
-	mu               sync.RWMutex
-	status           *EngineStatus
-	gatekeeperCRDs   []*k8s.CRDInfo
+	mu             sync.RWMutex
+	status         *EngineStatus
+	gatekeeperCRDs []*k8s.CRDInfo
+	onChange       PolicyChangeCallback
 }
 
 // NewDiscoverer creates a new policy engine discoverer.
@@ -35,6 +39,13 @@ func NewDiscoverer(k8sClient *k8s.ClientFactory, crdDiscovery *k8s.CRDDiscovery,
 			LastChecked: time.Now().UTC().Format(time.RFC3339),
 		},
 	}
+}
+
+// SetOnChange registers a callback invoked when engine availability changes.
+func (d *PolicyDiscoverer) SetOnChange(cb PolicyChangeCallback) {
+	d.mu.Lock()
+	d.onChange = cb
+	d.mu.Unlock()
 }
 
 // Status returns a copy of the cached engine status.
@@ -145,6 +156,7 @@ func (d *PolicyDiscoverer) Discover(ctx context.Context) {
 	d.mu.Lock()
 	d.status = status
 	d.gatekeeperCRDs = constraintCRDs
+	cb := d.onChange
 	d.mu.Unlock()
 
 	d.logger.Info("policy engine discovery complete",
@@ -153,6 +165,10 @@ func (d *PolicyDiscoverer) Discover(ctx context.Context) {
 		"gatekeeperAvailable", gatekeeperDetail != nil,
 		"constraintCRDs", len(constraintCRDs),
 	)
+
+	if cb != nil {
+		cb(kyvernoDetail != nil, gatekeeperDetail != nil)
+	}
 }
 
 // detectWebhooks counts validating/mutating webhooks containing the engine name

--- a/backend/internal/policy/gatekeeper.go
+++ b/backend/internal/policy/gatekeeper.go
@@ -70,7 +70,7 @@ func listGatekeeperPoliciesAndViolations(ctx context.Context, dynClient dynamic.
 
 			var r constraintCRDResult
 			for i := range list.Items {
-				r.policies = append(r.policies, normalizeGatekeeperConstraint(&list.Items[i], c.Kind))
+				r.policies = append(r.policies, NormalizeGatekeeperConstraint(&list.Items[i], c.Kind))
 				r.violations = append(r.violations, extractGatekeeperViolations(&list.Items[i], c.Kind)...)
 			}
 			results <- r
@@ -96,7 +96,7 @@ func listGatekeeperPoliciesAndViolations(ctx context.Context, dynClient dynamic.
 	return allPolicies, allViolations, nil
 }
 
-func normalizeGatekeeperConstraint(obj *unstructured.Unstructured, constraintKind string) NormalizedPolicy {
+func NormalizeGatekeeperConstraint(obj *unstructured.Unstructured, constraintKind string) NormalizedPolicy {
 	name := obj.GetName()
 	annotations := obj.GetAnnotations()
 

--- a/backend/internal/policy/handler.go
+++ b/backend/internal/policy/handler.go
@@ -61,6 +61,13 @@ func (h *Handler) fetchPoliciesAndViolations(ctx context.Context) ([]NormalizedP
 	return data.policies, data.violations, nil
 }
 
+// InvalidateCache clears the cached policy/violation data so the next REST call re-fetches.
+func (h *Handler) InvalidateCache() {
+	h.cacheMu.Lock()
+	h.cachedData = nil
+	h.cacheMu.Unlock()
+}
+
 // doFetch queries both engines based on discovery status and merges results.
 // It uses the service account's dynamic client for full cluster visibility.
 func (h *Handler) doFetch(ctx context.Context) (*cachedPolicyData, error) {

--- a/backend/internal/policy/handler.go
+++ b/backend/internal/policy/handler.go
@@ -28,6 +28,7 @@ type Handler struct {
 	fetchGroup singleflight.Group
 	cacheMu    sync.RWMutex
 	cachedData *cachedPolicyData
+	cacheGen   uint64 // incremented on invalidation; prevents stale writes
 }
 
 type cachedPolicyData struct {
@@ -65,12 +66,18 @@ func (h *Handler) fetchPoliciesAndViolations(ctx context.Context) ([]NormalizedP
 func (h *Handler) InvalidateCache() {
 	h.cacheMu.Lock()
 	h.cachedData = nil
+	h.cacheGen++
 	h.cacheMu.Unlock()
 }
 
 // doFetch queries both engines based on discovery status and merges results.
 // It uses the service account's dynamic client for full cluster visibility.
 func (h *Handler) doFetch(ctx context.Context) (*cachedPolicyData, error) {
+	// Capture current generation to detect concurrent invalidations.
+	h.cacheMu.RLock()
+	gen := h.cacheGen
+	h.cacheMu.RUnlock()
+
 	dynClient := h.K8sClient.BaseDynamicClient()
 
 	status := h.Discoverer.Status()
@@ -143,8 +150,11 @@ func (h *Handler) doFetch(ctx context.Context) (*cachedPolicyData, error) {
 		fetchedAt:  time.Now(),
 	}
 
+	// Only write cache if no invalidation occurred during fetch.
 	h.cacheMu.Lock()
-	h.cachedData = data
+	if h.cacheGen == gen {
+		h.cachedData = data
+	}
 	h.cacheMu.Unlock()
 
 	return data, nil

--- a/backend/internal/policy/kyverno.go
+++ b/backend/internal/policy/kyverno.go
@@ -12,10 +12,14 @@ import (
 )
 
 var (
-	kyvernoClusterPolicyGVR = schema.GroupVersionResource{Group: "kyverno.io", Version: "v1", Resource: "clusterpolicies"}
-	kyvernoPolicyGVR        = schema.GroupVersionResource{Group: "kyverno.io", Version: "v1", Resource: "policies"}
-	policyReportGVR         = schema.GroupVersionResource{Group: "wgpolicyk8s.io", Version: "v1alpha2", Resource: "policyreports"}
-	clusterPolicyReportGVR  = schema.GroupVersionResource{Group: "wgpolicyk8s.io", Version: "v1alpha2", Resource: "clusterpolicyreports"}
+	// KyvernoClusterPolicyGVR is the GVR for Kyverno ClusterPolicy resources.
+	KyvernoClusterPolicyGVR = schema.GroupVersionResource{Group: "kyverno.io", Version: "v1", Resource: "clusterpolicies"}
+	// KyvernoPolicyGVR is the GVR for Kyverno Policy resources.
+	KyvernoPolicyGVR = schema.GroupVersionResource{Group: "kyverno.io", Version: "v1", Resource: "policies"}
+	// PolicyReportGVR is the GVR for PolicyReport resources.
+	PolicyReportGVR = schema.GroupVersionResource{Group: "wgpolicyk8s.io", Version: "v1alpha2", Resource: "policyreports"}
+	// ClusterPolicyReportGVR is the GVR for ClusterPolicyReport resources.
+	ClusterPolicyReportGVR = schema.GroupVersionResource{Group: "wgpolicyk8s.io", Version: "v1alpha2", Resource: "clusterpolicyreports"}
 )
 
 // listKyvernoPolicies fetches Kyverno ClusterPolicies and namespaced Policies,
@@ -24,27 +28,27 @@ func listKyvernoPolicies(ctx context.Context, dynClient dynamic.Interface) ([]No
 	var policies []NormalizedPolicy
 
 	// Cluster-scoped policies
-	clusterList, err := dynClient.Resource(kyvernoClusterPolicyGVR).List(ctx, metav1.ListOptions{})
+	clusterList, err := dynClient.Resource(KyvernoClusterPolicyGVR).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("listing kyverno cluster policies: %w", err)
 	}
 	for i := range clusterList.Items {
-		policies = append(policies, normalizeKyvernoPolicy(&clusterList.Items[i], true))
+		policies = append(policies, NormalizeKyvernoPolicy(&clusterList.Items[i], true))
 	}
 
 	// Namespace-scoped policies
-	nsList, err := dynClient.Resource(kyvernoPolicyGVR).Namespace("").List(ctx, metav1.ListOptions{})
+	nsList, err := dynClient.Resource(KyvernoPolicyGVR).Namespace("").List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("listing kyverno policies: %w", err)
 	}
 	for i := range nsList.Items {
-		policies = append(policies, normalizeKyvernoPolicy(&nsList.Items[i], false))
+		policies = append(policies, NormalizeKyvernoPolicy(&nsList.Items[i], false))
 	}
 
 	return policies, nil
 }
 
-func normalizeKyvernoPolicy(obj *unstructured.Unstructured, clusterScoped bool) NormalizedPolicy {
+func NormalizeKyvernoPolicy(obj *unstructured.Unstructured, clusterScoped bool) NormalizedPolicy {
 	name := obj.GetName()
 	ns := obj.GetNamespace()
 	annotations := obj.GetAnnotations()
@@ -125,7 +129,7 @@ func listKyvernoViolations(ctx context.Context, dynClient dynamic.Interface) ([]
 	var violations []NormalizedViolation
 
 	// Namespace-scoped policy reports
-	nsList, err := dynClient.Resource(policyReportGVR).Namespace("").List(ctx, metav1.ListOptions{})
+	nsList, err := dynClient.Resource(PolicyReportGVR).Namespace("").List(ctx, metav1.ListOptions{})
 	if err == nil {
 		for i := range nsList.Items {
 			violations = append(violations, extractKyvernoViolations(&nsList.Items[i])...)
@@ -133,7 +137,7 @@ func listKyvernoViolations(ctx context.Context, dynClient dynamic.Interface) ([]
 	}
 
 	// Cluster-scoped policy reports
-	clusterList, err := dynClient.Resource(clusterPolicyReportGVR).List(ctx, metav1.ListOptions{})
+	clusterList, err := dynClient.Resource(ClusterPolicyReportGVR).List(ctx, metav1.ListOptions{})
 	if err == nil {
 		for i := range clusterList.Items {
 			violations = append(violations, extractKyvernoViolations(&clusterList.Items[i])...)

--- a/backend/internal/websocket/client.go
+++ b/backend/internal/websocket/client.go
@@ -17,7 +17,7 @@ const (
 	pingPeriod       = (pongWait * 9) / 10
 	maxMessageSize   = 64 * 1024
 	authTimeout      = 5 * time.Second
-	maxSubscriptions = 20
+	maxSubscriptions = 25
 	sendBufferSize   = 256
 )
 
@@ -196,14 +196,28 @@ func (c *Client) handleSubscribe(msg IncomingMessage) {
 	if !alwaysAllowKinds[normalizedKind] {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
-		allowed, err := c.hub.accessChecker.CanAccess(
-			ctx,
-			c.user.KubernetesUsername,
-			c.user.KubernetesGroups,
-			"list",
-			normalizedKind,
-			msg.Namespace,
-		)
+		var allowed bool
+		var err error
+		if apiGroup := crdAPIGroup(normalizedKind); apiGroup != "" {
+			allowed, err = c.hub.accessChecker.CanAccessGroupResource(
+				ctx,
+				c.user.KubernetesUsername,
+				c.user.KubernetesGroups,
+				"list",
+				apiGroup,
+				normalizedKind,
+				msg.Namespace,
+			)
+		} else {
+			allowed, err = c.hub.accessChecker.CanAccess(
+				ctx,
+				c.user.KubernetesUsername,
+				c.user.KubernetesGroups,
+				"list",
+				normalizedKind,
+				msg.Namespace,
+			)
+		}
 		if err != nil {
 			c.logger.Error("RBAC check failed",
 				"error", err, "user", c.user.Username,

--- a/backend/internal/websocket/events.go
+++ b/backend/internal/websocket/events.go
@@ -1,5 +1,7 @@
 package websocket
 
+import "sync"
+
 // ResourceEvent is emitted by informer event handlers and consumed by the Hub.
 type ResourceEvent struct {
 	EventType string `json:"eventType"` // ADDED, MODIFIED, DELETED
@@ -49,53 +51,83 @@ type OutgoingMessage struct {
 // allowedKinds is the set of resource kinds that clients may subscribe to via WebSocket.
 // Secrets are intentionally excluded — they are not in the informer cache and must only
 // be accessed via the REST API with masking and audit logging.
-var allowedKinds = map[string]bool{
-	"pods":                    true,
-	"services":                true,
-	"configmaps":              true,
-	"namespaces":              true,
-	"nodes":                   true,
-	"persistentvolumeclaims":  true,
-	"pvcs":                    true, // alias — normalized to persistentvolumeclaims
-	"persistentvolumes":       true,
-	"pvs":                     true, // alias — normalized to persistentvolumes
-	"endpoints":               true,
-	"events":                  true,
-	"deployments":             true,
-	"replicasets":              true,
-	"statefulsets":             true,
-	"daemonsets":               true,
-	"jobs":                    true,
-	"cronjobs":                true,
-	"ingresses":               true,
-	"networkpolicies":          true,
-	"horizontalpodautoscalers": true,
-	"hpas":                     true, // alias — normalized to horizontalpodautoscalers
-	"storageclasses":           true,
-	"roles":                   true,
-	"clusterroles":             true,
-	"rolebindings":             true,
-	"clusterrolebindings":      true,
-	"resourcequotas":                      true,
-	"limitranges":                         true,
-	"serviceaccounts":                     true,
-	"poddisruptionbudgets":                true,
-	"pdbs":                                true, // alias — normalized to poddisruptionbudgets
-	"endpointslices":                      true,
-	"alerts":                              true,
-	"validatingwebhookconfigurations":      true,
-	"mutatingwebhookconfigurations":        true,
-}
+// Protected by allowedKindsMu for concurrent access from discovery goroutines.
+var (
+	allowedKindsMu sync.RWMutex
+	allowedKinds   = map[string]bool{
+		"pods":                    true,
+		"services":                true,
+		"configmaps":              true,
+		"namespaces":              true,
+		"nodes":                   true,
+		"persistentvolumeclaims":  true,
+		"pvcs":                    true, // alias — normalized to persistentvolumeclaims
+		"persistentvolumes":       true,
+		"pvs":                     true, // alias — normalized to persistentvolumes
+		"endpoints":               true,
+		"events":                  true,
+		"deployments":             true,
+		"replicasets":             true,
+		"statefulsets":            true,
+		"daemonsets":              true,
+		"jobs":                    true,
+		"cronjobs":                true,
+		"ingresses":              true,
+		"networkpolicies":         true,
+		"horizontalpodautoscalers": true,
+		"hpas":                    true, // alias — normalized to horizontalpodautoscalers
+		"storageclasses":          true,
+		"roles":                   true,
+		"clusterroles":            true,
+		"rolebindings":            true,
+		"clusterrolebindings":     true,
+		"resourcequotas":          true,
+		"limitranges":             true,
+		"serviceaccounts":         true,
+		"poddisruptionbudgets":    true,
+		"pdbs":                    true, // alias — normalized to poddisruptionbudgets
+		"endpointslices":          true,
+		"alerts":                  true,
+		"validatingwebhookconfigurations": true,
+		"mutatingwebhookconfigurations":   true,
+	}
+	// crdKindGroups maps CRD kind strings to their API group for RBAC checks.
+	// Populated dynamically by RegisterAllowedKind when apiGroup is non-empty.
+	crdKindGroups = map[string]string{}
+)
 
 // RegisterAllowedKind dynamically adds a kind to the subscription allowlist.
-// Used for CRD-backed resources that are only available when the CRD is installed.
-func RegisterAllowedKind(kind string) {
+// If apiGroup is non-empty, the kind is treated as a CRD and RBAC checks will
+// use group-aware access checking.
+func RegisterAllowedKind(kind, apiGroup string) {
+	allowedKindsMu.Lock()
+	defer allowedKindsMu.Unlock()
 	allowedKinds[kind] = true
+	if apiGroup != "" {
+		crdKindGroups[kind] = apiGroup
+	}
+}
+
+// UnregisterAllowedKind removes a kind from the subscription allowlist.
+func UnregisterAllowedKind(kind string) {
+	allowedKindsMu.Lock()
+	defer allowedKindsMu.Unlock()
+	delete(allowedKinds, kind)
+	delete(crdKindGroups, kind)
 }
 
 // isAllowedKind returns true if the kind is in the subscription allowlist.
 func isAllowedKind(kind string) bool {
+	allowedKindsMu.RLock()
+	defer allowedKindsMu.RUnlock()
 	return allowedKinds[kind]
+}
+
+// crdAPIGroup returns the API group for a CRD kind, or empty string for core resources.
+func crdAPIGroup(kind string) string {
+	allowedKindsMu.RLock()
+	defer allowedKindsMu.RUnlock()
+	return crdKindGroups[kind]
 }
 
 // kindAliases maps frontend short names to the informer's canonical kind strings.

--- a/backend/internal/websocket/events.go
+++ b/backend/internal/websocket/events.go
@@ -102,6 +102,9 @@ var (
 func RegisterAllowedKind(kind, apiGroup string) {
 	allowedKindsMu.Lock()
 	defer allowedKindsMu.Unlock()
+	if allowedKinds[kind] {
+		return // already registered
+	}
 	allowedKinds[kind] = true
 	if apiGroup != "" {
 		crdKindGroups[kind] = apiGroup

--- a/backend/internal/websocket/hub.go
+++ b/backend/internal/websocket/hub.go
@@ -11,6 +11,7 @@ import (
 // AccessChecker verifies RBAC permissions for WebSocket subscriptions.
 type AccessChecker interface {
 	CanAccess(ctx context.Context, username string, groups []string, verb, resource, namespace string) (bool, error)
+	CanAccessGroupResource(ctx context.Context, username string, groups []string, verb, apiGroup, resource, namespace string) (bool, error)
 }
 
 // subChange represents a subscription addition.
@@ -262,14 +263,28 @@ func (h *Hub) revalidateSubscriptions(ctx context.Context) {
 				continue
 			}
 			checkCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-			allowed, err := h.accessChecker.CanAccess(
-				checkCtx,
-				client.user.KubernetesUsername,
-				client.user.KubernetesGroups,
-				"list",
-				key.Kind,
-				key.Namespace,
-			)
+			var allowed bool
+			var err error
+			if apiGroup := crdAPIGroup(key.Kind); apiGroup != "" {
+				allowed, err = h.accessChecker.CanAccessGroupResource(
+					checkCtx,
+					client.user.KubernetesUsername,
+					client.user.KubernetesGroups,
+					"list",
+					apiGroup,
+					key.Kind,
+					key.Namespace,
+				)
+			} else {
+				allowed, err = h.accessChecker.CanAccess(
+					checkCtx,
+					client.user.KubernetesUsername,
+					client.user.KubernetesGroups,
+					"list",
+					key.Kind,
+					key.Namespace,
+				)
+			}
 			cancel()
 			if err != nil {
 				h.logger.Warn("RBAC revalidation failed, keeping subscription",

--- a/backend/internal/websocket/hub.go
+++ b/backend/internal/websocket/hub.go
@@ -107,6 +107,9 @@ func (h *Hub) Register(client *Client) {
 }
 
 // rbacRevalidateInterval is how often the hub rechecks RBAC for active subscriptions.
+// A 5-minute interval balances security (revoked access continues for up to 5 min)
+// against API server load (one SelfSubjectAccessReview per active subscription per tick).
+// For higher-security deployments, this can be reduced to 1-2 minutes.
 const rbacRevalidateInterval = 5 * time.Minute
 
 // alwaysAllowKinds are subscription kinds that bypass RBAC revalidation.

--- a/backend/internal/websocket/hub_test.go
+++ b/backend/internal/websocket/hub_test.go
@@ -19,6 +19,10 @@ func (a *alwaysAllowChecker) CanAccess(_ context.Context, _ string, _ []string, 
 	return true, nil
 }
 
+func (a *alwaysAllowChecker) CanAccessGroupResource(_ context.Context, _ string, _ []string, _, _, _, _ string) (bool, error) {
+	return true, nil
+}
+
 func TestHub_ClientRegistration(t *testing.T) {
 	hub := testHub()
 	ctx, cancel := context.WithCancel(context.Background())

--- a/frontend/islands/ComplianceDashboard.tsx
+++ b/frontend/islands/ComplianceDashboard.tsx
@@ -1,7 +1,8 @@
 import { useSignal } from "@preact/signals";
 import { IS_BROWSER } from "fresh/runtime";
-import { useEffect } from "preact/hooks";
+import { useEffect, useRef } from "preact/hooks";
 import { apiGet } from "@/lib/api.ts";
+import { subscribe } from "@/lib/ws.ts";
 import { GaugeRing } from "@/components/ui/GaugeRing.tsx";
 import { Spinner } from "@/components/ui/Spinner.tsx";
 import { Button } from "@/components/ui/Button.tsx";
@@ -65,11 +66,33 @@ export default function ComplianceDashboard() {
     }
   }
 
+  const refetchTimer = useRef<number | null>(null);
+
   useEffect(() => {
     if (!IS_BROWSER) return;
     fetchData().then(() => {
       loading.value = false;
     });
+
+    // Subscribe to policy report events — compliance score requires full recalculation
+    // on the server, so we re-fetch via REST (debounced 5s to avoid storms).
+    const onEvent = () => {
+      if (refetchTimer.current !== null) clearTimeout(refetchTimer.current);
+      refetchTimer.current = globalThis.setTimeout(() => {
+        refetchTimer.current = null;
+        fetchData();
+      }, 5000) as unknown as number;
+    };
+
+    const unsubs = [
+      subscribe("compliance-policyreports", "policyreports", "", onEvent),
+      subscribe("compliance-clusterpolicyreports", "clusterpolicyreports", "", onEvent),
+    ];
+
+    return () => {
+      unsubs.forEach((fn) => fn());
+      if (refetchTimer.current !== null) clearTimeout(refetchTimer.current);
+    };
   }, []);
 
   async function handleRefresh() {

--- a/frontend/islands/ComplianceDashboard.tsx
+++ b/frontend/islands/ComplianceDashboard.tsx
@@ -1,8 +1,8 @@
 import { useSignal } from "@preact/signals";
 import { IS_BROWSER } from "fresh/runtime";
-import { useEffect, useRef } from "preact/hooks";
+import { useEffect } from "preact/hooks";
 import { apiGet } from "@/lib/api.ts";
-import { subscribe } from "@/lib/ws.ts";
+import { useWsRefetch } from "@/lib/useWsRefetch.ts";
 import { GaugeRing } from "@/components/ui/GaugeRing.tsx";
 import { Spinner } from "@/components/ui/Spinner.tsx";
 import { Button } from "@/components/ui/Button.tsx";
@@ -66,34 +66,17 @@ export default function ComplianceDashboard() {
     }
   }
 
-  const refetchTimer = useRef<number | null>(null);
-
   useEffect(() => {
     if (!IS_BROWSER) return;
     fetchData().then(() => {
       loading.value = false;
     });
-
-    // Subscribe to policy report events — compliance score requires full recalculation
-    // on the server, so we re-fetch via REST (debounced 5s to avoid storms).
-    const onEvent = () => {
-      if (refetchTimer.current !== null) clearTimeout(refetchTimer.current);
-      refetchTimer.current = globalThis.setTimeout(() => {
-        refetchTimer.current = null;
-        fetchData();
-      }, 5000) as unknown as number;
-    };
-
-    const unsubs = [
-      subscribe("compliance-policyreports", "policyreports", "", onEvent),
-      subscribe("compliance-clusterpolicyreports", "clusterpolicyreports", "", onEvent),
-    ];
-
-    return () => {
-      unsubs.forEach((fn) => fn());
-      if (refetchTimer.current !== null) clearTimeout(refetchTimer.current);
-    };
   }, []);
+
+  useWsRefetch(fetchData, [
+    ["compliance-policyreports", "policyreports", ""],
+    ["compliance-clusterpolicyreports", "clusterpolicyreports", ""],
+  ], 5000);
 
   async function handleRefresh() {
     refreshing.value = true;

--- a/frontend/islands/GitOpsAppDetail.tsx
+++ b/frontend/islands/GitOpsAppDetail.tsx
@@ -1,8 +1,8 @@
 import { useSignal } from "@preact/signals";
 import { IS_BROWSER } from "fresh/runtime";
-import { useEffect, useRef } from "preact/hooks";
+import { useEffect } from "preact/hooks";
 import { apiGet, apiPost } from "@/lib/api.ts";
-import { subscribe } from "@/lib/ws.ts";
+import { useWsRefetch } from "@/lib/useWsRefetch.ts";
 import { Spinner } from "@/components/ui/Spinner.tsx";
 import { Button } from "@/components/ui/Button.tsx";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog.tsx";
@@ -51,38 +51,24 @@ export default function GitOpsAppDetail({ id }: { id: string }) {
     }
   }
 
-  // Debounce timer for WS-triggered re-fetches
-  const refetchTimer = useRef<number | null>(null);
-
   useEffect(() => {
     if (!IS_BROWSER) return;
     fetchData().then(() => {
       loading.value = false;
     });
-
-    // Determine the CRD kind from the composite ID (e.g., "argo:ns:name" → "applications")
-    const toolPrefix = id.split(":")[0];
-    const kind = toolPrefix === "argo"
-      ? "applications"
-      : toolPrefix === "flux-hr"
-      ? "helmreleases"
-      : "kustomizations";
-
-    // Subscribe to the specific CRD kind for real-time updates.
-    // On any event, debounce a full REST re-fetch (3s) to get managed resources + history.
-    const unsub = subscribe(`gitops-detail-${id}`, kind, "", () => {
-      if (refetchTimer.current !== null) clearTimeout(refetchTimer.current);
-      refetchTimer.current = globalThis.setTimeout(() => {
-        refetchTimer.current = null;
-        fetchData();
-      }, 3000) as unknown as number;
-    });
-
-    return () => {
-      unsub();
-      if (refetchTimer.current !== null) clearTimeout(refetchTimer.current);
-    };
   }, []);
+
+  // Determine the CRD kind from the composite ID
+  const toolPrefix = id.split(":")[0];
+  const kind = toolPrefix === "argo"
+    ? "applications"
+    : toolPrefix === "flux-hr"
+    ? "helmreleases"
+    : "kustomizations";
+
+  useWsRefetch(fetchData, [
+    [`gitops-detail-${id}`, kind, ""],
+  ], 3000);
 
   async function handleRefresh() {
     refreshing.value = true;

--- a/frontend/islands/GitOpsAppDetail.tsx
+++ b/frontend/islands/GitOpsAppDetail.tsx
@@ -1,7 +1,8 @@
 import { useSignal } from "@preact/signals";
 import { IS_BROWSER } from "fresh/runtime";
-import { useEffect } from "preact/hooks";
+import { useEffect, useRef } from "preact/hooks";
 import { apiGet, apiPost } from "@/lib/api.ts";
+import { subscribe } from "@/lib/ws.ts";
 import { Spinner } from "@/components/ui/Spinner.tsx";
 import { Button } from "@/components/ui/Button.tsx";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog.tsx";
@@ -50,11 +51,37 @@ export default function GitOpsAppDetail({ id }: { id: string }) {
     }
   }
 
+  // Debounce timer for WS-triggered re-fetches
+  const refetchTimer = useRef<number | null>(null);
+
   useEffect(() => {
     if (!IS_BROWSER) return;
     fetchData().then(() => {
       loading.value = false;
     });
+
+    // Determine the CRD kind from the composite ID (e.g., "argo:ns:name" → "applications")
+    const toolPrefix = id.split(":")[0];
+    const kind = toolPrefix === "argo"
+      ? "applications"
+      : toolPrefix === "flux-hr"
+      ? "helmreleases"
+      : "kustomizations";
+
+    // Subscribe to the specific CRD kind for real-time updates.
+    // On any event, debounce a full REST re-fetch (3s) to get managed resources + history.
+    const unsub = subscribe(`gitops-detail-${id}`, kind, "", () => {
+      if (refetchTimer.current !== null) clearTimeout(refetchTimer.current);
+      refetchTimer.current = globalThis.setTimeout(() => {
+        refetchTimer.current = null;
+        fetchData();
+      }, 3000) as unknown as number;
+    });
+
+    return () => {
+      unsub();
+      if (refetchTimer.current !== null) clearTimeout(refetchTimer.current);
+    };
   }, []);
 
   async function handleRefresh() {

--- a/frontend/islands/GitOpsApplications.tsx
+++ b/frontend/islands/GitOpsApplications.tsx
@@ -1,7 +1,8 @@
 import { useSignal } from "@preact/signals";
 import { IS_BROWSER } from "fresh/runtime";
-import { useEffect } from "preact/hooks";
+import { useEffect, useRef } from "preact/hooks";
 import { apiGet } from "@/lib/api.ts";
+import { subscribe, wsStatus } from "@/lib/ws.ts";
 import { SearchBar } from "@/components/ui/SearchBar.tsx";
 import { Spinner } from "@/components/ui/Spinner.tsx";
 import { Button } from "@/components/ui/Button.tsx";
@@ -49,11 +50,35 @@ export default function GitOpsApplications() {
     }
   }
 
+  // Debounce timer for WS-triggered re-fetches
+  const refetchTimer = useRef<number | null>(null);
+
   useEffect(() => {
     if (!IS_BROWSER) return;
     fetchData().then(() => {
       loading.value = false;
     });
+
+    // Subscribe to GitOps CRD events for real-time updates.
+    // On any event, debounce a REST re-fetch (1s) to get fresh server-side data.
+    const onEvent = () => {
+      if (refetchTimer.current !== null) clearTimeout(refetchTimer.current);
+      refetchTimer.current = globalThis.setTimeout(() => {
+        refetchTimer.current = null;
+        fetchData();
+      }, 1000) as unknown as number;
+    };
+
+    const unsubs = [
+      subscribe("gitops-apps", "applications", "", onEvent),
+      subscribe("gitops-kustomizations", "kustomizations", "", onEvent),
+      subscribe("gitops-helmreleases", "helmreleases", "", onEvent),
+    ];
+
+    return () => {
+      unsubs.forEach((fn) => fn());
+      if (refetchTimer.current !== null) clearTimeout(refetchTimer.current);
+    };
   }, []);
 
   async function handleRefresh() {
@@ -101,7 +126,15 @@ export default function GitOpsApplications() {
   return (
     <div class="p-6">
       <div class="flex items-center justify-between mb-1">
-        <h1 class="text-2xl font-bold text-text-primary">Applications</h1>
+        <div class="flex items-center gap-2">
+          <h1 class="text-2xl font-bold text-text-primary">Applications</h1>
+          {wsStatus.value === "connected" && (
+            <span class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium text-success bg-success/10">
+              <span class="w-1.5 h-1.5 rounded-full bg-success animate-pulse" />
+              Live
+            </span>
+          )}
+        </div>
         {!loading.value && (
           <Button
             type="button"

--- a/frontend/islands/GitOpsApplications.tsx
+++ b/frontend/islands/GitOpsApplications.tsx
@@ -1,8 +1,9 @@
 import { useSignal } from "@preact/signals";
 import { IS_BROWSER } from "fresh/runtime";
-import { useEffect, useRef } from "preact/hooks";
+import { useEffect } from "preact/hooks";
 import { apiGet } from "@/lib/api.ts";
-import { subscribe, wsStatus } from "@/lib/ws.ts";
+import { wsStatus } from "@/lib/ws.ts";
+import { useWsRefetch } from "@/lib/useWsRefetch.ts";
 import { SearchBar } from "@/components/ui/SearchBar.tsx";
 import { Spinner } from "@/components/ui/Spinner.tsx";
 import { Button } from "@/components/ui/Button.tsx";
@@ -50,36 +51,18 @@ export default function GitOpsApplications() {
     }
   }
 
-  // Debounce timer for WS-triggered re-fetches
-  const refetchTimer = useRef<number | null>(null);
-
   useEffect(() => {
     if (!IS_BROWSER) return;
     fetchData().then(() => {
       loading.value = false;
     });
-
-    // Subscribe to GitOps CRD events for real-time updates.
-    // On any event, debounce a REST re-fetch (1s) to get fresh server-side data.
-    const onEvent = () => {
-      if (refetchTimer.current !== null) clearTimeout(refetchTimer.current);
-      refetchTimer.current = globalThis.setTimeout(() => {
-        refetchTimer.current = null;
-        fetchData();
-      }, 1000) as unknown as number;
-    };
-
-    const unsubs = [
-      subscribe("gitops-apps", "applications", "", onEvent),
-      subscribe("gitops-kustomizations", "kustomizations", "", onEvent),
-      subscribe("gitops-helmreleases", "helmreleases", "", onEvent),
-    ];
-
-    return () => {
-      unsubs.forEach((fn) => fn());
-      if (refetchTimer.current !== null) clearTimeout(refetchTimer.current);
-    };
   }, []);
+
+  useWsRefetch(fetchData, [
+    ["gitops-applications", "applications", ""],
+    ["gitops-kustomizations", "kustomizations", ""],
+    ["gitops-helmreleases", "helmreleases", ""],
+  ], 1000);
 
   async function handleRefresh() {
     refreshing.value = true;

--- a/frontend/islands/PolicyDashboard.tsx
+++ b/frontend/islands/PolicyDashboard.tsx
@@ -1,7 +1,8 @@
 import { useSignal } from "@preact/signals";
 import { IS_BROWSER } from "fresh/runtime";
-import { useEffect } from "preact/hooks";
+import { useEffect, useRef } from "preact/hooks";
 import { apiGet } from "@/lib/api.ts";
+import { subscribe, wsStatus } from "@/lib/ws.ts";
 import { SearchBar } from "@/components/ui/SearchBar.tsx";
 import { Spinner } from "@/components/ui/Spinner.tsx";
 import { Button } from "@/components/ui/Button.tsx";
@@ -40,11 +41,31 @@ export default function PolicyDashboard() {
     }
   }
 
+  const refetchTimer = useRef<number | null>(null);
+
   useEffect(() => {
     if (!IS_BROWSER) return;
     fetchData().then(() => {
       loading.value = false;
     });
+
+    const onEvent = () => {
+      if (refetchTimer.current !== null) clearTimeout(refetchTimer.current);
+      refetchTimer.current = globalThis.setTimeout(() => {
+        refetchTimer.current = null;
+        fetchData();
+      }, 2000) as unknown as number;
+    };
+
+    const unsubs = [
+      subscribe("policy-clusterpolicies", "clusterpolicies", "", onEvent),
+      subscribe("policy-policies", "policies", "", onEvent),
+    ];
+
+    return () => {
+      unsubs.forEach((fn) => fn());
+      if (refetchTimer.current !== null) clearTimeout(refetchTimer.current);
+    };
   }, []);
 
   async function handleRefresh() {
@@ -90,7 +111,15 @@ export default function PolicyDashboard() {
   return (
     <div class="p-6">
       <div class="flex items-center justify-between mb-1">
-        <h1 class="text-2xl font-bold text-text-primary">Policies</h1>
+        <div class="flex items-center gap-2">
+          <h1 class="text-2xl font-bold text-text-primary">Policies</h1>
+          {wsStatus.value === "connected" && (
+            <span class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium text-success bg-success/10">
+              <span class="w-1.5 h-1.5 rounded-full bg-success animate-pulse" />
+              Live
+            </span>
+          )}
+        </div>
         {!loading.value && (
           <Button
             type="button"

--- a/frontend/islands/PolicyDashboard.tsx
+++ b/frontend/islands/PolicyDashboard.tsx
@@ -1,8 +1,9 @@
 import { useSignal } from "@preact/signals";
 import { IS_BROWSER } from "fresh/runtime";
-import { useEffect, useRef } from "preact/hooks";
+import { useEffect } from "preact/hooks";
 import { apiGet } from "@/lib/api.ts";
-import { subscribe, wsStatus } from "@/lib/ws.ts";
+import { wsStatus } from "@/lib/ws.ts";
+import { useWsRefetch } from "@/lib/useWsRefetch.ts";
 import { SearchBar } from "@/components/ui/SearchBar.tsx";
 import { Spinner } from "@/components/ui/Spinner.tsx";
 import { Button } from "@/components/ui/Button.tsx";
@@ -41,32 +42,17 @@ export default function PolicyDashboard() {
     }
   }
 
-  const refetchTimer = useRef<number | null>(null);
-
   useEffect(() => {
     if (!IS_BROWSER) return;
     fetchData().then(() => {
       loading.value = false;
     });
-
-    const onEvent = () => {
-      if (refetchTimer.current !== null) clearTimeout(refetchTimer.current);
-      refetchTimer.current = globalThis.setTimeout(() => {
-        refetchTimer.current = null;
-        fetchData();
-      }, 2000) as unknown as number;
-    };
-
-    const unsubs = [
-      subscribe("policy-clusterpolicies", "clusterpolicies", "", onEvent),
-      subscribe("policy-policies", "policies", "", onEvent),
-    ];
-
-    return () => {
-      unsubs.forEach((fn) => fn());
-      if (refetchTimer.current !== null) clearTimeout(refetchTimer.current);
-    };
   }, []);
+
+  useWsRefetch(fetchData, [
+    ["policy-clusterpolicies", "clusterpolicies", ""],
+    ["policy-policies", "policies", ""],
+  ], 2000);
 
   async function handleRefresh() {
     refreshing.value = true;

--- a/frontend/islands/ViolationBrowser.tsx
+++ b/frontend/islands/ViolationBrowser.tsx
@@ -1,8 +1,8 @@
 import { useSignal } from "@preact/signals";
 import { IS_BROWSER } from "fresh/runtime";
-import { useEffect, useRef } from "preact/hooks";
+import { useEffect } from "preact/hooks";
 import { apiGet } from "@/lib/api.ts";
-import { subscribe } from "@/lib/ws.ts";
+import { useWsRefetch } from "@/lib/useWsRefetch.ts";
 import { SearchBar } from "@/components/ui/SearchBar.tsx";
 import { Spinner } from "@/components/ui/Spinner.tsx";
 import { Button } from "@/components/ui/Button.tsx";
@@ -46,34 +46,17 @@ export default function ViolationBrowser() {
     }
   }
 
-  const refetchTimer = useRef<number | null>(null);
-
   useEffect(() => {
     if (!IS_BROWSER) return;
     fetchData().then(() => {
       loading.value = false;
     });
-
-    // Subscribe to policy report events — violations are nested in reports,
-    // so any report change triggers a full violation re-fetch (debounced 2s).
-    const onEvent = () => {
-      if (refetchTimer.current !== null) clearTimeout(refetchTimer.current);
-      refetchTimer.current = globalThis.setTimeout(() => {
-        refetchTimer.current = null;
-        fetchData();
-      }, 2000) as unknown as number;
-    };
-
-    const unsubs = [
-      subscribe("violations-policyreports", "policyreports", "", onEvent),
-      subscribe("violations-clusterpolicyreports", "clusterpolicyreports", "", onEvent),
-    ];
-
-    return () => {
-      unsubs.forEach((fn) => fn());
-      if (refetchTimer.current !== null) clearTimeout(refetchTimer.current);
-    };
   }, []);
+
+  useWsRefetch(fetchData, [
+    ["violations-policyreports", "policyreports", ""],
+    ["violations-clusterpolicyreports", "clusterpolicyreports", ""],
+  ], 2000);
 
   async function handleRefresh() {
     refreshing.value = true;

--- a/frontend/islands/ViolationBrowser.tsx
+++ b/frontend/islands/ViolationBrowser.tsx
@@ -1,7 +1,8 @@
 import { useSignal } from "@preact/signals";
 import { IS_BROWSER } from "fresh/runtime";
-import { useEffect } from "preact/hooks";
+import { useEffect, useRef } from "preact/hooks";
 import { apiGet } from "@/lib/api.ts";
+import { subscribe } from "@/lib/ws.ts";
 import { SearchBar } from "@/components/ui/SearchBar.tsx";
 import { Spinner } from "@/components/ui/Spinner.tsx";
 import { Button } from "@/components/ui/Button.tsx";
@@ -45,11 +46,33 @@ export default function ViolationBrowser() {
     }
   }
 
+  const refetchTimer = useRef<number | null>(null);
+
   useEffect(() => {
     if (!IS_BROWSER) return;
     fetchData().then(() => {
       loading.value = false;
     });
+
+    // Subscribe to policy report events — violations are nested in reports,
+    // so any report change triggers a full violation re-fetch (debounced 2s).
+    const onEvent = () => {
+      if (refetchTimer.current !== null) clearTimeout(refetchTimer.current);
+      refetchTimer.current = globalThis.setTimeout(() => {
+        refetchTimer.current = null;
+        fetchData();
+      }, 2000) as unknown as number;
+    };
+
+    const unsubs = [
+      subscribe("violations-policyreports", "policyreports", "", onEvent),
+      subscribe("violations-clusterpolicyreports", "clusterpolicyreports", "", onEvent),
+    ];
+
+    return () => {
+      unsubs.forEach((fn) => fn());
+      if (refetchTimer.current !== null) clearTimeout(refetchTimer.current);
+    };
   }, []);
 
   async function handleRefresh() {

--- a/frontend/lib/useWsRefetch.ts
+++ b/frontend/lib/useWsRefetch.ts
@@ -1,0 +1,37 @@
+/**
+ * Hook that subscribes to WebSocket CRD events and triggers a debounced
+ * REST re-fetch when any event arrives. Handles cleanup on unmount.
+ *
+ * @param fetchFn - The async function to call for re-fetching data
+ * @param subscriptions - Array of [id, kind, namespace] tuples to subscribe to
+ * @param debounceMs - Debounce delay in milliseconds before re-fetching
+ */
+import { useEffect, useRef } from "preact/hooks";
+import { subscribe } from "@/lib/ws.ts";
+
+export function useWsRefetch(
+  fetchFn: () => Promise<void>,
+  subscriptions: Array<[string, string, string]>,
+  debounceMs: number,
+): void {
+  const refetchTimer = useRef<number | null>(null);
+
+  useEffect(() => {
+    const onEvent = () => {
+      if (refetchTimer.current !== null) clearTimeout(refetchTimer.current);
+      refetchTimer.current = globalThis.setTimeout(() => {
+        refetchTimer.current = null;
+        fetchFn();
+      }, debounceMs) as unknown as number;
+    };
+
+    const unsubs = subscriptions.map(([id, kind, ns]) =>
+      subscribe(id, kind, ns, onEvent)
+    );
+
+    return () => {
+      unsubs.forEach((fn) => fn());
+      if (refetchTimer.current !== null) clearTimeout(refetchTimer.current);
+    };
+  }, []);
+}

--- a/helm/kubecenter/templates/clusterrole.yaml
+++ b/helm/kubecenter/templates/clusterrole.yaml
@@ -95,6 +95,26 @@ rules:
     resources:
       - ciliumnetworkpolicies
     verbs: ["get", "list", "watch"]
+  # GitOps CRDs (dynamic informers for real-time WebSocket updates)
+  - apiGroups: ["argoproj.io"]
+    resources: ["applications"]
+    verbs: ["list", "watch"]
+  - apiGroups: ["kustomize.toolkit.fluxcd.io"]
+    resources: ["kustomizations"]
+    verbs: ["list", "watch"]
+  - apiGroups: ["helm.toolkit.fluxcd.io"]
+    resources: ["helmreleases"]
+    verbs: ["list", "watch"]
+  # Policy CRDs (dynamic informers for real-time WebSocket updates)
+  - apiGroups: ["kyverno.io"]
+    resources: ["clusterpolicies", "policies"]
+    verbs: ["list", "watch"]
+  - apiGroups: ["wgpolicyk8s.io"]
+    resources: ["policyreports", "clusterpolicyreports"]
+    verbs: ["list", "watch"]
+  - apiGroups: ["templates.gatekeeper.sh"]
+    resources: ["constrainttemplates"]
+    verbs: ["list", "watch"]
   # CRD discovery — list/watch CustomResourceDefinitions for Extensions Hub
   - apiGroups: ["apiextensions.k8s.io"]
     resources:

--- a/plans/realtime-websocket-crd-updates.md
+++ b/plans/realtime-websocket-crd-updates.md
@@ -1,0 +1,109 @@
+# feat: Real-Time WebSocket Updates for GitOps & Policy CRDs
+
+## Overview
+
+Add real-time WebSocket event streaming for GitOps (Argo CD, Flux CD) and Policy (Kyverno, Gatekeeper) CRD resources. Currently these pages use REST-only fetch-on-mount with manual refresh. This extends the existing informer → hub → WebSocket pipeline to CRDs.
+
+## Simplified Approach (post-review)
+
+Three reviewers (DHH, Kieran, Simplicity) agreed on key simplifications:
+
+1. **No separate CRDWatchManager** — extend `InformerManager` with `WatchCRD`/`StopCRD` methods (~40 lines)
+2. **No Debouncer component** — hub already has 1024-buffer + resync fallback; frontend already debounces re-fetches
+3. **No normalize.go files** — normalizers already exist as standalone functions, just export them (capitalize)
+4. **Re-fetch everywhere on frontend** — all 5 islands do debounced REST re-fetch on WS event (no client-side merge)
+5. **No LiveBadge component** — inline 3-5 lines of JSX
+6. **2 phases, not 3** — tests ship with code
+
+### Key technical decisions from review:
+- Use `dynamicinformer.ForResource().Informer().AddEventHandler(ResourceEventHandlerDetailedFuncs)` (not `cache.NewInformer` which lacks `isInInitialList`)
+- Widen `AccessChecker` interface to include `CanAccessGroupResource` (already exists on concrete type)
+- Co-locate API group with `RegisterAllowedKind` registration (not a static map)
+- Fix singleflight cache race as a standalone preparatory change
+- Explicitly scope out Gatekeeper dynamic constraints (watch `constrainttemplates` only, not per-constraint CRDs)
+
+---
+
+## Phase 1: Backend
+
+### Step 1: Fix singleflight cache invalidation race (standalone bug fix)
+
+**Files:** `gitops/handler.go`, `policy/handler.go`
+
+The `invalidateCache()` method calls `fetchGroup.Forget("fetch")` which can race with an in-flight singleflight fetch that repopulates cache with stale data. Fix by removing the `Forget` call — nil cache + zero time is sufficient.
+
+### Step 2: Export existing normalizer functions
+
+**Files:** `gitops/argocd.go`, `gitops/flux.go`, `policy/kyverno.go`, `policy/gatekeeper.go`
+
+Simply capitalize: `normalizeArgoApp` → `NormalizeArgoApp`, etc. These are already standalone functions with the right signatures.
+
+### Step 3: Add CRD watch support to InformerManager
+
+**File:** `k8s/informers.go`
+
+Add `WatchCRD(ctx, gvr, kind, normalizer, cb)` and `StopCRD(gvr)` methods. Each creates a dynamic informer via `dynamicinformer.NewDynamicSharedInformerFactory`, registers `ResourceEventHandlerDetailedFuncs` (for `isInInitialList` support), deep-copies + normalizes before calling the event callback. Individual per-GVR factories enable independent lifecycle.
+
+### Step 4: Extend WebSocket hub for CRD RBAC
+
+**Files:** `websocket/hub.go`, `websocket/events.go`, `websocket/client.go`
+
+- Add `CanAccessGroupResource` to `AccessChecker` interface
+- Add `sync.RWMutex` to protect `allowedKinds` map
+- Extend `RegisterAllowedKind` to accept API group: `RegisterAllowedKind(kind, apiGroup string)`
+- Update `handleSubscribe` and `revalidateSubscriptions` to use group-aware RBAC for CRD kinds
+- Raise `maxSubscriptions` from 20 to 25
+
+### Step 5: Wire discovery callbacks + cache invalidation
+
+**Files:** `gitops/discovery.go`, `policy/discovery.go`, `cmd/kubecenter/main.go`
+
+- Add `OnChange` callback to discoverers (fires when tool availability changes)
+- In `main.go`: when GitOps discovery detects Argo CD → call `informerMgr.WatchCRD(...)` + `RegisterAllowedKind(...)`
+- On each CRD event: call handler's `InvalidateCache()`
+
+### Step 6: Update Helm chart RBAC
+
+**File:** `helm/kubecenter/templates/clusterrole.yaml`
+
+Add list+watch for all CRD API groups (no-ops if CRDs don't exist).
+
+## Phase 2: Frontend
+
+### Step 7: Add WS subscriptions to GitOps islands
+
+**Files:** `islands/GitOpsApplications.tsx`, `islands/GitOpsAppDetail.tsx`
+
+Subscribe to CRD kinds, on any event → debounced REST re-fetch. Guard against remote clusters. Unsubscribe on unmount.
+
+### Step 8: Add WS subscriptions to Policy islands
+
+**Files:** `islands/PolicyDashboard.tsx`, `islands/ViolationBrowser.tsx`, `islands/ComplianceDashboard.tsx`
+
+Same pattern: subscribe, debounced re-fetch on event, cleanup on unmount.
+
+## File Change Summary
+
+| File | Action |
+|------|--------|
+| `backend/internal/gitops/handler.go` | MODIFY — fix cache invalidation race, add InvalidateCache |
+| `backend/internal/policy/handler.go` | MODIFY — fix cache invalidation race, add InvalidateCache |
+| `backend/internal/gitops/argocd.go` | MODIFY — export NormalizeArgoApp |
+| `backend/internal/gitops/flux.go` | MODIFY — export normalizers |
+| `backend/internal/policy/kyverno.go` | MODIFY — export normalizers |
+| `backend/internal/policy/gatekeeper.go` | MODIFY — export normalizers |
+| `backend/internal/k8s/informers.go` | MODIFY — add WatchCRD/StopCRD |
+| `backend/internal/websocket/hub.go` | MODIFY — extend AccessChecker interface |
+| `backend/internal/websocket/events.go` | MODIFY — mutex, group-aware registration |
+| `backend/internal/websocket/client.go` | MODIFY — group-aware subscribe, maxSubscriptions |
+| `backend/internal/gitops/discovery.go` | MODIFY — add OnChange callback |
+| `backend/internal/policy/discovery.go` | MODIFY — add OnChange callback |
+| `backend/cmd/kubecenter/main.go` | MODIFY — wire CRD watches + callbacks |
+| `helm/kubecenter/templates/clusterrole.yaml` | MODIFY — add CRD RBAC |
+| `frontend/islands/GitOpsApplications.tsx` | MODIFY — add WS subscription |
+| `frontend/islands/GitOpsAppDetail.tsx` | MODIFY — add WS subscription |
+| `frontend/islands/PolicyDashboard.tsx` | MODIFY — add WS subscription |
+| `frontend/islands/ViolationBrowser.tsx` | MODIFY — add WS subscription |
+| `frontend/islands/ComplianceDashboard.tsx` | MODIFY — add WS subscription |
+
+**Total: 0 new files, 19 modified files across 2 phases**


### PR DESCRIPTION
## Summary
- Extend the existing informer → hub → WebSocket pipeline to GitOps (Argo CD, Flux CD) and Policy (Kyverno, Gatekeeper) CRD resources
- GitOps and Policy pages now update in real-time without manual refresh — sync status transitions, new violations, and policy changes appear live
- Backend adds `WatchCRD`/`StopCRD` to `InformerManager`, group-aware RBAC for CRD WebSocket subscriptions, discovery change callbacks, and Helm RBAC rules
- Frontend islands subscribe to CRD kinds with debounced REST re-fetch (1-5s), plus "Live" badge indicator

## Key design decisions
- **No new abstractions** — extended `InformerManager` instead of creating a separate `CRDWatchManager` (reviewer feedback)
- **Re-fetch everywhere** — all 5 islands do debounced REST re-fetch on WS event instead of client-side merge (simpler, more correct)
- **No debouncer component** — hub's 1024-buffer + resync fallback + frontend debounce is sufficient for CRD event rates
- **Normalizers already existed** — just exported them (capitalized) instead of extracting to new files
- **Standalone bug fix** — fixed singleflight cache invalidation race in gitops handler (removed `fetchGroup.Forget`)

## Files changed (22 modified, 1 new)
- **Backend (16 files):** informers.go, websocket hub/events/client, gitops argocd/flux/handler/discovery, policy kyverno/gatekeeper/handler/discovery, main.go, Helm clusterrole
- **Frontend (5 files):** GitOpsApplications, GitOpsAppDetail, PolicyDashboard, ViolationBrowser, ComplianceDashboard
- **Plan (1 file):** plans/realtime-websocket-crd-updates.md

## Test plan
- [x] `go vet ./...` — clean
- [x] `go test ./internal/gitops/... ./internal/websocket/... ./internal/k8s/...` — all pass
- [x] `deno lint` — 335 files, 0 errors
- [x] `make helm-lint` — passes
- [ ] CI pipeline (go vet/test, deno lint/build, Trivy, E2E)
- [ ] Homelab smoke test: trigger Argo CD sync, observe real-time status update on GitOps page
- [ ] Verify RBAC filtering: non-admin user should not receive events for restricted namespaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)