### PR TITLE
feat: git commit display — enrich Argo CD revision history with GitHub commit messages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,17 +298,17 @@ make check-dashboards                             # Verify Grafana JSON sync
     - Nav: GitOps section with Applications tab, command palette quick action
 - **Phase 10 (Security Scanning):** COMPLETE
   - Trivy Operator + Kubescape integration (vulnerability reports, config audits, compliance frameworks)
-- **Post-Phase Enhancements:** COMPLETE — 3 items
+- **Post-Phase Enhancements:** COMPLETE — 7 items
   - GitOps actions: sync, suspend/resume, rollback for Argo CD + Flux CD (#147)
   - Real-time WebSocket updates: watch GitOps & Policy CRDs for live sync status (#148)
   - White flash fix: eliminated FOUC on page navigation (#146)
   - Policy creation wizards: 8 Kyverno/Gatekeeper templates with dual-engine support (#149)
   - Compliance trend storage: daily PostgreSQL snapshots + SVG trend chart (#150)
+  - Argo CD ApplicationSet support: list, detail, CRUD actions (#151)
+  - Flux Notification Controller support: Provider, Alert & Receiver CRUD (#152, #153)
 
 ## Future Features (Roadmap)
 
-- **ApplicationSet support** — Argo CD ApplicationSet generators and outputs
-- **Flux notifications** — webhook receiver integration for Flux alerts
 - **Git commit display** — Git provider API integration for commit messages in revision history
 - **Diff view** — show what changed between revisions in GitOps deployments
 

--- a/backend/cmd/kubecenter/main.go
+++ b/backend/cmd/kubecenter/main.go
@@ -149,11 +149,11 @@ func main() {
 			dbPing = db.Ping
 			dbPool = db.Pool
 			userStore = appstore.NewUserStore(db.Pool)
-			settingsService = appstore.NewSettingsService(db.Pool)
 			encKey := cfg.Database.EncryptionKey
 			if encKey == "" {
 				encKey = cfg.Auth.JWTSecret // fall back to JWT secret as encryption key
 			}
+			settingsService = appstore.NewSettingsService(db.Pool, encKey)
 			clusterStore = appstore.NewClusterStore(db.Pool, encKey)
 			complianceStore = appstore.NewComplianceStore(db.Pool)
 
@@ -473,15 +473,20 @@ func main() {
 		AuditLogger:   auditLogger,
 	}
 
-	// Wire git commit enrichment if a GitHub token is configured
-	if settingsService != nil {
-		if settings, err := settingsService.Get(ctx); err == nil && settings.GitHubToken != nil && *settings.GitHubToken != "" {
-			ghClient, err := gitprovider.NewGitHubClient(*settings.GitHubToken, "", logger)
-			if err != nil {
-				logger.Warn("failed to create github client for commit enrichment", "error", err)
-			} else {
-				gitopsHandler.CommitCache = gitprovider.NewCommitCache(dbPool, ghClient, logger)
-				logger.Info("git commit enrichment enabled")
+	// Wire git commit enrichment — always create cache, optionally set GitHub client
+	if dbPool != nil {
+		commitCache := gitprovider.NewCommitCache(dbPool, nil, logger)
+		gitopsHandler.CommitCache = commitCache
+
+		if settingsService != nil {
+			if settings, err := settingsService.Get(ctx); err == nil && settings.GitHubToken != nil && *settings.GitHubToken != "" {
+				ghClient, err := gitprovider.NewGitHubClient(*settings.GitHubToken, "", logger)
+				if err != nil {
+					logger.Warn("failed to create github client for commit enrichment", "error", err)
+				} else {
+					commitCache.SetGitHubClient(ghClient)
+					logger.Info("git commit enrichment enabled")
+				}
 			}
 		}
 	}

--- a/backend/cmd/kubecenter/main.go
+++ b/backend/cmd/kubecenter/main.go
@@ -29,7 +29,9 @@ import (
 	"github.com/kubecenter/kubecenter/internal/monitoring"
 	"github.com/kubecenter/kubecenter/internal/topology"
 	"github.com/kubecenter/kubecenter/internal/networking"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/kubecenter/kubecenter/internal/gitops"
+	"github.com/kubecenter/kubecenter/internal/gitprovider"
 	"github.com/kubecenter/kubecenter/internal/notification"
 	"github.com/kubecenter/kubecenter/internal/scanning"
 	"github.com/kubecenter/kubecenter/internal/policy"
@@ -131,6 +133,7 @@ func main() {
 	var userStore *appstore.UserStore
 	var complianceStore *appstore.ComplianceStore
 	var dbPing func(context.Context) error
+	var dbPool *pgxpool.Pool
 	if cfg.Database.URL != "" {
 		db, err := appstore.New(ctx, cfg.Database.URL, int32(cfg.Database.MaxConns), int32(cfg.Database.MinConns), logger)
 		if err != nil {
@@ -144,6 +147,7 @@ func main() {
 
 			// Initialize settings, user, and cluster stores
 			dbPing = db.Ping
+			dbPool = db.Pool
 			userStore = appstore.NewUserStore(db.Pool)
 			settingsService = appstore.NewSettingsService(db.Pool)
 			encKey := cfg.Database.EncryptionKey
@@ -467,6 +471,19 @@ func main() {
 		AccessChecker: accessChecker,
 		Logger:        logger,
 		AuditLogger:   auditLogger,
+	}
+
+	// Wire git commit enrichment if a GitHub token is configured
+	if settingsService != nil {
+		if settings, err := settingsService.Get(ctx); err == nil && settings.GitHubToken != nil && *settings.GitHubToken != "" {
+			ghClient, err := gitprovider.NewGitHubClient(*settings.GitHubToken, "", logger)
+			if err != nil {
+				logger.Warn("failed to create github client for commit enrichment", "error", err)
+			} else {
+				gitopsHandler.CommitCache = gitprovider.NewCommitCache(dbPool, ghClient, logger)
+				logger.Info("git commit enrichment enabled")
+			}
+		}
 	}
 
 	notificationHandler := &notification.Handler{

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/go-ldap/ldap/v3 v3.4.12
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/golang-migrate/migrate/v4 v4.19.1
+	github.com/google/go-github/v83 v83.0.0
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/jackc/pgx/v5 v5.8.0
 	github.com/knadh/koanf/parsers/yaml v1.1.0
@@ -45,6 +46,7 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -79,8 +79,13 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/gnostic-models v0.7.0 h1:qwTtogB15McXDaNqTZdzPJRHvaVJlAl+HVQnLmJEJxo=
 github.com/google/gnostic-models v0.7.0/go.mod h1:whL5G0m6dmc5cPxKc5bdKdEN3UjI7OUGxBlw57miDrQ=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/go-github/v83 v83.0.0 h1:Ydy4gAfqxrnFUwXAuKl/OMhhGa0KtMtnJ3EozIIuHT0=
+github.com/google/go-github/v83 v83.0.0/go.mod h1:gbqarhK37mpSu8Xy7sz21ITtznvzouyHSAajSaYCHe8=
+github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
+github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 h1:BHT72Gu3keYf3ZEu2J0b1vyeLSOYI8bm5wbJM/8yDe8=
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=

--- a/backend/internal/gitops/handler.go
+++ b/backend/internal/gitops/handler.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -56,6 +57,8 @@ type cachedAppSetData struct {
 }
 
 const cacheTTL = 30 * time.Second
+
+var shaPattern = regexp.MustCompile(`^[0-9a-fA-F]{7,40}$`)
 
 // toolGVR resolves a tool prefix to its Kubernetes API group and resource.
 func toolGVR(toolPrefix string) (apiGroup, resource string, ok bool) {
@@ -920,12 +923,24 @@ func (h *Handler) HandleGetCommits(w http.ResponseWriter, r *http.Request) {
 	// Parse and normalize the repo URL
 	ref, err := gitprovider.ParseRepoURL(repoURL)
 	if err != nil {
-		httputil.WriteError(w, http.StatusBadRequest, "invalid repoURL", err.Error())
+		httputil.WriteError(w, http.StatusBadRequest, "invalid repoURL", "")
 		return
 	}
 
-	// Parse SHAs, cap at 50
+	// Parse SHAs, filter to valid hex format, cap at 50
 	shas := strings.Split(shasParam, ",")
+	var validSHAs []string
+	for _, s := range shas {
+		s = strings.TrimSpace(s)
+		if shaPattern.MatchString(s) {
+			validSHAs = append(validSHAs, s)
+		}
+	}
+	shas = validSHAs
+	if len(shas) == 0 {
+		httputil.WriteData(w, gitprovider.ToResponse(nil, nil))
+		return
+	}
 	if len(shas) > 50 {
 		shas = shas[:50]
 	}
@@ -940,7 +955,7 @@ func (h *Handler) HandleGetCommits(w http.ResponseWriter, r *http.Request) {
 	apps = h.filterAppsByRBAC(r.Context(), user, apps)
 
 	canonicalURL := ref.CanonicalURL()
-	if !h.repoVisibleToUser(apps, repoURL, canonicalURL) {
+	if !repoVisibleToUser(apps, repoURL, canonicalURL) {
 		httputil.WriteError(w, http.StatusForbidden, "no visible application uses this repository", "")
 		return
 	}
@@ -951,7 +966,7 @@ func (h *Handler) HandleGetCommits(w http.ResponseWriter, r *http.Request) {
 }
 
 // repoVisibleToUser checks if any user-visible app uses the given repo URL.
-func (h *Handler) repoVisibleToUser(apps []NormalizedApp, rawURL, canonicalURL string) bool {
+func repoVisibleToUser(apps []NormalizedApp, rawURL, canonicalURL string) bool {
 	for _, app := range apps {
 		if app.Source.RepoURL == "" {
 			continue

--- a/backend/internal/gitops/handler.go
+++ b/backend/internal/gitops/handler.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/kubecenter/kubecenter/internal/audit"
 	"github.com/kubecenter/kubecenter/internal/auth"
+	"github.com/kubecenter/kubecenter/internal/gitprovider"
 	"github.com/kubecenter/kubecenter/internal/httputil"
 	"github.com/kubecenter/kubecenter/internal/k8s"
 	"github.com/kubecenter/kubecenter/internal/k8s/resources"
@@ -31,6 +32,7 @@ type Handler struct {
 	AccessChecker *resources.AccessChecker
 	Logger        *slog.Logger
 	AuditLogger   audit.Logger
+	CommitCache   *gitprovider.CommitCache
 
 	fetchGroup singleflight.Group
 	cacheMu    sync.RWMutex
@@ -892,4 +894,80 @@ func (h *Handler) HandleDeleteAppSet(w http.ResponseWriter, r *http.Request) {
 	h.auditLog(r, user, audit.ActionDelete, "ApplicationSet", ns, name, audit.ResultSuccess, "")
 	h.invalidateAppSetCache()
 	httputil.WriteData(w, map[string]string{"message": "Deleted applicationset " + name})
+}
+
+// HandleGetCommits returns commit metadata for a set of SHAs from a git repository.
+// GET /api/v1/gitops/commits?repoURL=<url>&shas=<sha1,sha2,...>
+func (h *Handler) HandleGetCommits(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	if h.CommitCache == nil || !h.CommitCache.HasGitHub() {
+		httputil.WriteData(w, gitprovider.ToResponse(nil, nil))
+		return
+	}
+
+	repoURL := r.URL.Query().Get("repoURL")
+	shasParam := r.URL.Query().Get("shas")
+
+	if repoURL == "" || shasParam == "" {
+		httputil.WriteError(w, http.StatusBadRequest, "repoURL and shas parameters are required", "")
+		return
+	}
+
+	// Parse and normalize the repo URL
+	ref, err := gitprovider.ParseRepoURL(repoURL)
+	if err != nil {
+		httputil.WriteError(w, http.StatusBadRequest, "invalid repoURL", err.Error())
+		return
+	}
+
+	// Parse SHAs, cap at 50
+	shas := strings.Split(shasParam, ",")
+	if len(shas) > 50 {
+		shas = shas[:50]
+	}
+
+	// RBAC: validate repoURL matches at least one app visible to this user
+	apps, err := h.fetchApps(r.Context())
+	if err != nil {
+		h.Logger.Error("failed to fetch apps for commit RBAC check", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to validate access", "")
+		return
+	}
+	apps = h.filterAppsByRBAC(r.Context(), user, apps)
+
+	canonicalURL := ref.CanonicalURL()
+	if !h.repoVisibleToUser(apps, repoURL, canonicalURL) {
+		httputil.WriteError(w, http.StatusForbidden, "no visible application uses this repository", "")
+		return
+	}
+
+	// Fetch commits (cache + GitHub API)
+	commits, unavailable := h.CommitCache.GetCommits(r.Context(), canonicalURL, ref.Owner, ref.Repo, shas)
+	httputil.WriteData(w, gitprovider.ToResponse(commits, unavailable))
+}
+
+// repoVisibleToUser checks if any user-visible app uses the given repo URL.
+func (h *Handler) repoVisibleToUser(apps []NormalizedApp, rawURL, canonicalURL string) bool {
+	for _, app := range apps {
+		if app.Source.RepoURL == "" {
+			continue
+		}
+		// Try exact match first (fast path)
+		if app.Source.RepoURL == rawURL {
+			return true
+		}
+		// Parse and normalize the app's repo URL for canonical comparison
+		appRef, err := gitprovider.ParseRepoURL(app.Source.RepoURL)
+		if err != nil {
+			continue
+		}
+		if appRef.CanonicalURL() == canonicalURL {
+			return true
+		}
+	}
+	return false
 }

--- a/backend/internal/gitprovider/cache.go
+++ b/backend/internal/gitprovider/cache.go
@@ -3,8 +3,9 @@ package gitprovider
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"log/slog"
+	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -15,6 +16,7 @@ import (
 type CommitCache struct {
 	db  *pgxpool.Pool
 	gh  *GitHubClient // nil if no token configured
+	ghMu sync.RWMutex
 	log *slog.Logger
 
 	group singleflight.Group
@@ -43,13 +45,18 @@ func (c *CommitCache) GetCommits(ctx context.Context, canonicalURL, owner, repo 
 		}
 	}
 
-	if len(missing) == 0 || c.gh == nil {
+	c.ghMu.RLock()
+	gh := c.gh
+	c.ghMu.RUnlock()
+
+	if len(missing) == 0 || gh == nil {
 		return cached, missing
 	}
 
 	// 2. Fan out fetches for uncached SHAs (bounded concurrency via singleflight)
 	var mu sync.Mutex
 	var unavailable []string
+	var fetched []*CommitInfo
 	var wg sync.WaitGroup
 
 	// Use a semaphore channel to limit concurrent GitHub API calls
@@ -64,7 +71,7 @@ func (c *CommitCache) GetCommits(ctx context.Context, canonicalURL, owner, repo 
 
 			key := canonicalURL + ":" + sha
 			result, err, _ := c.group.Do(key, func() (any, error) {
-				return c.gh.GetCommit(ctx, owner, repo, sha)
+				return gh.GetCommit(ctx, owner, repo, sha)
 			})
 
 			if err != nil {
@@ -76,15 +83,21 @@ func (c *CommitCache) GetCommits(ctx context.Context, canonicalURL, owner, repo 
 			}
 
 			info := result.(*CommitInfo)
-			c.put(ctx, canonicalURL, info)
 
 			mu.Lock()
 			cached[sha] = info
+			fetched = append(fetched, info)
 			mu.Unlock()
 		}(sha)
 	}
 
 	wg.Wait()
+
+	// Batch-insert all newly fetched commits in one query
+	if len(fetched) > 0 {
+		c.batchPut(ctx, canonicalURL, fetched)
+	}
+
 	return cached, unavailable
 }
 
@@ -120,37 +133,60 @@ func (c *CommitCache) batchGet(ctx context.Context, canonicalURL string, shas []
 	return result
 }
 
-// put writes a commit to the PostgreSQL cache.
-func (c *CommitCache) put(ctx context.Context, canonicalURL string, info *CommitInfo) {
-	data, err := json.Marshal(info)
-	if err != nil {
-		c.log.Error("marshaling commit for cache", "err", err)
+// batchPut writes multiple commits to the PostgreSQL cache in a single query.
+func (c *CommitCache) batchPut(ctx context.Context, canonicalURL string, infos []*CommitInfo) {
+	if len(infos) == 0 {
 		return
 	}
 
-	_, err = c.db.Exec(ctx,
-		`INSERT INTO git_commit_cache (canonical_url, sha, data) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING`,
-		canonicalURL, info.SHA, data,
-	)
-	if err != nil {
-		c.log.Error("caching commit", "sha", info.SHA[:min(7, len(info.SHA))], "err", err)
-	}
-}
+	var sb strings.Builder
+	sb.WriteString(`INSERT INTO git_commit_cache (canonical_url, sha, data) VALUES `)
 
-func min(a, b int) int {
-	if a < b {
-		return a
+	args := make([]any, 0, len(infos)*3)
+	written := 0
+	for _, info := range infos {
+		data, err := json.Marshal(info)
+		if err != nil {
+			c.log.Error("marshaling commit for cache", "err", err)
+			continue
+		}
+		if written > 0 {
+			sb.WriteString(", ")
+		}
+		base := written * 3
+		sb.WriteString("($")
+		sb.WriteString(strconv.Itoa(base + 1))
+		sb.WriteString(", $")
+		sb.WriteString(strconv.Itoa(base + 2))
+		sb.WriteString(", $")
+		sb.WriteString(strconv.Itoa(base + 3))
+		sb.WriteString(")")
+		args = append(args, canonicalURL, info.SHA, data)
+		written++
 	}
-	return b
+
+	if len(args) == 0 {
+		return
+	}
+
+	sb.WriteString(` ON CONFLICT DO NOTHING`)
+
+	if _, err := c.db.Exec(ctx, sb.String(), args...); err != nil {
+		c.log.Error("batch caching commits", "count", len(infos), "err", err)
+	}
 }
 
 // SetGitHubClient replaces the GitHub client (used when settings change at runtime).
 func (c *CommitCache) SetGitHubClient(gh *GitHubClient) {
+	c.ghMu.Lock()
 	c.gh = gh
+	c.ghMu.Unlock()
 }
 
 // HasGitHub returns true if a GitHub client is configured.
 func (c *CommitCache) HasGitHub() bool {
+	c.ghMu.RLock()
+	defer c.ghMu.RUnlock()
 	return c.gh != nil
 }
 
@@ -185,7 +221,7 @@ func ToResponse(commits map[string]*CommitInfo, unavailable []string) *CommitRes
 			Title:      c.Title(),
 			Message:    c.Message,
 			AuthorName: c.AuthorName,
-			AuthorDate: fmt.Sprintf("%s", c.AuthorDate.UTC().Format("2006-01-02T15:04:05Z")),
+			AuthorDate: c.AuthorDate.UTC().Format("2006-01-02T15:04:05Z"),
 			WebURL:     c.WebURL,
 		}
 	}

--- a/backend/internal/gitprovider/cache.go
+++ b/backend/internal/gitprovider/cache.go
@@ -1,0 +1,194 @@
+package gitprovider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"golang.org/x/sync/singleflight"
+)
+
+// CommitCache resolves commit SHAs to metadata, backed by PostgreSQL and singleflight.
+type CommitCache struct {
+	db  *pgxpool.Pool
+	gh  *GitHubClient // nil if no token configured
+	log *slog.Logger
+
+	group singleflight.Group
+}
+
+// NewCommitCache creates a commit cache. gh may be nil if no GitHub token is configured.
+func NewCommitCache(db *pgxpool.Pool, gh *GitHubClient, log *slog.Logger) *CommitCache {
+	return &CommitCache{db: db, gh: gh, log: log}
+}
+
+// GetCommits resolves a batch of SHAs to commit metadata.
+// Returns found commits and a list of SHAs that could not be resolved.
+func (c *CommitCache) GetCommits(ctx context.Context, canonicalURL, owner, repo string, shas []string) (map[string]*CommitInfo, []string) {
+	if len(shas) == 0 {
+		return nil, nil
+	}
+
+	// 1. Batch lookup from PostgreSQL
+	cached := c.batchGet(ctx, canonicalURL, shas)
+
+	// Collect uncached SHAs
+	var missing []string
+	for _, sha := range shas {
+		if _, ok := cached[sha]; !ok {
+			missing = append(missing, sha)
+		}
+	}
+
+	if len(missing) == 0 || c.gh == nil {
+		return cached, missing
+	}
+
+	// 2. Fan out fetches for uncached SHAs (bounded concurrency via singleflight)
+	var mu sync.Mutex
+	var unavailable []string
+	var wg sync.WaitGroup
+
+	// Use a semaphore channel to limit concurrent GitHub API calls
+	sem := make(chan struct{}, 5)
+
+	for _, sha := range missing {
+		wg.Add(1)
+		go func(sha string) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			key := canonicalURL + ":" + sha
+			result, err, _ := c.group.Do(key, func() (any, error) {
+				return c.gh.GetCommit(ctx, owner, repo, sha)
+			})
+
+			if err != nil {
+				c.log.Debug("commit fetch failed", "sha", sha[:min(7, len(sha))], "err", err)
+				mu.Lock()
+				unavailable = append(unavailable, sha)
+				mu.Unlock()
+				return
+			}
+
+			info := result.(*CommitInfo)
+			c.put(ctx, canonicalURL, info)
+
+			mu.Lock()
+			cached[sha] = info
+			mu.Unlock()
+		}(sha)
+	}
+
+	wg.Wait()
+	return cached, unavailable
+}
+
+// batchGet retrieves cached commits from PostgreSQL.
+func (c *CommitCache) batchGet(ctx context.Context, canonicalURL string, shas []string) map[string]*CommitInfo {
+	result := make(map[string]*CommitInfo, len(shas))
+
+	rows, err := c.db.Query(ctx,
+		`SELECT sha, data FROM git_commit_cache WHERE canonical_url = $1 AND sha = ANY($2)`,
+		canonicalURL, shas,
+	)
+	if err != nil {
+		c.log.Error("querying commit cache", "err", err)
+		return result
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var sha string
+		var data []byte
+		if err := rows.Scan(&sha, &data); err != nil {
+			c.log.Error("scanning commit cache row", "err", err)
+			continue
+		}
+		var info CommitInfo
+		if err := json.Unmarshal(data, &info); err != nil {
+			c.log.Error("unmarshaling cached commit", "err", err)
+			continue
+		}
+		result[sha] = &info
+	}
+
+	return result
+}
+
+// put writes a commit to the PostgreSQL cache.
+func (c *CommitCache) put(ctx context.Context, canonicalURL string, info *CommitInfo) {
+	data, err := json.Marshal(info)
+	if err != nil {
+		c.log.Error("marshaling commit for cache", "err", err)
+		return
+	}
+
+	_, err = c.db.Exec(ctx,
+		`INSERT INTO git_commit_cache (canonical_url, sha, data) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING`,
+		canonicalURL, info.SHA, data,
+	)
+	if err != nil {
+		c.log.Error("caching commit", "sha", info.SHA[:min(7, len(info.SHA))], "err", err)
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// SetGitHubClient replaces the GitHub client (used when settings change at runtime).
+func (c *CommitCache) SetGitHubClient(gh *GitHubClient) {
+	c.gh = gh
+}
+
+// HasGitHub returns true if a GitHub client is configured.
+func (c *CommitCache) HasGitHub() bool {
+	return c.gh != nil
+}
+
+// CommitResponse is the API response shape for the commits endpoint.
+type CommitResponse struct {
+	Commits     map[string]*commitResponseEntry `json:"commits"`
+	Unavailable []string                        `json:"unavailable"`
+}
+
+type commitResponseEntry struct {
+	SHA        string `json:"sha"`
+	Title      string `json:"title"`
+	Message    string `json:"message"`
+	AuthorName string `json:"authorName"`
+	AuthorDate string `json:"authorDate"`
+	WebURL     string `json:"webUrl,omitempty"`
+}
+
+// ToResponse converts the raw cache results into the API response format.
+func ToResponse(commits map[string]*CommitInfo, unavailable []string) *CommitResponse {
+	resp := &CommitResponse{
+		Commits:     make(map[string]*commitResponseEntry, len(commits)),
+		Unavailable: unavailable,
+	}
+	if resp.Unavailable == nil {
+		resp.Unavailable = []string{}
+	}
+
+	for sha, c := range commits {
+		resp.Commits[sha] = &commitResponseEntry{
+			SHA:        c.SHA,
+			Title:      c.Title(),
+			Message:    c.Message,
+			AuthorName: c.AuthorName,
+			AuthorDate: fmt.Sprintf("%s", c.AuthorDate.UTC().Format("2006-01-02T15:04:05Z")),
+			WebURL:     c.WebURL,
+		}
+	}
+
+	return resp
+}

--- a/backend/internal/gitprovider/github.go
+++ b/backend/internal/gitprovider/github.go
@@ -1,0 +1,74 @@
+package gitprovider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/go-github/v83/github"
+)
+
+// GitHubClient fetches commit metadata from the GitHub API.
+type GitHubClient struct {
+	client *github.Client
+	log    *slog.Logger
+}
+
+// NewGitHubClient creates a GitHub API client.
+// If enterpriseURL is non-empty, it configures the client for GitHub Enterprise.
+func NewGitHubClient(token, enterpriseURL string, log *slog.Logger) (*GitHubClient, error) {
+	client := github.NewClient(nil).WithAuthToken(token)
+
+	if enterpriseURL != "" {
+		var err error
+		client, err = client.WithEnterpriseURLs(enterpriseURL, enterpriseURL)
+		if err != nil {
+			return nil, fmt.Errorf("configuring github enterprise URL: %w", err)
+		}
+	}
+
+	return &GitHubClient{client: client, log: log}, nil
+}
+
+// GetCommit fetches commit metadata by SHA from the GitHub API.
+func (g *GitHubClient) GetCommit(ctx context.Context, owner, repo, sha string) (*CommitInfo, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	rc, _, err := g.client.Repositories.GetCommit(ctx, owner, repo, sha, nil)
+	if err != nil {
+		var rateLimitErr *github.RateLimitError
+		if errors.As(err, &rateLimitErr) {
+			g.log.Warn("github rate limit hit",
+				"remaining", rateLimitErr.Rate.Remaining,
+				"reset", rateLimitErr.Rate.Reset.Time,
+			)
+			return nil, fmt.Errorf("github rate limit exceeded, resets at %s", rateLimitErr.Rate.Reset.Time.Format(time.RFC3339))
+		}
+
+		var abuseErr *github.AbuseRateLimitError
+		if errors.As(err, &abuseErr) {
+			g.log.Warn("github secondary rate limit hit", "retryAfter", abuseErr.RetryAfter)
+			return nil, fmt.Errorf("github secondary rate limit hit")
+		}
+
+		return nil, fmt.Errorf("fetching commit %s/%s@%.7s: %w", owner, repo, sha, err)
+	}
+
+	info := &CommitInfo{
+		SHA:    rc.GetSHA(),
+		WebURL: rc.GetHTMLURL(),
+	}
+
+	if rc.Commit != nil {
+		info.Message = rc.Commit.GetMessage()
+		if rc.Commit.Author != nil {
+			info.AuthorName = rc.Commit.Author.GetName()
+			info.AuthorDate = rc.Commit.Author.GetDate().Time
+		}
+	}
+
+	return info, nil
+}

--- a/backend/internal/gitprovider/github_test.go
+++ b/backend/internal/gitprovider/github_test.go
@@ -1,0 +1,106 @@
+package gitprovider
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-github/v83/github"
+)
+
+func TestGitHubClient_GetCommit(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/commits/abc123") {
+			http.NotFound(w, r)
+			return
+		}
+
+		resp := github.RepositoryCommit{
+			SHA:     github.Ptr("abc123full"),
+			HTMLURL: github.Ptr("https://github.com/org/repo/commit/abc123full"),
+			Commit: &github.Commit{
+				Message: github.Ptr("fix: resolve bug\n\nDetailed description"),
+				Author: &github.CommitAuthor{
+					Name:  github.Ptr("Jane Smith"),
+					Email: github.Ptr("jane@example.com"),
+					Date:  &github.Timestamp{Time: time.Date(2026, 4, 7, 15, 0, 0, 0, time.UTC)},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer ts.Close()
+
+	client, err := NewGitHubClient("test-token", ts.URL+"/", slog.Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := client.GetCommit(context.Background(), "org", "repo", "abc123")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if info.SHA != "abc123full" {
+		t.Errorf("SHA = %q, want %q", info.SHA, "abc123full")
+	}
+	if info.Message != "fix: resolve bug\n\nDetailed description" {
+		t.Errorf("Message = %q, want %q", info.Message, "fix: resolve bug\n\nDetailed description")
+	}
+	if info.AuthorName != "Jane Smith" {
+		t.Errorf("AuthorName = %q, want %q", info.AuthorName, "Jane Smith")
+	}
+	if info.WebURL != "https://github.com/org/repo/commit/abc123full" {
+		t.Errorf("WebURL = %q", info.WebURL)
+	}
+	if info.Title() != "fix: resolve bug" {
+		t.Errorf("Title() = %q, want %q", info.Title(), "fix: resolve bug")
+	}
+}
+
+func TestGitHubClient_GetCommit_NotFound(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"message": "Not Found"})
+	}))
+	defer ts.Close()
+
+	client, err := NewGitHubClient("test-token", ts.URL+"/", slog.Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.GetCommit(context.Background(), "org", "repo", "deadbeef")
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+}
+
+func TestGitHubClient_GetCommit_RateLimit(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-RateLimit-Remaining", "0")
+		w.Header().Set("X-RateLimit-Reset", "1700000000")
+		w.WriteHeader(http.StatusForbidden)
+		json.NewEncoder(w).Encode(map[string]any{
+			"message":           "API rate limit exceeded",
+			"documentation_url": "https://docs.github.com/rest",
+		})
+	}))
+	defer ts.Close()
+
+	client, err := NewGitHubClient("test-token", ts.URL+"/", slog.Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.GetCommit(context.Background(), "org", "repo", "abc123")
+	if err == nil {
+		t.Fatal("expected error for rate limit")
+	}
+}

--- a/backend/internal/gitprovider/parse.go
+++ b/backend/internal/gitprovider/parse.go
@@ -1,0 +1,107 @@
+package gitprovider
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// CommitInfo is normalized commit metadata from a git provider.
+type CommitInfo struct {
+	SHA        string    `json:"sha"`
+	Message    string    `json:"message"`
+	AuthorName string    `json:"authorName"`
+	AuthorDate time.Time `json:"authorDate"`
+	WebURL     string    `json:"webUrl,omitempty"`
+}
+
+// Title returns the first line of the commit message.
+func (c *CommitInfo) Title() string {
+	if i := strings.IndexByte(c.Message, '\n'); i >= 0 {
+		return c.Message[:i]
+	}
+	return c.Message
+}
+
+// RepoRef is a parsed git repository URL.
+type RepoRef struct {
+	Host  string // "github.com", "github.enterprise.com"
+	Owner string // "org" or "group/subgroup"
+	Repo  string // "repo-name"
+}
+
+// CanonicalURL returns the normalized cache key form: https://{host}/{owner}/{repo}
+func (r *RepoRef) CanonicalURL() string {
+	return "https://" + r.Host + "/" + r.Owner + "/" + r.Repo
+}
+
+// sshPattern matches git@host:owner/repo.git
+var sshPattern = regexp.MustCompile(`^git@([^:]+):(.+?)(?:\.git)?$`)
+
+// ParseRepoURL parses a git repository URL into host, owner, and repo components.
+// Supported formats:
+//   - https://github.com/org/repo.git
+//   - https://github.com/org/repo
+//   - git@github.com:org/repo.git
+//   - ssh://git@github.com/org/repo.git
+//   - ssh://git@github.com:22/org/repo.git
+func ParseRepoURL(rawURL string) (*RepoRef, error) {
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" {
+		return nil, fmt.Errorf("empty repository URL")
+	}
+
+	// Handle SSH shorthand: git@host:owner/repo.git
+	if m := sshPattern.FindStringSubmatch(rawURL); m != nil {
+		host := strings.ToLower(m[1])
+		path := m[2]
+		owner, repo, err := splitOwnerRepo(path)
+		if err != nil {
+			return nil, fmt.Errorf("parsing SSH URL %q: %w", rawURL, err)
+		}
+		return &RepoRef{Host: host, Owner: owner, Repo: repo}, nil
+	}
+
+	// Handle ssh:// scheme: ssh://git@github.com/org/repo.git
+	// Handle https:// scheme: https://github.com/org/repo.git
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("parsing URL %q: %w", rawURL, err)
+	}
+
+	if u.Scheme != "https" && u.Scheme != "http" && u.Scheme != "ssh" {
+		return nil, fmt.Errorf("unsupported URL scheme %q in %q", u.Scheme, rawURL)
+	}
+
+	host := strings.ToLower(u.Hostname())
+	if host == "" {
+		return nil, fmt.Errorf("missing host in URL %q", rawURL)
+	}
+
+	path := strings.TrimPrefix(u.Path, "/")
+	path = strings.TrimSuffix(path, ".git")
+	path = strings.TrimSuffix(path, "/")
+
+	if path == "" {
+		return nil, fmt.Errorf("missing path in URL %q", rawURL)
+	}
+
+	owner, repo, err := splitOwnerRepo(path)
+	if err != nil {
+		return nil, fmt.Errorf("parsing URL %q: %w", rawURL, err)
+	}
+
+	return &RepoRef{Host: host, Owner: owner, Repo: repo}, nil
+}
+
+// splitOwnerRepo splits "owner/repo" or "group/subgroup/repo" into owner and repo.
+// The last path segment is always the repo; everything before it is the owner.
+func splitOwnerRepo(path string) (owner, repo string, err error) {
+	idx := strings.LastIndex(path, "/")
+	if idx < 0 || idx == 0 {
+		return "", "", fmt.Errorf("cannot extract owner/repo from path %q", path)
+	}
+	return path[:idx], path[idx+1:], nil
+}

--- a/backend/internal/gitprovider/parse_test.go
+++ b/backend/internal/gitprovider/parse_test.go
@@ -1,0 +1,146 @@
+package gitprovider
+
+import (
+	"testing"
+)
+
+func TestParseRepoURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    RepoRef
+		wantErr bool
+	}{
+		{
+			name:  "https with .git",
+			input: "https://github.com/org/repo.git",
+			want:  RepoRef{Host: "github.com", Owner: "org", Repo: "repo"},
+		},
+		{
+			name:  "https without .git",
+			input: "https://github.com/org/repo",
+			want:  RepoRef{Host: "github.com", Owner: "org", Repo: "repo"},
+		},
+		{
+			name:  "https trailing slash",
+			input: "https://github.com/org/repo/",
+			want:  RepoRef{Host: "github.com", Owner: "org", Repo: "repo"},
+		},
+		{
+			name:  "ssh shorthand",
+			input: "git@github.com:org/repo.git",
+			want:  RepoRef{Host: "github.com", Owner: "org", Repo: "repo"},
+		},
+		{
+			name:  "ssh shorthand without .git",
+			input: "git@github.com:org/repo",
+			want:  RepoRef{Host: "github.com", Owner: "org", Repo: "repo"},
+		},
+		{
+			name:  "ssh:// scheme",
+			input: "ssh://git@github.com/org/repo.git",
+			want:  RepoRef{Host: "github.com", Owner: "org", Repo: "repo"},
+		},
+		{
+			name:  "ssh:// with port",
+			input: "ssh://git@github.com:22/org/repo.git",
+			want:  RepoRef{Host: "github.com", Owner: "org", Repo: "repo"},
+		},
+		{
+			name:  "gitlab nested groups",
+			input: "https://gitlab.com/group/subgroup/repo.git",
+			want:  RepoRef{Host: "gitlab.com", Owner: "group/subgroup", Repo: "repo"},
+		},
+		{
+			name:  "github enterprise",
+			input: "https://github.internal.co/team/project.git",
+			want:  RepoRef{Host: "github.internal.co", Owner: "team", Repo: "project"},
+		},
+		{
+			name:  "bitbucket cloud",
+			input: "https://bitbucket.org/workspace/repo-name",
+			want:  RepoRef{Host: "bitbucket.org", Owner: "workspace", Repo: "repo-name"},
+		},
+		{
+			name:  "repo with dots in name",
+			input: "https://github.com/org/repo.v2.git",
+			want:  RepoRef{Host: "github.com", Owner: "org", Repo: "repo.v2"},
+		},
+		{
+			name:  "host is lowercased",
+			input: "https://GitHub.COM/Org/Repo",
+			want:  RepoRef{Host: "github.com", Owner: "Org", Repo: "Repo"},
+		},
+		{
+			name:  "http scheme",
+			input: "http://git.internal.co/team/project",
+			want:  RepoRef{Host: "git.internal.co", Owner: "team", Repo: "project"},
+		},
+		// Error cases
+		{
+			name:    "empty string",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "missing repo path",
+			input:   "https://github.com/",
+			wantErr: true,
+		},
+		{
+			name:    "only host, no path",
+			input:   "https://github.com",
+			wantErr: true,
+		},
+		{
+			name:    "unsupported scheme",
+			input:   "ftp://github.com/org/repo",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseRepoURL(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %+v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Host != tt.want.Host || got.Owner != tt.want.Owner || got.Repo != tt.want.Repo {
+				t.Errorf("got {%s, %s, %s}, want {%s, %s, %s}",
+					got.Host, got.Owner, got.Repo,
+					tt.want.Host, tt.want.Owner, tt.want.Repo)
+			}
+		})
+	}
+}
+
+func TestCanonicalURL(t *testing.T) {
+	ref := &RepoRef{Host: "github.com", Owner: "org", Repo: "repo"}
+	want := "https://github.com/org/repo"
+	if got := ref.CanonicalURL(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestCommitInfoTitle(t *testing.T) {
+	tests := []struct {
+		message string
+		want    string
+	}{
+		{"fix: bug", "fix: bug"},
+		{"fix: bug\n\nDetailed description", "fix: bug"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		c := &CommitInfo{Message: tt.message}
+		if got := c.Title(); got != tt.want {
+			t.Errorf("Title(%q) = %q, want %q", tt.message, got, tt.want)
+		}
+	}
+}

--- a/backend/internal/server/handle_settings.go
+++ b/backend/internal/server/handle_settings.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kubecenter/kubecenter/internal/audit"
 	"github.com/kubecenter/kubecenter/internal/auth"
+	"github.com/kubecenter/kubecenter/internal/gitprovider"
 	"github.com/kubecenter/kubecenter/internal/k8s"
 	"github.com/kubecenter/kubecenter/internal/store"
 	"github.com/kubecenter/kubecenter/pkg/api"
@@ -199,6 +200,22 @@ func (s *Server) handleUpdateAppSettings(w http.ResponseWriter, r *http.Request)
 	entry.ResourceKind = "Settings"
 	entry.Detail = "application settings updated"
 	s.AuditLogger.Log(r.Context(), entry)
+
+	// If GitHub token was updated, reconfigure the commit enrichment client
+	if patch.GitHubToken != nil && s.GitOpsHandler != nil && s.GitOpsHandler.CommitCache != nil {
+		if *patch.GitHubToken == "" {
+			s.GitOpsHandler.CommitCache.SetGitHubClient(nil)
+			s.Logger.Info("git commit enrichment disabled (token cleared)")
+		} else {
+			ghClient, err := gitprovider.NewGitHubClient(*patch.GitHubToken, "", s.Logger)
+			if err != nil {
+				s.Logger.Warn("failed to create github client after settings update", "error", err)
+			} else {
+				s.GitOpsHandler.CommitCache.SetGitHubClient(ghClient)
+				s.Logger.Info("git commit enrichment reconfigured")
+			}
+		}
+	}
 
 	// Return updated (masked) settings
 	settings, err := s.SettingsService.Get(r.Context())

--- a/backend/internal/server/routes.go
+++ b/backend/internal/server/routes.go
@@ -441,6 +441,7 @@ func (s *Server) registerGitOpsRoutes(ar chi.Router) {
 		gr.Get("/status", h.HandleStatus)
 		gr.Get("/applications", h.HandleListApplications)
 		gr.Get("/applications/{id}", h.HandleGetApplication)
+		gr.Get("/commits", h.HandleGetCommits)
 
 		// Action endpoints
 		gr.Post("/applications/{id}/sync", h.HandleSync)

--- a/backend/internal/store/migrations/000006_create_git_commit_cache.down.sql
+++ b/backend/internal/store/migrations/000006_create_git_commit_cache.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE app_settings DROP COLUMN IF EXISTS github_token;
+DROP TABLE IF EXISTS git_commit_cache;

--- a/backend/internal/store/migrations/000006_create_git_commit_cache.down.sql
+++ b/backend/internal/store/migrations/000006_create_git_commit_cache.down.sql
@@ -1,2 +1,3 @@
-ALTER TABLE app_settings DROP COLUMN IF EXISTS github_token;
+DROP INDEX IF EXISTS idx_git_commit_cache_created_at;
+ALTER TABLE app_settings DROP COLUMN IF EXISTS github_token_enc;
 DROP TABLE IF EXISTS git_commit_cache;

--- a/backend/internal/store/migrations/000006_create_git_commit_cache.up.sql
+++ b/backend/internal/store/migrations/000006_create_git_commit_cache.up.sql
@@ -6,5 +6,8 @@ CREATE TABLE IF NOT EXISTS git_commit_cache (
     PRIMARY KEY (canonical_url, sha)
 );
 
--- Add GitHub token column to existing settings table
-ALTER TABLE app_settings ADD COLUMN IF NOT EXISTS github_token TEXT;
+-- Add encrypted GitHub token column to existing settings table (AES-256-GCM)
+ALTER TABLE app_settings ADD COLUMN IF NOT EXISTS github_token_enc BYTEA;
+
+-- Index for future cache cleanup by age
+CREATE INDEX IF NOT EXISTS idx_git_commit_cache_created_at ON git_commit_cache (created_at);

--- a/backend/internal/store/migrations/000006_create_git_commit_cache.up.sql
+++ b/backend/internal/store/migrations/000006_create_git_commit_cache.up.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS git_commit_cache (
+    canonical_url TEXT NOT NULL,
+    sha           TEXT NOT NULL,
+    data          JSONB NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (canonical_url, sha)
+);
+
+-- Add GitHub token column to existing settings table
+ALTER TABLE app_settings ADD COLUMN IF NOT EXISTS github_token TEXT;

--- a/backend/internal/store/settings.go
+++ b/backend/internal/store/settings.go
@@ -30,14 +30,16 @@ type AppSettings struct {
 
 // SettingsService manages persistent application settings with an in-memory cache.
 type SettingsService struct {
-	pool  *pgxpool.Pool
-	mu    sync.RWMutex
-	cache *AppSettings
+	pool   *pgxpool.Pool
+	encKey string // encryption key for sensitive fields (empty = no encryption)
+	mu     sync.RWMutex
+	cache  *AppSettings
 }
 
 // NewSettingsService creates a settings service backed by PostgreSQL.
-func NewSettingsService(pool *pgxpool.Pool) *SettingsService {
-	return &SettingsService{pool: pool}
+// encKey is used for field-level encryption of sensitive values (e.g., GitHub token).
+func NewSettingsService(pool *pgxpool.Pool, encKey string) *SettingsService {
+	return &SettingsService{pool: pool, encKey: encKey}
 }
 
 // Get returns the current settings from cache (refreshes if stale).
@@ -55,6 +57,19 @@ func (s *SettingsService) Get(ctx context.Context) (*AppSettings, error) {
 
 // Update patches settings in the database and refreshes the cache.
 func (s *SettingsService) Update(ctx context.Context, patch AppSettings) error {
+	// Encrypt GitHub token before storing
+	var tokenParam any
+	if patch.GitHubToken != nil && *patch.GitHubToken != "" && s.encKey != "" {
+		encrypted, err := Encrypt([]byte(*patch.GitHubToken), s.encKey)
+		if err != nil {
+			return fmt.Errorf("encrypting github token: %w", err)
+		}
+		tokenParam = encrypted
+	} else if patch.GitHubToken != nil {
+		// Token explicitly set (possibly empty to clear it)
+		tokenParam = []byte(*patch.GitHubToken)
+	}
+
 	_, err := s.pool.Exec(ctx, `
 		UPDATE app_settings SET
 			monitoring_prometheus_url = COALESCE($1, monitoring_prometheus_url),
@@ -69,7 +84,7 @@ func (s *SettingsService) Update(ctx context.Context, patch AppSettings) error {
 			alerting_smtp_from = COALESCE($10, alerting_smtp_from),
 			alerting_rate_limit = COALESCE($11, alerting_rate_limit),
 			alerting_recipients = COALESCE($12, alerting_recipients),
-			github_token = COALESCE($13, github_token),
+			github_token_enc = COALESCE($13, github_token_enc),
 			updated_at = NOW()
 		WHERE id = 1`,
 		patch.MonitoringPrometheusURL, patch.MonitoringGrafanaURL,
@@ -78,7 +93,7 @@ func (s *SettingsService) Update(ctx context.Context, patch AppSettings) error {
 		patch.AlertingSMTPPort, patch.AlertingSMTPUsername,
 		patch.AlertingSMTPPassword, patch.AlertingSMTPFrom,
 		patch.AlertingRateLimit, patch.AlertingRecipients,
-		patch.GitHubToken,
+		tokenParam,
 	)
 	if err != nil {
 		return fmt.Errorf("updating settings: %w", err)
@@ -91,11 +106,12 @@ func (s *SettingsService) Update(ctx context.Context, patch AppSettings) error {
 
 func (s *SettingsService) refresh(ctx context.Context) (*AppSettings, error) {
 	var settings AppSettings
+	var tokenEnc []byte
 	err := s.pool.QueryRow(ctx, `
 		SELECT monitoring_prometheus_url, monitoring_grafana_url, monitoring_grafana_token,
 		       monitoring_namespace, alerting_enabled, alerting_smtp_host, alerting_smtp_port,
 		       alerting_smtp_username, alerting_smtp_password, alerting_smtp_from,
-		       alerting_rate_limit, alerting_recipients, github_token, updated_at
+		       alerting_rate_limit, alerting_recipients, github_token_enc, updated_at
 		FROM app_settings WHERE id = 1`).Scan(
 		&settings.MonitoringPrometheusURL, &settings.MonitoringGrafanaURL,
 		&settings.MonitoringGrafanaToken, &settings.MonitoringNamespace,
@@ -103,11 +119,20 @@ func (s *SettingsService) refresh(ctx context.Context) (*AppSettings, error) {
 		&settings.AlertingSMTPPort, &settings.AlertingSMTPUsername,
 		&settings.AlertingSMTPPassword, &settings.AlertingSMTPFrom,
 		&settings.AlertingRateLimit, &settings.AlertingRecipients,
-		&settings.GitHubToken,
+		&tokenEnc,
 		&settings.UpdatedAt,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("reading settings: %w", err)
+	}
+
+	// Decrypt GitHub token if present
+	if len(tokenEnc) > 0 && s.encKey != "" {
+		decrypted, err := Decrypt(tokenEnc, s.encKey)
+		if err == nil {
+			str := string(decrypted)
+			settings.GitHubToken = &str
+		}
 	}
 
 	s.mu.Lock()

--- a/backend/internal/store/settings.go
+++ b/backend/internal/store/settings.go
@@ -24,6 +24,7 @@ type AppSettings struct {
 	AlertingSMTPFrom        *string  `json:"alertingSmtpFrom,omitempty"`
 	AlertingRateLimit       *int     `json:"alertingRateLimit,omitempty"`
 	AlertingRecipients      []string `json:"alertingRecipients,omitempty"`
+	GitHubToken             *string  `json:"gitHubToken,omitempty"`
 	UpdatedAt               time.Time `json:"updatedAt"`
 }
 
@@ -68,6 +69,7 @@ func (s *SettingsService) Update(ctx context.Context, patch AppSettings) error {
 			alerting_smtp_from = COALESCE($10, alerting_smtp_from),
 			alerting_rate_limit = COALESCE($11, alerting_rate_limit),
 			alerting_recipients = COALESCE($12, alerting_recipients),
+			github_token = COALESCE($13, github_token),
 			updated_at = NOW()
 		WHERE id = 1`,
 		patch.MonitoringPrometheusURL, patch.MonitoringGrafanaURL,
@@ -76,6 +78,7 @@ func (s *SettingsService) Update(ctx context.Context, patch AppSettings) error {
 		patch.AlertingSMTPPort, patch.AlertingSMTPUsername,
 		patch.AlertingSMTPPassword, patch.AlertingSMTPFrom,
 		patch.AlertingRateLimit, patch.AlertingRecipients,
+		patch.GitHubToken,
 	)
 	if err != nil {
 		return fmt.Errorf("updating settings: %w", err)
@@ -92,7 +95,7 @@ func (s *SettingsService) refresh(ctx context.Context) (*AppSettings, error) {
 		SELECT monitoring_prometheus_url, monitoring_grafana_url, monitoring_grafana_token,
 		       monitoring_namespace, alerting_enabled, alerting_smtp_host, alerting_smtp_port,
 		       alerting_smtp_username, alerting_smtp_password, alerting_smtp_from,
-		       alerting_rate_limit, alerting_recipients, updated_at
+		       alerting_rate_limit, alerting_recipients, github_token, updated_at
 		FROM app_settings WHERE id = 1`).Scan(
 		&settings.MonitoringPrometheusURL, &settings.MonitoringGrafanaURL,
 		&settings.MonitoringGrafanaToken, &settings.MonitoringNamespace,
@@ -100,6 +103,7 @@ func (s *SettingsService) refresh(ctx context.Context) (*AppSettings, error) {
 		&settings.AlertingSMTPPort, &settings.AlertingSMTPUsername,
 		&settings.AlertingSMTPPassword, &settings.AlertingSMTPFrom,
 		&settings.AlertingRateLimit, &settings.AlertingRecipients,
+		&settings.GitHubToken,
 		&settings.UpdatedAt,
 	)
 	if err != nil {
@@ -127,6 +131,10 @@ func MaskedSettings(s *AppSettings) *AppSettings {
 	if masked.AlertingSMTPUsername != nil && *masked.AlertingSMTPUsername != "" {
 		m := "****"
 		masked.AlertingSMTPUsername = &m
+	}
+	if masked.GitHubToken != nil && *masked.GitHubToken != "" {
+		m := "****"
+		masked.GitHubToken = &m
 	}
 	return &masked
 }

--- a/frontend/islands/GitOpsAppDetail.tsx
+++ b/frontend/islands/GitOpsAppDetail.tsx
@@ -1,7 +1,7 @@
 import { useSignal } from "@preact/signals";
 import { IS_BROWSER } from "fresh/runtime";
 import { useEffect } from "preact/hooks";
-import { apiGet, apiPost } from "@/lib/api.ts";
+import { api, apiGet, apiPost } from "@/lib/api.ts";
 import { useWsRefetch } from "@/lib/useWsRefetch.ts";
 import { Spinner } from "@/components/ui/Spinner.tsx";
 import { Button } from "@/components/ui/Button.tsx";
@@ -16,6 +16,8 @@ import {
 } from "@/components/ui/GitOpsBadges.tsx";
 import type {
   AppDetail,
+  CommitInfo,
+  CommitsResponse,
   ManagedResource,
   RevisionEntry,
 } from "@/lib/gitops-types.ts";
@@ -27,6 +29,7 @@ export default function GitOpsAppDetail({ id }: { id: string }) {
   const error = useSignal<string | null>(null);
   const refreshing = useSignal(false);
   const actionInFlight = useSignal(false);
+  const commits = useSignal<Record<string, CommitInfo>>({});
 
   // Confirmation dialog state
   const confirmAction = useSignal<
@@ -57,6 +60,41 @@ export default function GitOpsAppDetail({ id }: { id: string }) {
       loading.value = false;
     });
   }, []);
+
+  // Async commit message enrichment — fetches after detail loads
+  useEffect(() => {
+    if (!IS_BROWSER || !detail.value) return;
+
+    const app = detail.value.app;
+    const repoURL = app.source?.repoURL;
+    if (!repoURL || !repoURL.includes("://")) return;
+
+    // Collect SHAs: current revision + history revisions
+    const shas = new Set<string>();
+    if (app.currentRevision) shas.add(app.currentRevision);
+    for (const h of detail.value.history ?? []) {
+      if (h.revision) shas.add(h.revision);
+    }
+    if (shas.size === 0) return;
+
+    const controller = new AbortController();
+    const shaList = [...shas].slice(0, 50).join(",");
+    const url = `/v1/gitops/commits?repoURL=${
+      encodeURIComponent(repoURL)
+    }&shas=${shaList}`;
+
+    api<CommitsResponse>(url, { method: "GET", signal: controller.signal })
+      .then((res) => {
+        if (res.data?.commits) {
+          commits.value = res.data.commits;
+        }
+      })
+      .catch(() => {
+        // Graceful degradation — commit enrichment is optional
+      });
+
+    return () => controller.abort();
+  }, [detail.value?.app?.id]);
 
   // Determine the CRD kind from the composite ID
   const toolPrefix = id.split(":")[0];
@@ -455,18 +493,53 @@ export default function GitOpsAppDetail({ id }: { id: string }) {
                   {history.map((h: RevisionEntry, i: number) => {
                     const syncColor = SYNC_COLORS[h.status.toLowerCase()] ??
                       "var(--text-secondary)";
+                    const ci = commits.value[h.revision];
+                    const shortSha = h.revision.length > 7
+                      ? h.revision.slice(0, 7)
+                      : h.revision;
                     return (
                       <tr key={`${h.revision}-${i}`} class="hover:bg-hover/30">
                         <td class="px-3 py-2 font-mono text-text-primary">
-                          {h.revision.length > 7
-                            ? h.revision.slice(0, 7)
-                            : h.revision}
+                          {ci?.webUrl
+                            ? (
+                              <a
+                                href={ci.webUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                class="hover:underline text-brand"
+                              >
+                                {shortSha}
+                              </a>
+                            )
+                            : shortSha}
                         </td>
                         <td class="px-3 py-2">
                           <span style={{ color: syncColor }}>{h.status}</span>
                         </td>
-                        <td class="px-3 py-2 text-text-secondary max-w-xs truncate">
-                          {h.message ?? "-"}
+                        <td class="px-3 py-2 text-text-secondary max-w-xs">
+                          {ci
+                            ? (
+                              <div class="min-w-0">
+                                <div class="truncate text-sm text-text-primary">
+                                  {ci.webUrl
+                                    ? (
+                                      <a
+                                        href={ci.webUrl}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        class="hover:underline"
+                                      >
+                                        {ci.title}
+                                      </a>
+                                    )
+                                    : ci.title}
+                                </div>
+                                <div class="text-xs text-text-muted truncate">
+                                  {ci.authorName}
+                                </div>
+                              </div>
+                            )
+                            : (h.message ?? "-")}
                         </td>
                         <td class="px-3 py-2 text-text-muted">
                           {h.deployedAt

--- a/frontend/islands/GitOpsAppDetail.tsx
+++ b/frontend/islands/GitOpsAppDetail.tsx
@@ -494,16 +494,19 @@ export default function GitOpsAppDetail({ id }: { id: string }) {
                     const syncColor = SYNC_COLORS[h.status.toLowerCase()] ??
                       "var(--text-secondary)";
                     const ci = commits.value[h.revision];
+                    const commitUrl = ci?.webUrl?.startsWith("https://")
+                      ? ci.webUrl
+                      : undefined;
                     const shortSha = h.revision.length > 7
                       ? h.revision.slice(0, 7)
                       : h.revision;
                     return (
                       <tr key={`${h.revision}-${i}`} class="hover:bg-hover/30">
                         <td class="px-3 py-2 font-mono text-text-primary">
-                          {ci?.webUrl
+                          {commitUrl
                             ? (
                               <a
-                                href={ci.webUrl}
+                                href={commitUrl}
                                 target="_blank"
                                 rel="noopener noreferrer"
                                 class="hover:underline text-brand"
@@ -521,10 +524,10 @@ export default function GitOpsAppDetail({ id }: { id: string }) {
                             ? (
                               <div class="min-w-0">
                                 <div class="truncate text-sm text-text-primary">
-                                  {ci.webUrl
+                                  {commitUrl
                                     ? (
                                       <a
-                                        href={ci.webUrl}
+                                        href={commitUrl}
                                         target="_blank"
                                         rel="noopener noreferrer"
                                         class="hover:underline"

--- a/frontend/lib/gitops-types.ts
+++ b/frontend/lib/gitops-types.ts
@@ -112,3 +112,18 @@ export interface AppSetDetail {
   conditions: AppSetCondition[];
   applications: NormalizedApp[];
 }
+
+/** Commit metadata returned by the /gitops/commits endpoint. */
+export interface CommitInfo {
+  sha: string;
+  title: string;
+  message: string;
+  authorName: string;
+  authorDate: string;
+  webUrl?: string;
+}
+
+export interface CommitsResponse {
+  commits: Record<string, CommitInfo>;
+  unavailable: string[];
+}

--- a/plans/step-32-git-commit-display.md
+++ b/plans/step-32-git-commit-display.md
@@ -1,0 +1,385 @@
+# Step 32: Git Commit Display
+
+## Overview
+
+Enrich Argo CD revision history with actual git commit messages, authors, and web URLs by calling the GitHub API. The revision history table in the app detail page currently shows SHAs with an empty Message column ("-"). This feature populates that column with real commit data fetched asynchronously.
+
+## Problem Statement
+
+When users view an Argo CD application's deployment history, they see raw commit SHAs and timestamps but no commit messages or authors. To understand what each deployment contained, they must manually look up commits in GitHub. Argo CD's own UI shows commit messages because its repo-server maintains local git clones — k8sCenter has no equivalent. This feature closes that gap using lightweight GitHub API calls instead of full clones.
+
+## Scope
+
+**In scope (v1 — GitHub only):**
+- Argo CD Application `status.history` enrichment (full git SHA history)
+- Argo CD `currentRevision` enrichment (single SHA)
+- GitHub.com + GitHub Enterprise
+- Token stored in existing `app_settings` table
+- PostgreSQL commit cache (immutable data, cache-forever)
+- Async frontend enrichment (never blocks page load)
+
+**Out of scope (v1):**
+- GitLab, Bitbucket adapters (add when requested — no Provider interface yet)
+- Flux Kustomization enrichment (no CRD-native revision history, `flux.go:87`)
+- Flux HelmRelease enrichment (chart versions, not git SHAs)
+- Author avatars
+- Admin CRUD UI for multiple providers (one token in settings is enough)
+- In-memory LRU cache (PostgreSQL PK lookup is sub-ms; singleflight prevents thundering herd)
+
+**Future (v2, on demand):**
+- Provider interface + GitLab/Bitbucket adapters
+- Dedicated `git_providers` table for multi-host token management
+- Flux `GitRepository` sourceRef resolution for Kustomization `currentRevision`
+
+## Technical Approach
+
+### Architecture
+
+```
+Frontend (GitOpsAppDetail)           Backend
+┌──────────────────────┐    ┌─────────────────────────────┐
+│ 1. Load detail page  │───>│ GET /gitops/applications/:id │
+│    (existing flow)   │<───│ Returns history[] with SHAs  │
+│                      │    └─────────────────────────────┘
+│ 2. Async enrichment  │───>│ GET /gitops/commits          │
+│    (new, after load) │    │   ?repoURL=...&shas=a,b,c   │
+│                      │    ├─────────────────────────────┤
+│ 3. Merge into table  │<───│ PostgreSQL cache + singleflight
+│    Message column    │    │   → GitHub API (on miss)     │
+└──────────────────────┘    └─────────────────────────────┘
+```
+
+**Key design choices:**
+
+1. **Separate endpoint** (`GET /gitops/commits`) — avoids latency on primary page load, follows async Prometheus pattern from Phase 6B
+2. **PostgreSQL-only cache** with `singleflight` — commits are immutable, PK lookup is sub-ms, no LRU complexity needed
+3. **Concrete `GitHubClient` struct** — no Provider interface until we need a second provider
+4. **Token in `app_settings`** — existing settings table + encryption + UI, no new CRUD infrastructure
+5. **Commits handler in `gitops/`** — it's a gitops concern, not a standalone domain
+
+### File Plan
+
+**New files (6):**
+
+```
+backend/internal/gitprovider/
+  github.go        — GitHubClient struct (~80 LOC)
+  cache.go         — CommitCache: PostgreSQL + singleflight (~60 LOC)
+  parse.go         — ParseRepoURL: host/owner/repo extraction (~50 LOC)
+  parse_test.go    — URL parsing tests (~60 LOC)
+  github_test.go   — GitHub adapter tests with httptest.Server (~80 LOC)
+
+backend/internal/store/migrations/
+  000006_create_git_commit_cache.up.sql
+  000006_create_git_commit_cache.down.sql
+```
+
+**Modified files (6):**
+
+```
+backend/internal/gitops/handler.go       — add HandleGetCommits method
+backend/internal/store/settings.go       — add GitHubToken field to AppSettings
+backend/internal/server/routes.go        — register GET /gitops/commits
+backend/internal/server/server.go        — wire CommitCache into GitOps handler
+backend/go.mod                           — add google/go-github/v83
+frontend/islands/GitOpsAppDetail.tsx     — async fetch + table enrichment
+frontend/lib/gitops-types.ts             — add CommitInfo + CommitsResponse interfaces
+```
+
+### Implementation Phases
+
+---
+
+#### Phase 1: Backend (GitHub adapter + cache + endpoint + settings)
+
+##### 1a. Types and URL Parsing (`gitprovider/parse.go`)
+
+```go
+// RepoRef is a parsed git repository URL.
+type RepoRef struct {
+    Host  string // "github.com", "github.enterprise.com"
+    Owner string // "org" or "group/subgroup"
+    Repo  string // "repo-name"
+}
+
+// CommitInfo is normalized commit metadata from a git provider.
+type CommitInfo struct {
+    SHA        string    `json:"sha"`
+    Message    string    `json:"message"`
+    AuthorName string    `json:"authorName"`
+    AuthorDate time.Time `json:"authorDate"`
+    WebURL     string    `json:"webUrl,omitempty"`
+}
+```
+
+`ParseRepoURL` handles all common formats:
+- `https://github.com/org/repo.git` → github.com, org, repo
+- `git@github.com:org/repo.git` → github.com, org, repo
+- `ssh://git@github.com/org/repo.git` → github.com, org, repo
+
+Uses `net/url` + regex for SSH format. `strings.LastIndex("/")` for owner/repo split. Strips `.git` suffix. Returns a **canonical form** for cache keys: `https://{host}/{owner}/{repo}` (lowercase host, no `.git`, HTTPS scheme).
+
+Design notes:
+- `CommitInfo.AuthorDate` is `time.Time` (not string) — JSON serialization handles ISO 8601
+- No `Title` field — derive first line from `Message` via `strings.SplitN(message, "\n", 2)[0]` in the response serializer
+- No `Provider` interface — concrete struct until we need a second adapter
+
+**Test matrix:** 10+ URL formats including dots in repo name, trailing slashes, port numbers, SSH variants.
+
+##### 1b. GitHub Adapter (`gitprovider/github.go`)
+
+```go
+type GitHubClient struct {
+    client *github.Client
+}
+
+func NewGitHubClient(token, enterpriseURL string) (*GitHubClient, error)
+
+func (g *GitHubClient) GetCommit(ctx context.Context, owner, repo, sha string) (*CommitInfo, error)
+```
+
+- Uses `google/go-github/v83` → `Repositories.GetCommit(ctx, owner, repo, sha, nil)`
+- Always use `Get*()` helper methods to avoid nil pointer panics on pointer fields
+- Handle `*github.RateLimitError` and `*github.AbuseRateLimitError` — log warning with reset time via `slog`
+- Support Enterprise via `client.WithEnterpriseURLs(enterpriseURL, enterpriseURL)`
+- 10-second context timeout on outbound calls
+
+Tests use `httptest.Server` returning canned responses, covering: success, 404 (unknown SHA), 401 (bad token), 429 (rate limit).
+
+##### 1c. Commit Cache (`gitprovider/cache.go`)
+
+```go
+type CommitCache struct {
+    db    *pgxpool.Pool
+    gh    *GitHubClient   // nil if no token configured
+    group singleflight.Group
+    log   *slog.Logger
+}
+
+func (c *CommitCache) GetCommits(ctx context.Context, canonicalURL, owner, repo string, shas []string) (map[string]*CommitInfo, []string)
+```
+
+- PostgreSQL-only cache. No in-memory LRU.
+- Batch lookup: `SELECT data FROM git_commit_cache WHERE canonical_url = $1 AND sha = ANY($2)`
+- `singleflight.Group` keyed per `canonicalURL:sha` to coalesce concurrent fetches for uncached SHAs
+- Fan out uncached SHA fetches with `errgroup` (max 5 concurrent GitHub API calls)
+- Write-back: `INSERT ... ON CONFLICT DO NOTHING` (immutable data)
+- **Negative results NOT cached** — 404/401 today might succeed after token config change
+- Returns `(commits map, unavailable []string)` — never errors the whole batch
+
+##### 1d. Migration (`000006`)
+
+```sql
+-- 000006_create_git_commit_cache.up.sql
+CREATE TABLE git_commit_cache (
+    canonical_url TEXT NOT NULL,
+    sha           TEXT NOT NULL,
+    data          JSONB NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (canonical_url, sha)
+);
+```
+
+```sql
+-- 000006_create_git_commit_cache.down.sql
+DROP TABLE IF EXISTS git_commit_cache;
+```
+
+Design notes:
+- `canonical_url` is the normalized repo URL from `ParseRepoURL` (not raw user input)
+- `data` is JSONB containing the full `CommitInfo` — no schema evolution needed when adding fields later
+- No secondary index on `sha` alone — the batch query always includes `canonical_url`
+- No TTL — commits are immutable
+
+##### 1e. Settings Extension (`store/settings.go`)
+
+Add `GitHubToken` to existing `AppSettings` struct:
+
+```go
+type AppSettings struct {
+    // ... existing fields ...
+    GitHubToken string `json:"gitHubToken,omitempty" koanf:"githubtoken"`
+}
+```
+
+- Encrypted at rest using existing `store.Encrypt`/`store.Decrypt` (same as Grafana token)
+- Masked in API responses via existing `MaskedSettings()` pattern — return `"****"` if non-empty
+- Configurable via existing settings endpoints (`GET/PUT /api/v1/settings`) and settings UI
+- Also settable via env var: `KUBECENTER_GITHUBTOKEN` (for CI/quick-start)
+
+No new table. No new CRUD endpoints. No new frontend island.
+
+##### 1f. HTTP Handler (in `gitops/handler.go`)
+
+Add `HandleGetCommits` to the existing `gitops.Handler`:
+
+```go
+// GET /api/v1/gitops/commits?repoURL=<url>&shas=<sha1,sha2,...>
+func (h *Handler) HandleGetCommits(w http.ResponseWriter, r *http.Request) {
+    // 1. Parse & validate query params
+    // 2. Parse repoURL → canonical form + owner/repo
+    // 3. Validate repoURL host is github.com or configured GHE host
+    // 4. Cap shas at 50 per request
+    // 5. Validate repoURL matches at least one app visible to the user (RBAC)
+    // 6. Batch lookup via CommitCache
+    // 7. Return map of sha → CommitInfo (title derived from message) + unavailable list
+}
+```
+
+**RBAC:** Validate that `repoURL` matches at least one application the requesting user can see (cross-reference against the cached app list). Prevents information leakage via arbitrary repo URLs.
+
+**Rate limiting:** Uses the existing GitOps route group rate limiter. No separate limiter needed — the endpoint is cached and lightweight.
+
+**Response shape:**
+
+```json
+{
+  "data": {
+    "commits": {
+      "abc1234def5678...": {
+        "sha": "abc1234def5678...",
+        "title": "fix: resolve memory leak in pod watcher",
+        "message": "fix: resolve memory leak in pod watcher\n\nThe informer...",
+        "authorName": "Jane Smith",
+        "authorDate": "2026-04-07T15:00:00Z",
+        "webUrl": "https://github.com/org/repo/commit/abc1234def5678..."
+      }
+    },
+    "unavailable": ["def5678..."]
+  }
+}
+```
+
+`title` is derived server-side: `strings.SplitN(message, "\n", 2)[0]`.
+
+`unavailable` lists SHAs that could not be fetched (no token configured, rate limited, not found on GitHub). Frontend uses this to leave those rows as "-".
+
+Route registration in `routes.go`:
+```go
+gr.Get("/commits", gitopsHandler.HandleGetCommits)
+```
+
+Registered inside the existing `/api/v1/gitops` route group (inherits auth + rate limiter).
+
+**Success criteria:**
+- [ ] `ParseRepoURL` handles 10+ URL formats with tests
+- [ ] GitHub adapter fetches commit by SHA, handles rate limits
+- [ ] Migration creates cache table, rollback drops it
+- [ ] Settings field stores/masks GitHub token
+- [ ] Handler returns cached commits without API calls
+- [ ] Handler fetches uncached commits from GitHub
+- [ ] RBAC validates repoURL against user-visible apps
+- [ ] SHA list capped at 50
+- [ ] `go vet` and `go test ./internal/gitprovider/... ./internal/gitops/...` pass
+
+---
+
+#### Phase 2: Frontend Enrichment (async commit fetch + table update)
+
+**Files to modify:**
+
+- `frontend/islands/GitOpsAppDetail.tsx` — async commit fetch + merge into revision table
+- `frontend/lib/gitops-types.ts` — add `CommitInfo` and `CommitsResponse` interfaces
+
+##### 2a. TypeScript Types (in `gitops-types.ts`)
+
+```ts
+export interface CommitInfo {
+  sha: string;
+  title: string;
+  message: string;
+  authorName: string;
+  authorDate: string;
+  webUrl?: string;
+}
+
+export interface CommitsResponse {
+  commits: Record<string, CommitInfo>;
+  unavailable: string[];
+}
+```
+
+Added inline to `gitops-types.ts` — no separate file for 15 lines.
+
+##### 2b. Enrichment Flow in `GitOpsAppDetail.tsx`
+
+1. After `detail.value` loads, extract `source.repoURL` and all `history[].revision` SHAs
+2. Skip if `repoURL` does not contain `://` (filters out Flux's `"GitRepository/name"` format)
+3. Create `AbortController` — cancel on component unmount or when `detail.value` changes
+4. Call `GET /api/v1/gitops/commits?repoURL=${encodeURIComponent(repoURL)}&shas=...`
+5. Store result in a Preact signal: `const commits = useSignal<Record<string, CommitInfo>>({});`
+6. In the table, replace `h.message ?? "-"` with enriched display
+
+Note: `repoURL` must be `encodeURIComponent()`-encoded in the query string (contains `://`, `/`).
+
+##### 2c. Message Column Display
+
+```
+┌──────────────────────────────────────────────┐
+│ fix: resolve memory leak in pod watcher  ↗   │  ← commit title (truncated, links to webUrl)
+│ Jane Smith                                   │  ← author name (text-xs, text-muted)
+└──────────────────────────────────────────────┘
+```
+
+- Two-line cell: title (truncated, `text-sm`) + author (`text-xs`, muted color via CSS var)
+- Title links to `webUrl` (opens in new tab) if available
+- Revision SHA column also links to `webUrl` if available (clickable monospace hash)
+- While loading: show "-" (same as today, no spinner, no layout shift)
+- On failure / unavailable / no token configured: show "-"
+
+##### 2d. Cleanup
+
+- `AbortController` in `useEffect` cleanup to prevent stale responses updating wrong detail view
+- No separate loading state — "-" placeholder is sufficient since enrichment is progressive enhancement
+
+**Success criteria:**
+- [ ] Argo CD app detail page shows commit messages + authors in history table
+- [ ] Commit titles are clickable links to GitHub
+- [ ] Revision SHAs are clickable links to GitHub
+- [ ] Loading state shows "-", no layout shift on enrichment
+- [ ] Navigation away cancels in-flight fetch (AbortController)
+- [ ] Pages without configured token degrade gracefully (no errors, shows "-")
+- [ ] `deno lint` and `deno fmt --check` pass
+
+---
+
+## Dependencies
+
+| Library | Version | Purpose |
+|---------|---------|---------|
+| `google/go-github/v83` | latest | GitHub API client |
+
+Single new dependency. No GitLab/Bitbucket libraries until needed.
+
+## Security Considerations
+
+1. **RBAC on commits endpoint:** Validate `repoURL` matches at least one application visible to the requesting user. Prevents using the endpoint to probe arbitrary private repos.
+2. **Token encryption:** AES-256-GCM via existing `store.Encrypt`/`store.Decrypt`. Token masked as `"****"` in settings API responses.
+3. **Token scope:** Document minimum required: GitHub fine-grained PAT with `contents:read` on target repos.
+4. **No SSRF concern for v1:** Outbound calls go only to `api.github.com` (or admin-configured GHE URL stored in settings). No user-supplied URL is used as an outbound target.
+5. **Audit logging:** Token save/update logged via existing settings audit trail. Read-only commit fetches not audited.
+
+## Risk Analysis
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| GitHub rate limit hit (5,000/hr) | Low | Low | PostgreSQL cache + singleflight; most SHAs cached after first view |
+| Token misconfigured (wrong scope) | Medium | Low | Graceful degradation — shows "-"; admin can test via settings |
+| GHE instance unreachable | Low | Low | 10s timeout, partial results, "-" for failed SHAs |
+| Cache table unbounded growth | Low | Low | Immutable data, no duplication; `VACUUM` handles dead tuples |
+
+## References
+
+### Internal
+- `backend/internal/gitops/types.go` — `RevisionEntry`, `AppSource`, `AppDetail`
+- `backend/internal/gitops/argocd.go:197-220` — `extractArgoHistory` (revision extraction)
+- `backend/internal/gitops/handler.go:28-105` — singleflight + cache pattern to follow
+- `backend/internal/store/settings.go` — `AppSettings` struct, `MaskedSettings()` pattern
+- `backend/internal/store/encrypt.go` — AES-256-GCM encryption
+- `frontend/islands/GitOpsAppDetail.tsx:424-503` — revision history table
+- `frontend/lib/gitops-types.ts:59-64` — `RevisionEntry` TypeScript interface
+
+### External
+- [GitHub REST API - Get a Commit](https://docs.github.com/en/rest/commits/commits#get-a-commit)
+- [google/go-github v83](https://github.com/google/go-github)
+- [Argo CD - RevisionMetadata](https://github.com/argoproj/argo-cd/blob/master/util/git/client.go)


### PR DESCRIPTION
## Summary
- New `internal/gitprovider/` package: GitHub API adapter (`google/go-github/v83`), URL parser, PostgreSQL commit cache with singleflight
- New `GET /api/v1/gitops/commits?repoURL=...&shas=...` endpoint with RBAC validation (repoURL must match a user-visible app)
- Frontend async enrichment: after detail page loads, fetches commit metadata and populates the Message column with title + author + clickable links
- GitHub token stored in existing `app_settings` table — masked in API responses, encrypted at rest
- Migration `000006`: `git_commit_cache` table (JSONB) + `github_token` column on `app_settings`

## Architecture
- **Separate endpoint** (not inline enrichment) — follows async Prometheus pattern, never blocks page load
- **PostgreSQL-only cache** + `singleflight` — no LRU; commits are immutable, PK lookup is sub-ms
- **Concrete `GitHubClient`** — no Provider interface until GitLab/Bitbucket needed
- **Token in `app_settings`** — no new CRUD UI, uses existing settings page

## New files (5)
- `backend/internal/gitprovider/parse.go` — URL parsing (HTTPS, SSH, .git normalization)
- `backend/internal/gitprovider/github.go` — GitHub adapter with rate limit handling
- `backend/internal/gitprovider/cache.go` — CommitCache: PostgreSQL + singleflight + response types
- `backend/internal/gitprovider/parse_test.go` — 18 URL format tests
- `backend/internal/gitprovider/github_test.go` — 3 tests (success, 404, rate limit) with httptest

## Test plan
- [ ] CI passes (go vet, go test, deno lint, deno build)
- [ ] With GitHub token configured: Argo CD app detail shows commit messages + authors
- [ ] Without token: revision table shows "-" gracefully (no errors)
- [ ] Commit SHAs and titles link to GitHub commit page
- [ ] Navigation away cancels in-flight fetch (AbortController)
- [ ] Cached commits served instantly on subsequent page loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)