### PR TITLE
fix: IPAM status crash when allocated/total are zero

### DIFF
--- a/backend/internal/networking/types.go
+++ b/backend/internal/networking/types.go
@@ -22,9 +22,9 @@ type CiliumIPAMResponse struct {
 	Configured     bool       `json:"configured"`
 	Mode           string     `json:"mode,omitempty"`
 	PodCIDRs       []string   `json:"podCIDRs,omitempty"`
-	Allocated      int        `json:"allocated,omitempty"`
-	Available      int        `json:"available,omitempty"`
-	Total          int        `json:"total,omitempty"`
+	Allocated      int        `json:"allocated"`
+	Available      int        `json:"available"`
+	Total          int        `json:"total"`
 	ExhaustionRisk string     `json:"exhaustionRisk,omitempty"` // none, medium, high
 	PerNode        []NodeIPAM `json:"perNode,omitempty"`
 }

--- a/frontend/islands/IpamStatus.tsx
+++ b/frontend/islands/IpamStatus.tsx
@@ -35,8 +35,11 @@ export default function IpamStatus() {
     );
   }
 
-  const pct = resp.total > 0
-    ? Math.round((resp.allocated / resp.total) * 100)
+  const allocated = resp.allocated ?? 0;
+  const total = resp.total ?? 0;
+
+  const pct = total > 0
+    ? Math.round((allocated / total) * 100)
     : 0;
 
   const riskVariant = resp.exhaustionRisk === "high"
@@ -70,7 +73,7 @@ export default function IpamStatus() {
         <div class="flex justify-between">
           <span class="text-text-muted">Allocated</span>
           <span class="font-mono text-sm text-text-primary">
-            {resp.allocated.toLocaleString()} / {resp.total.toLocaleString()}
+            {allocated.toLocaleString()} / {total.toLocaleString()}
           </span>
         </div>
         {/* Progress bar */}
@@ -84,7 +87,7 @@ export default function IpamStatus() {
                 : resp.exhaustionRisk === "medium"
                 ? "var(--warning)"
                 : "var(--accent)",
-              minWidth: resp.allocated > 0 ? "4px" : "0",
+              minWidth: allocated > 0 ? "4px" : "0",
             }}
           />
         </div>

--- a/frontend/islands/IpamStatus.tsx
+++ b/frontend/islands/IpamStatus.tsx
@@ -38,9 +38,7 @@ export default function IpamStatus() {
   const allocated = resp.allocated ?? 0;
   const total = resp.total ?? 0;
 
-  const pct = total > 0
-    ? Math.round((allocated / total) * 100)
-    : 0;
+  const pct = total > 0 ? Math.round((allocated / total) * 100) : 0;
 
   const riskVariant = resp.exhaustionRisk === "high"
     ? "danger"


### PR DESCRIPTION
## Summary
- **Root cause:** `CiliumIPAMResponse` Go struct used `omitempty` on `allocated`, `available`, `total` int fields. When values are `0`, Go's JSON encoder omits them entirely, so the frontend receives `{ configured: true }` with no numeric fields → `undefined.toLocaleString()` crash.
- **Backend fix:** Removed `omitempty` from the three int fields so zero values are always serialized.
- **Frontend fix:** Added `?? 0` nullish coalescing as a defensive guard.

## Test plan
- [ ] CI passes (go vet, deno lint)
- [ ] Deploy to homelab and verify IPAM card renders without console errors
- [ ] Verify IPAM card still shows correct data when Cilium is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)