### PR TITLE
fix: upgrade Deno 2.7.8 → 2.7.11 to resolve 7 Trivy OpenSSL CVEs

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,6 @@
 # Stage 1: Install dependencies and build (always on amd64 — Deno WASM loader
 # crashes under QEMU ARM64 emulation, but build output is arch-independent JS)
-FROM --platform=linux/amd64 denoland/deno:2.7.8 AS builder
+FROM --platform=linux/amd64 denoland/deno:2.7.11 AS builder
 
 WORKDIR /app
 
@@ -25,7 +25,7 @@ RUN find /app/node_modules -path '*/esbuild/bin/esbuild' -delete 2>/dev/null; \
 
 # Stage 2: Production runtime (uses target platform — arm64 or amd64)
 # Use distroless variant to minimize OS-level CVEs (no shell, no package manager)
-FROM denoland/deno:distroless-2.7.8
+FROM denoland/deno:distroless-2.7.11
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Upgrades both Deno Docker image stages (builder + runtime) from 2.7.8 → 2.7.11
- Resolves all 7 open Trivy code scanning alerts (#106–#112), all OpenSSL CVEs in `libssl3t64 3.5.5-1~deb13u1`
- Fixed version `3.5.5-1~deb13u2` ships in the `denoland/deno:distroless-2.7.11` base image

## CVEs resolved
| Alert | CVE | Severity |
|-------|-----|----------|
| #106 | CVE-2026-31790 | Medium |
| #107 | CVE-2026-2673 | Low |
| #108 | CVE-2026-28387 | Low |
| #109 | CVE-2026-28388 | Low |
| #110 | CVE-2026-28389 | Low |
| #111 | CVE-2026-28390 | Low |
| #112 | CVE-2026-31789 | Low |

## Test plan
- [ ] CI passes (lint, build, Trivy scan)
- [ ] Trivy scan shows 0 open alerts for frontend image
- [ ] Frontend container starts and serves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)