### PR TITLE
feat: Cilium agent collector — WireGuard, ClusterMesh, connectivity diagnostics

### DIFF
--- a/backend/cmd/kubecenter/main.go
+++ b/backend/cmd/kubecenter/main.go
@@ -302,7 +302,7 @@ func main() {
 
 	var agentCollector *networking.CiliumAgentCollector
 	if cfg.CiliumAgent.ExecEnabled {
-		agentCollector = networking.NewCiliumAgentCollector(k8sClient, auditLogger, logger)
+		agentCollector = networking.NewCiliumAgentCollector(k8sClient, auditLogger, logger, cfg.ClusterID)
 		logger.Info("cilium agent exec collector enabled")
 	}
 

--- a/backend/cmd/kubecenter/main.go
+++ b/backend/cmd/kubecenter/main.go
@@ -300,13 +300,20 @@ func main() {
 		}
 	}
 
+	var agentCollector *networking.CiliumAgentCollector
+	if cfg.CiliumAgent.ExecEnabled {
+		agentCollector = networking.NewCiliumAgentCollector(k8sClient, auditLogger, logger)
+		logger.Info("cilium agent exec collector enabled")
+	}
+
 	networkingHandler := &networking.Handler{
-		K8sClient:    k8sClient,
-		Detector:     cniDetector,
-		HubbleClient: hubbleClient,
-		AuditLogger:  auditLogger,
-		Logger:       logger,
-		ClusterID:    cfg.ClusterID,
+		K8sClient:      k8sClient,
+		Detector:       cniDetector,
+		HubbleClient:   hubbleClient,
+		AuditLogger:    auditLogger,
+		Logger:         logger,
+		ClusterID:      cfg.ClusterID,
+		AgentCollector: agentCollector,
 	}
 
 	// Initialize alerting

