### PR TITLE
feat: diff view — compare links between GitOps revision deployments

### DIFF
--- a/frontend/islands/GitOpsAppDetail.tsx
+++ b/frontend/islands/GitOpsAppDetail.tsx
@@ -234,6 +234,9 @@ export default function GitOpsAppDetail({ id }: { id: string }) {
   const { app, resources, history } = detail.value;
   const isArgo = app.tool === "argocd";
   const isSyncing = app.syncStatus === "progressing";
+  const compareBase = /^https?:\/\//i.test(app.source.repoURL ?? "")
+    ? app.source.repoURL!.replace(/\.git$/, "")
+    : null;
 
   return (
     <div class="p-6">
@@ -500,6 +503,7 @@ export default function GitOpsAppDetail({ id }: { id: string }) {
                     const shortSha = h.revision.length > 7
                       ? h.revision.slice(0, 7)
                       : h.revision;
+                    const prevRevision = i > 0 ? history[i - 1].revision : null;
                     return (
                       <tr key={`${h.revision}-${i}`} class="hover:bg-hover/30">
                         <td class="px-3 py-2 font-mono text-text-primary">
@@ -515,6 +519,17 @@ export default function GitOpsAppDetail({ id }: { id: string }) {
                               </a>
                             )
                             : shortSha}
+                          {compareBase && prevRevision && (
+                            <a
+                              href={`${compareBase}/compare/${prevRevision}...${h.revision}`}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              class="ml-2 text-xs text-text-muted hover:text-brand"
+                              title="Compare with previous deployment"
+                            >
+                              diff
+                            </a>
+                          )}
                         </td>
                         <td class="px-3 py-2">
                           <span style={{ color: syncColor }}>{h.status}</span>

--- a/plans/step-33-diff-view.md
+++ b/plans/step-33-diff-view.md
@@ -1,0 +1,63 @@
+# Step 33: Diff View — Compare GitOps Revisions
+
+## Overview
+
+Add compare links to the GitOps revision history table. Each row links to GitHub's compare view showing what changed since the previous deployment. Frontend-only — zero backend changes.
+
+## Problem Statement
+
+Users see revision SHAs but have no quick way to see what changed between deployments. They must manually navigate to GitHub and construct compare URLs. This feature automates that with a single link per history row.
+
+## Scope
+
+**In scope:**
+- Compare link per history row opening `{repoURL}/compare/{prevSha}...{thisSha}` in new tab
+- Argo CD applications with HTTP(S) repo URLs only
+- Full SHAs in URL (no truncation)
+
+**Out of scope:**
+- In-app diff viewer or change summary panel (GitHub's compare UI is better than anything we'd build)
+- Rendered manifest diff (would require Argo CD gRPC API, which k8sCenter doesn't use)
+- GitLab/Bitbucket compare URLs (future, trivial to add)
+- Flux Kustomization comparison (no history)
+
+## Implementation
+
+**Files to modify (1):**
+- `frontend/islands/GitOpsAppDetail.tsx`
+
+**Changes (~15 LOC):**
+
+1. Compute `canCompare` once from `app.source.repoURL`:
+```tsx
+const canCompare = repoURL && /^https?:\/\//i.test(repoURL);
+const compareBase = canCompare ? repoURL!.replace(/\.git$/, "") : null;
+```
+
+2. In the history table row, add a compare link after the SHA:
+```tsx
+const prevRevision = i < history.length - 1 ? history[i + 1].revision : null;
+// ...
+{canCompare && prevRevision && (
+  <a href={`${compareBase}/compare/${prevRevision}...${h.revision}`}
+     target="_blank" rel="noopener noreferrer"
+     class="text-xs text-brand hover:underline ml-2">
+    compare
+  </a>
+)}
+```
+
+**Assumption:** History is ordered most-recent-first, so `history[i+1]` is the previous deployment. Verify in `extractArgoHistory`.
+
+## Success Criteria
+
+- [ ] Each history row (except oldest) shows a "compare" link
+- [ ] Clicking opens GitHub's compare view in a new tab
+- [ ] Link absent for non-HTTP repo URLs and oldest entry
+- [ ] `deno lint` and `deno fmt --check` pass
+
+## References
+
+- `frontend/islands/GitOpsAppDetail.tsx:462-579` — revision history table
+- `backend/internal/gitops/argocd.go:197-220` — `extractArgoHistory` (verify sort order)
+- [GitHub Compare URL format](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/viewing-and-comparing-commits/comparing-commits)


### PR DESCRIPTION
## Summary
- Adds inline "diff" link per revision history row that opens GitHub's compare view between adjacent deployments
- URL format: `{repoURL}/compare/{previousSha}...{currentSha}`
- Zero backend changes — uses data already in the AppDetail response
- Only shown for HTTP(S) repo URLs; oldest history entry has no link

## Implementation
- ~15 LOC added to `GitOpsAppDetail.tsx`
- `compareBase` computed once from `app.source.repoURL` (stripped `.git`, validated HTTPS scheme)
- `prevRevision` is `history[i-1]` (history is chronological, oldest-first from Argo CD CRD)
- Full SHAs used in URLs (no truncation)

## Test plan
- [ ] CI passes (deno lint, deno build)
- [ ] Argo CD app with GitHub repo: "diff" links appear on all history rows except oldest
- [ ] Clicking "diff" opens GitHub compare view in new tab
- [ ] Non-HTTP repo URLs (SSH, Flux GitRepository refs): no "diff" link shown
- [ ] App with single history entry: no "diff" link

🤖 Generated with [Claude Code](https://claude.com/claude-code)