### PR TITLE
fix: patch OpenSSL CVEs in frontend distroless image

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -30,14 +30,18 @@ RUN find /app/node_modules -path '*/esbuild/bin/esbuild' -delete 2>/dev/null; \
 FROM denoland/deno:distroless-2.7.11 AS runtime-base
 FROM debian:trixie-slim AS security-patch
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends libssl3t64 && \
+    apt-get install -y --no-install-recommends libssl3t64=3.5.5-1~deb13u2 && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir -p /patch/usr/lib && \
     dpkg -L libssl3t64 | grep '/usr/lib' | while read f; do \
       [ -f "$f" ] && mkdir -p "/patch$(dirname "$f")" && cp -a "$f" "/patch$f"; \
     done
-# Update the distroless dpkg status.d entry so Trivy sees the patched version
+# Update the distroless dpkg status.d entry so Trivy sees the patched version.
+# TEMPORARY: remove this entire security-patch stage once the distroless base
+# ships with libssl3t64 >= 3.5.5-1~deb13u2.
 COPY --from=runtime-base /var/lib/dpkg/status.d/libssl3t64 /tmp/libssl3t64-orig
+RUN grep -q '3\.5\.5-1~deb13u1' /tmp/libssl3t64-orig || \
+    (echo "ERROR: base image no longer contains libssl3t64 3.5.5-1~deb13u1 — remove the security-patch stage" && exit 1)
 RUN sed 's/3\.5\.5-1~deb13u1/3.5.5-1~deb13u2/g' /tmp/libssl3t64-orig > /patch/libssl3t64-status
 
 # Stage 2: Production runtime (uses target platform — arm64 or amd64)

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -23,9 +23,30 @@ RUN find /app/node_modules -path '*/esbuild/bin/esbuild' -delete 2>/dev/null; \
     find /deno-dir -path '*/@esbuild/*/bin/esbuild' -delete 2>/dev/null; \
     true
 
+# Security patch stage: update OpenSSL to fix CVE-2026-31790, CVE-2026-2673,
+# CVE-2026-28387, CVE-2026-28388, CVE-2026-28389, CVE-2026-28390, CVE-2026-31789
+# (libssl3t64 3.5.5-1~deb13u1 → 3.5.5-1~deb13u2)
+# Uses target platform so library arch paths match the distroless runtime.
+FROM denoland/deno:distroless-2.7.11 AS runtime-base
+FROM debian:trixie-slim AS security-patch
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libssl3t64 && \
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir -p /patch/usr/lib && \
+    dpkg -L libssl3t64 | grep '/usr/lib' | while read f; do \
+      [ -f "$f" ] && mkdir -p "/patch$(dirname "$f")" && cp -a "$f" "/patch$f"; \
+    done
+# Update the distroless dpkg status.d entry so Trivy sees the patched version
+COPY --from=runtime-base /var/lib/dpkg/status.d/libssl3t64 /tmp/libssl3t64-orig
+RUN sed 's/3\.5\.5-1~deb13u1/3.5.5-1~deb13u2/g' /tmp/libssl3t64-orig > /patch/libssl3t64-status
+
 # Stage 2: Production runtime (uses target platform — arm64 or amd64)
 # Use distroless variant to minimize OS-level CVEs (no shell, no package manager)
 FROM denoland/deno:distroless-2.7.11
+
+# Overlay patched OpenSSL libraries and updated package metadata
+COPY --from=security-patch /patch/usr/lib/ /usr/lib/
+COPY --from=security-patch /patch/libssl3t64-status /var/lib/dpkg/status.d/libssl3t64
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Patches 7 open OpenSSL CVEs in the frontend container image by overlaying `libssl3t64 3.5.5-1~deb13u2` from `debian:trixie-slim` onto the distroless runtime
- Updates the `dpkg/status.d` metadata so Trivy correctly recognizes the patched version
- Preserves the distroless security posture (no shell, no package manager in final image)

## CVEs Resolved
| Alert | CVE | Severity |
|-------|-----|----------|
| #106 | CVE-2026-31790 — RSA public key info disclosure | Medium |
| #107 | CVE-2026-2673 — TLS 1.3 key agreement group | Low |
| #108 | CVE-2026-28387 — DANE TLS verification | Low |
| #109 | CVE-2026-28388 — Delta CRL indicator | Low |
| #110 | CVE-2026-28389 — CMS EnvelopedData | Low |
| #111 | CVE-2026-28390 — CMS EnvelopedData DoS | Low |
| #112 | CVE-2026-31789 — OCTET STRING conversion | Low |

## How it works
1. New `security-patch` stage pulls `libssl3t64` from `debian:trixie-slim` (target platform)
2. Extracts only the 4 OpenSSL library files via `dpkg -L` (surgical, not a full `/usr/lib` copy)
3. Overlays them onto the distroless runtime base
4. Patches the `status.d/libssl3t64` dpkg metadata so scanners see the correct version

## Test plan
- [x] Docker build succeeds (3-stage: builder, security-patch, runtime)
- [x] Trivy scan confirms 0 libssl/libcrypto CVEs in built image
- [x] Remaining findings are unrelated (glibc, zlib — no fix available)
- [ ] CI passes (Docker build + Trivy scan in workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)