--- a/backend/internal/audit/logger.go
+++ b/backend/internal/audit/logger.go
@@ -25,6 +25,7 @@ const (
 	ActionAlertSettingsUpdate Action = "alert_settings_update"
 	ActionAlertTest          Action = "alert_test"
 	ActionReadLogs           Action = "read_logs"
+	ActionAgentExec          Action = "agent_exec"
 	ActionGitOpsSync         Action = "gitops_sync"
 	ActionGitOpsSuspend      Action = "gitops_suspend"
 	ActionGitOpsResume       Action = "gitops_resume"

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -23,7 +23,8 @@ type Config struct {
 	Database   DatabaseConfig   `koanf:"database"`
 	Dev        bool             `koanf:"dev"`
 	ClusterID  string           `koanf:"clusterid"`
-	CORS       CORSConfig       `koanf:"cors"`
+	CORS        CORSConfig       `koanf:"cors"`
+	CiliumAgent CiliumAgentConfig `koanf:"ciliumagent"`
 }
 
 // AuditConfig holds configuration for audit logging.
@@ -105,6 +106,11 @@ type LogConfig struct {
 
 type CORSConfig struct {
 	AllowedOrigins []string `koanf:"allowedorigins"`
+}
+
+// CiliumAgentConfig controls opt-in exec-based Cilium agent diagnostics.
+type CiliumAgentConfig struct {
+	ExecEnabled bool `koanf:"execenabled"` // KUBECENTER_CILIUMAGENT_EXECENABLED
 }
 
 // LokiConfig holds configuration for Loki log aggregation integration.

--- a/backend/internal/networking/agent_exec.go
+++ b/backend/internal/networking/agent_exec.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/kubecenter/kubecenter/internal/audit"
@@ -29,11 +30,18 @@ const (
 	agentContainer     = "cilium-agent"
 )
 
-var agentCommand = []string{"cilium-dbg", "status", "-o", "json"}
+// agentCommandArgs returns the command to run in Cilium agent pods.
+// Returns a fresh slice to prevent accidental mutation of the shared command.
+func agentCommandArgs() []string {
+	return []string{"cilium-dbg", "status", "-o", "json"}
+}
 
-var agentPodLabels = []string{
-	"app.kubernetes.io/name=cilium-agent",
-	"k8s-app=cilium",
+// agentPodLabelSelectors returns the label selectors for finding Cilium agent pods.
+func agentPodLabelSelectors() []string {
+	return []string{
+		"app.kubernetes.io/name=cilium-agent",
+		"k8s-app=cilium",
+	}
 }
 
 // CiliumAgentCollector execs cilium-dbg into Cilium agent pods to collect
@@ -43,18 +51,21 @@ type CiliumAgentCollector struct {
 	k8sClient   *k8s.ClientFactory
 	auditLogger audit.Logger
 	logger      *slog.Logger
+	clusterID   string
 
-	group   singleflight.Group
-	cacheMu sync.RWMutex
-	cache   *agentCollectionResult
+	group    singleflight.Group
+	cacheMu  sync.RWMutex
+	cache    *agentCollectionResult
+	cacheGen uint64
 }
 
 // NewCiliumAgentCollector creates a collector for Cilium agent diagnostics.
-func NewCiliumAgentCollector(k8sClient *k8s.ClientFactory, auditLogger audit.Logger, logger *slog.Logger) *CiliumAgentCollector {
+func NewCiliumAgentCollector(k8sClient *k8s.ClientFactory, auditLogger audit.Logger, logger *slog.Logger, clusterID string) *CiliumAgentCollector {
 	return &CiliumAgentCollector{
 		k8sClient:   k8sClient,
 		auditLogger: auditLogger,
 		logger:      logger,
+		clusterID:   clusterID,
 	}
 }
 
@@ -62,6 +73,7 @@ func NewCiliumAgentCollector(k8sClient *k8s.ClientFactory, auditLogger audit.Log
 func (c *CiliumAgentCollector) InvalidateCache() {
 	c.cacheMu.Lock()
 	c.cache = nil
+	atomic.AddUint64(&c.cacheGen, 1)
 	c.cacheMu.Unlock()
 }
 
@@ -92,6 +104,7 @@ func (c *CiliumAgentCollector) Collect(ctx context.Context) (*agentCollectionRes
 }
 
 func (c *CiliumAgentCollector) collect(ctx context.Context) (*agentCollectionResult, error) {
+	gen := atomic.LoadUint64(&c.cacheGen)
 	ctx, cancel := context.WithTimeout(ctx, agentOuterTimeout)
 	defer cancel()
 
@@ -134,18 +147,20 @@ func (c *CiliumAgentCollector) collect(ctx context.Context) (*agentCollectionRes
 		partial:   partial,
 	}
 
-	// Cache the result
-	c.cacheMu.Lock()
-	c.cache = result
-	c.cacheMu.Unlock()
+	// Cache the result if generation hasn't changed (prevents stale writes across invalidation)
+	if atomic.LoadUint64(&c.cacheGen) == gen {
+		c.cacheMu.Lock()
+		c.cache = result
+		c.cacheMu.Unlock()
+	}
 
 	return result, nil
 }
 
-// findAgentPods searches ciliumSearchNamespaces for pods matching agentPodLabels.
+// findAgentPods searches ciliumSearchNamespaces for pods matching agent pod label selectors.
 func (c *CiliumAgentCollector) findAgentPods(ctx context.Context, cs kubernetes.Interface) ([]corev1.Pod, error) {
 	for _, ns := range ciliumSearchNamespaces {
-		for _, labelSelector := range agentPodLabels {
+		for _, labelSelector := range agentPodLabelSelectors() {
 			pods, err := cs.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{
 				LabelSelector: labelSelector,
 			})
@@ -194,7 +209,7 @@ func (c *CiliumAgentCollector) execPod(ctx context.Context, cs kubernetes.Interf
 	}
 
 	start := time.Now()
-	stdout, stderr, err := c.execInPod(ctx, pod.Namespace, pod.Name, agentContainer, agentCommand)
+	stdout, stderr, err := c.execInPod(ctx, pod.Namespace, pod.Name, agentContainer, agentCommandArgs())
 	elapsed := time.Since(start)
 
 	outcome := "success"
@@ -226,8 +241,9 @@ func (c *CiliumAgentCollector) execPod(ctx context.Context, cs kubernetes.Interf
 		auditResult = audit.ResultFailure
 		detail += ": " + result.err
 	}
-	_ = c.auditLogger.Log(ctx, audit.Entry{
+	if err := c.auditLogger.Log(ctx, audit.Entry{
 		Timestamp:         time.Now().UTC(),
+		ClusterID:         c.clusterID,
 		User:              "system:serviceaccount",
 		Action:            audit.ActionAgentExec,
 		ResourceKind:      "Pod",
@@ -235,7 +251,9 @@ func (c *CiliumAgentCollector) execPod(ctx context.Context, cs kubernetes.Interf
 		ResourceName:      pod.Name,
 		Result:            auditResult,
 		Detail:            truncate(detail, 500),
-	})
+	}); err != nil {
+		c.logger.Warn("failed to write audit log for agent exec", "pod", pod.Name, "error", err)
+	}
 
 	return result
 }

--- a/backend/internal/networking/agent_exec.go
+++ b/backend/internal/networking/agent_exec.go
@@ -24,7 +24,7 @@ const (
 	agentCacheTTL      = 30 * time.Second
 	agentOuterTimeout  = 30 * time.Second
 	agentExecTimeout   = 5 * time.Second
-	agentMaxConcurrent = 5
+	agentMaxConcurrent = 10
 	agentMaxOutput     = 1 << 20 // 1 MB stdout cap
 	agentContainer     = "cilium-agent"
 )
@@ -77,9 +77,13 @@ func (c *CiliumAgentCollector) Collect(ctx context.Context) (*agentCollectionRes
 	}
 	c.cacheMu.RUnlock()
 
-	// Singleflight coalesces concurrent requests
+	// Singleflight coalesces concurrent requests.
+	// Use a detached context so one caller's cancellation (e.g., browser tab close)
+	// does not cascade to all coalesced waiters.
 	v, err, _ := c.group.Do("agent-collect", func() (any, error) {
-		return c.collect(ctx)
+		detached, cancel := context.WithTimeout(context.Background(), agentOuterTimeout)
+		defer cancel()
+		return c.collect(detached)
 	})
 	if err != nil {
 		return nil, err
@@ -265,9 +269,10 @@ func (c *CiliumAgentCollector) execInPod(ctx context.Context, namespace, podName
 
 	var stdout, stderr bytes.Buffer
 	lw := &limitedWriter{w: &stdout, remaining: agentMaxOutput}
+	stderrLW := &limitedWriter{w: &stderr, remaining: 64 * 1024} // 64KB stderr cap
 	err = executor.StreamWithContext(ctx, remotecommand.StreamOptions{
 		Stdout: lw,
-		Stderr: &stderr,
+		Stderr: stderrLW,
 	})
 	if err != nil {
 		return stdout.Bytes(), stderr.Bytes(), err

--- a/backend/internal/networking/agent_exec.go
+++ b/backend/internal/networking/agent_exec.go
@@ -1,0 +1,311 @@
+package networking
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/kubecenter/kubecenter/internal/audit"
+	"github.com/kubecenter/kubecenter/internal/k8s"
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/singleflight"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+const (
+	agentCacheTTL      = 30 * time.Second
+	agentOuterTimeout  = 30 * time.Second
+	agentExecTimeout   = 5 * time.Second
+	agentMaxConcurrent = 5
+	agentMaxOutput     = 1 << 20 // 1 MB stdout cap
+	agentContainer     = "cilium-agent"
+)
+
+var agentCommand = []string{"cilium-dbg", "status", "-o", "json"}
+
+var agentPodLabels = []string{
+	"app.kubernetes.io/name=cilium-agent",
+	"k8s-app=cilium",
+}
+
+// CiliumAgentCollector execs cilium-dbg into Cilium agent pods to collect
+// diagnostic data (WireGuard peers, ClusterMesh, Envoy proxy, node health).
+// Uses service account credentials (not user impersonation) — see plan for rationale.
+type CiliumAgentCollector struct {
+	k8sClient   *k8s.ClientFactory
+	auditLogger audit.Logger
+	logger      *slog.Logger
+
+	group   singleflight.Group
+	cacheMu sync.RWMutex
+	cache   *agentCollectionResult
+}
+
+// NewCiliumAgentCollector creates a collector for Cilium agent diagnostics.
+func NewCiliumAgentCollector(k8sClient *k8s.ClientFactory, auditLogger audit.Logger, logger *slog.Logger) *CiliumAgentCollector {
+	return &CiliumAgentCollector{
+		k8sClient:   k8sClient,
+		auditLogger: auditLogger,
+		logger:      logger,
+	}
+}
+
+// InvalidateCache clears the agent collection cache.
+func (c *CiliumAgentCollector) InvalidateCache() {
+	c.cacheMu.Lock()
+	c.cache = nil
+	c.cacheMu.Unlock()
+}
+
+// Collect runs cilium-dbg status on all Cilium agent pods and returns parsed results.
+// Results are cached for 30s and coalesced via singleflight.
+func (c *CiliumAgentCollector) Collect(ctx context.Context) (*agentCollectionResult, error) {
+	// Check cache
+	c.cacheMu.RLock()
+	if c.cache != nil && time.Since(c.cache.collected) < agentCacheTTL {
+		result := c.cache
+		c.cacheMu.RUnlock()
+		return result, nil
+	}
+	c.cacheMu.RUnlock()
+
+	// Singleflight coalesces concurrent requests
+	v, err, _ := c.group.Do("agent-collect", func() (any, error) {
+		return c.collect(ctx)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return v.(*agentCollectionResult), nil
+}
+
+func (c *CiliumAgentCollector) collect(ctx context.Context) (*agentCollectionResult, error) {
+	ctx, cancel := context.WithTimeout(ctx, agentOuterTimeout)
+	defer cancel()
+
+	cs := c.k8sClient.BaseClientset()
+
+	// Find Cilium agent pods
+	pods, err := c.findAgentPods(ctx, cs)
+	if err != nil {
+		return nil, fmt.Errorf("finding cilium agent pods: %w", err)
+	}
+	if len(pods) == 0 {
+		return nil, fmt.Errorf("no cilium agent pods found")
+	}
+
+	// Exec into pods concurrently with bounded parallelism
+	results := make([]agentNodeResult, len(pods))
+	g, gCtx := errgroup.WithContext(ctx)
+	g.SetLimit(agentMaxConcurrent)
+
+	for i, pod := range pods {
+		g.Go(func() error {
+			results[i] = c.execPod(gCtx, cs, pod)
+			return nil // errors captured per-node
+		})
+	}
+	_ = g.Wait() // always nil — per-node errors in results
+
+	// Build result
+	partial := false
+	for _, r := range results {
+		if r.err != "" {
+			partial = true
+			break
+		}
+	}
+
+	result := &agentCollectionResult{
+		nodes:     results,
+		collected: time.Now(),
+		partial:   partial,
+	}
+
+	// Cache the result
+	c.cacheMu.Lock()
+	c.cache = result
+	c.cacheMu.Unlock()
+
+	return result, nil
+}
+
+// findAgentPods searches ciliumSearchNamespaces for pods matching agentPodLabels.
+func (c *CiliumAgentCollector) findAgentPods(ctx context.Context, cs kubernetes.Interface) ([]corev1.Pod, error) {
+	for _, ns := range ciliumSearchNamespaces {
+		for _, labelSelector := range agentPodLabels {
+			pods, err := cs.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{
+				LabelSelector: labelSelector,
+			})
+			if err != nil {
+				continue
+			}
+			if len(pods.Items) > 0 {
+				// Filter to running pods in expected namespaces
+				var valid []corev1.Pod
+				for _, p := range pods.Items {
+					if p.Status.Phase != corev1.PodRunning {
+						continue
+					}
+					if !isAllowedNamespace(p.Namespace) {
+						c.logger.Warn("cilium agent pod in unexpected namespace, skipping",
+							"pod", p.Name, "namespace", p.Namespace)
+						continue
+					}
+					valid = append(valid, p)
+				}
+				if len(valid) > 0 {
+					return valid, nil
+				}
+			}
+		}
+	}
+	return nil, nil
+}
+
+// isAllowedNamespace checks the pod is in an expected namespace.
+func isAllowedNamespace(ns string) bool {
+	for _, allowed := range ciliumSearchNamespaces {
+		if ns == allowed {
+			return true
+		}
+	}
+	return false
+}
+
+// execPod runs cilium-dbg status in a single pod and returns the parsed result.
+func (c *CiliumAgentCollector) execPod(ctx context.Context, cs kubernetes.Interface, pod corev1.Pod) agentNodeResult {
+	nodeName := pod.Spec.NodeName
+	result := agentNodeResult{
+		nodeName: nodeName,
+		podName:  pod.Name,
+	}
+
+	start := time.Now()
+	stdout, stderr, err := c.execInPod(ctx, pod.Namespace, pod.Name, agentContainer, agentCommand)
+	elapsed := time.Since(start)
+
+	outcome := "success"
+	if err != nil {
+		outcome = "exec_error"
+		result.err = fmt.Sprintf("exec failed: %v (stderr: %s)", err, truncate(string(stderr), 200))
+		c.logger.Warn("agent exec failed",
+			"pod", pod.Name, "node", nodeName, "duration", elapsed, "outcome", outcome, "error", err)
+	} else {
+		var status ciliumAgentStatus
+		if parseErr := json.Unmarshal(stdout, &status); parseErr != nil {
+			outcome = "parse_error"
+			result.err = fmt.Sprintf("JSON parse failed: %v (output size: %d bytes)", parseErr, len(stdout))
+			c.logger.Warn("agent exec parse failed",
+				"pod", pod.Name, "node", nodeName, "duration", elapsed, "outcome", outcome,
+				"outputSize", len(stdout), "error", parseErr)
+		} else {
+			result.status = &status
+			c.logger.Info("agent exec",
+				"pod", pod.Name, "node", nodeName, "duration", elapsed, "outcome", outcome)
+		}
+	}
+
+	// Audit log
+	auditResult := audit.ResultSuccess
+	detail := fmt.Sprintf("cilium-dbg status on %s/%s (node: %s, duration: %s, outcome: %s)",
+		pod.Namespace, pod.Name, nodeName, elapsed.Round(time.Millisecond), outcome)
+	if result.err != "" {
+		auditResult = audit.ResultFailure
+		detail += ": " + result.err
+	}
+	_ = c.auditLogger.Log(ctx, audit.Entry{
+		Timestamp:         time.Now().UTC(),
+		User:              "system:serviceaccount",
+		Action:            audit.ActionAgentExec,
+		ResourceKind:      "Pod",
+		ResourceNamespace: pod.Namespace,
+		ResourceName:      pod.Name,
+		Result:            auditResult,
+		Detail:            truncate(detail, 500),
+	})
+
+	return result
+}
+
+// execInPod runs a non-interactive command in a pod using the service account's credentials.
+func (c *CiliumAgentCollector) execInPod(ctx context.Context, namespace, podName, container string, command []string) ([]byte, []byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, agentExecTimeout)
+	defer cancel()
+
+	cs := c.k8sClient.BaseClientset()
+	cfg := c.k8sClient.BaseConfig()
+
+	// Build exec request URL using the same pattern as pods.go:256-266
+	execReq := cs.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(podName).
+		Namespace(namespace).
+		SubResource("exec").
+		Param("container", container).
+		Param("stdout", "true").
+		Param("stderr", "true")
+
+	for _, cmd := range command {
+		execReq = execReq.Param("command", cmd)
+	}
+
+	executor, err := remotecommand.NewSPDYExecutor(cfg, "POST", execReq.URL())
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating SPDY executor: %w", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	lw := &limitedWriter{w: &stdout, remaining: agentMaxOutput}
+	err = executor.StreamWithContext(ctx, remotecommand.StreamOptions{
+		Stdout: lw,
+		Stderr: &stderr,
+	})
+	if err != nil {
+		return stdout.Bytes(), stderr.Bytes(), err
+	}
+	if lw.exceeded {
+		return stdout.Bytes(), stderr.Bytes(), fmt.Errorf("output exceeded %d byte limit", agentMaxOutput)
+	}
+
+	return stdout.Bytes(), stderr.Bytes(), nil
+}
+
+// limitedWriter wraps an io.Writer and stops accepting data after a limit.
+type limitedWriter struct {
+	w         io.Writer
+	remaining int
+	exceeded  bool
+}
+
+func (lw *limitedWriter) Write(p []byte) (int, error) {
+	if lw.remaining <= 0 {
+		lw.exceeded = true
+		return len(p), nil // discard but don't error to let stream finish
+	}
+	if len(p) > lw.remaining {
+		lw.exceeded = true
+		n, err := lw.w.Write(p[:lw.remaining])
+		lw.remaining = 0
+		return n + (len(p) - n), err // report full length to avoid short write errors
+	}
+	n, err := lw.w.Write(p)
+	lw.remaining -= n
+	return n, err
+}
+
+// truncate shortens a string to maxLen, appending "..." if truncated.
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
+}

--- a/backend/internal/networking/agent_types.go
+++ b/backend/internal/networking/agent_types.go
@@ -1,0 +1,82 @@
+package networking
+
+import "time"
+
+// ciliumAgentStatus is a minimal subset of cilium-dbg's StatusResponse.
+type ciliumAgentStatus struct {
+	Encryption *agentEncryption  `json:"encryption,omitempty"`
+	ClusterMesh *agentClusterMesh `json:"cluster-mesh,omitempty"`
+	Proxy      *agentProxy       `json:"proxy,omitempty"`
+	Cluster    *agentCluster     `json:"cluster,omitempty"`
+}
+
+type agentEncryption struct {
+	Mode      string          `json:"mode,omitempty"`
+	Msg       string          `json:"msg,omitempty"`
+	Wireguard *agentWireguard `json:"wireguard,omitempty"`
+}
+
+type agentWireguard struct {
+	Interfaces []agentWGInterface `json:"interfaces"`
+}
+
+type agentWGInterface struct {
+	Name       string         `json:"name,omitempty"`
+	PublicKey  string         `json:"public-key,omitempty"`
+	ListenPort int64          `json:"listen-port,omitempty"`
+	PeerCount  int64          `json:"peer-count,omitempty"`
+	Peers      []agentWGPeer  `json:"peers"`
+}
+
+type agentWGPeer struct {
+	PublicKey         string `json:"public-key,omitempty"`
+	Endpoint          string `json:"endpoint,omitempty"`
+	LastHandshakeTime string `json:"last-handshake-time,omitempty"`
+	TransferRx        int64  `json:"transfer-rx,omitempty"`
+	TransferTx        int64  `json:"transfer-tx,omitempty"`
+}
+
+type agentClusterMesh struct {
+	Clusters []agentRemoteCluster `json:"clusters"`
+}
+
+type agentRemoteCluster struct {
+	Name              string `json:"name,omitempty"`
+	Connected         bool   `json:"connected,omitempty"`
+	Ready             bool   `json:"ready,omitempty"`
+	Status            string `json:"status,omitempty"`
+	NumNodes          int64  `json:"num-nodes,omitempty"`
+	NumEndpoints      int64  `json:"num-endpoints,omitempty"`
+	NumSharedServices int64  `json:"num-shared-services,omitempty"`
+	NumFailures       int64  `json:"num-failures,omitempty"`
+	LastFailure       string `json:"last-failure,omitempty"`
+}
+
+type agentProxy struct {
+	DeploymentMode string `json:"envoy-deployment-mode,omitempty"`
+	TotalRedirects int64  `json:"total-redirects,omitempty"`
+	TotalPorts     int64  `json:"total-ports,omitempty"`
+}
+
+type agentCluster struct {
+	CiliumHealth *agentCiliumHealth `json:"ciliumHealth,omitempty"`
+}
+
+type agentCiliumHealth struct {
+	State string `json:"state,omitempty"`
+	Msg   string `json:"msg,omitempty"`
+}
+
+// agentCollectionResult holds parsed results from all agent pods.
+type agentCollectionResult struct {
+	nodes     []agentNodeResult
+	collected time.Time
+	partial   bool
+}
+
+type agentNodeResult struct {
+	nodeName string
+	podName  string
+	status   *ciliumAgentStatus
+	err      string
+}

--- a/backend/internal/networking/detect.go
+++ b/backend/internal/networking/detect.go
@@ -257,7 +257,7 @@ func (d *Detector) detectCiliumFeatures(ctx context.Context) CNIFeatures {
 
 // DetectMesh returns the active service mesh engine based on cached feature detection.
 // Returns "cilium" if Cilium's Envoy-based mesh is enabled, "none" otherwise.
-// Istio/Linkerd detection is deferred to Phase B.
+// Istio/Linkerd detection is deferred to Phase C (needs per-mesh adapter + test environment).
 func (d *Detector) DetectMesh() string {
 	info := d.CachedInfo()
 	if info != nil && info.Features.EnvoyEnabled {

--- a/backend/internal/networking/handler.go
+++ b/backend/internal/networking/handler.go
@@ -693,11 +693,14 @@ func mergeAgentIntoSubsystems(resp *CiliumSubsystemsResponse, agent *agentCollec
 			}
 		}
 
-		// Mesh: Envoy proxy data (take from first node that reports it)
-		if resp.Mesh != nil && node.status.Proxy != nil && resp.Mesh.DeploymentMode == "" {
-			resp.Mesh.DeploymentMode = node.status.Proxy.DeploymentMode
-			resp.Mesh.TotalRedirects = node.status.Proxy.TotalRedirects
-			resp.Mesh.TotalPorts = node.status.Proxy.TotalPorts
+		// Mesh: Envoy proxy data — DeploymentMode from first node (uniform across cluster),
+		// TotalRedirects/TotalPorts aggregated across all nodes.
+		if resp.Mesh != nil && node.status.Proxy != nil {
+			if resp.Mesh.DeploymentMode == "" {
+				resp.Mesh.DeploymentMode = node.status.Proxy.DeploymentMode
+			}
+			resp.Mesh.TotalRedirects += node.status.Proxy.TotalRedirects
+			resp.Mesh.TotalPorts += node.status.Proxy.TotalPorts
 		}
 
 		// ClusterMesh: remote clusters (take from first node that reports it)

--- a/backend/internal/networking/handler.go
+++ b/backend/internal/networking/handler.go
@@ -54,6 +54,9 @@ type Handler struct {
 	ipamGroup singleflight.Group
 	ipamMu    sync.RWMutex
 	ipamCache *cachedIPAM
+
+	// Phase B: opt-in Cilium agent exec collector (nil when disabled).
+	AgentCollector *CiliumAgentCollector
 }
 
 const cacheTTL = 30 * time.Second
@@ -87,6 +90,10 @@ func (h *Handler) InvalidateCaches() {
 	h.ipamMu.Lock()
 	h.ipamCache = nil
 	h.ipamMu.Unlock()
+
+	if h.AgentCollector != nil {
+		h.AgentCollector.InvalidateCache()
+	}
 
 	atomic.AddUint64(&h.cacheGen, 1)
 }
@@ -621,6 +628,16 @@ func (h *Handler) fetchSubsystems(ctx context.Context) (*CiliumSubsystemsRespons
 		Endpoints:   &endpoints,
 	}
 
+	// Agent enrichment (opt-in, additive — never replaces CRD data)
+	if h.AgentCollector != nil {
+		agentResult, agentErr := h.AgentCollector.Collect(ctx)
+		if agentErr != nil {
+			h.Logger.Warn("agent collection failed, returning CRD-only data", "error", agentErr)
+		} else {
+			mergeAgentIntoSubsystems(resp, agentResult)
+		}
+	}
+
 	// Cache the result if generation hasn't changed
 	if atomic.LoadUint64(&h.cacheGen) == gen {
 		h.subsystemMu.Lock()
@@ -629,6 +646,128 @@ func (h *Handler) fetchSubsystems(ctx context.Context) (*CiliumSubsystemsRespons
 	}
 
 	return resp, nil
+}
+
+// mergeAgentIntoSubsystems enriches a CRD-based subsystems response with data
+// collected from Cilium agent pods. Only successful nodes contribute; failed
+// nodes retain their CRD-only data.
+func mergeAgentIntoSubsystems(resp *CiliumSubsystemsResponse, agent *agentCollectionResult) {
+	if agent == nil {
+		return
+	}
+
+	for _, node := range agent.nodes {
+		if node.status == nil {
+			continue
+		}
+
+		// Encryption: WireGuard peer data
+		if resp.Encryption != nil && node.status.Encryption != nil && node.status.Encryption.Wireguard != nil {
+			for _, iface := range node.status.Encryption.Wireguard.Interfaces {
+				wgNode := WireGuardNode{
+					NodeName:   node.nodeName,
+					PublicKey:  iface.PublicKey,
+					ListenPort: iface.ListenPort,
+					PeerCount:  iface.PeerCount,
+				}
+				for _, peer := range iface.Peers {
+					wgNode.Peers = append(wgNode.Peers, WireGuardPeer{
+						PublicKey:     peer.PublicKey,
+						Endpoint:      peer.Endpoint,
+						LastHandshake: peer.LastHandshakeTime,
+						TransferRx:    peer.TransferRx,
+						TransferTx:    peer.TransferTx,
+					})
+				}
+				if wgNode.Peers == nil {
+					wgNode.Peers = []WireGuardPeer{}
+				}
+				resp.Encryption.WireGuardNodes = append(resp.Encryption.WireGuardNodes, wgNode)
+			}
+		}
+
+		// Mesh: Envoy proxy data (take from first node that reports it)
+		if resp.Mesh != nil && node.status.Proxy != nil && resp.Mesh.DeploymentMode == "" {
+			resp.Mesh.DeploymentMode = node.status.Proxy.DeploymentMode
+			resp.Mesh.TotalRedirects = node.status.Proxy.TotalRedirects
+			resp.Mesh.TotalPorts = node.status.Proxy.TotalPorts
+		}
+
+		// ClusterMesh: remote clusters (take from first node that reports it)
+		if resp.ClusterMesh != nil && node.status.ClusterMesh != nil && resp.ClusterMesh.RemoteClusters == nil {
+			for _, rc := range node.status.ClusterMesh.Clusters {
+				resp.ClusterMesh.RemoteClusters = append(resp.ClusterMesh.RemoteClusters, RemoteCluster{
+					Name:              rc.Name,
+					Connected:         rc.Connected,
+					Ready:             rc.Ready,
+					Status:            rc.Status,
+					NumNodes:          rc.NumNodes,
+					NumEndpoints:      rc.NumEndpoints,
+					NumSharedServices: rc.NumSharedServices,
+					NumFailures:       rc.NumFailures,
+					LastFailure:       rc.LastFailure,
+				})
+			}
+		}
+	}
+}
+
+// HandleCiliumConnectivity returns per-node Cilium agent health status.
+// GET /api/v1/networking/cilium/connectivity
+func (h *Handler) HandleCiliumConnectivity(w http.ResponseWriter, r *http.Request) {
+	if _, ok := httputil.RequireUser(w, r); !ok {
+		return
+	}
+
+	if !h.isCiliumLocal(r) {
+		httputil.WriteData(w, CiliumConnectivityResponse{
+			Configured: false,
+			Nodes:      []NodeConnectivity{},
+		})
+		return
+	}
+
+	if h.AgentCollector == nil {
+		httputil.WriteData(w, CiliumConnectivityResponse{
+			Configured: true,
+			Nodes:      []NodeConnectivity{},
+		})
+		return
+	}
+
+	agentResult, err := h.AgentCollector.Collect(r.Context())
+	if err != nil {
+		h.Logger.Error("agent collection failed for connectivity", "error", err)
+		httputil.WriteError(w, http.StatusBadGateway, "failed to collect Cilium agent diagnostics", "")
+		return
+	}
+
+	var nodes []NodeConnectivity
+	for _, node := range agentResult.nodes {
+		nc := NodeConnectivity{
+			NodeName:    node.nodeName,
+			HealthState: "Unknown",
+		}
+		if node.status != nil && node.status.Cluster != nil && node.status.Cluster.CiliumHealth != nil {
+			nc.HealthState = node.status.Cluster.CiliumHealth.State
+			nc.Message = node.status.Cluster.CiliumHealth.Msg
+		} else if node.err != "" {
+			nc.HealthState = "Failure"
+			nc.Message = "agent exec failed"
+		}
+		nodes = append(nodes, nc)
+	}
+	if nodes == nil {
+		nodes = []NodeConnectivity{}
+	}
+
+	httputil.WriteData(w, CiliumConnectivityResponse{
+		Configured:  true,
+		ExecEnabled: true,
+		Nodes:       nodes,
+		CollectedAt: agentResult.collected.UTC().Format(time.RFC3339),
+		Partial:     agentResult.partial,
+	})
 }
 
 // formatChangedKeys returns a sorted, comma-separated list of changed key names for audit logging.

--- a/backend/internal/networking/handler.go
+++ b/backend/internal/networking/handler.go
@@ -579,11 +579,14 @@ func (h *Handler) fetchSubsystems(ctx context.Context) (*CiliumSubsystemsRespons
 		encInfo.Mode = info.Features.EncryptionMode
 	}
 
-	// Fetch CiliumNodes and CiliumEndpoints concurrently
+	// Fetch CiliumNodes, CiliumEndpoints, and agent data concurrently
 	dynClient := h.K8sClient.BaseDynamicClient()
 
 	var nodes []ciliumNodeIPAM
 	var endpoints EndpointCounts
+	var agentResult *agentCollectionResult
+	var agentErr error
+
 	g, gCtx := errgroup.WithContext(ctx)
 	g.Go(func() error {
 		var err error
@@ -595,6 +598,13 @@ func (h *Handler) fetchSubsystems(ctx context.Context) (*CiliumSubsystemsRespons
 		endpoints, err = aggregateEndpoints(gCtx, dynClient)
 		return err
 	})
+	// Agent collection runs in parallel with CRD reads (opt-in, never fails the group)
+	if h.AgentCollector != nil {
+		g.Go(func() error {
+			agentResult, agentErr = h.AgentCollector.Collect(gCtx)
+			return nil // agent errors captured separately
+		})
+	}
 	if err := g.Wait(); err != nil {
 		// Log but continue with partial data — one may have succeeded
 		h.Logger.Warn("partial failure fetching subsystem data", "error", err)
@@ -628,14 +638,11 @@ func (h *Handler) fetchSubsystems(ctx context.Context) (*CiliumSubsystemsRespons
 		Endpoints:   &endpoints,
 	}
 
-	// Agent enrichment (opt-in, additive — never replaces CRD data)
-	if h.AgentCollector != nil {
-		agentResult, agentErr := h.AgentCollector.Collect(ctx)
-		if agentErr != nil {
-			h.Logger.Warn("agent collection failed, returning CRD-only data", "error", agentErr)
-		} else {
-			mergeAgentIntoSubsystems(resp, agentResult)
-		}
+	// Agent enrichment (additive — never replaces CRD data)
+	if agentErr != nil {
+		h.Logger.Warn("agent collection failed, returning CRD-only data", "error", agentErr)
+	} else if agentResult != nil {
+		mergeAgentIntoSubsystems(resp, agentResult)
 	}
 
 	// Cache the result if generation hasn't changed

--- a/backend/internal/networking/networking_test.go
+++ b/backend/internal/networking/networking_test.go
@@ -557,24 +557,52 @@ func TestAgentCollector_ParseMinimalJSON(t *testing.T) {
 	}
 }
 
-func TestAgentCollector_PartialFailure(t *testing.T) {
-	result := &agentCollectionResult{
+func TestMergeAgentIntoSubsystems_PartialNodes(t *testing.T) {
+	// When some nodes fail, only successful nodes contribute enrichment data
+	resp := &CiliumSubsystemsResponse{
+		Configured: true,
+		Encryption: &EncryptionInfo{Enabled: true, Mode: "wireguard"},
+		Mesh:       &MeshInfo{Enabled: true, Engine: "cilium"},
+		ClusterMesh: &ClusterMeshInfo{Enabled: false},
+	}
+	agent := &agentCollectionResult{
 		nodes: []agentNodeResult{
-			{nodeName: "node-1", podName: "cilium-1", status: &ciliumAgentStatus{}},
-			{nodeName: "node-2", podName: "cilium-2", status: &ciliumAgentStatus{}},
-			{nodeName: "node-3", podName: "cilium-3", err: "exec failed: timeout"},
+			{
+				nodeName: "node-1",
+				status: &ciliumAgentStatus{
+					Encryption: &agentEncryption{
+						Wireguard: &agentWireguard{
+							Interfaces: []agentWGInterface{{PublicKey: "key1", Peers: []agentWGPeer{}}},
+						},
+					},
+				},
+			},
+			{nodeName: "node-2", err: "exec failed: timeout"}, // failed — should be skipped
+			{
+				nodeName: "node-3",
+				status: &ciliumAgentStatus{
+					Encryption: &agentEncryption{
+						Wireguard: &agentWireguard{
+							Interfaces: []agentWGInterface{{PublicKey: "key3", Peers: []agentWGPeer{}}},
+						},
+					},
+				},
+			},
 		},
-		collected: time.Now(),
+		partial: true,
 	}
-	// Compute partial flag same way as collect()
-	for _, r := range result.nodes {
-		if r.err != "" {
-			result.partial = true
-			break
-		}
+
+	mergeAgentIntoSubsystems(resp, agent)
+
+	// Only node-1 and node-3 should contribute (node-2 failed)
+	if len(resp.Encryption.WireGuardNodes) != 2 {
+		t.Fatalf("expected 2 WireGuard nodes (skipping failed), got %d", len(resp.Encryption.WireGuardNodes))
 	}
-	if !result.partial {
-		t.Error("expected partial=true when some pods fail")
+	if resp.Encryption.WireGuardNodes[0].PublicKey != "key1" {
+		t.Errorf("first node key = %q, want %q", resp.Encryption.WireGuardNodes[0].PublicKey, "key1")
+	}
+	if resp.Encryption.WireGuardNodes[1].PublicKey != "key3" {
+		t.Errorf("second node key = %q, want %q", resp.Encryption.WireGuardNodes[1].PublicKey, "key3")
 	}
 }
 

--- a/backend/internal/networking/networking_test.go
+++ b/backend/internal/networking/networking_test.go
@@ -2,9 +2,11 @@ package networking
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -423,5 +425,359 @@ func TestIsCiliumLocal(t *testing.T) {
 			}
 		})
 	}
+}
+
+// --- Phase B: Agent Collector Tests ---
+
+func TestAgentCollector_CacheHit(t *testing.T) {
+	c := &CiliumAgentCollector{}
+	cached := &agentCollectionResult{
+		nodes:     []agentNodeResult{{nodeName: "node-1", podName: "cilium-abc"}},
+		collected: time.Now(),
+		partial:   false,
+	}
+	c.cache = cached
+
+	result, err := c.Collect(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != cached {
+		t.Error("expected cached result to be returned")
+	}
+}
+
+func TestAgentCollector_PodValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		allowed   bool
+	}{
+		{"kube-system is allowed", "kube-system", true},
+		{"cilium is allowed", "cilium", true},
+		{"default is rejected", "default", false},
+		{"monitoring is rejected", "monitoring", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isAllowedNamespace(tt.namespace)
+			if got != tt.allowed {
+				t.Errorf("isAllowedNamespace(%q) = %v, want %v", tt.namespace, got, tt.allowed)
+			}
+		})
+	}
+}
+
+func TestAgentCollector_ParseMinimalJSON(t *testing.T) {
+	input := `{
+		"encryption": {
+			"mode": "Wireguard",
+			"wireguard": {
+				"interfaces": [{
+					"name": "cilium_wg0",
+					"public-key": "abc123",
+					"listen-port": 51871,
+					"peer-count": 2,
+					"peers": [{
+						"public-key": "def456",
+						"endpoint": "10.0.0.1:51871",
+						"last-handshake-time": "2026-04-09T10:00:00Z",
+						"transfer-rx": 12345678,
+						"transfer-tx": 87654321
+					}]
+				}]
+			}
+		},
+		"cluster-mesh": {
+			"clusters": [{
+				"name": "cluster-west",
+				"connected": true,
+				"ready": true,
+				"status": "ready",
+				"num-nodes": 5,
+				"num-endpoints": 42,
+				"num-shared-services": 12,
+				"num-failures": 0
+			}]
+		},
+		"proxy": {
+			"envoy-deployment-mode": "embedded",
+			"total-redirects": 150,
+			"total-ports": 3
+		},
+		"cluster": {
+			"ciliumHealth": {
+				"state": "Ok",
+				"msg": ""
+			}
+		}
+	}`
+
+	var status ciliumAgentStatus
+	if err := json.Unmarshal([]byte(input), &status); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	// Encryption
+	if status.Encryption == nil || status.Encryption.Mode != "Wireguard" {
+		t.Error("encryption mode mismatch")
+	}
+	if len(status.Encryption.Wireguard.Interfaces) != 1 {
+		t.Fatal("expected 1 WireGuard interface")
+	}
+	iface := status.Encryption.Wireguard.Interfaces[0]
+	if iface.PublicKey != "abc123" || iface.PeerCount != 2 {
+		t.Errorf("interface: key=%q, peerCount=%d", iface.PublicKey, iface.PeerCount)
+	}
+	if len(iface.Peers) != 1 || iface.Peers[0].TransferRx != 12345678 {
+		t.Error("peer data mismatch")
+	}
+
+	// ClusterMesh
+	if status.ClusterMesh == nil || len(status.ClusterMesh.Clusters) != 1 {
+		t.Fatal("expected 1 remote cluster")
+	}
+	rc := status.ClusterMesh.Clusters[0]
+	if rc.Name != "cluster-west" || !rc.Connected || rc.NumNodes != 5 {
+		t.Errorf("remote cluster: name=%q, connected=%v, nodes=%d", rc.Name, rc.Connected, rc.NumNodes)
+	}
+
+	// Proxy
+	if status.Proxy == nil || status.Proxy.DeploymentMode != "embedded" {
+		t.Error("proxy deployment mode mismatch")
+	}
+	if status.Proxy.TotalRedirects != 150 || status.Proxy.TotalPorts != 3 {
+		t.Errorf("proxy: redirects=%d, ports=%d", status.Proxy.TotalRedirects, status.Proxy.TotalPorts)
+	}
+
+	// Health
+	if status.Cluster == nil || status.Cluster.CiliumHealth == nil || status.Cluster.CiliumHealth.State != "Ok" {
+		t.Error("health state mismatch")
+	}
+}
+
+func TestAgentCollector_PartialFailure(t *testing.T) {
+	result := &agentCollectionResult{
+		nodes: []agentNodeResult{
+			{nodeName: "node-1", podName: "cilium-1", status: &ciliumAgentStatus{}},
+			{nodeName: "node-2", podName: "cilium-2", status: &ciliumAgentStatus{}},
+			{nodeName: "node-3", podName: "cilium-3", err: "exec failed: timeout"},
+		},
+		collected: time.Now(),
+	}
+	// Compute partial flag same way as collect()
+	for _, r := range result.nodes {
+		if r.err != "" {
+			result.partial = true
+			break
+		}
+	}
+	if !result.partial {
+		t.Error("expected partial=true when some pods fail")
+	}
+}
+
+// --- Phase B: Enrichment Merge Tests ---
+
+func TestMergeAgentIntoSubsystems_WireGuard(t *testing.T) {
+	resp := &CiliumSubsystemsResponse{
+		Configured: true,
+		Encryption: &EncryptionInfo{Enabled: true, Mode: "wireguard"},
+		Mesh:       &MeshInfo{Enabled: true, Engine: "cilium"},
+		ClusterMesh: &ClusterMeshInfo{Enabled: false},
+	}
+	agent := &agentCollectionResult{
+		nodes: []agentNodeResult{
+			{
+				nodeName: "node-1",
+				podName:  "cilium-1",
+				status: &ciliumAgentStatus{
+					Encryption: &agentEncryption{
+						Mode: "Wireguard",
+						Wireguard: &agentWireguard{
+							Interfaces: []agentWGInterface{{
+								Name:      "cilium_wg0",
+								PublicKey: "key1",
+								PeerCount: 2,
+								Peers: []agentWGPeer{
+									{PublicKey: "peer1", Endpoint: "10.0.0.1:51871", TransferRx: 100, TransferTx: 200},
+								},
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	mergeAgentIntoSubsystems(resp, agent)
+
+	if len(resp.Encryption.WireGuardNodes) != 1 {
+		t.Fatalf("expected 1 WireGuard node, got %d", len(resp.Encryption.WireGuardNodes))
+	}
+	wgn := resp.Encryption.WireGuardNodes[0]
+	if wgn.NodeName != "node-1" || wgn.PublicKey != "key1" {
+		t.Errorf("WireGuardNode: name=%q, key=%q", wgn.NodeName, wgn.PublicKey)
+	}
+	if len(wgn.Peers) != 1 || wgn.Peers[0].TransferRx != 100 {
+		t.Error("peer data not merged correctly")
+	}
+}
+
+func TestMergeAgentIntoSubsystems_ClusterMesh(t *testing.T) {
+	resp := &CiliumSubsystemsResponse{
+		Configured:  true,
+		Encryption:  &EncryptionInfo{},
+		Mesh:        &MeshInfo{},
+		ClusterMesh: &ClusterMeshInfo{Enabled: true},
+	}
+	agent := &agentCollectionResult{
+		nodes: []agentNodeResult{
+			{
+				nodeName: "node-1",
+				status: &ciliumAgentStatus{
+					ClusterMesh: &agentClusterMesh{
+						Clusters: []agentRemoteCluster{
+							{Name: "west", Connected: true, Ready: true, NumNodes: 3},
+							{Name: "east", Connected: false, NumFailures: 2},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	mergeAgentIntoSubsystems(resp, agent)
+
+	if len(resp.ClusterMesh.RemoteClusters) != 2 {
+		t.Fatalf("expected 2 remote clusters, got %d", len(resp.ClusterMesh.RemoteClusters))
+	}
+	if resp.ClusterMesh.RemoteClusters[0].Name != "west" || !resp.ClusterMesh.RemoteClusters[0].Connected {
+		t.Error("first remote cluster mismatch")
+	}
+	if resp.ClusterMesh.RemoteClusters[1].Connected {
+		t.Error("second remote cluster should not be connected")
+	}
+}
+
+func TestMergeAgentIntoSubsystems_Proxy(t *testing.T) {
+	resp := &CiliumSubsystemsResponse{
+		Configured: true,
+		Encryption: &EncryptionInfo{},
+		Mesh:       &MeshInfo{Enabled: true, Engine: "cilium"},
+		ClusterMesh: &ClusterMeshInfo{},
+	}
+	agent := &agentCollectionResult{
+		nodes: []agentNodeResult{
+			{
+				nodeName: "node-1",
+				status: &ciliumAgentStatus{
+					Proxy: &agentProxy{
+						DeploymentMode: "embedded",
+						TotalRedirects: 42,
+						TotalPorts:     3,
+					},
+				},
+			},
+		},
+	}
+
+	mergeAgentIntoSubsystems(resp, agent)
+
+	if resp.Mesh.DeploymentMode != "embedded" {
+		t.Errorf("DeploymentMode = %q, want %q", resp.Mesh.DeploymentMode, "embedded")
+	}
+	if resp.Mesh.TotalRedirects != 42 {
+		t.Errorf("TotalRedirects = %d, want 42", resp.Mesh.TotalRedirects)
+	}
+}
+
+func TestMergeAgentIntoSubsystems_NilGuards(t *testing.T) {
+	// Merge should not panic when sub-structs are nil
+	resp := &CiliumSubsystemsResponse{
+		Configured:  true,
+		Encryption:  nil,
+		Mesh:        nil,
+		ClusterMesh: nil,
+	}
+	agent := &agentCollectionResult{
+		nodes: []agentNodeResult{
+			{
+				nodeName: "node-1",
+				status: &ciliumAgentStatus{
+					Encryption: &agentEncryption{Mode: "Wireguard"},
+					Proxy:      &agentProxy{DeploymentMode: "embedded"},
+				},
+			},
+		},
+	}
+
+	// Should not panic
+	mergeAgentIntoSubsystems(resp, agent)
+
+	// Nil sub-structs should remain nil (agent data not injected into nil fields)
+	if resp.Encryption != nil {
+		t.Error("expected Encryption to remain nil")
+	}
+	if resp.Mesh != nil {
+		t.Error("expected Mesh to remain nil")
+	}
+}
+
+// --- Phase B: Connectivity Handler Tests ---
+
+func TestHandleCiliumConnectivity_ExecDisabled(t *testing.T) {
+	h := &Handler{
+		Detector: &Detector{},
+		// AgentCollector is nil (exec disabled)
+	}
+	h.Detector.cached = &CNIInfo{Name: CNICilium}
+
+	req, _ := http.NewRequest("GET", "/api/v1/networking/cilium/connectivity", nil)
+	// Note: isCiliumLocal requires no cluster context = local, which is the default
+
+	// We can't easily test the full HTTP handler without httputil.RequireUser,
+	// so test the logic directly: when AgentCollector is nil and CNI is Cilium,
+	// the handler should return configured=true with empty nodes.
+	if !h.isCiliumLocal(req) {
+		t.Fatal("expected isCiliumLocal to be true")
+	}
+	if h.AgentCollector != nil {
+		t.Fatal("expected AgentCollector to be nil")
+	}
+}
+
+func TestHandleCiliumConnectivity_NotCilium(t *testing.T) {
+	h := &Handler{
+		Detector: &Detector{},
+	}
+	h.Detector.cached = &CNIInfo{Name: CNICalico}
+
+	req, _ := http.NewRequest("GET", "/api/v1/networking/cilium/connectivity", nil)
+	if h.isCiliumLocal(req) {
+		t.Error("expected isCiliumLocal to be false for Calico")
+	}
+}
+
+func TestInvalidateCaches_IncludesAgentCache(t *testing.T) {
+	c := &CiliumAgentCollector{}
+	c.cache = &agentCollectionResult{
+		nodes:     []agentNodeResult{{nodeName: "node-1"}},
+		collected: time.Now(),
+	}
+
+	h := &Handler{
+		AgentCollector: c,
+	}
+	h.subsystemCache = &cachedSubsystems{data: &CiliumSubsystemsResponse{Configured: true}}
+
+	h.InvalidateCaches()
+
+	c.cacheMu.RLock()
+	if c.cache != nil {
+		t.Error("expected agent cache to be cleared after InvalidateCaches")
+	}
+	c.cacheMu.RUnlock()
 }
 

--- a/backend/internal/networking/types.go
+++ b/backend/internal/networking/types.go
@@ -113,10 +113,10 @@ type EndpointCounts struct {
 // CiliumConnectivityResponse is the response for GET /api/v1/networking/cilium/connectivity.
 type CiliumConnectivityResponse struct {
 	Configured  bool               `json:"configured"`
-	ExecEnabled bool               `json:"execEnabled,omitempty"`
+	ExecEnabled bool               `json:"execEnabled"`
 	Nodes       []NodeConnectivity `json:"nodes"`
 	CollectedAt string             `json:"collectedAt,omitempty"`
-	Partial     bool               `json:"partial,omitempty"`
+	Partial     bool               `json:"partial"`
 }
 
 // NodeConnectivity represents per-node Cilium agent health.

--- a/backend/internal/networking/types.go
+++ b/backend/internal/networking/types.go
@@ -48,21 +48,57 @@ type CiliumSubsystemsResponse struct {
 
 // EncryptionInfo describes the Cilium encryption configuration from ConfigMap and CiliumNode CRDs.
 type EncryptionInfo struct {
-	Enabled        bool   `json:"enabled"`
-	Mode           string `json:"mode"` // wireguard, ipsec
-	NodesEncrypted int    `json:"nodesEncrypted"`
-	NodesTotal     int    `json:"nodesTotal"`
+	Enabled        bool            `json:"enabled"`
+	Mode           string          `json:"mode"` // wireguard, ipsec
+	NodesEncrypted int             `json:"nodesEncrypted"`
+	NodesTotal     int             `json:"nodesTotal"`
+	WireGuardNodes []WireGuardNode `json:"wireGuardNodes,omitempty"` // Phase B (agent)
+}
+
+// WireGuardNode represents per-node WireGuard tunnel state from Cilium agent.
+type WireGuardNode struct {
+	NodeName   string          `json:"nodeName"`
+	PublicKey  string          `json:"publicKey"`
+	ListenPort int64           `json:"listenPort"`
+	PeerCount  int64           `json:"peerCount"`
+	Peers      []WireGuardPeer `json:"peers"`
+}
+
+// WireGuardPeer represents a single WireGuard peer tunnel.
+type WireGuardPeer struct {
+	PublicKey     string `json:"publicKey"`
+	Endpoint      string `json:"endpoint"`
+	LastHandshake string `json:"lastHandshake"`
+	TransferRx    int64  `json:"transferRx"`
+	TransferTx    int64  `json:"transferTx"`
 }
 
 // MeshInfo describes the detected service mesh engine.
 type MeshInfo struct {
-	Enabled bool   `json:"enabled"`
-	Engine  string `json:"engine"` // cilium, none (istio/linkerd deferred to Phase B)
+	Enabled        bool   `json:"enabled"`
+	Engine         string `json:"engine"`                            // cilium, none (istio/linkerd deferred to Phase C)
+	DeploymentMode string `json:"deploymentMode,omitempty"`          // Phase B (agent)
+	TotalRedirects int64  `json:"totalRedirects,omitempty"`          // Phase B (agent)
+	TotalPorts     int64  `json:"totalPorts,omitempty"`              // Phase B (agent)
 }
 
 // ClusterMeshInfo describes whether ClusterMesh is configured.
 type ClusterMeshInfo struct {
-	Enabled bool `json:"enabled"`
+	Enabled        bool            `json:"enabled"`
+	RemoteClusters []RemoteCluster `json:"remoteClusters,omitempty"` // Phase B (agent)
+}
+
+// RemoteCluster represents a ClusterMesh remote cluster connection.
+type RemoteCluster struct {
+	Name              string `json:"name"`
+	Connected         bool   `json:"connected"`
+	Ready             bool   `json:"ready"`
+	Status            string `json:"status"`
+	NumNodes          int64  `json:"numNodes"`
+	NumEndpoints      int64  `json:"numEndpoints"`
+	NumSharedServices int64  `json:"numSharedServices"`
+	NumFailures       int64  `json:"numFailures"`
+	LastFailure       string `json:"lastFailure,omitempty"`
 }
 
 // EndpointCounts aggregates Cilium endpoint states from CiliumEndpoint CRDs.
@@ -72,6 +108,22 @@ type EndpointCounts struct {
 	NotReady      int `json:"notReady"`
 	Disconnecting int `json:"disconnecting"`
 	Waiting       int `json:"waiting"`
+}
+
+// CiliumConnectivityResponse is the response for GET /api/v1/networking/cilium/connectivity.
+type CiliumConnectivityResponse struct {
+	Configured  bool               `json:"configured"`
+	ExecEnabled bool               `json:"execEnabled,omitempty"`
+	Nodes       []NodeConnectivity `json:"nodes"`
+	CollectedAt string             `json:"collectedAt,omitempty"`
+	Partial     bool               `json:"partial,omitempty"`
+}
+
+// NodeConnectivity represents per-node Cilium agent health.
+type NodeConnectivity struct {
+	NodeName    string `json:"nodeName"`
+	HealthState string `json:"healthState"` // Ok, Warning, Failure
+	Message     string `json:"message,omitempty"`
 }
 
 // computeExhaustionRisk returns the exhaustion risk level based on IPAM utilization.

--- a/backend/internal/server/routes.go
+++ b/backend/internal/server/routes.go
@@ -321,6 +321,7 @@ func (s *Server) registerNetworkingRoutes(ar chi.Router) {
 		nr.Get("/cilium/bgp", h.HandleCiliumBGP)
 		nr.Get("/cilium/ipam", h.HandleCiliumIPAM)
 		nr.Get("/cilium/subsystems", h.HandleCiliumSubsystems)
+		nr.Get("/cilium/connectivity", h.HandleCiliumConnectivity)
 	})
 }
 

--- a/backend/internal/server/routes.go
+++ b/backend/internal/server/routes.go
@@ -321,7 +321,7 @@ func (s *Server) registerNetworkingRoutes(ar chi.Router) {
 		nr.Get("/cilium/bgp", h.HandleCiliumBGP)
 		nr.Get("/cilium/ipam", h.HandleCiliumIPAM)
 		nr.Get("/cilium/subsystems", h.HandleCiliumSubsystems)
-		nr.Get("/cilium/connectivity", h.HandleCiliumConnectivity)
+		nr.With(middleware.RequireAdmin).Get("/cilium/connectivity", h.HandleCiliumConnectivity)
 	})
 }
 

--- a/frontend/islands/BgpStatus.tsx
+++ b/frontend/islands/BgpStatus.tsx
@@ -6,7 +6,7 @@ import { StatusBadge } from "@/components/ui/StatusBadge.tsx";
 import { ErrorBanner } from "@/components/ui/ErrorBanner.tsx";
 
 export default function BgpStatus() {
-  const { data, loading, error } = usePoll<CiliumBGPResponse>(
+  const { data, loading, error, lastFetchedAt } = usePoll<CiliumBGPResponse>(
     "/v1/networking/cilium/bgp",
     {
       interval: 60_000,
@@ -91,6 +91,13 @@ export default function BgpStatus() {
           </p>
         )}
       </div>
+      {lastFetchedAt.value && (
+        <div class="mt-3 pt-2 border-t border-border-subtle text-right">
+          <span class="text-xs text-text-muted">
+            Updated {lastFetchedAt.value.toLocaleTimeString()}
+          </span>
+        </div>
+      )}
     </Card>
   );
 }

--- a/frontend/islands/CiliumSubsystems.tsx
+++ b/frontend/islands/CiliumSubsystems.tsx
@@ -5,8 +5,19 @@ import { Card } from "@/components/ui/Card.tsx";
 import { StatusBadge } from "@/components/ui/StatusBadge.tsx";
 import { ErrorBanner } from "@/components/ui/ErrorBanner.tsx";
 
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+}
+
 export default function CiliumSubsystems() {
-  const { data, loading, error } = usePoll<CiliumSubsystemsResponse>(
+  const { data, loading, error, lastFetchedAt } = usePoll<
+    CiliumSubsystemsResponse
+  >(
     "/v1/networking/cilium/subsystems",
     {
       interval: 60_000,
@@ -62,6 +73,42 @@ export default function CiliumSubsystems() {
                     {encryption.nodesEncrypted} / {encryption.nodesTotal}
                   </span>
                 </div>
+                {encryption.wireGuardNodes &&
+                  encryption.wireGuardNodes.length > 0 && (
+                  <div class="mt-3 pt-2 border-t border-border-subtle">
+                    <p class="text-xs text-text-muted mb-1.5">
+                      WireGuard Peers
+                    </p>
+                    <div class="space-y-2">
+                      {encryption.wireGuardNodes.map((wgn) => (
+                        <div key={wgn.nodeName}>
+                          <div class="flex justify-between text-xs">
+                            <span class="font-mono text-text-secondary">
+                              {wgn.nodeName}
+                            </span>
+                            <span class="text-text-muted">
+                              {wgn.peerCount} peers
+                            </span>
+                          </div>
+                          {wgn.peers.map((peer) => (
+                            <div
+                              key={peer.publicKey}
+                              class="flex justify-between text-xs pl-3 mt-0.5"
+                            >
+                              <span class="font-mono text-text-muted">
+                                {peer.endpoint}
+                              </span>
+                              <span class="text-text-muted">
+                                ↓{formatBytes(peer.transferRx)}{" "}
+                                ↑{formatBytes(peer.transferTx)}
+                              </span>
+                            </div>
+                          ))}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
               </div>
             )
             : <p class="text-sm text-text-muted">Disabled</p>}
@@ -83,6 +130,22 @@ export default function CiliumSubsystems() {
                     variant="success"
                   />
                 </div>
+                {mesh.deploymentMode && (
+                  <div class="flex justify-between text-sm">
+                    <span class="text-text-muted">Mode</span>
+                    <span class="text-text-primary capitalize">
+                      {mesh.deploymentMode}
+                    </span>
+                  </div>
+                )}
+                {mesh.totalRedirects != null && (
+                  <div class="flex justify-between text-sm">
+                    <span class="text-text-muted">Redirects</span>
+                    <span class="font-mono text-text-primary">
+                      {mesh.totalRedirects}
+                    </span>
+                  </div>
+                )}
               </div>
             )
             : <p class="text-sm text-text-muted">Disabled</p>}
@@ -94,7 +157,37 @@ export default function CiliumSubsystems() {
             ClusterMesh
           </p>
           {clusterMesh.enabled
-            ? <StatusBadge status="Enabled" variant="success" />
+            ? (
+              <div class="space-y-1.5">
+                <StatusBadge status="Enabled" variant="success" />
+                {clusterMesh.remoteClusters &&
+                  clusterMesh.remoteClusters.length > 0 && (
+                  <div class="mt-2 space-y-1">
+                    {clusterMesh.remoteClusters.map((rc) => (
+                      <div
+                        key={rc.name}
+                        class="flex items-center justify-between text-xs"
+                      >
+                        <div class="flex items-center gap-1.5">
+                          <span
+                            class="w-2 h-2 rounded-full inline-block"
+                            style={{
+                              background: rc.connected
+                                ? "var(--success)"
+                                : "var(--error)",
+                            }}
+                          />
+                          <span class="font-mono text-text-secondary">
+                            {rc.name}
+                          </span>
+                        </div>
+                        <span class="text-text-muted">{rc.numNodes} nodes</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )
             : <p class="text-sm text-text-muted">Disabled</p>}
         </div>
 
@@ -191,6 +284,13 @@ export default function CiliumSubsystems() {
           </div>
         </div>
       </div>
+      {lastFetchedAt.value && (
+        <div class="mt-4 pt-2 border-t border-border-subtle text-right">
+          <span class="text-xs text-text-muted">
+            Updated {lastFetchedAt.value.toLocaleTimeString()}
+          </span>
+        </div>
+      )}
     </Card>
   );
 }

--- a/frontend/islands/IpamStatus.tsx
+++ b/frontend/islands/IpamStatus.tsx
@@ -6,7 +6,7 @@ import { StatusBadge } from "@/components/ui/StatusBadge.tsx";
 import { ErrorBanner } from "@/components/ui/ErrorBanner.tsx";
 
 export default function IpamStatus() {
-  const { data, loading, error } = usePoll<CiliumIPAMResponse>(
+  const { data, loading, error, lastFetchedAt } = usePoll<CiliumIPAMResponse>(
     "/v1/networking/cilium/ipam",
     {
       interval: 60_000,
@@ -126,6 +126,13 @@ export default function IpamStatus() {
           </div>
         )}
       </div>
+      {lastFetchedAt.value && (
+        <div class="mt-3 pt-2 border-t border-border-subtle text-right">
+          <span class="text-xs text-text-muted">
+            Updated {lastFetchedAt.value.toLocaleTimeString()}
+          </span>
+        </div>
+      )}
     </Card>
   );
 }

--- a/frontend/islands/NetworkOverview.tsx
+++ b/frontend/islands/NetworkOverview.tsx
@@ -7,6 +7,7 @@ import CiliumConfigEditor from "@/islands/CiliumConfigEditor.tsx";
 import BgpStatus from "@/islands/BgpStatus.tsx";
 import IpamStatus from "@/islands/IpamStatus.tsx";
 import CiliumSubsystems from "@/islands/CiliumSubsystems.tsx";
+import NodeConnectivity from "@/islands/NodeConnectivity.tsx";
 
 interface CNIInfo {
   name: string;
@@ -77,6 +78,11 @@ export default function NetworkOverview() {
               {/* Row 3: Subsystems (full-width) */}
               <div class="md:col-span-2">
                 <CiliumSubsystems />
+              </div>
+
+              {/* Row 4: Node Connectivity (full-width) */}
+              <div class="md:col-span-2">
+                <NodeConnectivity />
               </div>
             </>
           )}

--- a/frontend/islands/NodeConnectivity.tsx
+++ b/frontend/islands/NodeConnectivity.tsx
@@ -1,0 +1,116 @@
+import { IS_BROWSER } from "fresh/runtime";
+import { usePoll } from "@/lib/hooks/use-poll.ts";
+import type {
+  CiliumConnectivityResponse,
+  NodeConnectivity as NodeHealth,
+} from "@/lib/cilium-types.ts";
+import { Card } from "@/components/ui/Card.tsx";
+import { ErrorBanner } from "@/components/ui/ErrorBanner.tsx";
+
+export default function NodeConnectivity() {
+  const { data, loading, error, lastFetchedAt } = usePoll<
+    CiliumConnectivityResponse
+  >(
+    "/v1/networking/cilium/connectivity",
+    {
+      interval: 60_000,
+      shouldContinuePolling: (d) => d.configured,
+    },
+  );
+
+  if (!IS_BROWSER || loading.value) {
+    return <div class="animate-pulse h-24 bg-elevated rounded-lg" />;
+  }
+
+  if (error.value) {
+    return (
+      <Card title="Node Connectivity">
+        <ErrorBanner message={error.value} />
+      </Card>
+    );
+  }
+
+  const resp = data.value;
+  if (!resp || !resp.configured) {
+    return (
+      <Card title="Node Connectivity" class="opacity-50">
+        <p class="text-sm text-text-muted">
+          Connectivity data not available.
+        </p>
+      </Card>
+    );
+  }
+
+  // Exec disabled — show placeholder
+  if (resp.nodes.length === 0) {
+    return (
+      <Card title="Node Connectivity">
+        <p class="text-sm text-text-muted">
+          Enable{" "}
+          <code class="text-xs bg-elevated px-1 py-0.5 rounded">
+            ciliumAgent.execEnabled
+          </code>{" "}
+          in Helm values for node connectivity data.
+        </p>
+      </Card>
+    );
+  }
+
+  const healthColor = (state: string) => {
+    switch (state) {
+      case "Ok":
+        return "var(--success)";
+      case "Warning":
+        return "var(--warning)";
+      case "Failure":
+        return "var(--error)";
+      default:
+        return "var(--text-muted)";
+    }
+  };
+
+  return (
+    <Card title="Node Connectivity">
+      <div class="space-y-1.5">
+        {resp.nodes.map((node: NodeHealth) => (
+          <div
+            key={node.nodeName}
+            class="flex items-center justify-between text-sm"
+          >
+            <div class="flex items-center gap-2">
+              <span
+                class="w-2 h-2 rounded-full inline-block"
+                style={{ background: healthColor(node.healthState) }}
+              />
+              <span class="font-mono text-text-primary">
+                {node.nodeName}
+              </span>
+            </div>
+            <div class="flex items-center gap-2">
+              <span class="text-xs text-text-muted">
+                {node.healthState}
+              </span>
+              {node.message && (
+                <span class="text-xs text-text-muted">
+                  — {node.message}
+                </span>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+      {resp.partial && (
+        <p class="text-xs text-text-muted mt-2">
+          Partial data — some agent pods failed to respond.
+        </p>
+      )}
+      {lastFetchedAt.value && (
+        <div class="mt-3 pt-2 border-t border-border-subtle text-right">
+          <span class="text-xs text-text-muted">
+            Updated {lastFetchedAt.value.toLocaleTimeString()}
+          </span>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/frontend/lib/cilium-types.ts
+++ b/frontend/lib/cilium-types.ts
@@ -105,14 +105,16 @@ export interface EndpointCounts {
   waiting: number;
 }
 
-// Connectivity response (flat interface — matches BGP/IPAM pattern)
-export interface CiliumConnectivityResponse {
-  configured: boolean;
-  execEnabled: boolean;
-  nodes: NodeConnectivity[];
-  collectedAt?: string;
-  partial?: boolean;
-}
+// Connectivity response — discriminated union matching BGP/IPAM/Subsystems pattern.
+export type CiliumConnectivityResponse =
+  | { configured: false }
+  | {
+    configured: true;
+    execEnabled: boolean;
+    nodes: NodeConnectivity[];
+    collectedAt?: string;
+    partial?: boolean;
+  };
 
 export interface NodeConnectivity {
   nodeName: string;

--- a/frontend/lib/cilium-types.ts
+++ b/frontend/lib/cilium-types.ts
@@ -53,15 +53,48 @@ export interface EncryptionInfo {
   mode: string;
   nodesEncrypted: number;
   nodesTotal: number;
+  wireGuardNodes?: WireGuardNode[];
+}
+
+export interface WireGuardNode {
+  nodeName: string;
+  publicKey: string;
+  listenPort: number;
+  peerCount: number;
+  peers: WireGuardPeer[];
+}
+
+export interface WireGuardPeer {
+  publicKey: string;
+  endpoint: string;
+  lastHandshake: string;
+  transferRx: number;
+  transferTx: number;
 }
 
 export interface MeshInfo {
   enabled: boolean;
   engine: string;
+  deploymentMode?: string;
+  totalRedirects?: number;
+  totalPorts?: number;
 }
 
 export interface ClusterMeshInfo {
   enabled: boolean;
+  remoteClusters?: RemoteCluster[];
+}
+
+export interface RemoteCluster {
+  name: string;
+  connected: boolean;
+  ready: boolean;
+  status: string;
+  numNodes: number;
+  numEndpoints: number;
+  numSharedServices: number;
+  numFailures: number;
+  lastFailure?: string;
 }
 
 export interface EndpointCounts {
@@ -70,4 +103,19 @@ export interface EndpointCounts {
   notReady: number;
   disconnecting: number;
   waiting: number;
+}
+
+// Connectivity response (flat interface — matches BGP/IPAM pattern)
+export interface CiliumConnectivityResponse {
+  configured: boolean;
+  execEnabled: boolean;
+  nodes: NodeConnectivity[];
+  collectedAt?: string;
+  partial?: boolean;
+}
+
+export interface NodeConnectivity {
+  nodeName: string;
+  healthState: string;
+  message?: string;
 }

--- a/frontend/lib/hooks/use-poll.ts
+++ b/frontend/lib/hooks/use-poll.ts
@@ -19,6 +19,8 @@ interface UsePollResult<T> {
   error: Signal<string | null>;
   /** Trigger an immediate refetch outside the polling cycle. */
   refetch: () => Promise<void>;
+  /** Timestamp of the last successful fetch. */
+  lastFetchedAt: Signal<Date | null>;
 }
 
 const MAX_CONSECUTIVE_FAILURES = 3;
@@ -36,6 +38,7 @@ export function usePoll<T>(
   const data = useSignal<T | null>(null);
   const loading = useSignal(true);
   const error = useSignal<string | null>(null);
+  const lastFetchedAt = useSignal<Date | null>(null);
   const intervalRef = useRef<number | null>(null);
   const failureCount = useRef(0);
   const stoppedRef = useRef(false);
@@ -51,6 +54,7 @@ export function usePoll<T>(
         data.value = resp.data;
         error.value = null;
         failureCount.current = 0;
+        lastFetchedAt.value = new Date();
 
         // Check if polling should continue
         if (
@@ -122,5 +126,5 @@ export function usePoll<T>(
     if (doFetchRef.current) await doFetchRef.current();
   };
 
-  return { data, loading, error, refetch };
+  return { data, loading, error, refetch, lastFetchedAt };
 }

--- a/helm/kubecenter/templates/clusterrole.yaml
+++ b/helm/kubecenter/templates/clusterrole.yaml
@@ -134,3 +134,11 @@ rules:
   - apiGroups: ["authorization.k8s.io"]
     resources: ["selfsubjectaccessreviews"]
     verbs: ["create"]
+{{- if .Values.ciliumAgent.execEnabled }}
+  # Cilium agent exec — runs cilium-dbg status for deep diagnostics
+  # Cluster-wide scope: pod listing already requires cluster-wide pods:list.
+  # Application-level controls (label validation, namespace allowlist, hardcoded command) provide defense-in-depth.
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+{{- end }}

--- a/helm/kubecenter/templates/configmap-app.yaml
+++ b/helm/kubecenter/templates/configmap-app.yaml
@@ -33,3 +33,6 @@ data:
   {{- if .Values.cors.allowedOrigins }}
   KUBECENTER_CORS_ALLOWEDORIGINS: {{ join "," .Values.cors.allowedOrigins | quote }}
   {{- end }}
+  {{- if .Values.ciliumAgent.execEnabled }}
+  KUBECENTER_CILIUMAGENT_EXECENABLED: "true"
+  {{- end }}

--- a/helm/kubecenter/values.yaml
+++ b/helm/kubecenter/values.yaml
@@ -133,6 +133,11 @@ externalDatabase:
   existingSecret: ""      # k8s Secret with key "password"
   sslmode: require
 
+# -- Cilium agent deep diagnostics (requires pods/exec RBAC)
+ciliumAgent:
+  # -- Enable exec-based diagnostics for WireGuard details, ClusterMesh, Envoy stats
+  execEnabled: false
+
 # -- Alerting
 alerting:
   enabled: false

--- a/plans/networking-overview-phase-b.md
+++ b/plans/networking-overview-phase-b.md
@@ -1,0 +1,867 @@
+# Networking Overview Phase B — Cilium Agent Collector + Enrichment
+
+**Spec:** This document (self-contained)
+**Depends on:** Phase A (PR #157, merged), IPAM fix (PR #158, merged)
+**Branch:** `feat/networking-phase-b`
+**Estimated Steps:** 3
+
+---
+
+## Architecture Overview
+
+### Problem
+
+Phase A sources all networking data from CRDs and ConfigMaps. This covers the most operationally useful data (BGP peering state, IPAM allocation, encryption mode), but richer diagnostics are locked behind the Cilium agent's local status API — accessible only via `cilium-dbg status -o json` inside agent pods.
+
+### Solution: Opt-In Agent Collector
+
+A new `CiliumAgentCollector` execs `cilium-dbg status -o json` into cilium-agent pods using the service account's own credentials (not user impersonation). This is gated behind `ciliumAgent.execEnabled: false` (default off) in Helm values.
+
+**Why service account instead of user impersonation:** The SPDY executor for non-interactive exec uses the `rest.Config` transport directly. User impersonation headers on the base config interfere with the SPDY upgrade handshake when the request is made from inside the cluster. More importantly, the agent collector is a system-level diagnostic — it collects the same data regardless of which user views the dashboard. Caching agent-collected data under a per-user key would defeat singleflight coalescing.
+
+**Compensating controls for the impersonation exception:**
+1. Opt-in via Helm (off by default) — no `pods/exec` in ClusterRole unless explicitly enabled
+2. Pod label validation: only exec into pods matching `app.kubernetes.io/name=cilium-agent` or `k8s-app=cilium`
+3. Namespace allowlist: only `kube-system` and `cilium` (reuses existing `ciliumSearchNamespaces`)
+4. Hardcoded command: only `cilium-dbg status -o json` — never user-supplied
+5. Audit logging: every exec invocation logged via both `slog` (operational) AND `audit.Logger` (PostgreSQL audit trail) with pod name, namespace, node, outcome, duration
+6. Output size cap: 1 MB `io.LimitReader` on stdout buffer — if exceeded, the truncated JSON will fail to parse, the node is marked as failed in `agentNodeResult.Error`, and a warning is logged. The node falls back to CRD-only data.
+7. Prometheus metrics: `kubecenter_cilium_agent_exec_total` (counter, labels: outcome), `kubecenter_cilium_agent_exec_duration_seconds` (histogram)
+
+### Data Flow
+
+```
+┌──────────────────────────────────────────────────────────┐
+│                    HTTP Request                           │
+│   GET /api/v1/networking/cilium/subsystems                │
+│   GET /api/v1/networking/cilium/connectivity              │
+└──────────────┬───────────────────────────────────────────┘
+               │
+               ▼
+┌──────────────────────────────────────────────────────────┐
+│  Handler: singleflight + 30s cache (per endpoint)        │
+│                                                          │
+│  ┌─────────────────┐    ┌──────────────────────────┐     │
+│  │ CRD Data (P.A)  │    │ Agent Data (P.B, opt-in) │     │
+│  │ - ConfigMap      │    │ - singleflight "agent"   │     │
+│  │ - CiliumNode     │    │ - 30s shared cache       │     │
+│  │ - CiliumEndpoint │    │ - errgroup.SetLimit(5)   │     │
+│  └────────┬────────┘    │ - 5s timeout per pod     │     │
+│           │              │ - 30s outer timeout       │     │
+│           │              └─────────┬────────────────┘     │
+│           │                        │                      │
+│           ▼                        ▼                      │
+│  ┌─────────────────────────────────────────────────┐     │
+│  │        Merge: CRD base + agent enrichment       │     │
+│  │  (agent fields are additive, never replace CRD) │     │
+│  └─────────────────────────────────────────────────┘     │
+└──────────────────────────────────────────────────────────┘
+```
+
+**Key design: shared agent cache.** Both the subsystems enrichment and connectivity endpoint consume the same agent collection result. A single singleflight key `"agent-collect"` prevents duplicate exec bursts when both islands poll within the same 30s window. Both the agent cache and the subsystems cache use a 30s TTL — these are intentionally aligned. `InvalidateCaches()` clears both.
+
+### Phase B Feature Matrix
+
+| Feature | Backend | Frontend | Depends On |
+|---|---|---|---|
+| Agent collector | `agent_exec.go`, `agent_types.go` | — | Helm opt-in |
+| Enriched encryption | Merge WireGuard peer data into subsystems response | `CiliumSubsystems.tsx` shows handshake times, transfer stats | Agent collector |
+| Enriched service mesh | Merge Envoy proxy data into subsystems response | `CiliumSubsystems.tsx` shows deployment mode, redirect counts | Agent collector |
+| Enriched ClusterMesh | Merge remote cluster list into subsystems response | `CiliumSubsystems.tsx` shows connected clusters table | Agent collector |
+| Node connectivity | New endpoint from agent health data | New `NodeConnectivity.tsx` island | Agent collector |
+| Last updated footer | — | Static timestamp in card footers, updated on each poll cycle | `usePoll` extension |
+
+**Deferred to Phase C:** Istio/Linkerd detection (no test environment, needs per-mesh adapter pattern for deep integration), adaptive polling (fixed intervals sufficient for infrastructure diagnostics), full connectivity matrix (`cilium-dbg connectivity test` — destructive/long-running).
+
+---
+
+## Design Decisions
+
+| Decision | Resolution | Rationale |
+|---|---|---|
+| Agent collector uses service account, not impersonation | Accepted exception with 7 compensating controls | SPDY transport + system-level diagnostic + cache coalescing |
+| Shared agent cache for subsystems + connectivity | Single singleflight key `"agent-collect"`, 30s TTL (aligned with subsystems cache) | Prevents 2N execs on page load (N nodes × 2 endpoints) |
+| `InvalidateCaches()` clears agent cache too | Agent collector gains `InvalidateCache()` method, called by handler | ConfigMap update should refresh all data sources |
+| Outer timeout for collection | 30s hard cap via `context.WithTimeout` | Bounds worst case: 20-node cluster with all timeouts = ceil(20/5)×5s = 20s |
+| Partial success handling | Per-node results; enrichment merges successful nodes, skips failed | Graceful degradation: 3/5 pods succeed → 3 nodes enriched, 2 CRD-only |
+| `cilium-dbg` only (no `cilium` fallback) | Cilium renamed binary in v1.13 (mid-2023); all supported versions use `cilium-dbg` | YAGNI — add fallback only if someone reports it on an older cluster |
+| `NodeConnectivity` visibility when exec disabled | Rendered in SSR with "exec disabled" placeholder | Fresh islands must appear in SSR output to be bundled (per project memory) |
+| Polling intervals | Fixed: 30s for subsystems (matches cache TTL), 60s for connectivity | Backend cache is 30s; polling faster is wasted; this is a dashboard, not a trading terminal |
+| Last updated display | Static timestamp updated on each fetch cycle (no ticking timer) | A 1s `setInterval` to show "12s ago" vs "13s ago" adds runtime cost for zero operational value |
+| `pods/exec` RBAC | Conditional block in existing ClusterRole (cluster-wide) | Simpler than two namespace-scoped Roles + RoleBindings. Application-level controls (label validation, namespace allowlist) provide defense-in-depth. The alternative of namespace-scoped Roles was considered but rejected: the pod listing step already requires cluster-wide `pods:list`, and the Helm upgrade cleanly removes the rule on disable. |
+| Non-Cilium connectivity endpoint | Returns `{ configured: false }` (same as all Cilium endpoints) | Consistent with Phase A pattern |
+| Config wiring | `Config.CiliumAgent.ExecEnabled` → `KUBECENTER_CILIUMAGENT_EXECENABLED` | Follows koanf nested struct → underscore-joined env var convention |
+| No `ExecEnabled` bool on Handler | Use `h.AgentCollector != nil` as sole gate | Single source of truth; redundant bool invites divergence |
+| 1 MB output cap exceeded | Truncated JSON fails to parse → node marked as failed → CRD-only fallback | Logged as warning with pod name and output size |
+| Agent result types unexported | `agentCollectionResult` / `agentNodeResult` are internal; only enrichment merge function consumes them | Keeps public API surface clean; JSON tags are for parsing cilium-dbg output, not HTTP responses |
+| Connectivity response: flat interface | Simple struct with all fields (not discriminated union) | Matches existing BGP/IPAM response pattern; frontend checks `configured` then `nodes.length` |
+
+---
+
+## Agent Status JSON: Fields We Parse
+
+Minimal subset of `cilium-dbg status -o json` output. We define our own structs — no Cilium API model imports.
+
+```
+{
+  "encryption": {
+    "mode": "Wireguard",                          → EncryptionInfo.Mode (enriched)
+    "wireguard": {
+      "interfaces": [{
+        "name": "cilium_wg0",                     → per-node interface name
+        "public-key": "abc123...",                 → WireGuardNode.PublicKey
+        "listen-port": 51871,                      → WireGuardNode.ListenPort
+        "peer-count": 2,                           → WireGuardNode.PeerCount
+        "peers": [{
+          "public-key": "def456...",               → WireGuardPeer.PublicKey
+          "endpoint": "192.168.1.10:51871",        → WireGuardPeer.Endpoint
+          "last-handshake-time": "2026-04-09T...", → WireGuardPeer.LastHandshake
+          "transfer-rx": 12345678,                 → WireGuardPeer.TransferRx
+          "transfer-tx": 87654321                  → WireGuardPeer.TransferTx
+        }]
+      }]
+    }
+  },
+  "cluster-mesh": {
+    "clusters": [{
+      "name": "cluster-west",                     → RemoteCluster.Name
+      "connected": true,                           → RemoteCluster.Connected
+      "ready": true,                               → RemoteCluster.Ready
+      "status": "ready",                           → RemoteCluster.Status
+      "num-nodes": 5,                              → RemoteCluster.NumNodes
+      "num-endpoints": 42,                         → RemoteCluster.NumEndpoints
+      "num-shared-services": 12,                   → RemoteCluster.NumSharedServices
+      "num-failures": 0,                           → RemoteCluster.NumFailures
+      "last-failure": ""                           → RemoteCluster.LastFailure
+    }]
+  },
+  "proxy": {
+    "envoy-deployment-mode": "embedded",           → ProxyInfo.DeploymentMode
+    "total-redirects": 150,                        → ProxyInfo.TotalRedirects
+    "total-ports": 3                               → ProxyInfo.TotalPorts
+  },
+  "cluster": {
+    "ciliumHealth": {
+      "state": "Ok",                               → NodeHealth.State
+      "msg": ""                                    → NodeHealth.Message
+    }
+  }
+}
+```
+
+---
+
+## Step 1: Backend — Agent Collector + Enrichment + Config + Helm
+
+**Files:** 2 new, 5 modified
+**Goal:** Complete backend: agent types, collector, enrichment merge, connectivity handler, config wiring, Helm plumbing
+
+### Create `backend/internal/networking/agent_types.go`
+
+Minimal Go structs for parsing `cilium-dbg status -o json`. All unexported — internal parsing only.
+
+```go
+// ciliumAgentStatus is a minimal subset of cilium-dbg's StatusResponse.
+type ciliumAgentStatus struct {
+    Encryption  *agentEncryption  `json:"encryption,omitempty"`
+    ClusterMesh *agentClusterMesh `json:"cluster-mesh,omitempty"`
+    Proxy       *agentProxy       `json:"proxy,omitempty"`
+    Cluster     *agentCluster     `json:"cluster,omitempty"`
+}
+
+type agentEncryption struct {
+    Mode      string          `json:"mode,omitempty"`
+    Msg       string          `json:"msg,omitempty"`
+    Wireguard *agentWireguard `json:"wireguard,omitempty"`
+}
+
+type agentWireguard struct {
+    Interfaces []agentWGInterface `json:"interfaces"`
+}
+
+type agentWGInterface struct {
+    Name       string         `json:"name,omitempty"`
+    PublicKey  string         `json:"public-key,omitempty"`
+    ListenPort int64         `json:"listen-port,omitempty"`
+    PeerCount  int64         `json:"peer-count,omitempty"`
+    Peers      []agentWGPeer `json:"peers"`
+}
+
+type agentWGPeer struct {
+    PublicKey         string `json:"public-key,omitempty"`
+    Endpoint          string `json:"endpoint,omitempty"`
+    LastHandshakeTime string `json:"last-handshake-time,omitempty"`
+    TransferRx        int64  `json:"transfer-rx,omitempty"`
+    TransferTx        int64  `json:"transfer-tx,omitempty"`
+}
+
+type agentClusterMesh struct {
+    Clusters []agentRemoteCluster `json:"clusters"`
+}
+
+type agentRemoteCluster struct {
+    Name              string `json:"name,omitempty"`
+    Connected         bool   `json:"connected,omitempty"`
+    Ready             bool   `json:"ready,omitempty"`
+    Status            string `json:"status,omitempty"`
+    NumNodes          int64  `json:"num-nodes,omitempty"`
+    NumEndpoints      int64  `json:"num-endpoints,omitempty"`
+    NumSharedServices int64  `json:"num-shared-services,omitempty"`
+    NumFailures       int64  `json:"num-failures,omitempty"`
+    LastFailure       string `json:"last-failure,omitempty"`
+}
+
+type agentProxy struct {
+    DeploymentMode string `json:"envoy-deployment-mode,omitempty"`
+    TotalRedirects int64  `json:"total-redirects,omitempty"`
+    TotalPorts     int64  `json:"total-ports,omitempty"`
+}
+
+type agentCluster struct {
+    CiliumHealth *agentCiliumHealth `json:"ciliumHealth,omitempty"`
+}
+
+type agentCiliumHealth struct {
+    State string `json:"state,omitempty"`
+    Msg   string `json:"msg,omitempty"`
+}
+
+// agentCollectionResult holds parsed results from all agent pods (unexported — internal only).
+type agentCollectionResult struct {
+    nodes     []agentNodeResult
+    collected time.Time
+    partial   bool // true if some pods failed
+}
+
+type agentNodeResult struct {
+    nodeName string
+    podName  string
+    status   *ciliumAgentStatus // nil if exec failed
+    err      string
+}
+```
+
+### Create `backend/internal/networking/agent_exec.go`
+
+The `CiliumAgentCollector` struct:
+
+```go
+type CiliumAgentCollector struct {
+    k8sClient    *k8s.ClientFactory
+    auditLogger  audit.Logger
+    logger       *slog.Logger
+    // Singleflight + cache
+    group     singleflight.Group
+    cacheMu   sync.RWMutex
+    cache     *agentCollectionResult
+    cacheTime time.Time
+    // Prometheus metrics
+    execTotal    *prometheus.CounterVec   // labels: outcome
+    execDuration prometheus.Histogram
+}
+
+const (
+    agentCacheTTL      = 30 * time.Second
+    agentOuterTimeout  = 30 * time.Second
+    agentExecTimeout   = 5 * time.Second
+    agentMaxConcurrent = 5
+    agentMaxOutput     = 1 << 20 // 1 MB stdout cap
+    agentContainer     = "cilium-agent"
+)
+
+var agentCommand = []string{"cilium-dbg", "status", "-o", "json"}
+
+// Reuse ciliumSearchNamespaces from cilium.go — no duplicate constant.
+
+var agentPodLabels = []string{
+    "app.kubernetes.io/name=cilium-agent",
+    "k8s-app=cilium",
+}
+
+// NewCiliumAgentCollector creates a collector for Cilium agent diagnostics.
+func NewCiliumAgentCollector(k8sClient *k8s.ClientFactory, auditLogger audit.Logger, logger *slog.Logger) *CiliumAgentCollector {
+    execTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
+        Name: "kubecenter_cilium_agent_exec_total",
+        Help: "Total cilium-agent exec invocations by outcome",
+    }, []string{"outcome"})
+    execDuration := prometheus.NewHistogram(prometheus.HistogramOpts{
+        Name:    "kubecenter_cilium_agent_exec_duration_seconds",
+        Help:    "Duration of cilium-agent exec invocations",
+        Buckets: []float64{0.5, 1, 2, 5, 10, 30},
+    })
+    prometheus.MustRegister(execTotal, execDuration)
+
+    return &CiliumAgentCollector{
+        k8sClient:    k8sClient,
+        auditLogger:  auditLogger,
+        logger:       logger,
+        execTotal:    execTotal,
+        execDuration: execDuration,
+    }
+}
+```
+
+**`Collect(ctx) (*agentCollectionResult, error)` method:**
+
+1. Check cache under RLock — if fresh, return cached
+2. Singleflight on key `"agent-collect"`
+3. `context.WithTimeout(ctx, agentOuterTimeout)` — 30s hard cap
+4. List pods: try each `ciliumSearchNamespaces` × `agentPodLabels` combo until pods found
+5. Validate each pod: label match, `Running` phase, expected namespace
+6. `errgroup.WithContext` + `g.SetLimit(agentMaxConcurrent)`
+7. Per-pod: `context.WithTimeout(gCtx, agentExecTimeout)`, build exec request URL using existing `RESTClient().Post().Resource("pods").SubResource("exec").Param(...)` pattern from `pods.go:256`
+8. Create `remotecommand.NewSPDYExecutor(baseConfig, "POST", execReq.URL())`
+9. `executor.StreamWithContext(execCtx, StreamOptions{Stdout: io.LimitReader(&buf, agentMaxOutput), Stderr: &stderrBuf})`
+10. Parse stdout JSON into `ciliumAgentStatus` — if parse fails (including due to 1MB truncation), log warning with pod name and output size, mark node as failed
+11. Always return `nil` from `g.Go()` — errors captured per-node in results (graceful degradation)
+12. Structured slog: `h.logger.Info("agent exec", "pod", podName, "node", nodeName, "duration", elapsed, "outcome", "success|timeout|parse_error|exec_error")`
+13. Audit log: `h.auditLogger.Log(ctx, audit.Entry{Action: "cilium-agent-exec", Resource: podName, ...})`
+14. Prometheus: increment `execTotal` with outcome label, observe `execDuration`
+15. Store in cache, set `partial: true` if any node has non-empty `err`
+
+**`InvalidateCache()` method:** Clears cache under write lock.
+
+**`execInPod(ctx, namespace, podName, container, command) ([]byte, []byte, error)` helper:**
+
+Uses `BaseConfig()` and `BaseClientset()` (service account credentials). Builds the exec URL using the `.Param()` chain pattern matching `pods.go:256-266`. Returns stdout, stderr, error.
+
+### Extend response types in `backend/internal/networking/types.go`
+
+Add agent-sourced fields to existing types (all `omitempty` — absent when exec disabled):
+
+```go
+// Extend EncryptionInfo
+type EncryptionInfo struct {
+    // Phase A fields (unchanged)
+    Enabled        bool   `json:"enabled"`
+    Mode           string `json:"mode"`
+    NodesEncrypted int    `json:"nodesEncrypted"`
+    NodesTotal     int    `json:"nodesTotal"`
+    // Phase B fields (agent-sourced, optional)
+    WireGuardNodes []WireGuardNode `json:"wireGuardNodes,omitempty"`
+}
+
+type WireGuardNode struct {
+    NodeName   string          `json:"nodeName"`
+    PublicKey  string          `json:"publicKey"`
+    ListenPort int64          `json:"listenPort"`
+    PeerCount  int64          `json:"peerCount"`
+    Peers      []WireGuardPeer `json:"peers"`
+}
+
+type WireGuardPeer struct {
+    PublicKey     string `json:"publicKey"`
+    Endpoint      string `json:"endpoint"`
+    LastHandshake string `json:"lastHandshake"`
+    TransferRx    int64  `json:"transferRx"`
+    TransferTx    int64  `json:"transferTx"`
+}
+
+// Extend MeshInfo
+type MeshInfo struct {
+    Enabled        bool   `json:"enabled"`
+    Engine         string `json:"engine"`
+    DeploymentMode string `json:"deploymentMode,omitempty"` // Phase B (agent)
+    TotalRedirects int64  `json:"totalRedirects,omitempty"` // Phase B (agent)
+    TotalPorts     int64  `json:"totalPorts,omitempty"`     // Phase B (agent)
+}
+
+// Extend ClusterMeshInfo
+type ClusterMeshInfo struct {
+    Enabled        bool            `json:"enabled"`
+    RemoteClusters []RemoteCluster `json:"remoteClusters,omitempty"` // Phase B (agent)
+}
+
+type RemoteCluster struct {
+    Name              string `json:"name"`
+    Connected         bool   `json:"connected"`
+    Ready             bool   `json:"ready"`
+    Status            string `json:"status"`
+    NumNodes          int64  `json:"numNodes"`
+    NumEndpoints      int64  `json:"numEndpoints"`
+    NumSharedServices int64  `json:"numSharedServices"`
+    NumFailures       int64  `json:"numFailures"`
+    LastFailure       string `json:"lastFailure,omitempty"`
+}
+
+// New: Connectivity response (flat interface — matches BGP/IPAM pattern)
+type CiliumConnectivityResponse struct {
+    Configured  bool               `json:"configured"`
+    ExecEnabled bool               `json:"execEnabled,omitempty"` // omitempty: absent when configured=false
+    Nodes       []NodeConnectivity `json:"nodes"`
+    CollectedAt string             `json:"collectedAt,omitempty"`
+    Partial     bool               `json:"partial,omitempty"`
+}
+
+type NodeConnectivity struct {
+    NodeName    string `json:"nodeName"`
+    HealthState string `json:"healthState"` // Ok, Warning, Failure
+    Message     string `json:"message,omitempty"`
+}
+```
+
+### Modify `backend/internal/networking/handler.go`
+
+**Add to Handler struct:**
+```go
+AgentCollector *CiliumAgentCollector // nil when exec disabled
+```
+
+No `ExecEnabled` bool — use `h.AgentCollector != nil` as the sole gate.
+
+**Extend `InvalidateCaches()`:**
+```go
+func (h *Handler) InvalidateCaches() {
+    // ... existing cache clears ...
+
+    // Clear agent cache if collector is enabled
+    if h.AgentCollector != nil {
+        h.AgentCollector.InvalidateCache()
+    }
+
+    atomic.AddUint64(&h.cacheGen, 1)
+}
+```
+
+**Modify `fetchSubsystems()`:**
+
+After the existing errgroup that fetches CRD data (CiliumNodes + CiliumEndpoints), add an agent enrichment step:
+
+```go
+// After g.Wait() for CRD data...
+
+// Agent enrichment (opt-in, additive)
+if h.AgentCollector != nil {
+    agentResult, err := h.AgentCollector.Collect(ctx)
+    if err != nil {
+        h.Logger.Warn("agent collection failed, returning CRD-only data", "error", err)
+    } else {
+        mergeAgentIntoSubsystems(&resp, agentResult)
+    }
+}
+```
+
+**`mergeAgentIntoSubsystems(resp, agentResult)`:**
+- Nil-guard all response sub-structs before merging (e.g., `if resp.Encryption == nil { return }`)
+- Encryption: iterate agent nodes, build `WireGuardNode` slice from `encryption.wireguard.interfaces`
+- Mesh: copy `proxy.DeploymentMode`, `proxy.TotalRedirects`, `proxy.TotalPorts`
+- ClusterMesh: build `RemoteCluster` slice from `cluster-mesh.clusters`
+- Only merge data from nodes where `agentNodeResult.status != nil` (skip failed nodes)
+
+**New handler: `HandleCiliumConnectivity`:**
+1. Auth check + `isCiliumLocal()` guard → if not Cilium: `CiliumConnectivityResponse{Configured: false, Nodes: []NodeConnectivity{}}`
+2. If `h.AgentCollector == nil` → `CiliumConnectivityResponse{Configured: true, Nodes: []NodeConnectivity{}}`
+3. Call `h.AgentCollector.Collect(ctx)` (uses shared cache)
+4. Extract `cluster.ciliumHealth` from each node's agent status
+5. Return `CiliumConnectivityResponse` with per-node health, `ExecEnabled: true`
+
+### Modify `backend/internal/server/routes.go`
+
+Add connectivity endpoint under existing `/cilium` group:
+
+```go
+cr.Get("/connectivity", h.HandleCiliumConnectivity)
+```
+
+### Modify `backend/internal/config/config.go`
+
+Add to Config struct:
+
+```go
+type Config struct {
+    // ... existing fields ...
+    CiliumAgent CiliumAgentConfig
+}
+
+type CiliumAgentConfig struct {
+    ExecEnabled bool `koanf:"execenabled"`
+}
+```
+
+Env var: `KUBECENTER_CILIUMAGENT_EXECENABLED=true|false`
+
+### Modify `helm/kubecenter/values.yaml`
+
+```yaml
+# -- Cilium agent deep diagnostics (requires pods/exec RBAC)
+ciliumAgent:
+  # -- Enable exec-based diagnostics for WireGuard details, ClusterMesh, Envoy stats
+  execEnabled: false
+```
+
+### Modify `helm/kubecenter/templates/clusterrole.yaml`
+
+Add conditional `pods/exec` rule:
+
+```yaml
+{{- if .Values.ciliumAgent.execEnabled }}
+  # Cilium agent exec — runs cilium-dbg status for deep diagnostics
+  # Cluster-wide scope: pod listing already requires cluster-wide pods:list.
+  # Application-level controls (label validation, namespace allowlist, hardcoded command) provide defense-in-depth.
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+{{- end }}
+```
+
+### Modify `helm/kubecenter/templates/configmap-app.yaml`
+
+```yaml
+KUBECENTER_CILIUMAGENT_EXECENABLED: {{ .Values.ciliumAgent.execEnabled | quote }}
+```
+
+### Modify `backend/cmd/kubecenter/main.go`
+
+Conditionally construct agent collector:
+
+```go
+var agentCollector *networking.CiliumAgentCollector
+if cfg.CiliumAgent.ExecEnabled {
+    agentCollector = networking.NewCiliumAgentCollector(k8sClient, auditLogger, logger)
+    logger.Info("cilium agent exec collector enabled")
+}
+
+networkingHandler := &networking.Handler{
+    // ... existing fields ...
+    AgentCollector: agentCollector,
+}
+```
+
+### Update `backend/internal/networking/detect.go`
+
+Update the deferred comment:
+
+```go
+// DetectMesh returns the active service mesh engine based on cached feature detection.
+// Returns "cilium" if Cilium's Envoy-based mesh is enabled, "none" otherwise.
+// Istio/Linkerd detection is deferred to Phase C (needs per-mesh adapter + test environment).
+```
+
+### Backend unit tests in `backend/internal/networking/networking_test.go`
+
+**Agent collector tests (4):**
+- `TestAgentCollector_CacheHit` — verify cached result returned within TTL
+- `TestAgentCollector_PodValidation` — reject pods not matching expected labels/namespace
+- `TestAgentCollector_ParseMinimalJSON` — parse each agent type struct from sample JSON
+- `TestAgentCollector_PartialFailure` — 3/5 pods succeed, result marked `partial: true`
+
+**Enrichment tests (4):**
+- `TestMergeAgentIntoSubsystems_WireGuard` — encryption enriched with peer data
+- `TestMergeAgentIntoSubsystems_ClusterMesh` — remote cluster list populated
+- `TestMergeAgentIntoSubsystems_Proxy` — deployment mode and redirect counts merged
+- `TestMergeAgentIntoSubsystems_NilGuards` — merge with nil Encryption/MeshInfo/ClusterMeshInfo sub-structs does not panic
+
+**Connectivity tests (2):**
+- `TestHandleCiliumConnectivity_ExecDisabled` — returns `configured: true, nodes: []` when `AgentCollector == nil`
+- `TestHandleCiliumConnectivity_NotCilium` — returns `configured: false` when CNI is not Cilium
+
+### Verification
+- `go build ./cmd/kubecenter/...`
+- `go vet ./...`
+- `go test ./internal/networking/... -v -count=1`
+- `make helm-lint`
+- `make helm-template` — verify conditional ClusterRole rule appears/disappears
+
+---
+
+## Step 2: Frontend — Types + Islands + Integration
+
+**Files:** 1 new, 4 modified
+**Goal:** Display agent-enriched data, node connectivity, last-updated timestamps
+
+### Modify `frontend/lib/hooks/use-poll.ts`
+
+Add `lastFetchedAt` signal to return type (non-breaking — existing callers ignore it):
+
+```typescript
+interface UsePollResult<T> {
+    data: Signal<T | null>;
+    loading: Signal<boolean>;
+    error: Signal<string | null>;
+    refetch: () => void;
+    lastFetchedAt: Signal<Date | null>;  // NEW
+}
+```
+
+Inside the fetch success path, set `lastFetchedAt.value = new Date()`.
+
+### Modify `frontend/lib/cilium-types.ts`
+
+Add Phase B enrichment types and connectivity response:
+
+```typescript
+// Extend existing types with optional agent-sourced fields
+export interface EncryptionInfo {
+    enabled: boolean;
+    mode: string;
+    nodesEncrypted: number;
+    nodesTotal: number;
+    wireGuardNodes?: WireGuardNode[];  // Phase B
+}
+
+export interface WireGuardNode {
+    nodeName: string;
+    publicKey: string;
+    listenPort: number;
+    peerCount: number;
+    peers: WireGuardPeer[];
+}
+
+export interface WireGuardPeer {
+    publicKey: string;
+    endpoint: string;
+    lastHandshake: string;
+    transferRx: number;
+    transferTx: number;
+}
+
+export interface MeshInfo {
+    enabled: boolean;
+    engine: string;
+    deploymentMode?: string;    // Phase B (agent)
+    totalRedirects?: number;    // Phase B (agent)
+    totalPorts?: number;        // Phase B (agent)
+}
+
+export interface ClusterMeshInfo {
+    enabled: boolean;
+    remoteClusters?: RemoteCluster[];  // Phase B (agent)
+}
+
+export interface RemoteCluster {
+    name: string;
+    connected: boolean;
+    ready: boolean;
+    status: string;
+    numNodes: number;
+    numEndpoints: number;
+    numSharedServices: number;
+    numFailures: number;
+    lastFailure?: string;
+}
+
+// Flat interface — matches existing BGP/IPAM response pattern
+export interface CiliumConnectivityResponse {
+    configured: boolean;
+    execEnabled: boolean;
+    nodes: NodeConnectivity[];
+    collectedAt?: string;
+    partial?: boolean;
+}
+
+export interface NodeConnectivity {
+    nodeName: string;
+    healthState: string;
+    message?: string;
+}
+```
+
+### Modify `frontend/islands/CiliumSubsystems.tsx`
+
+Extend the existing four-section layout with Phase B data when present:
+
+**Encryption section:**
+- Existing: mode badge, "X/Y nodes encrypted"
+- Phase B: if `wireGuardNodes` present, expandable detail showing per-node:
+  - Public key (truncated to first 8 chars + `...`)
+  - Peer count
+  - For each peer: endpoint, last handshake (relative time), transfer rx/tx (human-readable bytes)
+
+**Service Mesh section:**
+- Existing: engine badge, enabled/disabled
+- Phase B: if `deploymentMode` present, show "embedded"/"external" badge
+- If `totalRedirects`/`totalPorts` present, show as key-value pairs
+
+**ClusterMesh section:**
+- Existing: enabled/disabled badge
+- Phase B: if `remoteClusters` present, show table:
+  - Cluster name, connected (green/red dot), nodes, endpoints, shared services, failures
+
+**Endpoints section:** Unchanged (no agent enrichment needed)
+
+**Last updated footer:** Inline static timestamp from `lastFetchedAt`:
+```tsx
+{lastFetchedAt.value && (
+    <span class="text-xs text-[var(--text-muted)]">
+        Updated {lastFetchedAt.value.toLocaleTimeString()}
+    </span>
+)}
+```
+
+No separate component file, no ticking timer. The timestamp updates on each poll cycle.
+
+### Create `frontend/islands/NodeConnectivity.tsx`
+
+New island rendered in `NetworkOverview.tsx` grid when CNI is Cilium:
+
+```tsx
+export default function NodeConnectivity() {
+    const { data, loading, error, lastFetchedAt } = usePoll<CiliumConnectivityResponse>(
+        "/v1/networking/cilium/connectivity",
+        { interval: 60000 }
+    );
+
+    // If not configured → muted card (same pattern as BgpStatus)
+    // If configured but nodes empty → placeholder card:
+    //   "Enable ciliumAgent.execEnabled in Helm values for node connectivity data"
+    // If configured + nodes present → node health table:
+    //   NodeName | Health State (colored dot) | Message
+    //   Green = Ok, Yellow = Warning, Red = Failure
+    // Footer: inline static timestamp from lastFetchedAt
+}
+```
+
+Grid placement: full-width row below Subsystems (`md:col-span-2`).
+
+### Modify `frontend/islands/NetworkOverview.tsx`
+
+Add `NodeConnectivity` to the Cilium-specific section:
+
+```tsx
+{isCilium && (
+    <>
+        <BgpStatus />
+        <IpamStatus />
+        <CiliumSubsystems />           {/* full-width */}
+        <NodeConnectivity />            {/* full-width, NEW */}
+    </>
+)}
+```
+
+### Modify `frontend/islands/BgpStatus.tsx` and `IpamStatus.tsx`
+
+Add inline last-updated footer to both islands. Minimal change — destructure `lastFetchedAt` from existing `usePoll` return and add the inline `<span>`.
+
+### Verification
+- `deno lint frontend/`
+- `deno fmt --check frontend/`
+- `deno check frontend/islands/CiliumSubsystems.tsx`
+- `deno check frontend/islands/NodeConnectivity.tsx`
+- `deno check frontend/islands/NetworkOverview.tsx`
+- Manual browser check: verify grid layout renders correctly
+
+---
+
+## Step 3: E2E Tests + Smoke Test
+
+**Files:** 1 new (possibly)
+**Goal:** E2E validation and homelab smoke test
+
+### Playwright E2E test in `e2e/`
+
+Add test cases to existing networking E2E or create `networking-phase-b.spec.ts`:
+
+- Navigate to `/networking` → Overview tab
+- Verify CiliumSubsystems card renders (Phase A — regression check)
+- Verify "Updated" timestamp appears on BGP, IPAM, Subsystems cards
+- Verify NodeConnectivity card renders (either with data or placeholder)
+- Verify no console errors on initial load and after 2 polling cycles
+
+**CI consideration:** Kind cluster in CI does not have Cilium, so Cilium-specific islands will show `configured: false`. Test for graceful degradation (no errors, muted cards visible). For full validation, rely on homelab smoke test.
+
+### Homelab smoke test
+
+Deploy to homelab cluster (Cilium 1.19.1, WireGuard enabled):
+
+1. **Without exec:** `ciliumAgent.execEnabled: false` (default)
+   - Verify all Phase A islands still work (BGP, IPAM, Subsystems)
+   - Verify "Updated" timestamps appear
+   - Verify NodeConnectivity shows placeholder
+   - Verify no new console errors
+
+2. **With exec:** `helm upgrade --set ciliumAgent.execEnabled=true`
+   - Verify ClusterRole now includes `pods/exec`
+   - Verify Subsystems card shows WireGuard peer details (handshake times, transfer stats)
+   - Verify Service Mesh section shows deployment mode
+   - Verify ClusterMesh section shows "Disabled" (not configured in homelab)
+   - Verify NodeConnectivity shows per-node health states
+   - Verify endpoint counts match: `kubectl get ciliumendpoints -A --no-headers | wc -l`
+   - Navigate between tabs — verify no console errors, no leaked timers
+   - Check backend logs for structured agent exec entries
+   - Check PostgreSQL audit log for exec entries
+
+### Run full verification suite
+
+```bash
+npx tsc --noEmit          # frontend type-check (if applicable)
+deno lint frontend/       # lint
+deno fmt --check frontend/ # formatting
+go vet ./...               # Go static analysis
+go test ./internal/networking/... -v -count=1  # unit tests
+make test-e2e              # Playwright
+```
+
+### Verification
+- All commands above pass
+- Homelab smoke test green
+
+---
+
+## Step-File Matrix
+
+| Step | New Files | Modified Files |
+|---|---|---|
+| 1 | `agent_types.go`, `agent_exec.go` | `types.go`, `handler.go`, `routes.go`, `config.go`, `values.yaml`, `clusterrole.yaml`, `configmap-app.yaml`, `main.go`, `detect.go`, `networking_test.go` |
+| 2 | `NodeConnectivity.tsx` | `use-poll.ts`, `cilium-types.ts`, `CiliumSubsystems.tsx`, `NetworkOverview.tsx`, `BgpStatus.tsx`, `IpamStatus.tsx` |
+| 3 | E2E test file (maybe) | — |
+
+**Total:** ~3 new files, ~16 modified files, 0 deleted files
+
+---
+
+## RBAC Requirements
+
+### Phase B Additions (opt-in)
+
+```yaml
+# Only when ciliumAgent.execEnabled: true
+- apiGroups: [""]
+  resources: ["pods/exec"]
+  verbs: ["create"]
+```
+
+### Full Cilium RBAC (Phase A + B combined)
+
+```yaml
+# Phase A (already present)
+- apiGroups: ["cilium.io"]
+  resources: ["ciliumbgpclusterconfigs", "ciliumbgppeerconfigs", "ciliumbgpnodeconfigs", "ciliumnodes", "ciliumendpoints"]
+  verbs: ["get", "list", "watch"]
+
+# Phase B (conditional on ciliumAgent.execEnabled)
+- apiGroups: [""]
+  resources: ["pods/exec"]
+  verbs: ["create"]
+```
+
+---
+
+## Risk Mitigation
+
+| Risk | Mitigation |
+|---|---|
+| Service account with `pods/exec` is a privilege escalation | Opt-in via Helm (default off), pod label validation, namespace allowlist, hardcoded command, 1MB output cap, Prometheus metrics, audit trail |
+| Agent exec hangs on unresponsive pod | 5s per-pod timeout + 30s outer timeout + errgroup context cancellation |
+| All agent pods fail | Graceful degradation: subsystems returns CRD-only data, connectivity returns empty nodes list |
+| 1 MB output cap exceeded | Truncated JSON fails to parse → node marked as failed → CRD-only fallback, warning logged |
+| Large cluster (50+ nodes) saturates exec capacity | errgroup.SetLimit(5) caps concurrent execs; 30s outer timeout bounds wall time to 50s worst case |
+| Singleflight thundering herd on cold cache | Singleflight key `"agent-collect"` coalesces concurrent requests |
+| `lastFetchedAt` addition breaks existing usePoll callers | Added as new return field — destructuring callers that don't use it are unaffected |
+| NodeConnectivity island not bundled by Fresh | Always rendered in SSR (even as placeholder) per project convention |
+| Remote cluster selected | All Cilium endpoints return `configured: false` (unchanged from Phase A) |
+| Agent cache stale after ConfigMap edit | `InvalidateCaches()` now clears agent cache too |
+| Merge function crashes on nil sub-structs | Nil-guard checks on Encryption/MeshInfo/ClusterMeshInfo before merging |
+
+---
+
+## Phase C Scope (Future — Beyond Phase B)
+
+| Feature | Requires | Notes |
+|---|---|---|
+| Istio/Linkerd detection | API group + Deployment checks (no exec) | Needs per-mesh adapter pattern, test environment, `DetectMesh()` return type change |
+| Full node connectivity matrix | `cilium-dbg connectivity test` (destructive, long-running) | Requires separate opt-in, background job pattern |
+| BPF map utilization | Agent exec + `cilium bpf map list` | Could inform capacity planning |
+| DNS proxy cache | Agent exec + `cilium fqdn cache list` | Useful for DNS-based policy debugging |
+| Service load-balancing view | Agent exec + `cilium service list` | Cross-references with Service topology |
+| `cilium` binary fallback | Try `cilium` if `cilium-dbg` not found | For Cilium < 1.13 (EOL) — add only if reported |
+| Adaptive polling | Dynamic interval based on health state | Fixed intervals are sufficient for now |


### PR DESCRIPTION
## Summary

- Adds opt-in `CiliumAgentCollector` that execs `cilium-dbg status -o json` into agent pods using service account credentials (SPDY transport incompatible with impersonation + system-level diagnostic + cache coalescing)
- 7 compensating controls for the impersonation exception: Helm opt-in (default off), pod label validation, namespace allowlist, hardcoded command, audit logging (slog + PostgreSQL), output cap (1MB), Prometheus metrics
- Enriches existing subsystems response with WireGuard peer data, Envoy proxy stats, and ClusterMesh remote clusters (additive — never replaces CRD data)
- New `GET /cilium/connectivity` endpoint for per-node health
- Frontend: enriched CiliumSubsystems island, new NodeConnectivity island, `lastFetchedAt` timestamps on all Cilium islands
- 10 new unit tests covering cache, pod validation, JSON parsing, partial failure, merge logic, nil guards, connectivity handler

## Architecture

- `singleflight` + 30s shared cache across both subsystems and connectivity endpoints (prevents 2N execs on page load)
- `errgroup.SetLimit(5)` + 5s per-pod timeout + 30s outer timeout
- Partial success: failed nodes fall back to CRD-only data, response marked `partial: true`
- Config: `KUBECENTER_CILIUMAGENT_EXECENABLED` → `Config.CiliumAgent.ExecEnabled`
- Helm: conditional `pods/exec` ClusterRole rule, only present when `ciliumAgent.execEnabled: true`

## Files Changed

- **3 new:** `agent_types.go`, `agent_exec.go`, `NodeConnectivity.tsx`
- **17 modified:** types, handler, routes, config, main, detect, tests, Helm (values, clusterrole, configmap), frontend islands + types + hook
- **1 plan:** `plans/networking-overview-phase-b.md`

## Test plan

- [x] `go build ./cmd/kubecenter/...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./internal/networking/... -count=1` — 27/27 pass (10 new)
- [x] `deno fmt --check frontend/` — 366 files clean
- [x] `deno lint frontend/` — 363 files clean
- [x] `helm lint` — 1 chart, 0 failures
- [x] `helm template` default — `pods/exec` absent
- [x] `helm template --set ciliumAgent.execEnabled=true` — `pods/exec` present
- [ ] Homelab smoke test: without exec (Phase A regression) + with exec (enriched data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)