### PR TITLE
feat: Notification Center — Phase 11A Step 1 (schema, types, store)

### DIFF
--- a/backend/cmd/kubecenter/main.go
+++ b/backend/cmd/kubecenter/main.go
@@ -355,7 +355,7 @@ func main() {
 	// Cluster health probing — background goroutine
 	var clusterProber *k8s.ClusterProber
 	if clusterStore != nil {
-		clusterProber = k8s.NewClusterProber(clusterStore, dbEncKey, logger)
+		clusterProber = k8s.NewClusterProber(clusterStore, dbEncKey, nil, logger)
 		go clusterProber.Run(ctx)
 	}
 

--- a/backend/cmd/kubecenter/main.go
+++ b/backend/cmd/kubecenter/main.go
@@ -498,7 +498,7 @@ func main() {
 		}
 	}
 
-	notificationHandler := &notification.Handler{
+	fluxNotifHandler := &notification.Handler{
 		K8sClient:     k8sClient,
 		AccessChecker: accessChecker,
 		Logger:        logger,
@@ -555,7 +555,7 @@ func main() {
 					return notification.NormalizeProvider(obj), nil
 				}, func(eventType, kind, ns, name string, obj any) {
 					hub.HandleEvent(eventType, kind, ns, name, obj)
-					notificationHandler.InvalidateProviders()
+					fluxNotifHandler.InvalidateProviders()
 				})
 
 				websocket.RegisterAllowedKind("flux-alerts", "notification.toolkit.fluxcd.io")
@@ -563,7 +563,7 @@ func main() {
 					return notification.NormalizeAlert(obj), nil
 				}, func(eventType, kind, ns, name string, obj any) {
 					hub.HandleEvent(eventType, kind, ns, name, obj)
-					notificationHandler.InvalidateAlerts()
+					fluxNotifHandler.InvalidateAlerts()
 				})
 
 				websocket.RegisterAllowedKind("flux-receivers", "notification.toolkit.fluxcd.io")
@@ -571,7 +571,7 @@ func main() {
 					return notification.NormalizeReceiver(obj), nil
 				}, func(eventType, kind, ns, name string, obj any) {
 					hub.HandleEvent(eventType, kind, ns, name, obj)
-					notificationHandler.InvalidateReceivers()
+					fluxNotifHandler.InvalidateReceivers()
 				})
 			} else {
 				informerMgr.StopCRD(notification.FluxProviderGVR)
@@ -635,7 +635,7 @@ func main() {
 		DiagnosticsHandler:   diagHandler,
 		PolicyHandler:        policyHandler,
 		GitOpsHandler:        gitopsHandler,
-		NotificationHandler:    notificationHandler,
+		FluxNotifHandler:    fluxNotifHandler,
 		ScanningHandler:      scanHandler,
 		CRDHandler:           crdHandler,
 		LogQueryLimiter:    logQueryLimiter,

--- a/backend/cmd/kubecenter/main.go
+++ b/backend/cmd/kubecenter/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/kubecenter/kubecenter/internal/gitops"
 	"github.com/kubecenter/kubecenter/internal/gitprovider"
 	"github.com/kubecenter/kubecenter/internal/notification"
+	"github.com/kubecenter/kubecenter/internal/notifications"
 	"github.com/kubecenter/kubecenter/internal/scanning"
 	"github.com/kubecenter/kubecenter/internal/policy"
 	"github.com/kubecenter/kubecenter/internal/server"
@@ -602,6 +603,47 @@ func main() {
 	}
 	scanHandler.InitCache()
 
+	// Notification center — aggregates events from all subsystems
+	var notifService *notifications.NotificationService
+	var notifCenterHandler *notifications.Handler
+	if dbPool != nil {
+		notifStore := notifications.NewStore(dbPool, dbEncKey)
+		notifService = notifications.NewService(notifStore, hub, alertNotifier, logger)
+		notifService.Start(ctx)
+
+		notifCenterHandler = &notifications.Handler{
+			Service:     notifService,
+			RBACChecker: rbacChecker,
+			AuditLogger: auditLogger,
+			Logger:      logger,
+		}
+
+		// Wire NotifService into event producers
+		if clusterProber != nil {
+			clusterProber.SetStatusChangeFunc(func(ctx context.Context, clusterID, oldStatus, newStatus string) {
+				sev := notifications.SeverityInfo
+				title := "Cluster " + clusterID + " is now " + newStatus
+				if newStatus != "connected" {
+					sev = notifications.SeverityCritical
+					title = "Cluster " + clusterID + " is " + newStatus
+				}
+				notifService.Emit(ctx, notifications.Notification{
+					Source:   notifications.SourceCluster,
+					Severity: sev,
+					Title:    title,
+					Message:  "Status changed from " + oldStatus + " to " + newStatus,
+				})
+			})
+		}
+		alertHandler.NotifService = notifService
+		if policyHandler != nil {
+			policyHandler.NotifService = notifService
+		}
+		gitopsHandler.NotifService = notifService
+		scanHandler.NotifService = notifService
+		diagHandler.NotifService = notifService
+	}
+
 	// Ready state: true after informer sync, false during shutdown
 	var ready atomic.Bool
 	ready.Store(true)
@@ -635,8 +677,10 @@ func main() {
 		DiagnosticsHandler:   diagHandler,
 		PolicyHandler:        policyHandler,
 		GitOpsHandler:        gitopsHandler,
-		FluxNotifHandler:    fluxNotifHandler,
-		ScanningHandler:      scanHandler,
+		FluxNotifHandler:       fluxNotifHandler,
+		NotifCenterHandler:    notifCenterHandler,
+		NotifCenterService:    notifService,
+		ScanningHandler:       scanHandler,
 		CRDHandler:           crdHandler,
 		LogQueryLimiter:    logQueryLimiter,
 		WebhookRateLimiter: webhookRateLimiter,

--- a/backend/internal/alerting/handler.go
+++ b/backend/internal/alerting/handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kubecenter/kubecenter/internal/audit"
 	"github.com/kubecenter/kubecenter/internal/config"
 	"github.com/kubecenter/kubecenter/internal/httputil"
+	"github.com/kubecenter/kubecenter/internal/notifications"
 	"github.com/kubecenter/kubecenter/internal/websocket"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
@@ -29,6 +30,7 @@ type Handler struct {
 	Rules        *RulesManager
 	Hub          *websocket.Hub
 	AuditLogger  audit.Logger
+	NotifService *notifications.NotificationService
 	Logger       *slog.Logger
 	ClusterID    string
 	WebhookToken string
@@ -133,6 +135,30 @@ func (h *Handler) HandleWebhook(w http.ResponseWriter, r *http.Request) {
 
 		if h.Notifier != nil {
 			h.Notifier.QueueAlert(action)
+		}
+
+		if h.NotifService != nil {
+			sev := notifications.SeverityWarning
+			if s, ok := action.Alert.Labels["severity"]; ok {
+				switch s {
+				case "critical":
+					sev = notifications.SeverityCritical
+				case "warning":
+					sev = notifications.SeverityWarning
+				default:
+					sev = notifications.SeverityInfo
+				}
+			}
+			title := "Alert " + action.Type + ": " + action.Alert.Labels["alertname"]
+			h.NotifService.Emit(r.Context(), notifications.Notification{
+				Source:       notifications.SourceAlert,
+				Severity:     sev,
+				Title:        title,
+				Message:      action.Alert.Annotations["description"],
+				ResourceKind: action.Alert.Labels["kind"],
+				ResourceNS:   action.Alert.Labels["namespace"],
+				ResourceName: action.Alert.Labels["name"],
+			})
 		}
 	}
 

--- a/backend/internal/alerting/notifier.go
+++ b/backend/internal/alerting/notifier.go
@@ -46,9 +46,10 @@ var emailTemplates = template.Must(
 
 // EmailMessage represents an email to be sent.
 type EmailMessage struct {
-	Subject  string
-	Body     string
-	Priority string // "high" for critical alerts
+	Subject    string
+	Body       string
+	Priority   string   // "high" for critical alerts
+	Recipients []string // optional override; nil uses configured recipients
 }
 
 // Notifier sends alert email notifications via SMTP.
@@ -161,6 +162,25 @@ func (n *Notifier) QueueTestEmail() error {
 		Body:    buf.String(),
 	}
 
+	select {
+	case n.queue <- msg:
+		return nil
+	default:
+		return fmt.Errorf("email queue is full")
+	}
+}
+
+// QueueEmail queues an arbitrary HTML email for delivery.
+// Used by the notification center for digest emails with custom recipients.
+func (n *Notifier) QueueEmail(recipients []string, subject, htmlBody string) error {
+	if !n.SMTPConfigured() {
+		return fmt.Errorf("SMTP is not configured")
+	}
+	msg := &EmailMessage{
+		Subject:    subject,
+		Body:       htmlBody,
+		Recipients: recipients,
+	}
 	select {
 	case n.queue <- msg:
 		return nil
@@ -314,8 +334,11 @@ func (n *Notifier) send(msg *EmailMessage) error {
 		return fmt.Errorf("SMTP host not configured")
 	}
 
-	// Determine recipients: configured list, or fall back to from address
+	// Use per-message recipients if set, otherwise configured list, otherwise from address
 	rcpts := recipients
+	if len(msg.Recipients) > 0 {
+		rcpts = msg.Recipients
+	}
 	if len(rcpts) == 0 {
 		rcpts = []string{from}
 	}

--- a/backend/internal/diagnostics/handler.go
+++ b/backend/internal/diagnostics/handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kubecenter/kubecenter/internal/auth"
 	"github.com/kubecenter/kubecenter/internal/httputil"
 	"github.com/kubecenter/kubecenter/internal/k8s/resources"
+	"github.com/kubecenter/kubecenter/internal/notifications"
 	"github.com/kubecenter/kubecenter/internal/topology"
 )
 
@@ -21,6 +22,7 @@ type Handler struct {
 	Lister        topology.ResourceLister
 	TopoBuilder   *topology.Builder
 	AccessChecker *resources.AccessChecker
+	NotifService  *notifications.NotificationService
 	Logger        *slog.Logger
 }
 
@@ -126,6 +128,27 @@ func (h *Handler) HandleDiagnostics(w http.ResponseWriter, r *http.Request) {
 		blast = &BlastResult{
 			DirectlyAffected:    []AffectedResource{},
 			PotentiallyAffected: []AffectedResource{},
+		}
+	}
+
+	// Emit notifications for critical/warning diagnostic findings
+	if h.NotifService != nil {
+		for _, result := range results {
+			if result.Status == "fail" {
+				sev := notifications.SeverityWarning
+				if result.Severity == SeverityCritical {
+					sev = notifications.SeverityCritical
+				}
+				h.NotifService.Emit(ctx, notifications.Notification{
+					Source:       notifications.SourceDiagnostic,
+					Severity:     sev,
+					Title:        result.RuleName + ": " + name,
+					Message:      result.Message,
+					ResourceKind: kind,
+					ResourceNS:   namespace,
+					ResourceName: name,
+				})
+			}
 		}
 	}
 

--- a/backend/internal/gitops/handler.go
+++ b/backend/internal/gitops/handler.go
@@ -23,6 +23,7 @@ import (
 	"github.com/kubecenter/kubecenter/internal/httputil"
 	"github.com/kubecenter/kubecenter/internal/k8s"
 	"github.com/kubecenter/kubecenter/internal/k8s/resources"
+	"github.com/kubecenter/kubecenter/internal/notifications"
 	"github.com/kubecenter/kubecenter/internal/server/middleware"
 )
 
@@ -34,6 +35,7 @@ type Handler struct {
 	Logger        *slog.Logger
 	AuditLogger   audit.Logger
 	CommitCache   *gitprovider.CommitCache
+	NotifService  *notifications.NotificationService
 
 	fetchGroup singleflight.Group
 	cacheMu    sync.RWMutex
@@ -446,11 +448,26 @@ func (h *Handler) invalidateCache() {
 	h.cachedData = nil
 	h.cacheGen++
 	h.cacheMu.Unlock()
+	go h.notifyGitOpsChange(context.Background())
 }
 
 // InvalidateCache is the exported version for use by CRD event handlers.
 func (h *Handler) InvalidateCache() {
 	h.invalidateCache()
+}
+
+// notifyGitOpsChange emits a notification when the GitOps cache is invalidated
+// (i.e. CRD watch detected a sync status change). Dedup in the service suppresses bursts.
+func (h *Handler) notifyGitOpsChange(ctx context.Context) {
+	if h.NotifService == nil {
+		return
+	}
+	h.NotifService.Emit(ctx, notifications.Notification{
+		Source:   notifications.SourceGitOps,
+		Severity: notifications.SeverityWarning,
+		Title:    "GitOps sync status changed",
+		Message:  "A GitOps application sync status has changed. Check the GitOps dashboard for details.",
+	})
 }
 
 // prepareAction extracts the common preamble for action handlers:

--- a/backend/internal/gitops/handler.go
+++ b/backend/internal/gitops/handler.go
@@ -448,26 +448,19 @@ func (h *Handler) invalidateCache() {
 	h.cachedData = nil
 	h.cacheGen++
 	h.cacheMu.Unlock()
-	go h.notifyGitOpsChange(context.Background())
+	if h.NotifService != nil {
+		go h.NotifService.Emit(context.Background(), notifications.Notification{
+			Source:   notifications.SourceGitOps,
+			Severity: notifications.SeverityInfo,
+			Title:    "GitOps sync status changed",
+			Message:  "A GitOps application sync status has changed. Check the GitOps dashboard for details.",
+		})
+	}
 }
 
 // InvalidateCache is the exported version for use by CRD event handlers.
 func (h *Handler) InvalidateCache() {
 	h.invalidateCache()
-}
-
-// notifyGitOpsChange emits a notification when the GitOps cache is invalidated
-// (i.e. CRD watch detected a sync status change). Dedup in the service suppresses bursts.
-func (h *Handler) notifyGitOpsChange(ctx context.Context) {
-	if h.NotifService == nil {
-		return
-	}
-	h.NotifService.Emit(ctx, notifications.Notification{
-		Source:   notifications.SourceGitOps,
-		Severity: notifications.SeverityWarning,
-		Title:    "GitOps sync status changed",
-		Message:  "A GitOps application sync status has changed. Check the GitOps dashboard for details.",
-	})
 }
 
 // prepareAction extracts the common preamble for action handlers:

--- a/backend/internal/k8s/cluster_prober.go
+++ b/backend/internal/k8s/cluster_prober.go
@@ -14,20 +14,26 @@ import (
 	"github.com/kubecenter/kubecenter/internal/store"
 )
 
+// StatusChangeFunc is called when a cluster's probe status transitions.
+// Parameters: ctx, clusterID, oldStatus, newStatus.
+type StatusChangeFunc func(ctx context.Context, clusterID, oldStatus, newStatus string)
+
 // ClusterProber periodically checks the health of registered remote clusters.
 // It also exposes ProbeOne for on-demand testing from the API.
 type ClusterProber struct {
-	clusterStore *store.ClusterStore
-	encKey       string
-	logger       *slog.Logger
+	clusterStore   *store.ClusterStore
+	encKey         string
+	onStatusChange StatusChangeFunc
+	logger         *slog.Logger
 }
 
 // NewClusterProber creates a cluster health prober.
-func NewClusterProber(cs *store.ClusterStore, encKey string, logger *slog.Logger) *ClusterProber {
+func NewClusterProber(cs *store.ClusterStore, encKey string, onStatusChange StatusChangeFunc, logger *slog.Logger) *ClusterProber {
 	return &ClusterProber{
-		clusterStore: cs,
-		encKey:       encKey,
-		logger:       logger,
+		clusterStore:   cs,
+		encKey:         encKey,
+		onStatusChange: onStatusChange,
+		logger:         logger,
 	}
 }
 
@@ -73,9 +79,12 @@ func (p *ClusterProber) ProbeOne(ctx context.Context, clusterID string) (*store.
 		return nil, fmt.Errorf("cluster %s not found: %w", clusterID, err)
 	}
 
+	oldStatus := cluster.Status
+
 	// SSRF check — re-resolve DNS at probe time (DNS rebinding defense)
 	if err := ValidateRemoteURL(cluster.APIServerURL); err != nil {
 		_ = p.clusterStore.UpdateStatus(ctx, clusterID, "blocked", "URL resolves to private address", "", 0)
+		p.emitStatusChange(ctx, clusterID, oldStatus, "blocked")
 		return nil, fmt.Errorf("SSRF blocked: %w", err)
 	}
 
@@ -83,6 +92,7 @@ func (p *ClusterProber) ProbeOne(ctx context.Context, clusterID string) (*store.
 	token, err := store.Decrypt(cluster.AuthData, p.encKey)
 	if err != nil {
 		_ = p.clusterStore.UpdateStatus(ctx, clusterID, "error", "credential error", "", 0)
+		p.emitStatusChange(ctx, clusterID, oldStatus, "error")
 		return nil, fmt.Errorf("decryption failed: %w", err)
 	}
 
@@ -92,6 +102,7 @@ func (p *ClusterProber) ProbeOne(ctx context.Context, clusterID string) (*store.
 		if err != nil {
 			// CA was stored but can't be decrypted — don't auto-downgrade to insecure
 			_ = p.clusterStore.UpdateStatus(ctx, clusterID, "error", "credential error", "", 0)
+			p.emitStatusChange(ctx, clusterID, oldStatus, "error")
 			return nil, fmt.Errorf("CA decryption failed: %w", err)
 		}
 	}
@@ -113,12 +124,14 @@ func (p *ClusterProber) ProbeOne(ctx context.Context, clusterID string) (*store.
 	cs, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		_ = p.clusterStore.UpdateStatus(ctx, clusterID, "error", sanitizeProbeError(err), "", 0)
+		p.emitStatusChange(ctx, clusterID, oldStatus, "error")
 		return nil, err
 	}
 
 	version, err := cs.Discovery().ServerVersion()
 	if err != nil {
 		_ = p.clusterStore.UpdateStatus(ctx, clusterID, "disconnected", sanitizeProbeError(err), "", 0)
+		p.emitStatusChange(ctx, clusterID, oldStatus, "disconnected")
 		return nil, err
 	}
 
@@ -131,10 +144,19 @@ func (p *ClusterProber) ProbeOne(ctx context.Context, clusterID string) (*store.
 
 	// Update status
 	_ = p.clusterStore.UpdateStatus(ctx, clusterID, "connected", "", version.GitVersion, nodeCount)
+	p.emitStatusChange(ctx, clusterID, oldStatus, "connected")
 	p.logger.Debug("cluster probe succeeded", "clusterID", clusterID, "version", version.GitVersion, "nodes", nodeCount)
 
 	updated, _ := p.clusterStore.Get(ctx, clusterID)
 	return updated, nil
+}
+
+// emitStatusChange invokes the status change callback when a cluster transitions state.
+func (p *ClusterProber) emitStatusChange(ctx context.Context, clusterID, oldStatus, newStatus string) {
+	if p.onStatusChange == nil || oldStatus == newStatus {
+		return
+	}
+	p.onStatusChange(ctx, clusterID, oldStatus, newStatus)
 }
 
 // sanitizeProbeError strips raw Go error details. Returns only safe categories.

--- a/backend/internal/k8s/cluster_prober.go
+++ b/backend/internal/k8s/cluster_prober.go
@@ -27,6 +27,12 @@ type ClusterProber struct {
 	logger         *slog.Logger
 }
 
+// SetStatusChangeFunc sets the callback for cluster status transitions.
+// This allows late-binding when the notification service isn't available at construction time.
+func (p *ClusterProber) SetStatusChangeFunc(fn StatusChangeFunc) {
+	p.onStatusChange = fn
+}
+
 // NewClusterProber creates a cluster health prober.
 func NewClusterProber(cs *store.ClusterStore, encKey string, onStatusChange StatusChangeFunc, logger *slog.Logger) *ClusterProber {
 	return &ClusterProber{

--- a/backend/internal/notifications/handler.go
+++ b/backend/internal/notifications/handler.go
@@ -1,0 +1,454 @@
+package notifications
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/kubecenter/kubecenter/internal/audit"
+	"github.com/kubecenter/kubecenter/internal/auth"
+	"github.com/kubecenter/kubecenter/internal/httputil"
+	"github.com/kubecenter/kubecenter/internal/k8s"
+)
+
+// Handler handles HTTP requests for the notification center.
+type Handler struct {
+	Service       *NotificationService
+	RBACChecker   *auth.RBACChecker
+	AuditLogger   audit.Logger
+}
+
+// --- Feed endpoints (all authenticated users) ---
+
+// HandleList returns paginated, RBAC-filtered notifications for the current user.
+func (h *Handler) HandleList(w http.ResponseWriter, r *http.Request) {
+	user, ok := auth.UserFromContext(r.Context())
+	if !ok {
+		httputil.WriteError(w, http.StatusUnauthorized, "unauthorized", "")
+		return
+	}
+
+	namespaces, err := h.accessibleNamespaces(r, user)
+	if err != nil {
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to check RBAC", "")
+		return
+	}
+
+	opts := ListOpts{
+		UserID:     user.KubernetesUsername,
+		Namespaces: namespaces,
+		Source:     Source(r.URL.Query().Get("source")),
+		Severity:   Severity(r.URL.Query().Get("severity")),
+		ReadFilter: r.URL.Query().Get("read"),
+	}
+	if limit := r.URL.Query().Get("limit"); limit != "" {
+		if v, err := strconv.Atoi(limit); err == nil {
+			opts.Limit = v
+		}
+	}
+	if offset := r.URL.Query().Get("offset"); offset != "" {
+		if v, err := strconv.Atoi(offset); err == nil {
+			opts.Offset = v
+		}
+	}
+	if since := r.URL.Query().Get("since"); since != "" {
+		if t, err := time.Parse(time.RFC3339, since); err == nil {
+			opts.Since = t
+		}
+	}
+	if until := r.URL.Query().Get("until"); until != "" {
+		if t, err := time.Parse(time.RFC3339, until); err == nil {
+			opts.Until = t
+		}
+	}
+
+	notifications, total, err := h.Service.store.ListNotifications(r.Context(), opts)
+	if err != nil {
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to list notifications", "")
+		return
+	}
+
+	httputil.WriteJSON(w, http.StatusOK, map[string]any{
+		"data":     notifications,
+		"metadata": map[string]any{"total": total},
+	})
+}
+
+// HandleUnreadCount returns the unread notification count for the current user.
+func (h *Handler) HandleUnreadCount(w http.ResponseWriter, r *http.Request) {
+	user, ok := auth.UserFromContext(r.Context())
+	if !ok {
+		httputil.WriteError(w, http.StatusUnauthorized, "unauthorized", "")
+		return
+	}
+
+	namespaces, err := h.accessibleNamespaces(r, user)
+	if err != nil {
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to check RBAC", "")
+		return
+	}
+
+	count, err := h.Service.store.UnreadCount(r.Context(), user.KubernetesUsername, namespaces)
+	if err != nil {
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to count unread", "")
+		return
+	}
+
+	httputil.WriteJSON(w, http.StatusOK, map[string]any{
+		"data": map[string]int{"count": count},
+	})
+}
+
+// HandleMarkRead marks a single notification as read.
+func (h *Handler) HandleMarkRead(w http.ResponseWriter, r *http.Request) {
+	user, ok := auth.UserFromContext(r.Context())
+	if !ok {
+		httputil.WriteError(w, http.StatusUnauthorized, "unauthorized", "")
+		return
+	}
+
+	id := chi.URLParam(r, "id")
+	if id == "" {
+		httputil.WriteError(w, http.StatusBadRequest, "notification id required", "")
+		return
+	}
+
+	if err := h.Service.store.MarkRead(r.Context(), user.KubernetesUsername, id); err != nil {
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to mark read", "")
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// HandleMarkAllRead marks all notifications as read for the current user.
+func (h *Handler) HandleMarkAllRead(w http.ResponseWriter, r *http.Request) {
+	user, ok := auth.UserFromContext(r.Context())
+	if !ok {
+		httputil.WriteError(w, http.StatusUnauthorized, "unauthorized", "")
+		return
+	}
+
+	if err := h.Service.store.MarkAllRead(r.Context(), user.KubernetesUsername); err != nil {
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to mark all read", "")
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// --- Channel management (admin only) ---
+
+// HandleListChannels returns all notification channels with masked config.
+func (h *Handler) HandleListChannels(w http.ResponseWriter, r *http.Request) {
+	channels, err := h.Service.store.ListChannels(r.Context())
+	if err != nil {
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to list channels", "")
+		return
+	}
+
+	// Mask sensitive config fields
+	for i := range channels {
+		channels[i].Config = maskConfig(channels[i].Config)
+	}
+
+	httputil.WriteJSON(w, http.StatusOK, map[string]any{"data": channels})
+}
+
+// HandleCreateChannel creates a new notification channel.
+func (h *Handler) HandleCreateChannel(w http.ResponseWriter, r *http.Request) {
+	user, ok := auth.UserFromContext(r.Context())
+	if !ok {
+		httputil.WriteError(w, http.StatusUnauthorized, "unauthorized", "")
+		return
+	}
+
+	var ch Channel
+	if err := json.NewDecoder(r.Body).Decode(&ch); err != nil {
+		httputil.WriteError(w, http.StatusBadRequest, "invalid request body", err.Error())
+		return
+	}
+
+	if ch.Name == "" || ch.Type == "" {
+		httputil.WriteError(w, http.StatusBadRequest, "name and type are required", "")
+		return
+	}
+
+	// SSRF validation for webhook/Slack URLs
+	if err := validateChannelURLs(ch); err != nil {
+		httputil.WriteError(w, http.StatusBadRequest, err.Error(), "")
+		return
+	}
+
+	ch.CreatedBy = user.KubernetesUsername
+	id, err := h.Service.store.CreateChannel(r.Context(), ch)
+	if err != nil {
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to create channel", "")
+		return
+	}
+
+	h.Service.RefreshCache(r.Context())
+	h.auditLog(r, user, audit.ActionCreate, "notification-channel", ch.Name)
+
+	httputil.WriteJSON(w, http.StatusCreated, map[string]any{"data": map[string]string{"id": id}})
+}
+
+// HandleUpdateChannel updates a notification channel.
+func (h *Handler) HandleUpdateChannel(w http.ResponseWriter, r *http.Request) {
+	user, ok := auth.UserFromContext(r.Context())
+	if !ok {
+		httputil.WriteError(w, http.StatusUnauthorized, "unauthorized", "")
+		return
+	}
+
+	id := chi.URLParam(r, "id")
+	var ch Channel
+	if err := json.NewDecoder(r.Body).Decode(&ch); err != nil {
+		httputil.WriteError(w, http.StatusBadRequest, "invalid request body", err.Error())
+		return
+	}
+
+	if err := validateChannelURLs(ch); err != nil {
+		httputil.WriteError(w, http.StatusBadRequest, err.Error(), "")
+		return
+	}
+
+	ch.ID = id
+	ch.UpdatedBy = user.KubernetesUsername
+	if err := h.Service.store.UpdateChannel(r.Context(), ch); err != nil {
+		if errors.Is(err, ErrNotFound) {
+			httputil.WriteError(w, http.StatusNotFound, "channel not found", "")
+			return
+		}
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to update channel", "")
+		return
+	}
+
+	h.Service.RefreshCache(r.Context())
+	h.auditLog(r, user, audit.ActionUpdate, "notification-channel", ch.Name)
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// HandleDeleteChannel deletes a notification channel (cascades to rules).
+func (h *Handler) HandleDeleteChannel(w http.ResponseWriter, r *http.Request) {
+	user, ok := auth.UserFromContext(r.Context())
+	if !ok {
+		httputil.WriteError(w, http.StatusUnauthorized, "unauthorized", "")
+		return
+	}
+
+	id := chi.URLParam(r, "id")
+	if err := h.Service.store.DeleteChannel(r.Context(), id); err != nil {
+		if errors.Is(err, ErrNotFound) {
+			httputil.WriteError(w, http.StatusNotFound, "channel not found", "")
+			return
+		}
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to delete channel", "")
+		return
+	}
+
+	h.Service.RefreshCache(r.Context())
+	h.auditLog(r, user, audit.ActionDelete, "notification-channel", id)
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// HandleTestChannel sends a test notification to a channel.
+func (h *Handler) HandleTestChannel(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	ch, err := h.Service.store.GetChannel(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			httputil.WriteError(w, http.StatusNotFound, "channel not found", "")
+			return
+		}
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to get channel", "")
+		return
+	}
+
+	if err := h.Service.TestChannel(r.Context(), ch); err != nil {
+		httputil.WriteError(w, http.StatusBadGateway, "test failed", err.Error())
+		return
+	}
+
+	httputil.WriteJSON(w, http.StatusOK, map[string]any{"data": map[string]string{"status": "ok"}})
+}
+
+// --- Rule management (admin only) ---
+
+// HandleListRules returns all notification routing rules.
+func (h *Handler) HandleListRules(w http.ResponseWriter, r *http.Request) {
+	rules, err := h.Service.store.ListRules(r.Context())
+	if err != nil {
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to list rules", "")
+		return
+	}
+
+	httputil.WriteJSON(w, http.StatusOK, map[string]any{"data": rules})
+}
+
+// HandleCreateRule creates a new notification routing rule.
+func (h *Handler) HandleCreateRule(w http.ResponseWriter, r *http.Request) {
+	user, ok := auth.UserFromContext(r.Context())
+	if !ok {
+		httputil.WriteError(w, http.StatusUnauthorized, "unauthorized", "")
+		return
+	}
+
+	var rule Rule
+	if err := json.NewDecoder(r.Body).Decode(&rule); err != nil {
+		httputil.WriteError(w, http.StatusBadRequest, "invalid request body", err.Error())
+		return
+	}
+
+	if rule.Name == "" || rule.ChannelID == "" {
+		httputil.WriteError(w, http.StatusBadRequest, "name and channelId are required", "")
+		return
+	}
+
+	rule.CreatedBy = user.KubernetesUsername
+	id, err := h.Service.store.CreateRule(r.Context(), rule)
+	if err != nil {
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to create rule", "")
+		return
+	}
+
+	h.Service.RefreshCache(r.Context())
+	h.auditLog(r, user, audit.ActionCreate, "notification-rule", rule.Name)
+
+	httputil.WriteJSON(w, http.StatusCreated, map[string]any{"data": map[string]string{"id": id}})
+}
+
+// HandleUpdateRule updates a notification routing rule.
+func (h *Handler) HandleUpdateRule(w http.ResponseWriter, r *http.Request) {
+	user, ok := auth.UserFromContext(r.Context())
+	if !ok {
+		httputil.WriteError(w, http.StatusUnauthorized, "unauthorized", "")
+		return
+	}
+
+	id := chi.URLParam(r, "id")
+	var rule Rule
+	if err := json.NewDecoder(r.Body).Decode(&rule); err != nil {
+		httputil.WriteError(w, http.StatusBadRequest, "invalid request body", err.Error())
+		return
+	}
+
+	rule.ID = id
+	rule.UpdatedBy = user.KubernetesUsername
+	if err := h.Service.store.UpdateRule(r.Context(), rule); err != nil {
+		if errors.Is(err, ErrNotFound) {
+			httputil.WriteError(w, http.StatusNotFound, "rule not found", "")
+			return
+		}
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to update rule", "")
+		return
+	}
+
+	h.Service.RefreshCache(r.Context())
+	h.auditLog(r, user, audit.ActionUpdate, "notification-rule", rule.Name)
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// HandleDeleteRule deletes a notification routing rule.
+func (h *Handler) HandleDeleteRule(w http.ResponseWriter, r *http.Request) {
+	user, ok := auth.UserFromContext(r.Context())
+	if !ok {
+		httputil.WriteError(w, http.StatusUnauthorized, "unauthorized", "")
+		return
+	}
+
+	id := chi.URLParam(r, "id")
+	if err := h.Service.store.DeleteRule(r.Context(), id); err != nil {
+		if errors.Is(err, ErrNotFound) {
+			httputil.WriteError(w, http.StatusNotFound, "rule not found", "")
+			return
+		}
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to delete rule", "")
+		return
+	}
+
+	h.Service.RefreshCache(r.Context())
+	h.auditLog(r, user, audit.ActionDelete, "notification-rule", id)
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// --- Helpers ---
+
+// accessibleNamespaces returns the list of namespaces the user can access.
+// Uses the RBAC summary cache (60s TTL). Returns nil for cluster-admin users
+// (no namespace filtering needed).
+func (h *Handler) accessibleNamespaces(r *http.Request, user *auth.User) ([]string, error) {
+	if auth.IsAdmin(user) {
+		return nil, nil // admin sees everything
+	}
+
+	summary, err := h.RBACChecker.GetSummary(r.Context(), user, nil)
+	if err != nil {
+		return nil, fmt.Errorf("get RBAC summary: %w", err)
+	}
+
+	namespaces := make([]string, 0, len(summary.Namespaces))
+	for ns := range summary.Namespaces {
+		namespaces = append(namespaces, ns)
+	}
+	return namespaces, nil
+}
+
+// validateChannelURLs validates webhook/Slack URLs against the SSRF blocklist.
+func validateChannelURLs(ch Channel) error {
+	if ch.Type == ChannelSlack {
+		if url, _ := ch.Config["webhookUrl"].(string); url != "" {
+			if err := k8s.ValidateRemoteURL(url); err != nil {
+				return fmt.Errorf("invalid Slack webhook URL: %w", err)
+			}
+		}
+	}
+	if ch.Type == ChannelWebhook {
+		if url, _ := ch.Config["url"].(string); url != "" {
+			if err := k8s.ValidateRemoteURL(url); err != nil {
+				return fmt.Errorf("invalid webhook URL: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+// maskConfig replaces sensitive values with "****" for API responses.
+func maskConfig(cfg ChannelConfig) ChannelConfig {
+	masked := make(ChannelConfig, len(cfg))
+	for k, v := range cfg {
+		switch k {
+		case "webhookUrl", "url", "secret":
+			if s, ok := v.(string); ok && len(s) > 4 {
+				masked[k] = "****" + s[len(s)-4:]
+			} else {
+				masked[k] = "****"
+			}
+		default:
+			masked[k] = v
+		}
+	}
+	return masked
+}
+
+func (h *Handler) auditLog(r *http.Request, user *auth.User, action audit.Action, kind, name string) {
+	if h.AuditLogger == nil {
+		return
+	}
+	h.AuditLogger.Log(r.Context(), audit.Entry{
+		Action:            action,
+		ResourceKind:      kind,
+		ResourceName:      name,
+		User:              user.KubernetesUsername,
+		SourceIP:          r.RemoteAddr,
+		Result:            audit.ResultSuccess,
+	})
+}

--- a/backend/internal/notifications/handler.go
+++ b/backend/internal/notifications/handler.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -15,11 +17,18 @@ import (
 	"github.com/kubecenter/kubecenter/internal/k8s"
 )
 
+// maxRequestBody limits JSON request body size to 64KB.
+const maxRequestBody = 64 * 1024
+
 // Handler handles HTTP requests for the notification center.
+// The handler accesses the store directly via h.Service.store because both
+// handler and service are in the same package. The service layer owns Emit,
+// dispatch, and caching logic; the handler owns HTTP concerns and RBAC.
 type Handler struct {
-	Service       *NotificationService
-	RBACChecker   *auth.RBACChecker
-	AuditLogger   audit.Logger
+	Service     *NotificationService
+	RBACChecker *auth.RBACChecker
+	AuditLogger audit.Logger
+	Logger      *slog.Logger
 }
 
 // --- Feed endpoints (all authenticated users) ---
@@ -151,7 +160,6 @@ func (h *Handler) HandleListChannels(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Mask sensitive config fields
 	for i := range channels {
 		channels[i].Config = maskConfig(channels[i].Config)
 	}
@@ -168,8 +176,8 @@ func (h *Handler) HandleCreateChannel(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var ch Channel
-	if err := json.NewDecoder(r.Body).Decode(&ch); err != nil {
-		httputil.WriteError(w, http.StatusBadRequest, "invalid request body", err.Error())
+	if err := decodeJSON(r, &ch); err != nil {
+		httputil.WriteError(w, http.StatusBadRequest, "invalid request body", "")
 		return
 	}
 
@@ -177,8 +185,10 @@ func (h *Handler) HandleCreateChannel(w http.ResponseWriter, r *http.Request) {
 		httputil.WriteError(w, http.StatusBadRequest, "name and type are required", "")
 		return
 	}
-
-	// SSRF validation for webhook/Slack URLs
+	if !isValidChannelType(ch.Type) {
+		httputil.WriteError(w, http.StatusBadRequest, "type must be slack, email, or webhook", "")
+		return
+	}
 	if err := validateChannelURLs(ch); err != nil {
 		httputil.WriteError(w, http.StatusBadRequest, err.Error(), "")
 		return
@@ -206,12 +216,28 @@ func (h *Handler) HandleUpdateChannel(w http.ResponseWriter, r *http.Request) {
 	}
 
 	id := chi.URLParam(r, "id")
-	var ch Channel
-	if err := json.NewDecoder(r.Body).Decode(&ch); err != nil {
-		httputil.WriteError(w, http.StatusBadRequest, "invalid request body", err.Error())
+
+	// Fetch existing channel to validate URL against its type (not the request body type)
+	existing, err := h.Service.store.GetChannel(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			httputil.WriteError(w, http.StatusNotFound, "channel not found", "")
+			return
+		}
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to get channel", "")
 		return
 	}
 
+	var ch Channel
+	if err := decodeJSON(r, &ch); err != nil {
+		httputil.WriteError(w, http.StatusBadRequest, "invalid request body", "")
+		return
+	}
+
+	// Use existing type for SSRF validation if not provided in request
+	if ch.Type == "" {
+		ch.Type = existing.Type
+	}
 	if err := validateChannelURLs(ch); err != nil {
 		httputil.WriteError(w, http.StatusBadRequest, err.Error(), "")
 		return
@@ -260,6 +286,12 @@ func (h *Handler) HandleDeleteChannel(w http.ResponseWriter, r *http.Request) {
 
 // HandleTestChannel sends a test notification to a channel.
 func (h *Handler) HandleTestChannel(w http.ResponseWriter, r *http.Request) {
+	user, ok := auth.UserFromContext(r.Context())
+	if !ok {
+		httputil.WriteError(w, http.StatusUnauthorized, "unauthorized", "")
+		return
+	}
+
 	id := chi.URLParam(r, "id")
 	ch, err := h.Service.store.GetChannel(r.Context(), id)
 	if err != nil {
@@ -272,10 +304,12 @@ func (h *Handler) HandleTestChannel(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.Service.TestChannel(r.Context(), ch); err != nil {
-		httputil.WriteError(w, http.StatusBadGateway, "test failed", err.Error())
+		h.Logger.Error("channel test failed", "channel", ch.Name, "type", ch.Type, "error", err)
+		httputil.WriteError(w, http.StatusBadGateway, "channel test failed", "")
 		return
 	}
 
+	h.auditLog(r, user, audit.ActionUpdate, "notification-channel-test", ch.Name)
 	httputil.WriteJSON(w, http.StatusOK, map[string]any{"data": map[string]string{"status": "ok"}})
 }
 
@@ -301,8 +335,8 @@ func (h *Handler) HandleCreateRule(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var rule Rule
-	if err := json.NewDecoder(r.Body).Decode(&rule); err != nil {
-		httputil.WriteError(w, http.StatusBadRequest, "invalid request body", err.Error())
+	if err := decodeJSON(r, &rule); err != nil {
+		httputil.WriteError(w, http.StatusBadRequest, "invalid request body", "")
 		return
 	}
 
@@ -334,8 +368,8 @@ func (h *Handler) HandleUpdateRule(w http.ResponseWriter, r *http.Request) {
 
 	id := chi.URLParam(r, "id")
 	var rule Rule
-	if err := json.NewDecoder(r.Body).Decode(&rule); err != nil {
-		httputil.WriteError(w, http.StatusBadRequest, "invalid request body", err.Error())
+	if err := decodeJSON(r, &rule); err != nil {
+		httputil.WriteError(w, http.StatusBadRequest, "invalid request body", "")
 		return
 	}
 
@@ -382,12 +416,22 @@ func (h *Handler) HandleDeleteRule(w http.ResponseWriter, r *http.Request) {
 
 // --- Helpers ---
 
+// decodeJSON decodes a JSON request body with a 64KB size limit.
+func decodeJSON(r *http.Request, v any) error {
+	r.Body = http.MaxBytesReader(nil, r.Body, maxRequestBody)
+	return json.NewDecoder(r.Body).Decode(v)
+}
+
+// isValidChannelType checks if the channel type is one of the known types.
+func isValidChannelType(t ChannelType) bool {
+	return t == ChannelSlack || t == ChannelEmail || t == ChannelWebhook
+}
+
 // accessibleNamespaces returns the list of namespaces the user can access.
-// Uses the RBAC summary cache (60s TTL). Returns nil for cluster-admin users
-// (no namespace filtering needed).
+// Returns nil for admin users (no namespace filtering needed — store treats nil as "all").
 func (h *Handler) accessibleNamespaces(r *http.Request, user *auth.User) ([]string, error) {
 	if auth.IsAdmin(user) {
-		return nil, nil // admin sees everything
+		return nil, nil
 	}
 
 	summary, err := h.RBACChecker.GetSummary(r.Context(), user, nil)
@@ -403,40 +447,70 @@ func (h *Handler) accessibleNamespaces(r *http.Request, user *auth.User) ([]stri
 }
 
 // validateChannelURLs validates webhook/Slack URLs against the SSRF blocklist.
+// Requires URL to be non-empty for Slack and Webhook channel types.
 func validateChannelURLs(ch Channel) error {
-	if ch.Type == ChannelSlack {
-		if url, _ := ch.Config["webhookUrl"].(string); url != "" {
-			if err := k8s.ValidateRemoteURL(url); err != nil {
-				return fmt.Errorf("invalid Slack webhook URL: %w", err)
-			}
+	switch ch.Type {
+	case ChannelSlack:
+		url, _ := ch.Config["webhookUrl"].(string)
+		if url == "" {
+			return fmt.Errorf("Slack channel requires a webhookUrl")
 		}
-	}
-	if ch.Type == ChannelWebhook {
-		if url, _ := ch.Config["url"].(string); url != "" {
-			if err := k8s.ValidateRemoteURL(url); err != nil {
-				return fmt.Errorf("invalid webhook URL: %w", err)
-			}
+		if err := k8s.ValidateRemoteURL(url); err != nil {
+			return fmt.Errorf("invalid Slack webhook URL: %w", err)
+		}
+	case ChannelWebhook:
+		url, _ := ch.Config["url"].(string)
+		if url == "" {
+			return fmt.Errorf("Webhook channel requires a url")
+		}
+		if err := k8s.ValidateRemoteURL(url); err != nil {
+			return fmt.Errorf("invalid webhook URL: %w", err)
 		}
 	}
 	return nil
 }
 
+// sensitiveKeys are config key patterns that should be masked in API responses.
+var sensitiveKeys = []string{"url", "secret", "password", "token", "key", "authorization"}
+
 // maskConfig replaces sensitive values with "****" for API responses.
+// Nested maps (like headers) are deep-masked.
 func maskConfig(cfg ChannelConfig) ChannelConfig {
 	masked := make(ChannelConfig, len(cfg))
 	for k, v := range cfg {
-		switch k {
-		case "webhookUrl", "url", "secret":
-			if s, ok := v.(string); ok && len(s) > 4 {
-				masked[k] = "****" + s[len(s)-4:]
-			} else {
+		if isSensitiveKey(k) {
+			switch val := v.(type) {
+			case string:
+				if len(val) > 4 {
+					masked[k] = "****" + val[len(val)-4:]
+				} else {
+					masked[k] = "****"
+				}
+			case map[string]any:
+				// Deep-mask all values in nested maps (e.g., headers with Authorization)
+				maskedMap := make(map[string]any, len(val))
+				for hk := range val {
+					maskedMap[hk] = "****"
+				}
+				masked[k] = maskedMap
+			default:
 				masked[k] = "****"
 			}
-		default:
+		} else {
 			masked[k] = v
 		}
 	}
 	return masked
+}
+
+func isSensitiveKey(key string) bool {
+	lower := strings.ToLower(key)
+	for _, s := range sensitiveKeys {
+		if strings.Contains(lower, s) {
+			return true
+		}
+	}
+	return false
 }
 
 func (h *Handler) auditLog(r *http.Request, user *auth.User, action audit.Action, kind, name string) {
@@ -444,11 +518,11 @@ func (h *Handler) auditLog(r *http.Request, user *auth.User, action audit.Action
 		return
 	}
 	h.AuditLogger.Log(r.Context(), audit.Entry{
-		Action:            action,
-		ResourceKind:      kind,
-		ResourceName:      name,
-		User:              user.KubernetesUsername,
-		SourceIP:          r.RemoteAddr,
-		Result:            audit.ResultSuccess,
+		Action:       action,
+		ResourceKind: kind,
+		ResourceName: name,
+		User:         user.KubernetesUsername,
+		SourceIP:     r.RemoteAddr,
+		Result:       audit.ResultSuccess,
 	})
 }

--- a/backend/internal/notifications/service.go
+++ b/backend/internal/notifications/service.go
@@ -1,0 +1,551 @@
+package notifications
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"io"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/kubecenter/kubecenter/internal/alerting"
+	"github.com/kubecenter/kubecenter/internal/k8s"
+	"github.com/kubecenter/kubecenter/internal/websocket"
+)
+
+const (
+	dedupWindow    = 15 * time.Minute
+	queueSize      = 1000
+	semaphoreSize  = 20
+	dispatchTimeout = 10 * time.Second
+)
+
+// NotificationService is the core notification center.
+// It persists notifications, broadcasts via WebSocket, and dispatches to external channels.
+type NotificationService struct {
+	store    *Store
+	hub      *websocket.Hub
+	notifier *alerting.Notifier // for email digest (existing SMTP pipeline)
+	queue    chan Notification
+	sem      chan struct{} // dispatch semaphore
+	rules    []Rule
+	channels []Channel
+	mu       sync.RWMutex
+	logger   *slog.Logger
+}
+
+// NewService creates a notification service.
+func NewService(store *Store, hub *websocket.Hub, notifier *alerting.Notifier, logger *slog.Logger) *NotificationService {
+	return &NotificationService{
+		store:    store,
+		hub:      hub,
+		notifier: notifier,
+		queue:    make(chan Notification, queueSize),
+		sem:      make(chan struct{}, semaphoreSize),
+		logger:   logger,
+	}
+}
+
+// Start loads cached rules/channels and launches the dispatch and digest goroutines.
+func (s *NotificationService) Start(ctx context.Context) {
+	s.refreshCache(ctx)
+	go s.runDispatcher(ctx)
+	go s.runDigest(ctx)
+	go s.runRetention(ctx)
+}
+
+// RefreshCache reloads rules and channels from the database.
+// Called on startup and after channel/rule CRUD.
+func (s *NotificationService) RefreshCache(ctx context.Context) {
+	s.refreshCache(ctx)
+}
+
+func (s *NotificationService) refreshCache(ctx context.Context) {
+	rules, err := s.store.ListRules(ctx)
+	if err != nil {
+		s.logger.Error("failed to load notification rules", "error", err)
+		return
+	}
+	channels, err := s.store.ListChannels(ctx)
+	if err != nil {
+		s.logger.Error("failed to load notification channels", "error", err)
+		return
+	}
+	s.mu.Lock()
+	s.rules = rules
+	s.channels = channels
+	s.mu.Unlock()
+}
+
+// Emit persists a notification, broadcasts via WebSocket, and enqueues for external dispatch.
+// Safe to call from any goroutine. Non-blocking.
+func (s *NotificationService) Emit(ctx context.Context, n Notification) {
+	// Guard: skip audit-source to prevent circular audit → Emit → audit loop
+	if n.Source == SourceAudit {
+		if err := s.persistAndBroadcast(ctx, n); err != nil {
+			s.logger.Error("emit notification", "error", err)
+		}
+		return
+	}
+
+	// Dedup: suppress if same (source, kind, ns, name, title) within 15 min
+	exists, err := s.store.DedupExists(ctx, n, dedupWindow)
+	if err != nil {
+		s.logger.Error("dedup check failed", "error", err)
+		// Continue — better to duplicate than to drop
+	}
+	if exists {
+		return
+	}
+
+	if err := s.persistAndBroadcast(ctx, n); err != nil {
+		s.logger.Error("emit notification", "error", err)
+		return
+	}
+
+	// Enqueue for external dispatch (non-blocking)
+	select {
+	case s.queue <- n:
+	default:
+		s.logger.Warn("notification dispatch queue full, dropping external dispatch",
+			"source", n.Source, "title", n.Title)
+	}
+}
+
+func (s *NotificationService) persistAndBroadcast(ctx context.Context, n Notification) error {
+	id, err := s.store.InsertNotification(ctx, n)
+	if err != nil {
+		return fmt.Errorf("persist: %w", err)
+	}
+	n.ID = id
+
+	// Broadcast stripped payload via WebSocket (no resource fields to prevent namespace leakage)
+	stripped := map[string]any{
+		"id":       n.ID,
+		"source":   n.Source,
+		"severity": n.Severity,
+		"title":    n.Title,
+	}
+	strippedJSON, _ := json.Marshal(stripped)
+	s.hub.HandleEvent("ADDED", "notifications", "", n.ID, json.RawMessage(strippedJSON))
+	return nil
+}
+
+// --- Dispatch goroutine ---
+
+func (s *NotificationService) runDispatcher(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case n := <-s.queue:
+			s.dispatchToChannels(ctx, n)
+		}
+	}
+}
+
+func (s *NotificationService) dispatchToChannels(ctx context.Context, n Notification) {
+	s.mu.RLock()
+	rules := s.rules
+	channels := s.channels
+	s.mu.RUnlock()
+
+	channelMap := make(map[string]Channel, len(channels))
+	for _, ch := range channels {
+		channelMap[ch.ID] = ch
+	}
+
+	for _, rule := range rules {
+		if !rule.Enabled {
+			continue
+		}
+		if !ruleMatches(rule, n) {
+			continue
+		}
+		ch, ok := channelMap[rule.ChannelID]
+		if !ok {
+			continue
+		}
+		if ch.Type == ChannelEmail {
+			continue // email is digest-only, not per-notification
+		}
+
+		// Acquire semaphore, dispatch in goroutine
+		s.sem <- struct{}{}
+		go func(ch Channel, n Notification) {
+			defer func() { <-s.sem }()
+			dctx, cancel := context.WithTimeout(context.Background(), dispatchTimeout)
+			defer cancel()
+			if err := s.dispatch(dctx, ch, n); err != nil {
+				s.logger.Error("dispatch failed",
+					"channel", ch.Name, "type", ch.Type, "error", err)
+				_ = s.store.UpdateChannelError(dctx, ch.ID, err.Error())
+			}
+		}(ch, n)
+	}
+}
+
+func ruleMatches(rule Rule, n Notification) bool {
+	if len(rule.SourceFilter) > 0 {
+		found := false
+		for _, src := range rule.SourceFilter {
+			if src == n.Source {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	if len(rule.SeverityFilter) > 0 {
+		found := false
+		for _, sev := range rule.SeverityFilter {
+			if sev == n.Severity {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+// --- Channel dispatch (switch, no interface) ---
+
+func (s *NotificationService) dispatch(ctx context.Context, ch Channel, n Notification) error {
+	switch ch.Type {
+	case ChannelSlack:
+		return s.sendSlack(ctx, ch, n)
+	case ChannelWebhook:
+		return s.sendWebhook(ctx, ch, n)
+	default:
+		return fmt.Errorf("unsupported channel type: %s", ch.Type)
+	}
+}
+
+// TestChannel sends a test notification to a channel.
+func (s *NotificationService) TestChannel(ctx context.Context, ch Channel) error {
+	test := Notification{
+		Source:   SourceCluster,
+		Severity: SeverityInfo,
+		Title:    "Test notification from k8sCenter",
+		Message:  "This is a test notification to verify channel connectivity.",
+	}
+	switch ch.Type {
+	case ChannelSlack:
+		return s.sendSlack(ctx, ch, test)
+	case ChannelWebhook:
+		return s.sendWebhook(ctx, ch, test)
+	case ChannelEmail:
+		return s.sendTestEmail(ch)
+	default:
+		return fmt.Errorf("unsupported channel type: %s", ch.Type)
+	}
+}
+
+// --- Slack dispatch ---
+
+func (s *NotificationService) sendSlack(ctx context.Context, ch Channel, n Notification) error {
+	webhookURL, _ := ch.Config["webhookUrl"].(string)
+	if webhookURL == "" {
+		return fmt.Errorf("slack channel %q has no webhookUrl configured", ch.Name)
+	}
+
+	color := severityColor(n.Severity)
+	payload := map[string]any{
+		"text": fmt.Sprintf("[%s] %s", n.Severity, n.Title),
+		"blocks": []map[string]any{
+			{"type": "header", "text": map[string]string{"type": "plain_text", "text": n.Title}},
+			{"type": "section", "text": map[string]string{
+				"type": "mrkdwn",
+				"text": fmt.Sprintf("*Severity:* %s %s\n*Source:* %s\n*Resource:* %s/%s/%s",
+					color, n.Severity, n.Source, n.ResourceKind, n.ResourceNS, n.ResourceName),
+			}},
+		},
+	}
+	if n.Message != "" {
+		blocks := payload["blocks"].([]map[string]any)
+		blocks = append(blocks, map[string]any{
+			"type": "section",
+			"text": map[string]string{"type": "mrkdwn", "text": n.Message},
+		})
+		payload["blocks"] = blocks
+	}
+
+	body, _ := json.Marshal(payload)
+	req, err := http.NewRequestWithContext(ctx, "POST", webhookURL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create slack request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("slack request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("slack error %d: %s", resp.StatusCode, string(respBody))
+	}
+	return nil
+}
+
+func severityColor(sev Severity) string {
+	switch sev {
+	case SeverityCritical:
+		return ":red_circle:"
+	case SeverityWarning:
+		return ":large_orange_circle:"
+	default:
+		return ":large_blue_circle:"
+	}
+}
+
+// --- Webhook dispatch ---
+
+func (s *NotificationService) sendWebhook(ctx context.Context, ch Channel, n Notification) error {
+	webhookURL, _ := ch.Config["url"].(string)
+	if webhookURL == "" {
+		return fmt.Errorf("webhook channel %q has no url configured", ch.Name)
+	}
+
+	payload, _ := json.Marshal(n)
+
+	req, err := http.NewRequestWithContext(ctx, "POST", webhookURL, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("create webhook request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "k8sCenter-Webhook/1.0")
+
+	// HMAC-SHA256 signature if secret is configured
+	if secret, _ := ch.Config["secret"].(string); secret != "" {
+		mac := hmac.New(sha256.New, []byte(secret))
+		mac.Write(payload)
+		req.Header.Set("X-Signature-256", "sha256="+hex.EncodeToString(mac.Sum(nil)))
+	}
+
+	// Custom headers from channel config
+	if headers, ok := ch.Config["headers"].(map[string]any); ok {
+		for k, v := range headers {
+			if sv, ok := v.(string); ok {
+				req.Header.Set(k, sv)
+			}
+		}
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("webhook request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("webhook error %d: %s", resp.StatusCode, string(respBody))
+	}
+	return nil
+}
+
+// --- Email digest ---
+
+func (s *NotificationService) sendTestEmail(ch Channel) error {
+	if s.notifier == nil {
+		return fmt.Errorf("SMTP notifier not configured")
+	}
+	recipients := channelRecipients(ch)
+	if len(recipients) == 0 {
+		return fmt.Errorf("email channel %q has no recipients", ch.Name)
+	}
+	return s.notifier.QueueEmail(recipients, "[k8sCenter] Test Notification", "<p>This is a test notification from k8sCenter.</p>")
+}
+
+func (s *NotificationService) runDigest(ctx context.Context) {
+	for {
+		next := nextDigestTime(time.Now())
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(time.Until(next)):
+			s.sendDigests(ctx)
+		}
+	}
+}
+
+func nextDigestTime(now time.Time) time.Time {
+	// Next 08:00 UTC
+	t := time.Date(now.Year(), now.Month(), now.Day(), 8, 0, 0, 0, time.UTC)
+	if !t.After(now) {
+		t = t.Add(24 * time.Hour)
+	}
+	return t
+}
+
+func (s *NotificationService) sendDigests(ctx context.Context) {
+	if s.notifier == nil {
+		return
+	}
+
+	s.mu.RLock()
+	channels := s.channels
+	rules := s.rules
+	s.mu.RUnlock()
+
+	for _, ch := range channels {
+		if ch.Type != ChannelEmail {
+			continue
+		}
+
+		recipients := channelRecipients(ch)
+		if len(recipients) == 0 {
+			continue
+		}
+
+		since := time.Now().Add(-24 * time.Hour) // default: last 24h
+		if ch.LastSentAt != nil {
+			since = *ch.LastSentAt
+		}
+
+		// Collect source/severity filters from rules targeting this channel
+		var sourceFilter, sevFilter []string
+		for _, r := range rules {
+			if r.ChannelID != ch.ID || !r.Enabled {
+				continue
+			}
+			for _, src := range r.SourceFilter {
+				sourceFilter = append(sourceFilter, string(src))
+			}
+			for _, sev := range r.SeverityFilter {
+				sevFilter = append(sevFilter, string(sev))
+			}
+		}
+
+		notifications, err := s.store.NotificationsSince(ctx, since, nil, sourceFilter, sevFilter)
+		if err != nil {
+			s.logger.Error("digest query failed", "channel", ch.Name, "error", err)
+			continue
+		}
+
+		// Always advance last_sent_at (even on empty digest to prevent accumulation)
+		if err := s.store.UpdateChannelLastSent(ctx, ch.ID); err != nil {
+			s.logger.Error("update last_sent_at", "channel", ch.Name, "error", err)
+		}
+
+		if len(notifications) == 0 {
+			continue
+		}
+
+		htmlBody, err := renderDigestEmail(notifications)
+		if err != nil {
+			s.logger.Error("render digest", "channel", ch.Name, "error", err)
+			continue
+		}
+
+		subject := fmt.Sprintf("k8sCenter Notification Digest — %s — %d notifications",
+			time.Now().UTC().Format("Jan 2, 2006"), len(notifications))
+
+		if err := s.notifier.QueueEmail(recipients, subject, htmlBody); err != nil {
+			s.logger.Error("queue digest email", "channel", ch.Name, "error", err)
+			_ = s.store.UpdateChannelError(ctx, ch.ID, err.Error())
+		}
+	}
+}
+
+func channelRecipients(ch Channel) []string {
+	raw, ok := ch.Config["recipients"]
+	if !ok {
+		return nil
+	}
+	switch v := raw.(type) {
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok && s != "" {
+				out = append(out, s)
+			}
+		}
+		return out
+	case []string:
+		return v
+	default:
+		return nil
+	}
+}
+
+var digestTemplate = template.Must(template.New("digest").Funcs(template.FuncMap{
+	"severityEmoji": func(sev Severity) string {
+		switch sev {
+		case SeverityCritical:
+			return "🔴"
+		case SeverityWarning:
+			return "🟡"
+		default:
+			return "🔵"
+		}
+	},
+}).Parse(`<!DOCTYPE html>
+<html><body>
+<table width="600" style="margin:0 auto;font-family:sans-serif;border-collapse:collapse;">
+  <tr><td style="background:#1a1b26;color:#c0caf5;padding:20px;">
+    <h2 style="margin:0;">k8sCenter — Notification Digest</h2>
+    <p style="margin:8px 0 0;">{{len .}} notifications since last digest</p>
+  </td></tr>
+  {{range .}}
+  <tr><td style="padding:12px;border-bottom:1px solid #333;">
+    <strong>{{severityEmoji .Severity}} {{.Title}}</strong><br>
+    <span style="color:#888;font-size:13px;">{{.Source}} · {{.ResourceKind}}/{{.ResourceNS}}/{{.ResourceName}} · {{.CreatedAt.Format "Jan 2, 15:04 UTC"}}</span>
+    {{if .Message}}<br><span style="font-size:13px;">{{.Message}}</span>{{end}}
+  </td></tr>
+  {{end}}
+  <tr><td style="padding:16px;text-align:center;font-size:13px;color:#888;">
+    All times UTC · <a href="#" style="color:#7aa2f7;">Open k8sCenter</a>
+  </td></tr>
+</table>
+</body></html>`))
+
+func renderDigestEmail(notifications []Notification) (string, error) {
+	var buf bytes.Buffer
+	if err := digestTemplate.Execute(&buf, notifications); err != nil {
+		return "", fmt.Errorf("render digest template: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// --- Retention ---
+
+func (s *NotificationService) runRetention(ctx context.Context) {
+	ticker := time.NewTicker(24 * time.Hour)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			count, err := s.store.PruneOlderThan(ctx, 90*24*time.Hour)
+			if err != nil {
+				s.logger.Error("prune notifications", "error", err)
+			} else if count > 0 {
+				s.logger.Info("pruned old notifications", "count", count)
+			}
+		}
+	}
+}
+
+// --- SSRF validation (re-exported for handler use) ---
+
+// ValidateChannelURL validates webhook/Slack URLs against the SSRF blocklist.
+func ValidateChannelURL(url string) error {
+	return k8s.ValidateRemoteURL(url)
+}

--- a/backend/internal/notifications/service.go
+++ b/backend/internal/notifications/service.go
@@ -11,45 +11,96 @@ import (
 	"html/template"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
+	"slices"
+	"strings"
 	"sync"
 	"time"
 
-	"github.com/kubecenter/kubecenter/internal/alerting"
-	"github.com/kubecenter/kubecenter/internal/k8s"
 	"github.com/kubecenter/kubecenter/internal/websocket"
 )
 
 const (
-	dedupWindow    = 15 * time.Minute
-	queueSize      = 1000
-	semaphoreSize  = 20
+	dedupWindow     = 15 * time.Minute
+	queueSize       = 1000
+	semaphoreSize   = 20
 	dispatchTimeout = 10 * time.Second
 )
+
+// httpClient is a dedicated client for outbound Slack/webhook dispatch.
+// It has explicit timeouts and disables automatic redirects.
+var httpClient = &http.Client{
+	Timeout: dispatchTimeout,
+	CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	},
+	Transport: &http.Transport{
+		MaxIdleConns:        50,
+		MaxIdleConnsPerHost: 5,
+		IdleConnTimeout:     90 * time.Second,
+		DialContext: (&net.Dialer{
+			Timeout: 5 * time.Second,
+		}).DialContext,
+	},
+}
+
+// blockedHeaders are HTTP headers that custom webhook headers cannot override.
+var blockedHeaders = map[string]bool{
+	"host":              true,
+	"authorization":     true,
+	"cookie":            true,
+	"x-signature-256":   true,
+	"x-forwarded-for":   true,
+	"x-forwarded-host":  true,
+	"x-forwarded-proto": true,
+	"content-type":      true,
+	"user-agent":        true,
+}
+
+// EmailSender abstracts email sending so the service doesn't depend on *alerting.Notifier directly.
+type EmailSender interface {
+	QueueEmail(recipients []string, subject, htmlBody string) error
+	SMTPConfigured() bool
+}
+
+// webhookPayload defines the external-facing payload for webhook dispatch.
+// Excludes internal fields like ClusterID.
+type webhookPayload struct {
+	ID           string   `json:"id"`
+	Source       Source   `json:"source"`
+	Severity     Severity `json:"severity"`
+	Title        string   `json:"title"`
+	Message      string   `json:"message"`
+	ResourceKind string   `json:"resourceKind,omitempty"`
+	ResourceNS   string   `json:"resourceNamespace,omitempty"`
+	ResourceName string   `json:"resourceName,omitempty"`
+	CreatedAt    time.Time `json:"createdAt"`
+}
 
 // NotificationService is the core notification center.
 // It persists notifications, broadcasts via WebSocket, and dispatches to external channels.
 type NotificationService struct {
-	store    *Store
-	hub      *websocket.Hub
-	notifier *alerting.Notifier // for email digest (existing SMTP pipeline)
-	queue    chan Notification
-	sem      chan struct{} // dispatch semaphore
-	rules    []Rule
-	channels []Channel
-	mu       sync.RWMutex
-	logger   *slog.Logger
+	store       *Store
+	hub         *websocket.Hub
+	emailSender EmailSender
+	queue       chan Notification
+	sem         chan struct{} // dispatch semaphore
+	rules       []Rule
+	channels    []Channel
+	mu          sync.RWMutex
+	logger      *slog.Logger
 }
 
 // NewService creates a notification service.
-func NewService(store *Store, hub *websocket.Hub, notifier *alerting.Notifier, logger *slog.Logger) *NotificationService {
+func NewService(store *Store, hub *websocket.Hub, emailSender EmailSender, logger *slog.Logger) *NotificationService {
 	return &NotificationService{
-		store:    store,
-		hub:      hub,
-		notifier: notifier,
-		queue:    make(chan Notification, queueSize),
-		sem:      make(chan struct{}, semaphoreSize),
-		logger:   logger,
+		store:       store,
+		hub:         hub,
+		emailSender: emailSender,
+		queue:       make(chan Notification, queueSize),
+		sem:         make(chan struct{}, semaphoreSize),
+		logger:      logger,
 	}
 }
 
@@ -87,7 +138,8 @@ func (s *NotificationService) refreshCache(ctx context.Context) {
 // Emit persists a notification, broadcasts via WebSocket, and enqueues for external dispatch.
 // Safe to call from any goroutine. Non-blocking.
 func (s *NotificationService) Emit(ctx context.Context, n Notification) {
-	// Guard: skip audit-source to prevent circular audit → Emit → audit loop
+	// Guard: skip audit-source to prevent circular audit → Emit → audit loop.
+	// Audit notifications are persisted and broadcast but never externally dispatched.
 	if n.Source == SourceAudit {
 		if err := s.persistAndBroadcast(ctx, n); err != nil {
 			s.logger.Error("emit notification", "error", err)
@@ -126,7 +178,9 @@ func (s *NotificationService) persistAndBroadcast(ctx context.Context, n Notific
 	}
 	n.ID = id
 
-	// Broadcast stripped payload via WebSocket (no resource fields to prevent namespace leakage)
+	// Broadcast stripped payload via WebSocket — only id, source, severity, title.
+	// No resource fields to prevent namespace leakage to unauthorized WS subscribers.
+	// Clients fetch full details via REST (which enforces RBAC).
 	stripped := map[string]any{
 		"id":       n.ID,
 		"source":   n.Source,
@@ -163,22 +217,20 @@ func (s *NotificationService) dispatchToChannels(ctx context.Context, n Notifica
 	}
 
 	for _, rule := range rules {
-		if !rule.Enabled {
-			continue
-		}
-		if !ruleMatches(rule, n) {
+		if !rule.Enabled || !ruleMatches(rule, n) {
 			continue
 		}
 		ch, ok := channelMap[rule.ChannelID]
-		if !ok {
-			continue
-		}
-		if ch.Type == ChannelEmail {
-			continue // email is digest-only, not per-notification
+		if !ok || ch.Type == ChannelEmail {
+			continue // email is digest-only
 		}
 
-		// Acquire semaphore, dispatch in goroutine
-		s.sem <- struct{}{}
+		// Acquire semaphore with ctx guard to prevent goroutine hang on shutdown
+		select {
+		case s.sem <- struct{}{}:
+		case <-ctx.Done():
+			return
+		}
 		go func(ch Channel, n Notification) {
 			defer func() { <-s.sem }()
 			dctx, cancel := context.WithTimeout(context.Background(), dispatchTimeout)
@@ -193,29 +245,11 @@ func (s *NotificationService) dispatchToChannels(ctx context.Context, n Notifica
 }
 
 func ruleMatches(rule Rule, n Notification) bool {
-	if len(rule.SourceFilter) > 0 {
-		found := false
-		for _, src := range rule.SourceFilter {
-			if src == n.Source {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return false
-		}
+	if len(rule.SourceFilter) > 0 && !slices.Contains(rule.SourceFilter, n.Source) {
+		return false
 	}
-	if len(rule.SeverityFilter) > 0 {
-		found := false
-		for _, sev := range rule.SeverityFilter {
-			if sev == n.Severity {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return false
-		}
+	if len(rule.SeverityFilter) > 0 && !slices.Contains(rule.SeverityFilter, n.Severity) {
+		return false
 	}
 	return true
 }
@@ -289,7 +323,7 @@ func (s *NotificationService) sendSlack(ctx context.Context, ch Channel, n Notif
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("slack request: %w", err)
 	}
@@ -316,14 +350,26 @@ func severityColor(sev Severity) string {
 // --- Webhook dispatch ---
 
 func (s *NotificationService) sendWebhook(ctx context.Context, ch Channel, n Notification) error {
-	webhookURL, _ := ch.Config["url"].(string)
-	if webhookURL == "" {
+	url, _ := ch.Config["url"].(string)
+	if url == "" {
 		return fmt.Errorf("webhook channel %q has no url configured", ch.Name)
 	}
 
-	payload, _ := json.Marshal(n)
+	// Build external-facing payload (excludes ClusterID and other internal fields)
+	wp := webhookPayload{
+		ID:           n.ID,
+		Source:       n.Source,
+		Severity:     n.Severity,
+		Title:        n.Title,
+		Message:      n.Message,
+		ResourceKind: n.ResourceKind,
+		ResourceNS:   n.ResourceNS,
+		ResourceName: n.ResourceName,
+		CreatedAt:    n.CreatedAt,
+	}
+	payload, _ := json.Marshal(wp)
 
-	req, err := http.NewRequestWithContext(ctx, "POST", webhookURL, bytes.NewReader(payload))
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(payload))
 	if err != nil {
 		return fmt.Errorf("create webhook request: %w", err)
 	}
@@ -337,16 +383,19 @@ func (s *NotificationService) sendWebhook(ctx context.Context, ch Channel, n Not
 		req.Header.Set("X-Signature-256", "sha256="+hex.EncodeToString(mac.Sum(nil)))
 	}
 
-	// Custom headers from channel config
+	// Custom headers — blocklist prevents overriding security-sensitive headers
 	if headers, ok := ch.Config["headers"].(map[string]any); ok {
 		for k, v := range headers {
+			if blockedHeaders[strings.ToLower(k)] {
+				continue
+			}
 			if sv, ok := v.(string); ok {
 				req.Header.Set(k, sv)
 			}
 		}
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("webhook request: %w", err)
 	}
@@ -362,14 +411,14 @@ func (s *NotificationService) sendWebhook(ctx context.Context, ch Channel, n Not
 // --- Email digest ---
 
 func (s *NotificationService) sendTestEmail(ch Channel) error {
-	if s.notifier == nil {
-		return fmt.Errorf("SMTP notifier not configured")
+	if s.emailSender == nil || !s.emailSender.SMTPConfigured() {
+		return fmt.Errorf("SMTP not configured")
 	}
 	recipients := channelRecipients(ch)
 	if len(recipients) == 0 {
 		return fmt.Errorf("email channel %q has no recipients", ch.Name)
 	}
-	return s.notifier.QueueEmail(recipients, "[k8sCenter] Test Notification", "<p>This is a test notification from k8sCenter.</p>")
+	return s.emailSender.QueueEmail(recipients, "[k8sCenter] Test Notification", "<p>This is a test notification from k8sCenter.</p>")
 }
 
 func (s *NotificationService) runDigest(ctx context.Context) {
@@ -394,7 +443,7 @@ func nextDigestTime(now time.Time) time.Time {
 }
 
 func (s *NotificationService) sendDigests(ctx context.Context) {
-	if s.notifier == nil {
+	if s.emailSender == nil || !s.emailSender.SMTPConfigured() {
 		return
 	}
 
@@ -456,7 +505,7 @@ func (s *NotificationService) sendDigests(ctx context.Context) {
 		subject := fmt.Sprintf("k8sCenter Notification Digest — %s — %d notifications",
 			time.Now().UTC().Format("Jan 2, 2006"), len(notifications))
 
-		if err := s.notifier.QueueEmail(recipients, subject, htmlBody); err != nil {
+		if err := s.emailSender.QueueEmail(recipients, subject, htmlBody); err != nil {
 			s.logger.Error("queue digest email", "channel", ch.Name, "error", err)
 			_ = s.store.UpdateChannelError(ctx, ch.ID, err.Error())
 		}
@@ -541,11 +590,4 @@ func (s *NotificationService) runRetention(ctx context.Context) {
 			}
 		}
 	}
-}
-
-// --- SSRF validation (re-exported for handler use) ---
-
-// ValidateChannelURL validates webhook/Slack URLs against the SSRF blocklist.
-func ValidateChannelURL(url string) error {
-	return k8s.ValidateRemoteURL(url)
 }

--- a/backend/internal/notifications/service_test.go
+++ b/backend/internal/notifications/service_test.go
@@ -190,3 +190,72 @@ func TestRenderDigestEmail(t *testing.T) {
 		t.Error("digest HTML should contain header")
 	}
 }
+
+func TestRenderDigestEmailEscapesHTML(t *testing.T) {
+	// Verify html/template escapes malicious input (XSS protection)
+	notifications := []Notification{
+		{
+			Source:    SourceAlert,
+			Severity:  SeverityCritical,
+			Title:     "<script>alert('xss')</script>",
+			Message:   "<img src=x onerror=alert(1)>",
+			CreatedAt: time.Now().UTC(),
+		},
+	}
+	html, err := renderDigestEmail(notifications)
+	if err != nil {
+		t.Fatalf("renderDigestEmail failed: %v", err)
+	}
+	// html/template should escape the angle brackets so the browser sees them
+	// as text, not HTML elements. We don't strip "onerror=" — we just ensure
+	// the < > characters are escaped so the tag never executes.
+	if strings.Contains(html, "<script>") {
+		t.Error("digest HTML should escape <script> tags")
+	}
+	if strings.Contains(html, "<img src=x") {
+		t.Error("digest HTML should escape <img> tags")
+	}
+	// Should contain escaped versions
+	if !strings.Contains(html, "&lt;script&gt;") {
+		t.Error("digest HTML should contain HTML-escaped script tags")
+	}
+}
+
+func TestBlockedHeaders(t *testing.T) {
+	// Verify all security-sensitive headers are blocked
+	required := []string{
+		"host",
+		"authorization",
+		"cookie",
+		"x-signature-256",
+		"x-forwarded-for",
+		"x-forwarded-host",
+		"x-forwarded-proto",
+		"content-type",
+		"user-agent",
+	}
+	for _, h := range required {
+		if !blockedHeaders[h] {
+			t.Errorf("blockedHeaders should contain %q", h)
+		}
+	}
+}
+
+func TestSeverityColorFallback(t *testing.T) {
+	// Unknown severity should fall back to info color
+	if got := severityColor(Severity("unknown")); got != ":large_blue_circle:" {
+		t.Errorf("severityColor for unknown should fall back to info color, got %q", got)
+	}
+	if got := severityColor(""); got != ":large_blue_circle:" {
+		t.Errorf("severityColor for empty should fall back to info color, got %q", got)
+	}
+}
+
+func TestNextDigestTimeBoundary(t *testing.T) {
+	// Exactly at 08:00:00 — should advance to tomorrow (uses !t.After(now))
+	exactly := time.Date(2026, 4, 10, 8, 0, 0, 0, time.UTC)
+	next := nextDigestTime(exactly)
+	if next.Day() != 11 {
+		t.Errorf("nextDigestTime at exactly 08:00 should advance to tomorrow, got day %d", next.Day())
+	}
+}

--- a/backend/internal/notifications/service_test.go
+++ b/backend/internal/notifications/service_test.go
@@ -1,0 +1,192 @@
+package notifications
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRuleMatches(t *testing.T) {
+	tests := []struct {
+		name     string
+		rule     Rule
+		notif    Notification
+		expected bool
+	}{
+		{
+			name:     "empty filters match anything",
+			rule:     Rule{},
+			notif:    Notification{Source: SourceAlert, Severity: SeverityCritical},
+			expected: true,
+		},
+		{
+			name: "source match",
+			rule: Rule{
+				SourceFilter: []Source{SourceAlert, SourcePolicy},
+			},
+			notif:    Notification{Source: SourceAlert, Severity: SeverityWarning},
+			expected: true,
+		},
+		{
+			name: "source no match",
+			rule: Rule{
+				SourceFilter: []Source{SourceAlert},
+			},
+			notif:    Notification{Source: SourceGitOps, Severity: SeverityWarning},
+			expected: false,
+		},
+		{
+			name: "severity match",
+			rule: Rule{
+				SeverityFilter: []Severity{SeverityCritical},
+			},
+			notif:    Notification{Source: SourceAlert, Severity: SeverityCritical},
+			expected: true,
+		},
+		{
+			name: "severity no match",
+			rule: Rule{
+				SeverityFilter: []Severity{SeverityCritical},
+			},
+			notif:    Notification{Source: SourceAlert, Severity: SeverityInfo},
+			expected: false,
+		},
+		{
+			name: "both filters match",
+			rule: Rule{
+				SourceFilter:   []Source{SourceAlert},
+				SeverityFilter: []Severity{SeverityCritical, SeverityWarning},
+			},
+			notif:    Notification{Source: SourceAlert, Severity: SeverityWarning},
+			expected: true,
+		},
+		{
+			name: "source matches but severity doesn't",
+			rule: Rule{
+				SourceFilter:   []Source{SourceAlert},
+				SeverityFilter: []Severity{SeverityCritical},
+			},
+			notif:    Notification{Source: SourceAlert, Severity: SeverityInfo},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ruleMatches(tt.rule, tt.notif)
+			if got != tt.expected {
+				t.Errorf("ruleMatches() = %v, expected %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSeverityColor(t *testing.T) {
+	tests := []struct {
+		severity Severity
+		want     string
+	}{
+		{SeverityCritical, ":red_circle:"},
+		{SeverityWarning, ":large_orange_circle:"},
+		{SeverityInfo, ":large_blue_circle:"},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.severity), func(t *testing.T) {
+			if got := severityColor(tt.severity); got != tt.want {
+				t.Errorf("severityColor(%s) = %q, want %q", tt.severity, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestChannelRecipients(t *testing.T) {
+	tests := []struct {
+		name string
+		ch   Channel
+		want []string
+	}{
+		{
+			name: "no recipients",
+			ch:   Channel{Config: ChannelConfig{}},
+			want: nil,
+		},
+		{
+			name: "string slice",
+			ch: Channel{
+				Config: ChannelConfig{"recipients": []string{"a@x.com", "b@x.com"}},
+			},
+			want: []string{"a@x.com", "b@x.com"},
+		},
+		{
+			name: "any slice (from JSON unmarshal)",
+			ch: Channel{
+				Config: ChannelConfig{"recipients": []any{"a@x.com", "b@x.com"}},
+			},
+			want: []string{"a@x.com", "b@x.com"},
+		},
+		{
+			name: "filters empty strings from any slice",
+			ch: Channel{
+				Config: ChannelConfig{"recipients": []any{"a@x.com", "", "b@x.com"}},
+			},
+			want: []string{"a@x.com", "b@x.com"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := channelRecipients(tt.ch)
+			if len(got) != len(tt.want) {
+				t.Errorf("channelRecipients() len = %d, want %d", len(got), len(tt.want))
+				return
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("channelRecipients()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestNextDigestTime(t *testing.T) {
+	now := time.Date(2026, 4, 10, 5, 0, 0, 0, time.UTC)
+	next := nextDigestTime(now)
+	if !next.After(now) {
+		t.Errorf("nextDigestTime should return a time after now, got %v vs %v", next, now)
+	}
+	if next.Hour() != 8 || next.Minute() != 0 {
+		t.Errorf("nextDigestTime should fire at 08:00 UTC, got %02d:%02d", next.Hour(), next.Minute())
+	}
+
+	// If now is past 8am, next should be tomorrow
+	pastEight := time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC)
+	nextDay := nextDigestTime(pastEight)
+	if nextDay.Day() != 11 {
+		t.Errorf("nextDigestTime past 8am should be tomorrow, got day %d", nextDay.Day())
+	}
+}
+
+func TestRenderDigestEmail(t *testing.T) {
+	notifications := []Notification{
+		{
+			Source:    SourceAlert,
+			Severity:  SeverityCritical,
+			Title:     "High memory usage",
+			Message:   "Pod nginx exceeded 90% memory",
+			CreatedAt: time.Now().UTC(),
+		},
+	}
+	html, err := renderDigestEmail(notifications)
+	if err != nil {
+		t.Fatalf("renderDigestEmail failed: %v", err)
+	}
+	if html == "" {
+		t.Error("renderDigestEmail returned empty string")
+	}
+	if !strings.Contains(html, "High memory usage") {
+		t.Error("digest HTML should contain notification title")
+	}
+	if !strings.Contains(html, "Notification Digest") {
+		t.Error("digest HTML should contain header")
+	}
+}

--- a/backend/internal/notifications/store.go
+++ b/backend/internal/notifications/store.go
@@ -3,6 +3,7 @@ package notifications
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -10,6 +11,9 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/kubecenter/kubecenter/internal/store"
 )
+
+// ErrNotFound is returned when a record does not exist.
+var ErrNotFound = errors.New("not found")
 
 // Store handles PostgreSQL CRUD for the notification center tables.
 type Store struct {
@@ -41,6 +45,7 @@ func (s *Store) InsertNotification(ctx context.Context, n Notification) (string,
 }
 
 // DedupExists checks whether a matching notification was created within the dedup window.
+// Uses database time (now()) to avoid clock drift between app server and PostgreSQL.
 func (s *Store) DedupExists(ctx context.Context, n Notification, window time.Duration) (bool, error) {
 	var exists bool
 	err := s.pool.QueryRow(ctx, `
@@ -48,10 +53,10 @@ func (s *Store) DedupExists(ctx context.Context, n Notification, window time.Dur
 			SELECT 1 FROM nc_notifications
 			WHERE source = $1 AND resource_kind = $2 AND resource_ns = $3
 			  AND resource_name = $4 AND title = $5
-			  AND created_at > $6
+			  AND created_at > now() - $6::interval
 		)`,
 		n.Source, n.ResourceKind, n.ResourceNS, n.ResourceName, n.Title,
-		time.Now().Add(-window),
+		fmt.Sprintf("%d seconds", int(window.Seconds())),
 	).Scan(&exists)
 	if err != nil {
 		return false, fmt.Errorf("dedup check: %w", err)
@@ -68,7 +73,6 @@ func (s *Store) ListNotifications(ctx context.Context, opts ListOpts) ([]Notific
 		opts.Limit = 200
 	}
 
-	// Build WHERE clause dynamically
 	args := []any{opts.UserID}
 	where := "WHERE 1=1"
 	argIdx := 2
@@ -104,7 +108,6 @@ func (s *Store) ListNotifications(ctx context.Context, opts ListOpts) ([]Notific
 		where += " AND nr.notification_id IS NULL"
 	}
 
-	// Count total
 	countQuery := fmt.Sprintf(`
 		SELECT COUNT(*) FROM nc_notifications n
 		LEFT JOIN nc_reads nr ON nr.notification_id = n.id AND nr.user_id = $1
@@ -114,7 +117,6 @@ func (s *Store) ListNotifications(ctx context.Context, opts ListOpts) ([]Notific
 		return nil, 0, fmt.Errorf("count notifications: %w", err)
 	}
 
-	// Fetch page
 	listQuery := fmt.Sprintf(`
 		SELECT n.id, n.source, n.severity, n.title, n.message,
 		       n.resource_kind, n.resource_ns, n.resource_name, n.cluster_id, n.created_at,
@@ -178,17 +180,23 @@ func (s *Store) MarkRead(ctx context.Context, userID, notificationID string) err
 	return nil
 }
 
-// MarkAllRead marks all notifications as read for a user.
+// MarkAllRead marks all notifications as read for a user (batched to avoid WAL pressure).
 func (s *Store) MarkAllRead(ctx context.Context, userID string) error {
-	_, err := s.pool.Exec(ctx, `
-		INSERT INTO nc_reads (user_id, notification_id)
-		SELECT $1, n.id FROM nc_notifications n
-		LEFT JOIN nc_reads nr ON nr.notification_id = n.id AND nr.user_id = $1
-		WHERE nr.notification_id IS NULL
-		  AND n.created_at > now() - INTERVAL '90 days'`,
-		userID)
-	if err != nil {
-		return fmt.Errorf("mark all read: %w", err)
+	for {
+		tag, err := s.pool.Exec(ctx, `
+			INSERT INTO nc_reads (user_id, notification_id)
+			SELECT $1, n.id FROM nc_notifications n
+			LEFT JOIN nc_reads nr ON nr.notification_id = n.id AND nr.user_id = $1
+			WHERE nr.notification_id IS NULL
+			  AND n.created_at > now() - INTERVAL '90 days'
+			LIMIT 5000`,
+			userID)
+		if err != nil {
+			return fmt.Errorf("mark all read: %w", err)
+		}
+		if tag.RowsAffected() == 0 {
+			break
+		}
 	}
 	return nil
 }
@@ -196,8 +204,8 @@ func (s *Store) MarkAllRead(ctx context.Context, userID string) error {
 // PruneOlderThan deletes notifications older than the given duration. Returns count deleted.
 func (s *Store) PruneOlderThan(ctx context.Context, age time.Duration) (int64, error) {
 	tag, err := s.pool.Exec(ctx,
-		"DELETE FROM nc_notifications WHERE created_at < $1",
-		time.Now().Add(-age))
+		"DELETE FROM nc_notifications WHERE created_at < now() - $1::interval",
+		fmt.Sprintf("%d seconds", int(age.Seconds())))
 	if err != nil {
 		return 0, fmt.Errorf("prune notifications: %w", err)
 	}
@@ -205,7 +213,8 @@ func (s *Store) PruneOlderThan(ctx context.Context, age time.Duration) (int64, e
 }
 
 // NotificationsSince returns notifications matching filters created after the given time.
-func (s *Store) NotificationsSince(ctx context.Context, since time.Time, sourceFilter []string, severityFilter []string) ([]Notification, error) {
+// Includes namespace filtering for RBAC compliance.
+func (s *Store) NotificationsSince(ctx context.Context, since time.Time, namespaces []string, sourceFilter []string, severityFilter []string) ([]Notification, error) {
 	query := `
 		SELECT id, source, severity, title, message,
 		       resource_kind, resource_ns, resource_name, cluster_id, created_at
@@ -214,6 +223,11 @@ func (s *Store) NotificationsSince(ctx context.Context, since time.Time, sourceF
 	args := []any{since}
 	argIdx := 2
 
+	if len(namespaces) > 0 {
+		query += fmt.Sprintf(" AND (resource_ns = ANY($%d) OR resource_ns = '')", argIdx)
+		args = append(args, namespaces)
+		argIdx++
+	}
 	if len(sourceFilter) > 0 {
 		query += fmt.Sprintf(" AND source = ANY($%d)", argIdx)
 		args = append(args, sourceFilter)
@@ -247,11 +261,35 @@ func (s *Store) NotificationsSince(ctx context.Context, since time.Time, sourceF
 
 // --- Channels ---
 
+// channelScanner is satisfied by both pgx.Row and pgx.Rows.
+type channelScanner interface {
+	Scan(dest ...any) error
+}
+
+func (s *Store) scanChannelFrom(sc channelScanner) (Channel, error) {
+	var ch Channel
+	var configBytes []byte
+	if err := sc.Scan(
+		&ch.ID, &ch.Name, &ch.Type, &configBytes, &ch.CreatedBy, &ch.CreatedAt,
+		&ch.UpdatedAt, &ch.UpdatedBy, &ch.LastSentAt, &ch.LastError, &ch.LastErrorAt,
+	); err != nil {
+		return Channel{}, fmt.Errorf("scan channel: %w", err)
+	}
+	cfg, err := s.decryptConfig(configBytes)
+	if err != nil {
+		return Channel{}, err
+	}
+	ch.Config = cfg
+	return ch, nil
+}
+
+const channelColumns = `id, name, type, config, created_by, created_at,
+	updated_at, updated_by, last_sent_at, last_error, last_error_at`
+
 // ListChannels returns all notification channels.
 func (s *Store) ListChannels(ctx context.Context) ([]Channel, error) {
 	rows, err := s.pool.Query(ctx, `
-		SELECT id, name, type, config, created_by, created_at,
-		       updated_at, updated_by, last_sent_at, last_error, last_error_at
+		SELECT `+channelColumns+`
 		FROM nc_channels
 		ORDER BY created_at`)
 	if err != nil {
@@ -261,7 +299,7 @@ func (s *Store) ListChannels(ctx context.Context) ([]Channel, error) {
 
 	var channels []Channel
 	for rows.Next() {
-		ch, err := s.scanChannel(rows)
+		ch, err := s.scanChannelFrom(rows)
 		if err != nil {
 			return nil, err
 		}
@@ -273,10 +311,13 @@ func (s *Store) ListChannels(ctx context.Context) ([]Channel, error) {
 // GetChannel returns a single channel by ID.
 func (s *Store) GetChannel(ctx context.Context, id string) (Channel, error) {
 	row := s.pool.QueryRow(ctx, `
-		SELECT id, name, type, config, created_by, created_at,
-		       updated_at, updated_by, last_sent_at, last_error, last_error_at
+		SELECT `+channelColumns+`
 		FROM nc_channels WHERE id = $1`, id)
-	return s.scanChannelRow(row)
+	ch, err := s.scanChannelFrom(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Channel{}, ErrNotFound
+	}
+	return ch, err
 }
 
 // CreateChannel creates a new channel with encrypted config.
@@ -299,28 +340,34 @@ func (s *Store) CreateChannel(ctx context.Context, ch Channel) (string, error) {
 	return id, nil
 }
 
-// UpdateChannel updates a channel's name and config.
+// UpdateChannel updates a channel's name and config. Returns ErrNotFound if ID doesn't exist.
 func (s *Store) UpdateChannel(ctx context.Context, ch Channel) error {
 	configBytes, err := s.encryptConfig(ch.Config)
 	if err != nil {
 		return err
 	}
 
-	_, err = s.pool.Exec(ctx, `
+	tag, err := s.pool.Exec(ctx, `
 		UPDATE nc_channels SET name = $1, config = $2, updated_at = now(), updated_by = $3
 		WHERE id = $4`,
 		ch.Name, configBytes, ch.UpdatedBy, ch.ID)
 	if err != nil {
 		return fmt.Errorf("update channel: %w", err)
 	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
 	return nil
 }
 
-// DeleteChannel deletes a channel (cascades to rules).
+// DeleteChannel deletes a channel (cascades to rules). Returns ErrNotFound if ID doesn't exist.
 func (s *Store) DeleteChannel(ctx context.Context, id string) error {
-	_, err := s.pool.Exec(ctx, "DELETE FROM nc_channels WHERE id = $1", id)
+	tag, err := s.pool.Exec(ctx, "DELETE FROM nc_channels WHERE id = $1", id)
 	if err != nil {
 		return fmt.Errorf("delete channel: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
 	}
 	return nil
 }
@@ -336,7 +383,7 @@ func (s *Store) UpdateChannelError(ctx context.Context, id, errMsg string) error
 	return nil
 }
 
-// UpdateChannelLastSent updates the last_sent_at timestamp for digest tracking.
+// UpdateChannelLastSent updates the last_sent_at timestamp and clears errors for digest tracking.
 func (s *Store) UpdateChannelLastSent(ctx context.Context, id string) error {
 	_, err := s.pool.Exec(ctx, `
 		UPDATE nc_channels SET last_sent_at = now(), last_error = NULL, last_error_at = NULL WHERE id = $1`, id)
@@ -348,13 +395,31 @@ func (s *Store) UpdateChannelLastSent(ctx context.Context, id string) error {
 
 // --- Rules ---
 
+// sourcesToStrings converts a Source slice to a string slice for PostgreSQL TEXT[] columns.
+func sourcesToStrings(sources []Source) []string {
+	out := make([]string, len(sources))
+	for i, v := range sources {
+		out[i] = string(v)
+	}
+	return out
+}
+
+// severitiesToStrings converts a Severity slice to a string slice for PostgreSQL TEXT[] columns.
+func severitiesToStrings(severities []Severity) []string {
+	out := make([]string, len(severities))
+	for i, v := range severities {
+		out[i] = string(v)
+	}
+	return out
+}
+
 // ListRules returns all notification rules with channel names.
 func (s *Store) ListRules(ctx context.Context) ([]Rule, error) {
 	rows, err := s.pool.Query(ctx, `
 		SELECT r.id, r.name, r.source_filter, r.severity_filter, r.channel_id,
-		       COALESCE(c.name, ''), r.enabled, r.created_by, r.created_at, r.updated_at, r.updated_by
+		       c.name, r.enabled, r.created_by, r.created_at, r.updated_at, r.updated_by
 		FROM nc_rules r
-		LEFT JOIN nc_channels c ON c.id = r.channel_id
+		INNER JOIN nc_channels c ON c.id = r.channel_id
 		ORDER BY r.created_at`)
 	if err != nil {
 		return nil, fmt.Errorf("list rules: %w", err)
@@ -377,21 +442,13 @@ func (s *Store) ListRules(ctx context.Context) ([]Rule, error) {
 
 // CreateRule creates a new routing rule.
 func (s *Store) CreateRule(ctx context.Context, r Rule) (string, error) {
-	sourceStrs := make([]string, len(r.SourceFilter))
-	for i, v := range r.SourceFilter {
-		sourceStrs[i] = string(v)
-	}
-	sevStrs := make([]string, len(r.SeverityFilter))
-	for i, v := range r.SeverityFilter {
-		sevStrs[i] = string(v)
-	}
-
 	var id string
 	err := s.pool.QueryRow(ctx, `
 		INSERT INTO nc_rules (name, source_filter, severity_filter, channel_id, enabled, created_by)
 		VALUES ($1, $2, $3, $4, $5, $6)
 		RETURNING id`,
-		r.Name, sourceStrs, sevStrs, r.ChannelID, r.Enabled, r.CreatedBy,
+		r.Name, sourcesToStrings(r.SourceFilter), severitiesToStrings(r.SeverityFilter),
+		r.ChannelID, r.Enabled, r.CreatedBy,
 	).Scan(&id)
 	if err != nil {
 		return "", fmt.Errorf("create rule: %w", err)
@@ -399,34 +456,32 @@ func (s *Store) CreateRule(ctx context.Context, r Rule) (string, error) {
 	return id, nil
 }
 
-// UpdateRule updates a rule's filters, channel, and enabled state.
+// UpdateRule updates a rule's filters, channel, and enabled state. Returns ErrNotFound if ID doesn't exist.
 func (s *Store) UpdateRule(ctx context.Context, r Rule) error {
-	sourceStrs := make([]string, len(r.SourceFilter))
-	for i, v := range r.SourceFilter {
-		sourceStrs[i] = string(v)
-	}
-	sevStrs := make([]string, len(r.SeverityFilter))
-	for i, v := range r.SeverityFilter {
-		sevStrs[i] = string(v)
-	}
-
-	_, err := s.pool.Exec(ctx, `
+	tag, err := s.pool.Exec(ctx, `
 		UPDATE nc_rules
 		SET name = $1, source_filter = $2, severity_filter = $3, channel_id = $4,
 		    enabled = $5, updated_at = now(), updated_by = $6
 		WHERE id = $7`,
-		r.Name, sourceStrs, sevStrs, r.ChannelID, r.Enabled, r.UpdatedBy, r.ID)
+		r.Name, sourcesToStrings(r.SourceFilter), severitiesToStrings(r.SeverityFilter),
+		r.ChannelID, r.Enabled, r.UpdatedBy, r.ID)
 	if err != nil {
 		return fmt.Errorf("update rule: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
 	}
 	return nil
 }
 
-// DeleteRule deletes a routing rule.
+// DeleteRule deletes a routing rule. Returns ErrNotFound if ID doesn't exist.
 func (s *Store) DeleteRule(ctx context.Context, id string) error {
-	_, err := s.pool.Exec(ctx, "DELETE FROM nc_rules WHERE id = $1", id)
+	tag, err := s.pool.Exec(ctx, "DELETE FROM nc_rules WHERE id = $1", id)
 	if err != nil {
 		return fmt.Errorf("delete rule: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
 	}
 	return nil
 }
@@ -455,38 +510,4 @@ func (s *Store) decryptConfig(encrypted []byte) (ChannelConfig, error) {
 		return nil, fmt.Errorf("unmarshal channel config: %w", err)
 	}
 	return cfg, nil
-}
-
-func (s *Store) scanChannel(rows pgx.Rows) (Channel, error) {
-	var ch Channel
-	var configBytes []byte
-	if err := rows.Scan(
-		&ch.ID, &ch.Name, &ch.Type, &configBytes, &ch.CreatedBy, &ch.CreatedAt,
-		&ch.UpdatedAt, &ch.UpdatedBy, &ch.LastSentAt, &ch.LastError, &ch.LastErrorAt,
-	); err != nil {
-		return Channel{}, fmt.Errorf("scan channel: %w", err)
-	}
-	cfg, err := s.decryptConfig(configBytes)
-	if err != nil {
-		return Channel{}, err
-	}
-	ch.Config = cfg
-	return ch, nil
-}
-
-func (s *Store) scanChannelRow(row pgx.Row) (Channel, error) {
-	var ch Channel
-	var configBytes []byte
-	if err := row.Scan(
-		&ch.ID, &ch.Name, &ch.Type, &configBytes, &ch.CreatedBy, &ch.CreatedAt,
-		&ch.UpdatedAt, &ch.UpdatedBy, &ch.LastSentAt, &ch.LastError, &ch.LastErrorAt,
-	); err != nil {
-		return Channel{}, fmt.Errorf("scan channel: %w", err)
-	}
-	cfg, err := s.decryptConfig(configBytes)
-	if err != nil {
-		return Channel{}, err
-	}
-	ch.Config = cfg
-	return ch, nil
 }

--- a/backend/internal/notifications/store.go
+++ b/backend/internal/notifications/store.go
@@ -1,0 +1,492 @@
+package notifications
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/kubecenter/kubecenter/internal/store"
+)
+
+// Store handles PostgreSQL CRUD for the notification center tables.
+type Store struct {
+	pool         *pgxpool.Pool
+	masterSecret string
+}
+
+// NewStore creates a notification store backed by PostgreSQL.
+func NewStore(pool *pgxpool.Pool, masterSecret string) *Store {
+	return &Store{pool: pool, masterSecret: masterSecret}
+}
+
+// --- Notifications ---
+
+// InsertNotification persists a notification and returns its ID.
+func (s *Store) InsertNotification(ctx context.Context, n Notification) (string, error) {
+	var id string
+	err := s.pool.QueryRow(ctx, `
+		INSERT INTO nc_notifications (source, severity, title, message, resource_kind, resource_ns, resource_name, cluster_id)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		RETURNING id`,
+		n.Source, n.Severity, n.Title, n.Message,
+		n.ResourceKind, n.ResourceNS, n.ResourceName, n.ClusterID,
+	).Scan(&id)
+	if err != nil {
+		return "", fmt.Errorf("insert notification: %w", err)
+	}
+	return id, nil
+}
+
+// DedupExists checks whether a matching notification was created within the dedup window.
+func (s *Store) DedupExists(ctx context.Context, n Notification, window time.Duration) (bool, error) {
+	var exists bool
+	err := s.pool.QueryRow(ctx, `
+		SELECT EXISTS(
+			SELECT 1 FROM nc_notifications
+			WHERE source = $1 AND resource_kind = $2 AND resource_ns = $3
+			  AND resource_name = $4 AND title = $5
+			  AND created_at > $6
+		)`,
+		n.Source, n.ResourceKind, n.ResourceNS, n.ResourceName, n.Title,
+		time.Now().Add(-window),
+	).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("dedup check: %w", err)
+	}
+	return exists, nil
+}
+
+// ListNotifications returns paginated, RBAC-filtered notifications for a user.
+func (s *Store) ListNotifications(ctx context.Context, opts ListOpts) ([]Notification, int, error) {
+	if opts.Limit <= 0 {
+		opts.Limit = 25
+	}
+	if opts.Limit > 200 {
+		opts.Limit = 200
+	}
+
+	// Build WHERE clause dynamically
+	args := []any{opts.UserID}
+	where := "WHERE 1=1"
+	argIdx := 2
+
+	if len(opts.Namespaces) > 0 {
+		where += fmt.Sprintf(" AND (n.resource_ns = ANY($%d) OR n.resource_ns = '')", argIdx)
+		args = append(args, opts.Namespaces)
+		argIdx++
+	}
+	if opts.Source != "" {
+		where += fmt.Sprintf(" AND n.source = $%d", argIdx)
+		args = append(args, string(opts.Source))
+		argIdx++
+	}
+	if opts.Severity != "" {
+		where += fmt.Sprintf(" AND n.severity = $%d", argIdx)
+		args = append(args, string(opts.Severity))
+		argIdx++
+	}
+	if !opts.Since.IsZero() {
+		where += fmt.Sprintf(" AND n.created_at >= $%d", argIdx)
+		args = append(args, opts.Since)
+		argIdx++
+	}
+	if !opts.Until.IsZero() {
+		where += fmt.Sprintf(" AND n.created_at <= $%d", argIdx)
+		args = append(args, opts.Until)
+		argIdx++
+	}
+	if opts.ReadFilter == "read" {
+		where += " AND nr.notification_id IS NOT NULL"
+	} else if opts.ReadFilter == "unread" {
+		where += " AND nr.notification_id IS NULL"
+	}
+
+	// Count total
+	countQuery := fmt.Sprintf(`
+		SELECT COUNT(*) FROM nc_notifications n
+		LEFT JOIN nc_reads nr ON nr.notification_id = n.id AND nr.user_id = $1
+		%s`, where)
+	var total int
+	if err := s.pool.QueryRow(ctx, countQuery, args...).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("count notifications: %w", err)
+	}
+
+	// Fetch page
+	listQuery := fmt.Sprintf(`
+		SELECT n.id, n.source, n.severity, n.title, n.message,
+		       n.resource_kind, n.resource_ns, n.resource_name, n.cluster_id, n.created_at,
+		       (nr.notification_id IS NOT NULL) AS read
+		FROM nc_notifications n
+		LEFT JOIN nc_reads nr ON nr.notification_id = n.id AND nr.user_id = $1
+		%s
+		ORDER BY n.created_at DESC
+		LIMIT $%d OFFSET $%d`,
+		where, argIdx, argIdx+1)
+	args = append(args, opts.Limit, opts.Offset)
+
+	rows, err := s.pool.Query(ctx, listQuery, args...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("list notifications: %w", err)
+	}
+	defer rows.Close()
+
+	var notifications []Notification
+	for rows.Next() {
+		var n Notification
+		if err := rows.Scan(
+			&n.ID, &n.Source, &n.Severity, &n.Title, &n.Message,
+			&n.ResourceKind, &n.ResourceNS, &n.ResourceName, &n.ClusterID, &n.CreatedAt,
+			&n.Read,
+		); err != nil {
+			return nil, 0, fmt.Errorf("scan notification: %w", err)
+		}
+		notifications = append(notifications, n)
+	}
+	return notifications, total, rows.Err()
+}
+
+// UnreadCount returns the number of unread notifications for a user.
+func (s *Store) UnreadCount(ctx context.Context, userID string, namespaces []string) (int, error) {
+	var count int
+	err := s.pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM nc_notifications n
+		LEFT JOIN nc_reads nr ON nr.notification_id = n.id AND nr.user_id = $1
+		WHERE nr.notification_id IS NULL
+		  AND n.created_at > now() - INTERVAL '30 days'
+		  AND (n.resource_ns = ANY($2) OR n.resource_ns = '')`,
+		userID, namespaces,
+	).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("unread count: %w", err)
+	}
+	return count, nil
+}
+
+// MarkRead marks a single notification as read for a user.
+func (s *Store) MarkRead(ctx context.Context, userID, notificationID string) error {
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO nc_reads (user_id, notification_id)
+		VALUES ($1, $2)
+		ON CONFLICT DO NOTHING`,
+		userID, notificationID)
+	if err != nil {
+		return fmt.Errorf("mark read: %w", err)
+	}
+	return nil
+}
+
+// MarkAllRead marks all notifications as read for a user.
+func (s *Store) MarkAllRead(ctx context.Context, userID string) error {
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO nc_reads (user_id, notification_id)
+		SELECT $1, n.id FROM nc_notifications n
+		LEFT JOIN nc_reads nr ON nr.notification_id = n.id AND nr.user_id = $1
+		WHERE nr.notification_id IS NULL
+		  AND n.created_at > now() - INTERVAL '90 days'`,
+		userID)
+	if err != nil {
+		return fmt.Errorf("mark all read: %w", err)
+	}
+	return nil
+}
+
+// PruneOlderThan deletes notifications older than the given duration. Returns count deleted.
+func (s *Store) PruneOlderThan(ctx context.Context, age time.Duration) (int64, error) {
+	tag, err := s.pool.Exec(ctx,
+		"DELETE FROM nc_notifications WHERE created_at < $1",
+		time.Now().Add(-age))
+	if err != nil {
+		return 0, fmt.Errorf("prune notifications: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}
+
+// NotificationsSince returns notifications matching filters created after the given time.
+func (s *Store) NotificationsSince(ctx context.Context, since time.Time, sourceFilter []string, severityFilter []string) ([]Notification, error) {
+	query := `
+		SELECT id, source, severity, title, message,
+		       resource_kind, resource_ns, resource_name, cluster_id, created_at
+		FROM nc_notifications
+		WHERE created_at > $1`
+	args := []any{since}
+	argIdx := 2
+
+	if len(sourceFilter) > 0 {
+		query += fmt.Sprintf(" AND source = ANY($%d)", argIdx)
+		args = append(args, sourceFilter)
+		argIdx++
+	}
+	if len(severityFilter) > 0 {
+		query += fmt.Sprintf(" AND severity = ANY($%d)", argIdx)
+		args = append(args, severityFilter)
+	}
+	query += " ORDER BY created_at DESC LIMIT 500"
+
+	rows, err := s.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("notifications since: %w", err)
+	}
+	defer rows.Close()
+
+	var notifications []Notification
+	for rows.Next() {
+		var n Notification
+		if err := rows.Scan(
+			&n.ID, &n.Source, &n.Severity, &n.Title, &n.Message,
+			&n.ResourceKind, &n.ResourceNS, &n.ResourceName, &n.ClusterID, &n.CreatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan notification: %w", err)
+		}
+		notifications = append(notifications, n)
+	}
+	return notifications, rows.Err()
+}
+
+// --- Channels ---
+
+// ListChannels returns all notification channels.
+func (s *Store) ListChannels(ctx context.Context) ([]Channel, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, name, type, config, created_by, created_at,
+		       updated_at, updated_by, last_sent_at, last_error, last_error_at
+		FROM nc_channels
+		ORDER BY created_at`)
+	if err != nil {
+		return nil, fmt.Errorf("list channels: %w", err)
+	}
+	defer rows.Close()
+
+	var channels []Channel
+	for rows.Next() {
+		ch, err := s.scanChannel(rows)
+		if err != nil {
+			return nil, err
+		}
+		channels = append(channels, ch)
+	}
+	return channels, rows.Err()
+}
+
+// GetChannel returns a single channel by ID.
+func (s *Store) GetChannel(ctx context.Context, id string) (Channel, error) {
+	row := s.pool.QueryRow(ctx, `
+		SELECT id, name, type, config, created_by, created_at,
+		       updated_at, updated_by, last_sent_at, last_error, last_error_at
+		FROM nc_channels WHERE id = $1`, id)
+	return s.scanChannelRow(row)
+}
+
+// CreateChannel creates a new channel with encrypted config.
+func (s *Store) CreateChannel(ctx context.Context, ch Channel) (string, error) {
+	configBytes, err := s.encryptConfig(ch.Config)
+	if err != nil {
+		return "", err
+	}
+
+	var id string
+	err = s.pool.QueryRow(ctx, `
+		INSERT INTO nc_channels (name, type, config, created_by)
+		VALUES ($1, $2, $3, $4)
+		RETURNING id`,
+		ch.Name, ch.Type, configBytes, ch.CreatedBy,
+	).Scan(&id)
+	if err != nil {
+		return "", fmt.Errorf("create channel: %w", err)
+	}
+	return id, nil
+}
+
+// UpdateChannel updates a channel's name and config.
+func (s *Store) UpdateChannel(ctx context.Context, ch Channel) error {
+	configBytes, err := s.encryptConfig(ch.Config)
+	if err != nil {
+		return err
+	}
+
+	_, err = s.pool.Exec(ctx, `
+		UPDATE nc_channels SET name = $1, config = $2, updated_at = now(), updated_by = $3
+		WHERE id = $4`,
+		ch.Name, configBytes, ch.UpdatedBy, ch.ID)
+	if err != nil {
+		return fmt.Errorf("update channel: %w", err)
+	}
+	return nil
+}
+
+// DeleteChannel deletes a channel (cascades to rules).
+func (s *Store) DeleteChannel(ctx context.Context, id string) error {
+	_, err := s.pool.Exec(ctx, "DELETE FROM nc_channels WHERE id = $1", id)
+	if err != nil {
+		return fmt.Errorf("delete channel: %w", err)
+	}
+	return nil
+}
+
+// UpdateChannelError records a dispatch error on a channel.
+func (s *Store) UpdateChannelError(ctx context.Context, id, errMsg string) error {
+	_, err := s.pool.Exec(ctx, `
+		UPDATE nc_channels SET last_error = $1, last_error_at = now() WHERE id = $2`,
+		errMsg, id)
+	if err != nil {
+		return fmt.Errorf("update channel error: %w", err)
+	}
+	return nil
+}
+
+// UpdateChannelLastSent updates the last_sent_at timestamp for digest tracking.
+func (s *Store) UpdateChannelLastSent(ctx context.Context, id string) error {
+	_, err := s.pool.Exec(ctx, `
+		UPDATE nc_channels SET last_sent_at = now(), last_error = NULL, last_error_at = NULL WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("update channel last sent: %w", err)
+	}
+	return nil
+}
+
+// --- Rules ---
+
+// ListRules returns all notification rules with channel names.
+func (s *Store) ListRules(ctx context.Context) ([]Rule, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT r.id, r.name, r.source_filter, r.severity_filter, r.channel_id,
+		       COALESCE(c.name, ''), r.enabled, r.created_by, r.created_at, r.updated_at, r.updated_by
+		FROM nc_rules r
+		LEFT JOIN nc_channels c ON c.id = r.channel_id
+		ORDER BY r.created_at`)
+	if err != nil {
+		return nil, fmt.Errorf("list rules: %w", err)
+	}
+	defer rows.Close()
+
+	var rules []Rule
+	for rows.Next() {
+		var r Rule
+		if err := rows.Scan(
+			&r.ID, &r.Name, &r.SourceFilter, &r.SeverityFilter, &r.ChannelID,
+			&r.ChannelName, &r.Enabled, &r.CreatedBy, &r.CreatedAt, &r.UpdatedAt, &r.UpdatedBy,
+		); err != nil {
+			return nil, fmt.Errorf("scan rule: %w", err)
+		}
+		rules = append(rules, r)
+	}
+	return rules, rows.Err()
+}
+
+// CreateRule creates a new routing rule.
+func (s *Store) CreateRule(ctx context.Context, r Rule) (string, error) {
+	sourceStrs := make([]string, len(r.SourceFilter))
+	for i, v := range r.SourceFilter {
+		sourceStrs[i] = string(v)
+	}
+	sevStrs := make([]string, len(r.SeverityFilter))
+	for i, v := range r.SeverityFilter {
+		sevStrs[i] = string(v)
+	}
+
+	var id string
+	err := s.pool.QueryRow(ctx, `
+		INSERT INTO nc_rules (name, source_filter, severity_filter, channel_id, enabled, created_by)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		RETURNING id`,
+		r.Name, sourceStrs, sevStrs, r.ChannelID, r.Enabled, r.CreatedBy,
+	).Scan(&id)
+	if err != nil {
+		return "", fmt.Errorf("create rule: %w", err)
+	}
+	return id, nil
+}
+
+// UpdateRule updates a rule's filters, channel, and enabled state.
+func (s *Store) UpdateRule(ctx context.Context, r Rule) error {
+	sourceStrs := make([]string, len(r.SourceFilter))
+	for i, v := range r.SourceFilter {
+		sourceStrs[i] = string(v)
+	}
+	sevStrs := make([]string, len(r.SeverityFilter))
+	for i, v := range r.SeverityFilter {
+		sevStrs[i] = string(v)
+	}
+
+	_, err := s.pool.Exec(ctx, `
+		UPDATE nc_rules
+		SET name = $1, source_filter = $2, severity_filter = $3, channel_id = $4,
+		    enabled = $5, updated_at = now(), updated_by = $6
+		WHERE id = $7`,
+		r.Name, sourceStrs, sevStrs, r.ChannelID, r.Enabled, r.UpdatedBy, r.ID)
+	if err != nil {
+		return fmt.Errorf("update rule: %w", err)
+	}
+	return nil
+}
+
+// DeleteRule deletes a routing rule.
+func (s *Store) DeleteRule(ctx context.Context, id string) error {
+	_, err := s.pool.Exec(ctx, "DELETE FROM nc_rules WHERE id = $1", id)
+	if err != nil {
+		return fmt.Errorf("delete rule: %w", err)
+	}
+	return nil
+}
+
+// --- Helpers ---
+
+func (s *Store) encryptConfig(cfg ChannelConfig) ([]byte, error) {
+	plaintext, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("marshal channel config: %w", err)
+	}
+	encrypted, err := store.Encrypt(plaintext, s.masterSecret)
+	if err != nil {
+		return nil, fmt.Errorf("encrypt channel config: %w", err)
+	}
+	return encrypted, nil
+}
+
+func (s *Store) decryptConfig(encrypted []byte) (ChannelConfig, error) {
+	plaintext, err := store.Decrypt(encrypted, s.masterSecret)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt channel config: %w", err)
+	}
+	var cfg ChannelConfig
+	if err := json.Unmarshal(plaintext, &cfg); err != nil {
+		return nil, fmt.Errorf("unmarshal channel config: %w", err)
+	}
+	return cfg, nil
+}
+
+func (s *Store) scanChannel(rows pgx.Rows) (Channel, error) {
+	var ch Channel
+	var configBytes []byte
+	if err := rows.Scan(
+		&ch.ID, &ch.Name, &ch.Type, &configBytes, &ch.CreatedBy, &ch.CreatedAt,
+		&ch.UpdatedAt, &ch.UpdatedBy, &ch.LastSentAt, &ch.LastError, &ch.LastErrorAt,
+	); err != nil {
+		return Channel{}, fmt.Errorf("scan channel: %w", err)
+	}
+	cfg, err := s.decryptConfig(configBytes)
+	if err != nil {
+		return Channel{}, err
+	}
+	ch.Config = cfg
+	return ch, nil
+}
+
+func (s *Store) scanChannelRow(row pgx.Row) (Channel, error) {
+	var ch Channel
+	var configBytes []byte
+	if err := row.Scan(
+		&ch.ID, &ch.Name, &ch.Type, &configBytes, &ch.CreatedBy, &ch.CreatedAt,
+		&ch.UpdatedAt, &ch.UpdatedBy, &ch.LastSentAt, &ch.LastError, &ch.LastErrorAt,
+	); err != nil {
+		return Channel{}, fmt.Errorf("scan channel: %w", err)
+	}
+	cfg, err := s.decryptConfig(configBytes)
+	if err != nil {
+		return Channel{}, err
+	}
+	ch.Config = cfg
+	return ch, nil
+}

--- a/backend/internal/notifications/types.go
+++ b/backend/internal/notifications/types.go
@@ -1,0 +1,98 @@
+package notifications
+
+import "time"
+
+// Source identifies the subsystem that produced a notification.
+type Source string
+
+const (
+	SourceAlert      Source = "alert"
+	SourcePolicy     Source = "policy"
+	SourceGitOps     Source = "gitops"
+	SourceDiagnostic Source = "diagnostic"
+	SourceScan       Source = "scan"
+	SourceCluster    Source = "cluster"
+	SourceAudit      Source = "audit"
+)
+
+// Severity indicates how critical a notification is.
+type Severity string
+
+const (
+	SeverityInfo     Severity = "info"
+	SeverityWarning  Severity = "warning"
+	SeverityCritical Severity = "critical"
+)
+
+// ChannelType identifies the external dispatch mechanism.
+type ChannelType string
+
+const (
+	ChannelSlack   ChannelType = "slack"
+	ChannelEmail   ChannelType = "email"
+	ChannelWebhook ChannelType = "webhook"
+)
+
+// Notification is a single event from any subsystem.
+type Notification struct {
+	ID           string   `json:"id"`
+	Source       Source   `json:"source"`
+	Severity     Severity `json:"severity"`
+	Title        string   `json:"title"`
+	Message      string   `json:"message"`
+	ResourceKind string   `json:"resourceKind,omitempty"`
+	ResourceNS   string   `json:"resourceNamespace,omitempty"`
+	ResourceName string   `json:"resourceName,omitempty"`
+	ClusterID    string   `json:"clusterId,omitempty"`
+	CreatedAt    time.Time `json:"createdAt"`
+	Read         bool     `json:"read,omitempty"`
+}
+
+// Channel is an external dispatch target (Slack, email, webhook).
+type Channel struct {
+	ID          string      `json:"id"`
+	Name        string      `json:"name"`
+	Type        ChannelType `json:"type"`
+	Config      ChannelConfig `json:"config"`
+	CreatedBy   string      `json:"createdBy"`
+	CreatedAt   time.Time   `json:"createdAt"`
+	UpdatedAt   *time.Time  `json:"updatedAt,omitempty"`
+	UpdatedBy   string      `json:"updatedBy,omitempty"`
+	LastSentAt  *time.Time  `json:"lastSentAt,omitempty"`
+	LastError   string      `json:"lastError,omitempty"`
+	LastErrorAt *time.Time  `json:"lastErrorAt,omitempty"`
+}
+
+// ChannelConfig holds type-specific settings, stored as encrypted BYTEA.
+// Slack:   {"webhookUrl": "https://hooks.slack.com/..."}
+// Email:   {"recipients": ["ops@team.com"], "schedule": "daily"}
+// Webhook: {"url": "https://...", "secret": "...", "headers": {"Authorization": "Bearer ..."}}
+type ChannelConfig map[string]any
+
+// Rule maps notifications to channels based on source and severity filters.
+type Rule struct {
+	ID             string     `json:"id"`
+	Name           string     `json:"name"`
+	SourceFilter   []Source   `json:"sourceFilter"`
+	SeverityFilter []Severity `json:"severityFilter"`
+	ChannelID      string     `json:"channelId"`
+	ChannelName    string     `json:"channelName,omitempty"`
+	Enabled        bool       `json:"enabled"`
+	CreatedBy      string     `json:"createdBy"`
+	CreatedAt      time.Time  `json:"createdAt"`
+	UpdatedAt      *time.Time `json:"updatedAt,omitempty"`
+	UpdatedBy      string     `json:"updatedBy,omitempty"`
+}
+
+// ListOpts controls notification feed pagination and filtering.
+type ListOpts struct {
+	UserID     string
+	Namespaces []string
+	Source     Source
+	Severity   Severity
+	ReadFilter string // "read", "unread", or "" (all)
+	Since      time.Time
+	Until      time.Time
+	Limit      int
+	Offset     int
+}

--- a/backend/internal/policy/handler.go
+++ b/backend/internal/policy/handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kubecenter/kubecenter/internal/httputil"
 	"github.com/kubecenter/kubecenter/internal/k8s"
 	"github.com/kubecenter/kubecenter/internal/k8s/resources"
+	"github.com/kubecenter/kubecenter/internal/notifications"
 	"github.com/kubecenter/kubecenter/internal/store"
 )
 
@@ -26,6 +27,7 @@ type Handler struct {
 	CRDDiscovery    *k8s.CRDDiscovery
 	AccessChecker   *resources.AccessChecker
 	ComplianceStore *store.ComplianceStore
+	NotifService    *notifications.NotificationService
 	Logger          *slog.Logger
 
 	fetchGroup singleflight.Group
@@ -71,6 +73,21 @@ func (h *Handler) InvalidateCache() {
 	h.cachedData = nil
 	h.cacheGen++
 	h.cacheMu.Unlock()
+	go h.notifyPolicyChange(context.Background())
+}
+
+// notifyPolicyChange emits a notification when the policy cache is invalidated
+// (i.e. CRD watch detected a change). Dedup in the service suppresses bursts.
+func (h *Handler) notifyPolicyChange(ctx context.Context) {
+	if h.NotifService == nil {
+		return
+	}
+	h.NotifService.Emit(ctx, notifications.Notification{
+		Source:   notifications.SourcePolicy,
+		Severity: notifications.SeverityWarning,
+		Title:    "Policy violations detected",
+		Message:  "Policy engine reported changes. Check the policy dashboard for details.",
+	})
 }
 
 // doFetch queries both engines based on discovery status and merges results.

--- a/backend/internal/policy/handler.go
+++ b/backend/internal/policy/handler.go
@@ -73,21 +73,14 @@ func (h *Handler) InvalidateCache() {
 	h.cachedData = nil
 	h.cacheGen++
 	h.cacheMu.Unlock()
-	go h.notifyPolicyChange(context.Background())
-}
-
-// notifyPolicyChange emits a notification when the policy cache is invalidated
-// (i.e. CRD watch detected a change). Dedup in the service suppresses bursts.
-func (h *Handler) notifyPolicyChange(ctx context.Context) {
-	if h.NotifService == nil {
-		return
+	if h.NotifService != nil {
+		go h.NotifService.Emit(context.Background(), notifications.Notification{
+			Source:   notifications.SourcePolicy,
+			Severity: notifications.SeverityInfo,
+			Title:    "Policy engine change detected",
+			Message:  "Policy engine reported changes. Check the policy dashboard for details.",
+		})
 	}
-	h.NotifService.Emit(ctx, notifications.Notification{
-		Source:   notifications.SourcePolicy,
-		Severity: notifications.SeverityWarning,
-		Title:    "Policy violations detected",
-		Message:  "Policy engine reported changes. Check the policy dashboard for details.",
-	})
 }
 
 // doFetch queries both engines based on discovery status and merges results.

--- a/backend/internal/scanning/handler.go
+++ b/backend/internal/scanning/handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kubecenter/kubecenter/internal/httputil"
 	"github.com/kubecenter/kubecenter/internal/k8s"
 	"github.com/kubecenter/kubecenter/internal/k8s/resources"
+	"github.com/kubecenter/kubecenter/internal/notifications"
 )
 
 // Handler serves security scanning HTTP endpoints.
@@ -22,6 +23,7 @@ type Handler struct {
 	K8sClient     *k8s.ClientFactory
 	Discoverer    *ScannerDiscoverer
 	AccessChecker *resources.AccessChecker
+	NotifService  *notifications.NotificationService
 	Logger        *slog.Logger
 
 	fetchGroup singleflight.Group
@@ -45,6 +47,28 @@ var validNamespace = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`)
 // This avoids lazy init under locks.
 func (h *Handler) InitCache() {
 	h.nsCache = make(map[string]*cachedNSData)
+}
+
+// InvalidateCache clears all cached scan data so subsequent requests re-fetch.
+func (h *Handler) InvalidateCache() {
+	h.cacheMu.Lock()
+	h.nsCache = make(map[string]*cachedNSData)
+	h.cacheMu.Unlock()
+	go h.notifyScanChange(context.Background())
+}
+
+// notifyScanChange emits a notification when scan data is invalidated
+// (i.e. CRD watch detected new vulnerability reports). Dedup suppresses bursts.
+func (h *Handler) notifyScanChange(ctx context.Context) {
+	if h.NotifService == nil {
+		return
+	}
+	h.NotifService.Emit(ctx, notifications.Notification{
+		Source:   notifications.SourceScan,
+		Severity: notifications.SeverityWarning,
+		Title:    "Security scan results updated",
+		Message:  "New vulnerability scan results available. Check the security dashboard for details.",
+	})
 }
 
 // fetchVulns returns cached vulnerability data for a namespace, refreshing if stale.

--- a/backend/internal/scanning/handler.go
+++ b/backend/internal/scanning/handler.go
@@ -54,21 +54,14 @@ func (h *Handler) InvalidateCache() {
 	h.cacheMu.Lock()
 	h.nsCache = make(map[string]*cachedNSData)
 	h.cacheMu.Unlock()
-	go h.notifyScanChange(context.Background())
-}
-
-// notifyScanChange emits a notification when scan data is invalidated
-// (i.e. CRD watch detected new vulnerability reports). Dedup suppresses bursts.
-func (h *Handler) notifyScanChange(ctx context.Context) {
-	if h.NotifService == nil {
-		return
+	if h.NotifService != nil {
+		go h.NotifService.Emit(context.Background(), notifications.Notification{
+			Source:   notifications.SourceScan,
+			Severity: notifications.SeverityInfo,
+			Title:    "Security scan results updated",
+			Message:  "New vulnerability scan results available. Check the security dashboard for details.",
+		})
 	}
-	h.NotifService.Emit(ctx, notifications.Notification{
-		Source:   notifications.SourceScan,
-		Severity: notifications.SeverityWarning,
-		Title:    "Security scan results updated",
-		Message:  "New vulnerability scan results available. Check the security dashboard for details.",
-	})
 }
 
 // fetchVulns returns cached vulnerability data for a namespace, refreshing if stale.

--- a/backend/internal/server/routes.go
+++ b/backend/internal/server/routes.go
@@ -156,6 +156,11 @@ func (s *Server) registerRoutes() {
 				s.registerScanningRoutes(ar)
 			}
 
+			// Notification center routes
+			if s.NotifCenterHandler != nil {
+				s.registerNotifCenterRoutes(ar)
+			}
+
 			// User management — admin only
 			ar.Route("/users", func(ur chi.Router) {
 				ur.Use(middleware.RequireAdmin)
@@ -707,4 +712,37 @@ func (s *Server) registerResourceEndpoints(ar chi.Router, h *resources.Handler) 
 	ar.Post("/resources/clusterrolebindings", h.HandleCreateClusterRoleBinding)
 	ar.Put("/resources/clusterrolebindings/{name}", h.HandleUpdateClusterRoleBinding)
 	ar.Delete("/resources/clusterrolebindings/{name}", h.HandleDeleteClusterRoleBinding)
+}
+
+// registerNotifCenterRoutes registers notification center endpoints.
+// Feed endpoints are accessible to all authenticated users.
+// Channel and rule management require admin role.
+func (s *Server) registerNotifCenterRoutes(ar chi.Router) {
+	h := s.NotifCenterHandler
+	ar.Route("/notifications", func(r chi.Router) {
+		// Feed — all authenticated users
+		r.Get("/", h.HandleList)
+		r.Post("/{id}/read", h.HandleMarkRead)
+		r.Post("/read-all", h.HandleMarkAllRead)
+		r.Get("/unread-count", h.HandleUnreadCount)
+
+		// Channels — admin only
+		r.Route("/channels", func(cr chi.Router) {
+			cr.Use(middleware.RequireAdmin)
+			cr.Get("/", h.HandleListChannels)
+			cr.Post("/", h.HandleCreateChannel)
+			cr.Put("/{id}", h.HandleUpdateChannel)
+			cr.Delete("/{id}", h.HandleDeleteChannel)
+			cr.Post("/{id}/test", h.HandleTestChannel)
+		})
+
+		// Rules — admin only
+		r.Route("/rules", func(rr chi.Router) {
+			rr.Use(middleware.RequireAdmin)
+			rr.Get("/", h.HandleListRules)
+			rr.Post("/", h.HandleCreateRule)
+			rr.Put("/{id}", h.HandleUpdateRule)
+			rr.Delete("/{id}", h.HandleDeleteRule)
+		})
+	})
 }

--- a/backend/internal/server/routes.go
+++ b/backend/internal/server/routes.go
@@ -466,8 +466,8 @@ func (s *Server) registerGitOpsRoutes(ar chi.Router) {
 		gr.Delete("/applicationsets/{id}", h.HandleDeleteAppSet)
 
 		// Notification routes — only if handler is available
-		if s.NotificationHandler != nil {
-			nh := s.NotificationHandler
+		if s.FluxNotifHandler != nil {
+			nh := s.FluxNotifHandler
 			gr.Route("/notifications", func(nr chi.Router) {
 				nr.Get("/status", nh.HandleStatus)
 				nr.Get("/providers", nh.HandleListProviders)

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -65,7 +65,7 @@ type Server struct {
 	DiagnosticsHandler   *diagnostics.Handler
 	PolicyHandler        *policy.Handler
 	GitOpsHandler        *gitops.Handler
-	NotificationHandler  *notification.Handler
+	FluxNotifHandler     *notification.Handler
 	ScanningHandler      *scanning.Handler
 	CRDHandler           *resources.GenericCRDHandler
 	NotifCenterHandler   *notifications.Handler
@@ -106,7 +106,7 @@ type Deps struct {
 	DiagnosticsHandler   *diagnostics.Handler
 	PolicyHandler        *policy.Handler
 	GitOpsHandler        *gitops.Handler
-	NotificationHandler  *notification.Handler
+	FluxNotifHandler     *notification.Handler
 	ScanningHandler        *scanning.Handler
 	CRDHandler             *resources.GenericCRDHandler
 	NotifCenterHandler     *notifications.Handler
@@ -236,8 +236,8 @@ func New(deps Deps) *Server {
 	}
 
 	// Notification handler
-	if deps.NotificationHandler != nil {
-		s.NotificationHandler = deps.NotificationHandler
+	if deps.FluxNotifHandler != nil {
+		s.FluxNotifHandler = deps.FluxNotifHandler
 	}
 
 	// Scanning handler

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/kubecenter/kubecenter/internal/diagnostics"
 	"github.com/kubecenter/kubecenter/internal/gitops"
 	"github.com/kubecenter/kubecenter/internal/notification"
+	"github.com/kubecenter/kubecenter/internal/notifications"
 	"github.com/kubecenter/kubecenter/internal/scanning"
 	"github.com/kubecenter/kubecenter/internal/server/middleware" // used by Deps type
 	"github.com/kubecenter/kubecenter/internal/store"
@@ -67,6 +68,8 @@ type Server struct {
 	NotificationHandler  *notification.Handler
 	ScanningHandler      *scanning.Handler
 	CRDHandler           *resources.GenericCRDHandler
+	NotifCenterHandler   *notifications.Handler
+	NotifCenterService   *notifications.NotificationService
 	Hub                  *websocket.Hub
 	LogQueryLimiter    *middleware.RateLimiter
 	WebhookRateLimiter *middleware.RateLimiter
@@ -104,13 +107,15 @@ type Deps struct {
 	PolicyHandler        *policy.Handler
 	GitOpsHandler        *gitops.Handler
 	NotificationHandler  *notification.Handler
-	ScanningHandler      *scanning.Handler
-	CRDHandler           *resources.GenericCRDHandler
-	LogQueryLimiter      *middleware.RateLimiter
-	WebhookRateLimiter *middleware.RateLimiter
-	AccessChecker      *resources.AccessChecker
-	ReadyFn            func() bool
-	DBPing             func(context.Context) error // nil if no database
+	ScanningHandler        *scanning.Handler
+	CRDHandler             *resources.GenericCRDHandler
+	NotifCenterHandler     *notifications.Handler
+	NotifCenterService     *notifications.NotificationService
+	LogQueryLimiter        *middleware.RateLimiter
+	WebhookRateLimiter     *middleware.RateLimiter
+	AccessChecker          *resources.AccessChecker
+	ReadyFn                func() bool
+	DBPing                 func(context.Context) error // nil if no database
 }
 
 // New creates a configured HTTP server with middleware and routes.
@@ -238,6 +243,12 @@ func New(deps Deps) *Server {
 	// Scanning handler
 	if deps.ScanningHandler != nil {
 		s.ScanningHandler = deps.ScanningHandler
+	}
+
+	// Notification center
+	if deps.NotifCenterHandler != nil {
+		s.NotifCenterHandler = deps.NotifCenterHandler
+		s.NotifCenterService = deps.NotifCenterService
 	}
 
 	// CRD handler

--- a/backend/internal/store/migrations/000007_create_notification_center.down.sql
+++ b/backend/internal/store/migrations/000007_create_notification_center.down.sql
@@ -1,0 +1,4 @@
+DROP TABLE IF EXISTS nc_rules;
+DROP TABLE IF EXISTS nc_channels;
+DROP TABLE IF EXISTS nc_reads;
+DROP TABLE IF EXISTS nc_notifications;

--- a/backend/internal/store/migrations/000007_create_notification_center.up.sql
+++ b/backend/internal/store/migrations/000007_create_notification_center.up.sql
@@ -1,9 +1,9 @@
-CREATE TABLE nc_notifications (
+CREATE TABLE IF NOT EXISTS nc_notifications (
     id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    source        TEXT NOT NULL,
+    source        TEXT NOT NULL CHECK (source IN ('alert','policy','gitops','diagnostic','scan','cluster','audit')),
     severity      TEXT NOT NULL CHECK (severity IN ('critical','warning','info')),
-    title         TEXT NOT NULL,
-    message       TEXT NOT NULL DEFAULT '',
+    title         TEXT NOT NULL CHECK (length(title) <= 500),
+    message       TEXT NOT NULL DEFAULT '' CHECK (length(message) <= 10000),
     resource_kind TEXT NOT NULL DEFAULT '',
     resource_ns   TEXT NOT NULL DEFAULT '',
     resource_name TEXT NOT NULL DEFAULT '',
@@ -11,22 +11,23 @@ CREATE TABLE nc_notifications (
     created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
-CREATE INDEX idx_nc_notif_created_at ON nc_notifications (created_at DESC);
-CREATE INDEX idx_nc_notif_source ON nc_notifications (source);
-CREATE INDEX idx_nc_notif_dedup ON nc_notifications (source, resource_kind, resource_ns, resource_name, title, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_nc_notif_created_at ON nc_notifications (created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_nc_notif_source ON nc_notifications (source);
+CREATE INDEX IF NOT EXISTS idx_nc_notif_dedup ON nc_notifications (source, resource_kind, resource_ns, resource_name, title, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_nc_notif_ns_created ON nc_notifications (resource_ns, created_at DESC);
 
-CREATE TABLE nc_reads (
+CREATE TABLE IF NOT EXISTS nc_reads (
     user_id         TEXT NOT NULL,
     notification_id UUID NOT NULL REFERENCES nc_notifications(id) ON DELETE CASCADE,
     read_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
     PRIMARY KEY (user_id, notification_id)
 );
 
-CREATE INDEX idx_nc_reads_notification_id ON nc_reads (notification_id);
+CREATE INDEX IF NOT EXISTS idx_nc_reads_notification_id ON nc_reads (notification_id);
 
-CREATE TABLE nc_channels (
+CREATE TABLE IF NOT EXISTS nc_channels (
     id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    name          TEXT NOT NULL,
+    name          TEXT NOT NULL UNIQUE,
     type          TEXT NOT NULL CHECK (type IN ('slack','email','webhook')),
     config        BYTEA NOT NULL,
     created_by    TEXT NOT NULL,
@@ -38,7 +39,7 @@ CREATE TABLE nc_channels (
     last_error_at TIMESTAMPTZ
 );
 
-CREATE TABLE nc_rules (
+CREATE TABLE IF NOT EXISTS nc_rules (
     id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     name            TEXT NOT NULL,
     source_filter   TEXT[] NOT NULL DEFAULT '{}',

--- a/backend/internal/store/migrations/000007_create_notification_center.up.sql
+++ b/backend/internal/store/migrations/000007_create_notification_center.up.sql
@@ -1,0 +1,52 @@
+CREATE TABLE nc_notifications (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    source        TEXT NOT NULL,
+    severity      TEXT NOT NULL CHECK (severity IN ('critical','warning','info')),
+    title         TEXT NOT NULL,
+    message       TEXT NOT NULL DEFAULT '',
+    resource_kind TEXT NOT NULL DEFAULT '',
+    resource_ns   TEXT NOT NULL DEFAULT '',
+    resource_name TEXT NOT NULL DEFAULT '',
+    cluster_id    TEXT NOT NULL DEFAULT '',
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_nc_notif_created_at ON nc_notifications (created_at DESC);
+CREATE INDEX idx_nc_notif_source ON nc_notifications (source);
+CREATE INDEX idx_nc_notif_dedup ON nc_notifications (source, resource_kind, resource_ns, resource_name, title, created_at DESC);
+
+CREATE TABLE nc_reads (
+    user_id         TEXT NOT NULL,
+    notification_id UUID NOT NULL REFERENCES nc_notifications(id) ON DELETE CASCADE,
+    read_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (user_id, notification_id)
+);
+
+CREATE INDEX idx_nc_reads_notification_id ON nc_reads (notification_id);
+
+CREATE TABLE nc_channels (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name          TEXT NOT NULL,
+    type          TEXT NOT NULL CHECK (type IN ('slack','email','webhook')),
+    config        BYTEA NOT NULL,
+    created_by    TEXT NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at    TIMESTAMPTZ,
+    updated_by    TEXT,
+    last_sent_at  TIMESTAMPTZ,
+    last_error    TEXT,
+    last_error_at TIMESTAMPTZ
+);
+
+CREATE TABLE nc_rules (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name            TEXT NOT NULL,
+    source_filter   TEXT[] NOT NULL DEFAULT '{}',
+    severity_filter TEXT[] NOT NULL DEFAULT '{}',
+    channel_id      UUID NOT NULL REFERENCES nc_channels(id) ON DELETE CASCADE,
+    enabled         BOOLEAN NOT NULL DEFAULT true,
+    created_by      TEXT NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ,
+    updated_by      TEXT
+);

--- a/backend/internal/websocket/events.go
+++ b/backend/internal/websocket/events.go
@@ -55,6 +55,7 @@ type OutgoingMessage struct {
 var (
 	allowedKindsMu sync.RWMutex
 	allowedKinds   = map[string]bool{
+		"notifications":           true,
 		"pods":                    true,
 		"services":                true,
 		"configmaps":              true,

--- a/backend/internal/websocket/hub.go
+++ b/backend/internal/websocket/hub.go
@@ -113,9 +113,12 @@ func (h *Hub) Register(client *Client) {
 const rbacRevalidateInterval = 5 * time.Minute
 
 // alwaysAllowKinds are subscription kinds that bypass RBAC revalidation.
-// "alerts" is not a Kubernetes resource — JWT auth alone is sufficient.
+// These are not Kubernetes resources — JWT auth alone is sufficient.
+// "notifications" broadcasts stripped payloads (no resource fields);
+// full details are fetched via the REST API which enforces RBAC.
 var alwaysAllowKinds = map[string]bool{
-	"alerts": true,
+	"alerts":        true,
+	"notifications": true,
 }
 
 // Run is the main hub goroutine. Call as `go hub.Run(ctx)`.

--- a/frontend/components/ui/NotifCenterBadges.tsx
+++ b/frontend/components/ui/NotifCenterBadges.tsx
@@ -1,13 +1,24 @@
 import {
+  NOTIF_SEVERITY_COLORS,
   type NotifSeverity,
   type NotifSource,
-  SEVERITY_COLORS,
   SOURCE_LABELS,
 } from "@/lib/notif-center-types.ts";
 
+/** Per-source color map for visual differentiation. */
+const SOURCE_COLORS: Record<NotifSource, string> = {
+  alert: "var(--danger)",
+  policy: "var(--warning)",
+  gitops: "var(--accent)",
+  diagnostic: "var(--danger)",
+  scan: "var(--warning)",
+  cluster: "var(--success)",
+  audit: "var(--text-muted)",
+};
+
 /** Colored dot indicating notification severity. */
 export function SeverityDot({ severity }: { severity: NotifSeverity }) {
-  const color = SEVERITY_COLORS[severity] ?? "var(--text-muted)";
+  const color = NOTIF_SEVERITY_COLORS[severity] ?? "var(--text-muted)";
   return (
     <span
       style={{
@@ -23,10 +34,10 @@ export function SeverityDot({ severity }: { severity: NotifSeverity }) {
   );
 }
 
-/** Tinted pill badge for notification source. */
+/** Tinted pill badge for notification source with per-source coloring. */
 export function SourceBadge({ source }: { source: NotifSource }) {
   const label = SOURCE_LABELS[source] ?? source;
-  const color = "var(--text-muted)";
+  const color = SOURCE_COLORS[source] ?? "var(--text-muted)";
   return (
     <span
       class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium"

--- a/frontend/components/ui/NotifCenterBadges.tsx
+++ b/frontend/components/ui/NotifCenterBadges.tsx
@@ -1,0 +1,41 @@
+import {
+  type NotifSeverity,
+  type NotifSource,
+  SEVERITY_COLORS,
+  SOURCE_LABELS,
+} from "@/lib/notif-center-types.ts";
+
+/** Colored dot indicating notification severity. */
+export function SeverityDot({ severity }: { severity: NotifSeverity }) {
+  const color = SEVERITY_COLORS[severity] ?? "var(--text-muted)";
+  return (
+    <span
+      style={{
+        display: "inline-block",
+        width: "8px",
+        height: "8px",
+        borderRadius: "50%",
+        backgroundColor: color,
+        flexShrink: 0,
+      }}
+      title={severity}
+    />
+  );
+}
+
+/** Tinted pill badge for notification source. */
+export function SourceBadge({ source }: { source: NotifSource }) {
+  const label = SOURCE_LABELS[source] ?? source;
+  const color = "var(--text-muted)";
+  return (
+    <span
+      class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium"
+      style={{
+        color,
+        backgroundColor: `color-mix(in srgb, ${color} 12%, transparent)`,
+      }}
+    >
+      {label}
+    </span>
+  );
+}

--- a/frontend/islands/CommandPalette.tsx
+++ b/frontend/islands/CommandPalette.tsx
@@ -83,6 +83,9 @@ function buildSearchIndex(): SearchItem[] {
     { label: "View ApplicationSets", href: "/gitops/applicationsets" },
     { label: "View GitOps Notifications", href: "/gitops/notifications" },
     { label: "View Vulnerabilities", href: "/security/vulnerabilities" },
+    { label: "View Notifications", href: "/notifications" },
+    { label: "Notification Channels", href: "/admin/notifications/channels" },
+    { label: "Notification Rules", href: "/admin/notifications/rules" },
   ];
   for (const a of actions) {
     items.push({

--- a/frontend/islands/NotificationBell.tsx
+++ b/frontend/islands/NotificationBell.tsx
@@ -1,0 +1,351 @@
+import { useSignal } from "@preact/signals";
+import { useEffect, useRef } from "preact/hooks";
+import { IS_BROWSER } from "fresh/runtime";
+import { subscribe } from "@/lib/ws.ts";
+import { notifApi } from "@/lib/api.ts";
+import { useAuth } from "@/lib/auth.ts";
+import type { AppNotification } from "@/lib/notif-center-types.ts";
+import {
+  SeverityDot,
+  SourceBadge,
+} from "@/components/ui/NotifCenterBadges.tsx";
+
+/** Time-ago helper for relative timestamps. */
+function timeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export default function NotificationBell() {
+  const unreadCount = useSignal(0);
+  const showPanel = useSignal(false);
+  const recent = useSignal<AppNotification[]>([]);
+  const loading = useSignal(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const { user } = useAuth();
+
+  // Fetch initial unread count on mount
+  useEffect(() => {
+    if (!IS_BROWSER) return;
+    notifApi.unreadCount().then((res) => {
+      unreadCount.value = res.data.count;
+    }).catch(() => {});
+  }, []);
+
+  // Subscribe to WS notifications for real-time badge updates
+  useEffect(() => {
+    if (!IS_BROWSER) return;
+    const unsub = subscribe(
+      "notif-bell",
+      "notifications",
+      "",
+      (_eventType, _obj) => {
+        // Increment badge on any new notification
+        unreadCount.value++;
+      },
+    );
+    return unsub;
+  }, []);
+
+  // Close panel on outside click or Escape
+  useEffect(() => {
+    if (!IS_BROWSER) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (
+        showPanel.value && panelRef.current &&
+        !panelRef.current.contains(e.target as Node)
+      ) {
+        showPanel.value = false;
+      }
+    };
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") showPanel.value = false;
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, []);
+
+  // Fetch recent notifications when panel opens
+  const openPanel = async () => {
+    showPanel.value = !showPanel.value;
+    if (showPanel.value && recent.value.length === 0) {
+      loading.value = true;
+      try {
+        const res = await notifApi.list({ limit: 20 });
+        recent.value = res.data ?? [];
+      } catch {
+        // Silently fail — panel shows empty state
+      }
+      loading.value = false;
+    }
+  };
+
+  const handleMarkAllRead = async () => {
+    try {
+      await notifApi.markAllRead();
+      unreadCount.value = 0;
+      recent.value = recent.value.map((n) => ({ ...n, read: true }));
+    } catch {
+      // Silently fail
+    }
+  };
+
+  const handleClickNotification = async (n: AppNotification) => {
+    // Mark as read
+    if (!n.read) {
+      try {
+        await notifApi.markRead(n.id);
+        unreadCount.value = Math.max(0, unreadCount.value - 1);
+        recent.value = recent.value.map((item) =>
+          item.id === n.id ? { ...item, read: true } : item
+        );
+      } catch {
+        // Silently fail
+      }
+    }
+    // Navigate to resource if available
+    if (n.resourceKind && n.resourceNamespace && n.resourceName) {
+      const kind = n.resourceKind.toLowerCase() + "s";
+      globalThis.location.href =
+        `/workloads/${kind}/${n.resourceNamespace}/${n.resourceName}`;
+    }
+    showPanel.value = false;
+  };
+
+  // Determine "View all" target based on user role
+  const isAdmin = user.value?.roles?.includes("admin");
+  const viewAllHref = isAdmin ? "/admin/notifications" : "/notifications";
+
+  const badgeCount = unreadCount.value > 99 ? "99+" : unreadCount.value;
+
+  return (
+    <div style={{ position: "relative" }} ref={panelRef}>
+      {/* Bell button */}
+      <button
+        type="button"
+        aria-label="Notifications"
+        onClick={openPanel}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          width: "32px",
+          height: "32px",
+          borderRadius: "6px",
+          background: "transparent",
+          border: "none",
+          color: "var(--text-muted)",
+          cursor: "pointer",
+          position: "relative",
+        }}
+      >
+        <svg
+          width="18"
+          height="18"
+          viewBox="0 0 20 20"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M10 2a5 5 0 00-5 5v3l-1.5 2.5h13L15 10V7a5 5 0 00-5-5Z" />
+          <path d="M8 16a2 2 0 004 0" />
+        </svg>
+
+        {/* Badge */}
+        {unreadCount.value > 0 && (
+          <span
+            style={{
+              position: "absolute",
+              top: "2px",
+              right: "2px",
+              minWidth: "16px",
+              height: "16px",
+              borderRadius: "8px",
+              background: "var(--danger)",
+              color: "#fff",
+              fontSize: "10px",
+              fontWeight: 600,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              padding: "0 4px",
+              lineHeight: 1,
+            }}
+          >
+            {badgeCount}
+          </span>
+        )}
+      </button>
+
+      {/* Dropdown panel */}
+      {showPanel.value && (
+        <div
+          style={{
+            position: "absolute",
+            right: 0,
+            top: "calc(100% + 4px)",
+            width: "360px",
+            maxHeight: "480px",
+            overflowY: "auto",
+            background: "var(--bg-elevated)",
+            border: "1px solid var(--border-primary)",
+            borderRadius: "8px",
+            boxShadow: "0 4px 16px rgba(0,0,0,0.3)",
+            zIndex: 100,
+          }}
+        >
+          {/* Header */}
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              padding: "12px 16px",
+              borderBottom: "1px solid var(--border-subtle)",
+            }}
+          >
+            <span
+              style={{
+                fontWeight: 600,
+                fontSize: "14px",
+                color: "var(--text-primary)",
+              }}
+            >
+              Notifications
+            </span>
+            <button
+              type="button"
+              onClick={handleMarkAllRead}
+              style={{
+                background: "none",
+                border: "none",
+                color: "var(--accent)",
+                fontSize: "12px",
+                cursor: "pointer",
+                padding: 0,
+              }}
+            >
+              Mark all read
+            </button>
+          </div>
+
+          {/* Notification list */}
+          {loading.value
+            ? (
+              <div
+                style={{
+                  padding: "24px",
+                  textAlign: "center",
+                  color: "var(--text-muted)",
+                }}
+              >
+                Loading...
+              </div>
+            )
+            : recent.value.length === 0
+            ? (
+              <div
+                style={{
+                  padding: "24px",
+                  textAlign: "center",
+                  color: "var(--text-muted)",
+                  fontSize: "13px",
+                }}
+              >
+                No notifications yet
+              </div>
+            )
+            : (
+              <div>
+                {recent.value.map((n) => (
+                  <button
+                    key={n.id}
+                    type="button"
+                    onClick={() => handleClickNotification(n)}
+                    style={{
+                      display: "flex",
+                      alignItems: "flex-start",
+                      gap: "8px",
+                      width: "100%",
+                      padding: "10px 16px",
+                      background: n.read
+                        ? "transparent"
+                        : "color-mix(in srgb, var(--accent) 5%, transparent)",
+                      border: "none",
+                      borderBottom: "1px solid var(--border-subtle)",
+                      cursor: "pointer",
+                      textAlign: "left",
+                    }}
+                  >
+                    <div style={{ paddingTop: "4px" }}>
+                      <SeverityDot severity={n.severity} />
+                    </div>
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div
+                        style={{
+                          display: "flex",
+                          alignItems: "center",
+                          gap: "6px",
+                          marginBottom: "2px",
+                        }}
+                      >
+                        <SourceBadge source={n.source} />
+                        <span
+                          style={{
+                            fontSize: "11px",
+                            color: "var(--text-muted)",
+                          }}
+                        >
+                          {timeAgo(n.createdAt)}
+                        </span>
+                      </div>
+                      <div
+                        style={{
+                          fontSize: "13px",
+                          color: "var(--text-primary)",
+                          fontWeight: n.read ? 400 : 500,
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        {n.title}
+                      </div>
+                    </div>
+                  </button>
+                ))}
+              </div>
+            )}
+
+          {/* Footer */}
+          <a
+            href={viewAllHref}
+            style={{
+              display: "block",
+              padding: "10px 16px",
+              textAlign: "center",
+              fontSize: "12px",
+              color: "var(--accent)",
+              borderTop: "1px solid var(--border-subtle)",
+              textDecoration: "none",
+            }}
+          >
+            View all notifications
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/islands/NotificationBell.tsx
+++ b/frontend/islands/NotificationBell.tsx
@@ -1,9 +1,10 @@
 import { useSignal } from "@preact/signals";
 import { useEffect, useRef } from "preact/hooks";
 import { IS_BROWSER } from "fresh/runtime";
-import { subscribe } from "@/lib/ws.ts";
+import { subscribe, wsStatus } from "@/lib/ws.ts";
 import { notifApi } from "@/lib/api.ts";
 import { useAuth } from "@/lib/auth.ts";
+import { resourceHref } from "@/lib/k8s-links.ts";
 import type { AppNotification } from "@/lib/notif-center-types.ts";
 import {
   SeverityDot,
@@ -27,18 +28,25 @@ export default function NotificationBell() {
   const showPanel = useSignal(false);
   const recent = useSignal<AppNotification[]>([]);
   const loading = useSignal(false);
+  const suppressWsUntil = useSignal(0); // timestamp: suppress WS increments after markAllRead
   const panelRef = useRef<HTMLDivElement>(null);
   const { user } = useAuth();
+
+  /** Fetch the absolute unread count from the server. */
+  const fetchUnreadCount = () => {
+    notifApi.unreadCount().then((res) => {
+      unreadCount.value = res.data.count;
+    }).catch(() => {});
+  };
 
   // Fetch initial unread count on mount
   useEffect(() => {
     if (!IS_BROWSER) return;
-    notifApi.unreadCount().then((res) => {
-      unreadCount.value = res.data.count;
-    }).catch(() => {});
+    fetchUnreadCount();
   }, []);
 
-  // Subscribe to WS notifications for real-time badge updates
+  // Subscribe to WS notifications — fetch absolute count instead of blind increment.
+  // This resolves badge drift, reconnect staleness, and markAllRead zombies.
   useEffect(() => {
     if (!IS_BROWSER) return;
     const unsub = subscribe(
@@ -46,21 +54,32 @@ export default function NotificationBell() {
       "notifications",
       "",
       (_eventType, _obj) => {
-        // Increment badge on any new notification
-        unreadCount.value++;
+        // Suppress WS-triggered re-fetches briefly after markAllRead
+        if (Date.now() < suppressWsUntil.value) return;
+        fetchUnreadCount();
       },
     );
     return unsub;
   }, []);
 
-  // Close panel on outside click or Escape
+  // Re-fetch unread count when WS reconnects (covers missed events during disconnect)
   useEffect(() => {
     if (!IS_BROWSER) return;
+    // wsStatus is a Preact signal — subscribe to its changes
+    const checkStatus = () => {
+      if (wsStatus.value === "connected") {
+        fetchUnreadCount();
+      }
+    };
+    // Use effect dependency on wsStatus.value to re-run on changes
+    checkStatus();
+  }, [wsStatus.value]);
+
+  // Close panel on outside click or Escape — only when panel is open
+  useEffect(() => {
+    if (!IS_BROWSER || !showPanel.value) return;
     const handleClickOutside = (e: MouseEvent) => {
-      if (
-        showPanel.value && panelRef.current &&
-        !panelRef.current.contains(e.target as Node)
-      ) {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
         showPanel.value = false;
       }
     };
@@ -73,12 +92,13 @@ export default function NotificationBell() {
       document.removeEventListener("mousedown", handleClickOutside);
       document.removeEventListener("keydown", handleKeyDown);
     };
-  }, []);
+  }, [showPanel.value]);
 
-  // Fetch recent notifications when panel opens
+  // Fetch recent notifications when panel opens (guarded against double-open)
   const openPanel = async () => {
+    if (loading.value) return; // prevent double-fetch on rapid clicks
     showPanel.value = !showPanel.value;
-    if (showPanel.value && recent.value.length === 0) {
+    if (showPanel.value) {
       loading.value = true;
       try {
         const res = await notifApi.list({ limit: 20 });
@@ -92,16 +112,17 @@ export default function NotificationBell() {
 
   const handleMarkAllRead = async () => {
     try {
+      // Suppress WS increments for 3s to prevent badge resurrection
+      suppressWsUntil.value = Date.now() + 3000;
       await notifApi.markAllRead();
       unreadCount.value = 0;
       recent.value = recent.value.map((n) => ({ ...n, read: true }));
     } catch {
-      // Silently fail
+      suppressWsUntil.value = 0;
     }
   };
 
   const handleClickNotification = async (n: AppNotification) => {
-    // Mark as read
     if (!n.read) {
       try {
         await notifApi.markRead(n.id);
@@ -113,19 +134,22 @@ export default function NotificationBell() {
         // Silently fail
       }
     }
-    // Navigate to resource if available
-    if (n.resourceKind && n.resourceNamespace && n.resourceName) {
-      const kind = n.resourceKind.toLowerCase() + "s";
-      globalThis.location.href =
-        `/workloads/${kind}/${n.resourceNamespace}/${n.resourceName}`;
+    // Navigate using resourceHref which handles irregular plurals correctly
+    if (n.resourceKind && n.resourceName) {
+      const href = resourceHref(
+        n.resourceKind,
+        n.resourceNamespace,
+        n.resourceName,
+      );
+      if (href) {
+        globalThis.location.href = href;
+      }
     }
     showPanel.value = false;
   };
 
-  // Determine "View all" target based on user role
   const isAdmin = user.value?.roles?.includes("admin");
   const viewAllHref = isAdmin ? "/admin/notifications" : "/notifications";
-
   const badgeCount = unreadCount.value > 99 ? "99+" : unreadCount.value;
 
   return (

--- a/frontend/islands/NotificationChannels.tsx
+++ b/frontend/islands/NotificationChannels.tsx
@@ -1,5 +1,5 @@
 import { useSignal } from "@preact/signals";
-import { useEffect } from "preact/hooks";
+import { useEffect, useRef } from "preact/hooks";
 import { IS_BROWSER } from "fresh/runtime";
 import { notifApi } from "@/lib/api.ts";
 import type {
@@ -140,10 +140,34 @@ export default function NotificationChannels() {
     }
   }
 
+  function validateUrl(url: string): boolean {
+    try {
+      const u = new URL(url);
+      return u.protocol === "https:" || u.protocol === "http:";
+    } catch {
+      return false;
+    }
+  }
+
   async function handleSave() {
     if (!formName.value.trim()) {
       showToast("Name is required", "error");
       return;
+    }
+    // Client-side URL validation for Slack and Webhook channels
+    if (formType.value === "slack") {
+      const url = (formConfig.value as Record<string, string>).webhookUrl ?? "";
+      if (!url || !validateUrl(url)) {
+        showToast("Valid Slack webhook URL is required", "error");
+        return;
+      }
+    }
+    if (formType.value === "webhook") {
+      const url = (formConfig.value as Record<string, string>).url ?? "";
+      if (!url || !validateUrl(url)) {
+        showToast("Valid webhook URL is required", "error");
+        return;
+      }
     }
     saving.value = true;
     try {
@@ -168,7 +192,13 @@ export default function NotificationChannels() {
     }
   }
 
+  const testTimers = useRef<Record<string, number>>({});
+
   async function handleTest(ch: NotifChannel) {
+    // Clear any previous timer for this channel
+    if (testTimers.current[ch.id]) {
+      clearTimeout(testTimers.current[ch.id]);
+    }
     try {
       await notifApi.testChannel(ch.id);
       testResults.value = {
@@ -182,11 +212,12 @@ export default function NotificationChannels() {
       };
     }
     // Clear after 3 seconds
-    setTimeout(() => {
+    testTimers.current[ch.id] = setTimeout(() => {
       const cur = { ...testResults.value };
       delete cur[ch.id];
       testResults.value = cur;
-    }, 3000);
+      delete testTimers.current[ch.id];
+    }, 3000) as unknown as number;
   }
 
   async function handleDelete() {

--- a/frontend/islands/NotificationChannels.tsx
+++ b/frontend/islands/NotificationChannels.tsx
@@ -1,0 +1,674 @@
+import { useSignal } from "@preact/signals";
+import { useEffect } from "preact/hooks";
+import { IS_BROWSER } from "fresh/runtime";
+import { notifApi } from "@/lib/api.ts";
+import type {
+  NotifChannel,
+  NotifChannelInput,
+  NotifChannelType,
+} from "@/lib/notif-center-types.ts";
+import { showToast } from "@/islands/ToastProvider.tsx";
+
+const CHANNEL_TYPES: { value: NotifChannelType; label: string }[] = [
+  { value: "slack", label: "Slack" },
+  { value: "email", label: "Email" },
+  { value: "webhook", label: "Webhook" },
+];
+
+const TYPE_ICONS: Record<NotifChannelType, string> = {
+  slack: "#",
+  email: "\u2709",
+  webhook: "\u21C4",
+};
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+export default function NotificationChannels() {
+  const channels = useSignal<NotifChannel[]>([]);
+  const loading = useSignal(true);
+  const error = useSignal<string | null>(null);
+
+  // Modal state
+  const modalOpen = useSignal(false);
+  const editingId = useSignal<string | null>(null);
+  const saving = useSignal(false);
+
+  // Form state
+  const formName = useSignal("");
+  const formType = useSignal<NotifChannelType>("slack");
+  const formWebhookUrl = useSignal("");
+  const formRecipients = useSignal("");
+  const formSchedule = useSignal("daily");
+  const formUrl = useSignal("");
+  const formSecret = useSignal("");
+
+  // Delete confirmation
+  const deleteTarget = useSignal<NotifChannel | null>(null);
+  const deleteConfirmText = useSignal("");
+
+  // Test result: channelId -> { ok, timestamp }
+  const testResults = useSignal<
+    Record<string, { ok: boolean; ts: number }>
+  >({});
+
+  async function fetchChannels() {
+    loading.value = true;
+    error.value = null;
+    try {
+      const res = await notifApi.listChannels();
+      channels.value = res.data ?? [];
+    } catch (err) {
+      error.value = err instanceof Error
+        ? err.message
+        : "Failed to load channels";
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  useEffect(() => {
+    if (!IS_BROWSER) return;
+    fetchChannels();
+  }, []);
+
+  function resetForm() {
+    formName.value = "";
+    formType.value = "slack";
+    formWebhookUrl.value = "";
+    formRecipients.value = "";
+    formSchedule.value = "daily";
+    formUrl.value = "";
+    formSecret.value = "";
+    editingId.value = null;
+  }
+
+  function openCreate() {
+    resetForm();
+    modalOpen.value = true;
+  }
+
+  function openEdit(ch: NotifChannel) {
+    editingId.value = ch.id;
+    formName.value = ch.name;
+    formType.value = ch.type;
+    // Pre-fill config (values come masked from API)
+    const cfg = ch.config ?? {};
+    formWebhookUrl.value = (cfg.webhookUrl as string) ?? "";
+    formRecipients.value = Array.isArray(cfg.recipients)
+      ? (cfg.recipients as string[]).join(", ")
+      : (cfg.recipients as string) ?? "";
+    formSchedule.value = (cfg.schedule as string) ?? "daily";
+    formUrl.value = (cfg.url as string) ?? "";
+    formSecret.value = (cfg.secret as string) ?? "";
+    modalOpen.value = true;
+  }
+
+  function buildInput(): NotifChannelInput {
+    const base = { name: formName.value.trim(), type: formType.value };
+    switch (formType.value) {
+      case "slack":
+        return { ...base, config: { webhookUrl: formWebhookUrl.value.trim() } };
+      case "email":
+        return {
+          ...base,
+          config: {
+            recipients: formRecipients.value.split(",").map((r) => r.trim())
+              .filter(Boolean),
+            schedule: formSchedule.value,
+          },
+        };
+      case "webhook":
+        return {
+          ...base,
+          config: {
+            url: formUrl.value.trim(),
+            ...(formSecret.value.trim()
+              ? { secret: formSecret.value.trim() }
+              : {}),
+          },
+        };
+    }
+  }
+
+  async function handleSave() {
+    if (!formName.value.trim()) {
+      showToast("Name is required", "error");
+      return;
+    }
+    saving.value = true;
+    try {
+      const input = buildInput();
+      if (editingId.value) {
+        await notifApi.updateChannel(editingId.value, input);
+        showToast("Channel updated", "success");
+      } else {
+        await notifApi.createChannel(input);
+        showToast("Channel created", "success");
+      }
+      modalOpen.value = false;
+      resetForm();
+      await fetchChannels();
+    } catch (err) {
+      showToast(
+        err instanceof Error ? err.message : "Save failed",
+        "error",
+      );
+    } finally {
+      saving.value = false;
+    }
+  }
+
+  async function handleTest(ch: NotifChannel) {
+    try {
+      await notifApi.testChannel(ch.id);
+      testResults.value = {
+        ...testResults.value,
+        [ch.id]: { ok: true, ts: Date.now() },
+      };
+    } catch {
+      testResults.value = {
+        ...testResults.value,
+        [ch.id]: { ok: false, ts: Date.now() },
+      };
+    }
+    // Clear after 3 seconds
+    setTimeout(() => {
+      const cur = { ...testResults.value };
+      delete cur[ch.id];
+      testResults.value = cur;
+    }, 3000);
+  }
+
+  async function handleDelete() {
+    const target = deleteTarget.value;
+    if (!target) return;
+    saving.value = true;
+    try {
+      await notifApi.deleteChannel(target.id);
+      showToast(`Deleted "${target.name}"`, "success");
+      deleteTarget.value = null;
+      deleteConfirmText.value = "";
+      await fetchChannels();
+    } catch (err) {
+      showToast(
+        err instanceof Error ? err.message : "Delete failed",
+        "error",
+      );
+    } finally {
+      saving.value = false;
+    }
+  }
+
+  // --- Render helpers ---
+
+  const inputClass =
+    "w-full rounded-md border border-border-primary bg-surface px-3 py-2 text-sm text-text-primary";
+
+  function renderConfigForm() {
+    switch (formType.value) {
+      case "slack":
+        return (
+          <div class="mt-3">
+            <label class="block text-xs font-medium text-text-primary mb-1">
+              Webhook URL
+            </label>
+            <input
+              type="url"
+              class={inputClass}
+              placeholder="https://hooks.slack.com/services/..."
+              value={formWebhookUrl.value}
+              onInput={(e) =>
+                formWebhookUrl.value = (e.target as HTMLInputElement).value}
+            />
+          </div>
+        );
+      case "email":
+        return (
+          <div class="mt-3 space-y-3">
+            <div>
+              <label class="block text-xs font-medium text-text-primary mb-1">
+                Recipients (comma-separated)
+              </label>
+              <input
+                type="text"
+                class={inputClass}
+                placeholder="admin@example.com, ops@example.com"
+                value={formRecipients.value}
+                onInput={(e) =>
+                  formRecipients.value = (e.target as HTMLInputElement).value}
+              />
+            </div>
+            <div>
+              <label class="block text-xs font-medium text-text-primary mb-1">
+                Schedule
+              </label>
+              <select
+                class={inputClass}
+                value={formSchedule.value}
+                onChange={(e) =>
+                  formSchedule.value = (e.target as HTMLSelectElement).value}
+              >
+                <option value="daily">Daily digest</option>
+                <option value="weekly">Weekly digest</option>
+              </select>
+            </div>
+          </div>
+        );
+      case "webhook":
+        return (
+          <div class="mt-3 space-y-3">
+            <div>
+              <label class="block text-xs font-medium text-text-primary mb-1">
+                URL
+              </label>
+              <input
+                type="url"
+                class={inputClass}
+                placeholder="https://example.com/webhook"
+                value={formUrl.value}
+                onInput={(e) =>
+                  formUrl.value = (e.target as HTMLInputElement).value}
+              />
+            </div>
+            <div>
+              <label class="block text-xs font-medium text-text-primary mb-1">
+                Secret (optional)
+              </label>
+              <input
+                type="password"
+                class={inputClass}
+                placeholder="HMAC signing secret"
+                value={formSecret.value}
+                onInput={(e) =>
+                  formSecret.value = (e.target as HTMLInputElement).value}
+              />
+            </div>
+          </div>
+        );
+    }
+  }
+
+  function renderTestResult(ch: NotifChannel) {
+    const result = testResults.value[ch.id];
+    if (!result) return null;
+    return result.ok
+      ? (
+        <span class="ml-2 text-xs" style={{ color: "var(--success)" }}>
+          {"\u2713"}
+        </span>
+      )
+      : (
+        <span class="ml-2 text-xs" style={{ color: "var(--danger)" }}>
+          {"\u2717"}
+        </span>
+      );
+  }
+
+  // --- Main render ---
+
+  if (loading.value && channels.value.length === 0) {
+    return (
+      <div class="flex items-center justify-center py-12">
+        <div
+          class="h-6 w-6 animate-spin rounded-full border-2 border-current border-t-transparent"
+          style={{ color: "var(--accent)" }}
+        />
+      </div>
+    );
+  }
+
+  if (error.value) {
+    return (
+      <div
+        class="rounded-md px-4 py-3 text-sm"
+        style={{
+          backgroundColor: "color-mix(in srgb, var(--danger) 10%, transparent)",
+          color: "var(--danger)",
+        }}
+      >
+        {error.value}
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {/* Header */}
+      <div class="flex items-center justify-between mb-4">
+        <h2
+          class="text-lg font-semibold"
+          style={{ color: "var(--text-primary)" }}
+        >
+          Notification Channels
+        </h2>
+        <button
+          type="button"
+          class="rounded-md px-3 py-1.5 text-sm font-medium text-white"
+          style={{ backgroundColor: "var(--accent)" }}
+          onClick={openCreate}
+        >
+          Create Channel
+        </button>
+      </div>
+
+      {/* Table */}
+      {channels.value.length === 0
+        ? (
+          <p
+            class="py-8 text-center text-sm"
+            style={{ color: "var(--text-primary)", opacity: 0.6 }}
+          >
+            No channels configured yet.
+          </p>
+        )
+        : (
+          <div
+            class="overflow-x-auto rounded-lg border"
+            style={{
+              borderColor: "var(--border-primary)",
+              backgroundColor: "var(--bg-elevated)",
+            }}
+          >
+            <table
+              class="w-full text-sm"
+              style={{ color: "var(--text-primary)" }}
+            >
+              <thead>
+                <tr
+                  class="text-left text-xs uppercase tracking-wider"
+                  style={{
+                    borderBottom: "1px solid var(--border-primary)",
+                    color: "var(--text-primary)",
+                    opacity: 0.7,
+                  }}
+                >
+                  <th class="px-4 py-3 font-medium">Type</th>
+                  <th class="px-4 py-3 font-medium">Name</th>
+                  <th class="px-4 py-3 font-medium">Status</th>
+                  <th class="px-4 py-3 font-medium">Config</th>
+                  <th class="px-4 py-3 font-medium">Created</th>
+                  <th class="px-4 py-3 font-medium text-right">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {channels.value.map((ch) => (
+                  <tr
+                    key={ch.id}
+                    class="border-t"
+                    style={{ borderColor: "var(--border-primary)" }}
+                  >
+                    <td class="px-4 py-3">
+                      <span
+                        class="inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium"
+                        style={{
+                          backgroundColor:
+                            "color-mix(in srgb, var(--accent) 15%, transparent)",
+                          color: "var(--accent)",
+                        }}
+                      >
+                        <span>{TYPE_ICONS[ch.type]}</span>
+                        {CHANNEL_TYPES.find((t) => t.value === ch.type)
+                          ?.label ??
+                          ch.type}
+                      </span>
+                    </td>
+                    <td class="px-4 py-3 font-medium">{ch.name}</td>
+                    <td class="px-4 py-3">
+                      {ch.lastError
+                        ? (
+                          <span class="inline-flex items-center gap-1.5">
+                            <span
+                              class="inline-block h-2 w-2 rounded-full"
+                              style={{ backgroundColor: "var(--danger)" }}
+                            />
+                            <span
+                              class="text-xs max-w-[200px] truncate"
+                              style={{ color: "var(--danger)" }}
+                              title={ch.lastError}
+                            >
+                              {ch.lastError}
+                            </span>
+                          </span>
+                        )
+                        : (
+                          <span class="inline-flex items-center gap-1.5">
+                            <span
+                              class="inline-block h-2 w-2 rounded-full"
+                              style={{ backgroundColor: "var(--success)" }}
+                            />
+                            <span class="text-xs" style={{ opacity: 0.7 }}>
+                              OK
+                            </span>
+                          </span>
+                        )}
+                    </td>
+                    <td class="px-4 py-3">
+                      <span class="text-xs font-mono" style={{ opacity: 0.6 }}>
+                        {Object.entries(ch.config ?? {}).map(([k, v]) => (
+                          <span key={k} class="mr-2">
+                            {k}: {String(v)}
+                          </span>
+                        ))}
+                      </span>
+                    </td>
+                    <td class="px-4 py-3 text-xs" style={{ opacity: 0.7 }}>
+                      {formatDate(ch.createdAt)}
+                    </td>
+                    <td class="px-4 py-3 text-right">
+                      <div class="inline-flex items-center gap-2">
+                        <button
+                          type="button"
+                          class="text-xs font-medium hover:underline"
+                          style={{ color: "var(--accent)" }}
+                          onClick={() => openEdit(ch)}
+                        >
+                          Edit
+                        </button>
+                        <button
+                          type="button"
+                          class="text-xs font-medium hover:underline"
+                          style={{ color: "var(--accent)" }}
+                          onClick={() => handleTest(ch)}
+                        >
+                          Test
+                        </button>
+                        {renderTestResult(ch)}
+                        <button
+                          type="button"
+                          class="text-xs font-medium hover:underline"
+                          style={{ color: "var(--danger)" }}
+                          onClick={() => {
+                            deleteTarget.value = ch;
+                            deleteConfirmText.value = "";
+                          }}
+                        >
+                          Delete
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+      {/* Create/Edit Modal */}
+      {modalOpen.value && (
+        <div
+          class="fixed inset-0 z-50 flex items-center justify-center"
+          style={{ backgroundColor: "rgba(0,0,0,0.5)" }}
+          onClick={(e) => {
+            if (e.target === e.currentTarget) {
+              modalOpen.value = false;
+              resetForm();
+            }
+          }}
+        >
+          <div
+            class="w-full max-w-[480px] rounded-xl p-6 shadow-xl"
+            style={{
+              backgroundColor: "var(--bg-elevated)",
+              border: "1px solid var(--border-primary)",
+            }}
+          >
+            <h3
+              class="text-base font-semibold mb-4"
+              style={{ color: "var(--text-primary)" }}
+            >
+              {editingId.value ? "Edit Channel" : "Create Channel"}
+            </h3>
+
+            {/* Name */}
+            <label class="block text-xs font-medium text-text-primary mb-1">
+              Name
+            </label>
+            <input
+              type="text"
+              class={inputClass}
+              placeholder="my-slack-alerts"
+              value={formName.value}
+              onInput={(e) =>
+                formName.value = (e.target as HTMLInputElement).value}
+            />
+
+            {/* Type radio */}
+            <fieldset class="mt-4">
+              <legend class="text-xs font-medium text-text-primary mb-2">
+                Type
+              </legend>
+              <div class="flex gap-4">
+                {CHANNEL_TYPES.map((t) => (
+                  <label
+                    key={t.value}
+                    class="flex items-center gap-1.5 text-sm cursor-pointer"
+                    style={{ color: "var(--text-primary)" }}
+                  >
+                    <input
+                      type="radio"
+                      name="channel-type"
+                      value={t.value}
+                      checked={formType.value === t.value}
+                      onChange={() => formType.value = t.value}
+                    />
+                    <span>{TYPE_ICONS[t.value]}</span>
+                    {t.label}
+                  </label>
+                ))}
+              </div>
+            </fieldset>
+
+            {/* Type-specific config */}
+            {renderConfigForm()}
+
+            {/* Actions */}
+            <div class="mt-6 flex justify-end gap-2">
+              <button
+                type="button"
+                class="rounded-md px-3 py-1.5 text-sm font-medium"
+                style={{
+                  color: "var(--text-primary)",
+                  backgroundColor: "var(--surface)",
+                  border: "1px solid var(--border-primary)",
+                }}
+                onClick={() => {
+                  modalOpen.value = false;
+                  resetForm();
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                class="rounded-md px-3 py-1.5 text-sm font-medium text-white"
+                style={{ backgroundColor: "var(--accent)" }}
+                disabled={saving.value}
+                onClick={handleSave}
+              >
+                {saving.value ? "Saving\u2026" : "Save"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Delete Confirmation Modal */}
+      {deleteTarget.value && (
+        <div
+          class="fixed inset-0 z-50 flex items-center justify-center"
+          style={{ backgroundColor: "rgba(0,0,0,0.5)" }}
+          onClick={(e) => {
+            if (e.target === e.currentTarget) {
+              deleteTarget.value = null;
+              deleteConfirmText.value = "";
+            }
+          }}
+        >
+          <div
+            class="w-full max-w-[480px] rounded-xl p-6 shadow-xl"
+            style={{
+              backgroundColor: "var(--bg-elevated)",
+              border: "1px solid var(--border-primary)",
+            }}
+          >
+            <h3
+              class="text-base font-semibold mb-2"
+              style={{ color: "var(--danger)" }}
+            >
+              Delete Channel
+            </h3>
+            <p class="text-sm mb-4" style={{ color: "var(--text-primary)" }}>
+              This action cannot be undone. Type{" "}
+              <strong>{deleteTarget.value.name}</strong> to confirm.
+            </p>
+            <input
+              type="text"
+              class={inputClass}
+              placeholder={deleteTarget.value.name}
+              value={deleteConfirmText.value}
+              onInput={(e) =>
+                deleteConfirmText.value = (e.target as HTMLInputElement).value}
+            />
+            <div class="mt-4 flex justify-end gap-2">
+              <button
+                type="button"
+                class="rounded-md px-3 py-1.5 text-sm font-medium"
+                style={{
+                  color: "var(--text-primary)",
+                  backgroundColor: "var(--surface)",
+                  border: "1px solid var(--border-primary)",
+                }}
+                onClick={() => {
+                  deleteTarget.value = null;
+                  deleteConfirmText.value = "";
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                class="rounded-md px-3 py-1.5 text-sm font-medium text-white"
+                style={{ backgroundColor: "var(--danger)" }}
+                disabled={saving.value ||
+                  deleteConfirmText.value !== deleteTarget.value.name}
+                onClick={handleDelete}
+              >
+                {saving.value ? "Deleting\u2026" : "Delete"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/islands/NotificationFeed.tsx
+++ b/frontend/islands/NotificationFeed.tsx
@@ -1,5 +1,5 @@
 import { useSignal } from "@preact/signals";
-import { useEffect } from "preact/hooks";
+import { useEffect, useRef } from "preact/hooks";
 import { IS_BROWSER } from "fresh/runtime";
 import { notifApi } from "@/lib/api.ts";
 import { useWsRefetch } from "@/lib/useWsRefetch.ts";
@@ -22,8 +22,15 @@ export default function NotificationFeed() {
   const filterSource = useSignal<string>("all");
   const filterSeverity = useSignal<string>("all");
   const filterRead = useSignal<string>("all");
+  const fetchSeq = useRef(0); // sequence counter to discard stale fetch results
+  const mounted = useRef(true);
+
+  useEffect(() => () => {
+    mounted.current = false;
+  }, []);
 
   async function fetchData() {
+    const seq = ++fetchSeq.current;
     try {
       const params: Record<string, string | number> = {
         limit: PAGE_SIZE,
@@ -38,22 +45,19 @@ export default function NotificationFeed() {
       const res = await notifApi.list(
         params as unknown as Parameters<typeof notifApi.list>[0],
       );
+      if (seq !== fetchSeq.current || !mounted.current) return; // stale response
       notifications.value = res.data?.data ?? [];
       total.value = res.data?.metadata?.total ?? 0;
     } catch {
+      if (seq !== fetchSeq.current || !mounted.current) return;
       notifications.value = [];
       total.value = 0;
     } finally {
-      loading.value = false;
+      if (seq === fetchSeq.current) loading.value = false;
     }
   }
 
-  useEffect(() => {
-    if (!IS_BROWSER) return;
-    fetchData();
-  }, []);
-
-  // Re-fetch when filters or page change
+  // Fetch on mount + re-fetch when filters or page change
   useEffect(() => {
     if (!IS_BROWSER) return;
     loading.value = true;

--- a/frontend/islands/NotificationFeed.tsx
+++ b/frontend/islands/NotificationFeed.tsx
@@ -1,0 +1,425 @@
+import { useSignal } from "@preact/signals";
+import { useEffect } from "preact/hooks";
+import { IS_BROWSER } from "fresh/runtime";
+import { notifApi } from "@/lib/api.ts";
+import { useWsRefetch } from "@/lib/useWsRefetch.ts";
+import { resourceHref } from "@/lib/k8s-links.ts";
+import {
+  SeverityDot,
+  SourceBadge,
+} from "@/components/ui/NotifCenterBadges.tsx";
+import { timeAgo } from "@/lib/timeAgo.ts";
+import type { AppNotification } from "@/lib/notif-center-types.ts";
+import { NOTIF_SEVERITIES, NOTIF_SOURCES } from "@/lib/notif-center-types.ts";
+
+const PAGE_SIZE = 25;
+
+export default function NotificationFeed() {
+  const notifications = useSignal<AppNotification[]>([]);
+  const total = useSignal(0);
+  const loading = useSignal(true);
+  const page = useSignal(0);
+  const filterSource = useSignal<string>("all");
+  const filterSeverity = useSignal<string>("all");
+  const filterRead = useSignal<string>("all");
+
+  async function fetchData() {
+    try {
+      const params: Record<string, string | number> = {
+        limit: PAGE_SIZE,
+        offset: page.value * PAGE_SIZE,
+      };
+      if (filterSource.value !== "all") params.source = filterSource.value;
+      if (filterSeverity.value !== "all") {
+        params.severity = filterSeverity.value;
+      }
+      if (filterRead.value !== "all") params.read = filterRead.value;
+
+      const res = await notifApi.list(
+        params as unknown as Parameters<typeof notifApi.list>[0],
+      );
+      notifications.value = res.data?.data ?? [];
+      total.value = res.data?.metadata?.total ?? 0;
+    } catch {
+      notifications.value = [];
+      total.value = 0;
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  useEffect(() => {
+    if (!IS_BROWSER) return;
+    fetchData();
+  }, []);
+
+  // Re-fetch when filters or page change
+  useEffect(() => {
+    if (!IS_BROWSER) return;
+    loading.value = true;
+    fetchData();
+  }, [
+    filterSource.value,
+    filterSeverity.value,
+    filterRead.value,
+    page.value,
+  ]);
+
+  // Live WS updates with 2s debounce
+  useWsRefetch(fetchData, [
+    ["notif-feed", "notifications", ""],
+  ], 2000);
+
+  function resetAndFilter() {
+    page.value = 0;
+  }
+
+  function handleSourceChange(e: Event) {
+    filterSource.value = (e.target as HTMLSelectElement).value;
+    resetAndFilter();
+  }
+
+  function handleSeverityChange(e: Event) {
+    filterSeverity.value = (e.target as HTMLSelectElement).value;
+    resetAndFilter();
+  }
+
+  function handleReadChange(e: Event) {
+    filterRead.value = (e.target as HTMLSelectElement).value;
+    resetAndFilter();
+  }
+
+  async function handleRowClick(n: AppNotification) {
+    // Mark as read
+    if (!n.read) {
+      await notifApi.markRead(n.id);
+    }
+    // Navigate to resource detail if possible
+    if (n.resourceKind && n.resourceName) {
+      const href = resourceHref(
+        n.resourceKind,
+        n.resourceNamespace,
+        n.resourceName,
+      );
+      if (href) {
+        globalThis.location.href = href;
+        return;
+      }
+    }
+  }
+
+  if (!IS_BROWSER) return null;
+
+  const start = page.value * PAGE_SIZE;
+  const end = Math.min(start + PAGE_SIZE, total.value);
+  const hasNext = end < total.value;
+  const hasPrev = page.value > 0;
+
+  const selectStyle = {
+    padding: "6px 10px",
+    borderRadius: "6px",
+    border: "1px solid var(--border-primary)",
+    backgroundColor: "var(--surface)",
+    color: "var(--text-primary)",
+    fontSize: "13px",
+    outline: "none",
+  };
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+      {/* Filter bar */}
+      <div
+        class="flex flex-wrap items-center gap-3"
+        style={{
+          padding: "12px 16px",
+          backgroundColor: "var(--bg-elevated)",
+          borderRadius: "8px",
+          border: "1px solid var(--border-primary)",
+        }}
+      >
+        <label
+          class="flex items-center gap-1.5 text-xs"
+          style={{ color: "var(--text-muted)" }}
+        >
+          Source
+          <select
+            value={filterSource.value}
+            onChange={handleSourceChange}
+            style={selectStyle}
+          >
+            <option value="all">All</option>
+            {NOTIF_SOURCES.map((s) => (
+              <option key={s} value={s}>
+                {s.charAt(0).toUpperCase() + s.slice(1)}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label
+          class="flex items-center gap-1.5 text-xs"
+          style={{ color: "var(--text-muted)" }}
+        >
+          Severity
+          <select
+            value={filterSeverity.value}
+            onChange={handleSeverityChange}
+            style={selectStyle}
+          >
+            <option value="all">All</option>
+            {NOTIF_SEVERITIES.map((s) => (
+              <option key={s} value={s}>
+                {s.charAt(0).toUpperCase() + s.slice(1)}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label
+          class="flex items-center gap-1.5 text-xs"
+          style={{ color: "var(--text-muted)" }}
+        >
+          Status
+          <select
+            value={filterRead.value}
+            onChange={handleReadChange}
+            style={selectStyle}
+          >
+            <option value="all">All</option>
+            <option value="read">Read</option>
+            <option value="unread">Unread</option>
+          </select>
+        </label>
+      </div>
+
+      {/* Content */}
+      {loading.value
+        ? (
+          <div
+            class="flex items-center justify-center"
+            style={{ padding: "48px 0", color: "var(--text-muted)" }}
+          >
+            Loading...
+          </div>
+        )
+        : notifications.value.length === 0
+        ? (
+          <div
+            class="flex items-center justify-center"
+            style={{ padding: "48px 0", color: "var(--text-muted)" }}
+          >
+            No notifications yet
+          </div>
+        )
+        : (
+          <>
+            {/* Table */}
+            <div
+              style={{
+                borderRadius: "8px",
+                border: "1px solid var(--border-primary)",
+                overflow: "hidden",
+              }}
+            >
+              <table
+                style={{
+                  width: "100%",
+                  borderCollapse: "collapse",
+                  fontSize: "13px",
+                }}
+              >
+                <thead>
+                  <tr
+                    style={{
+                      backgroundColor: "var(--bg-elevated)",
+                      borderBottom: "1px solid var(--border-primary)",
+                    }}
+                  >
+                    <th
+                      style={{
+                        padding: "10px 12px",
+                        textAlign: "left",
+                        color: "var(--text-muted)",
+                        fontWeight: 500,
+                        width: "32px",
+                      }}
+                    >
+                    </th>
+                    <th
+                      style={{
+                        padding: "10px 12px",
+                        textAlign: "left",
+                        color: "var(--text-muted)",
+                        fontWeight: 500,
+                        width: "80px",
+                      }}
+                    >
+                      Source
+                    </th>
+                    <th
+                      style={{
+                        padding: "10px 12px",
+                        textAlign: "left",
+                        color: "var(--text-muted)",
+                        fontWeight: 500,
+                      }}
+                    >
+                      Title
+                    </th>
+                    <th
+                      style={{
+                        padding: "10px 12px",
+                        textAlign: "right",
+                        color: "var(--text-muted)",
+                        fontWeight: 500,
+                        width: "120px",
+                      }}
+                    >
+                      Time
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {notifications.value.map((n) => {
+                    const isUnread = !n.read;
+                    const href = n.resourceKind && n.resourceName
+                      ? resourceHref(
+                        n.resourceKind,
+                        n.resourceNamespace,
+                        n.resourceName,
+                      )
+                      : null;
+                    return (
+                      <tr
+                        key={n.id}
+                        onClick={() => handleRowClick(n)}
+                        style={{
+                          backgroundColor: isUnread
+                            ? "color-mix(in srgb, var(--accent) 6%, transparent)"
+                            : "transparent",
+                          borderBottom: "1px solid var(--border-primary)",
+                          cursor: href ? "pointer" : "default",
+                          transition: "background-color 0.15s",
+                        }}
+                        onMouseEnter={(e) => {
+                          (e.currentTarget as HTMLTableRowElement).style
+                            .backgroundColor = isUnread
+                              ? "color-mix(in srgb, var(--accent) 12%, transparent)"
+                              : "color-mix(in srgb, var(--text-primary) 4%, transparent)";
+                        }}
+                        onMouseLeave={(e) => {
+                          (e.currentTarget as HTMLTableRowElement).style
+                            .backgroundColor = isUnread
+                              ? "color-mix(in srgb, var(--accent) 6%, transparent)"
+                              : "transparent";
+                        }}
+                      >
+                        <td
+                          style={{ padding: "10px 12px", textAlign: "center" }}
+                        >
+                          <SeverityDot severity={n.severity} />
+                        </td>
+                        <td style={{ padding: "10px 12px" }}>
+                          <SourceBadge source={n.source} />
+                        </td>
+                        <td
+                          style={{
+                            padding: "10px 12px",
+                            color: isUnread
+                              ? "var(--text-primary)"
+                              : "var(--text-muted)",
+                            fontWeight: isUnread ? 500 : 400,
+                          }}
+                        >
+                          {href
+                            ? (
+                              <span
+                                style={{
+                                  color: "var(--accent)",
+                                  textDecoration: "none",
+                                }}
+                              >
+                                {n.title}
+                              </span>
+                            )
+                            : n.title}
+                        </td>
+                        <td
+                          style={{
+                            padding: "10px 12px",
+                            textAlign: "right",
+                            color: "var(--text-muted)",
+                            whiteSpace: "nowrap",
+                          }}
+                        >
+                          {n.createdAt ? timeAgo(n.createdAt) : "-"}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+
+            {/* Pagination */}
+            <div
+              class="flex items-center justify-between"
+              style={{
+                padding: "0 4px",
+                color: "var(--text-muted)",
+                fontSize: "13px",
+              }}
+            >
+              <span>
+                Showing {start + 1}-{end} of {total.value}
+              </span>
+              <div class="flex items-center gap-2">
+                <button
+                  type="button"
+                  disabled={!hasPrev}
+                  onClick={() => {
+                    page.value = page.value - 1;
+                  }}
+                  style={{
+                    padding: "6px 14px",
+                    borderRadius: "6px",
+                    border: "1px solid var(--border-primary)",
+                    backgroundColor: "var(--surface)",
+                    color: hasPrev
+                      ? "var(--text-primary)"
+                      : "var(--text-muted)",
+                    cursor: hasPrev ? "pointer" : "not-allowed",
+                    opacity: hasPrev ? 1 : 0.5,
+                    fontSize: "13px",
+                  }}
+                >
+                  Previous
+                </button>
+                <button
+                  type="button"
+                  disabled={!hasNext}
+                  onClick={() => {
+                    page.value = page.value + 1;
+                  }}
+                  style={{
+                    padding: "6px 14px",
+                    borderRadius: "6px",
+                    border: "1px solid var(--border-primary)",
+                    backgroundColor: "var(--surface)",
+                    color: hasNext
+                      ? "var(--text-primary)"
+                      : "var(--text-muted)",
+                    cursor: hasNext ? "pointer" : "not-allowed",
+                    opacity: hasNext ? 1 : 0.5,
+                    fontSize: "13px",
+                  }}
+                >
+                  Next
+                </button>
+              </div>
+            </div>
+          </>
+        )}
+    </div>
+  );
+}

--- a/frontend/islands/NotificationRules.tsx
+++ b/frontend/islands/NotificationRules.tsx
@@ -114,7 +114,11 @@ export default function NotificationRules() {
     saving.value = false;
   };
 
+  const togglingIds = useSignal<Set<string>>(new Set());
+
   const handleToggle = async (rule: NotifRule) => {
+    if (togglingIds.value.has(rule.id)) return; // prevent rapid-fire
+    togglingIds.value = new Set([...togglingIds.value, rule.id]);
     try {
       await notifApi.updateRule(rule.id, {
         name: rule.name,
@@ -127,6 +131,9 @@ export default function NotificationRules() {
     } catch {
       error.value = "Failed to toggle rule";
     }
+    const next = new Set(togglingIds.value);
+    next.delete(rule.id);
+    togglingIds.value = next;
   };
 
   const handleDelete = async (id: string) => {

--- a/frontend/islands/NotificationRules.tsx
+++ b/frontend/islands/NotificationRules.tsx
@@ -1,0 +1,710 @@
+import { useSignal } from "@preact/signals";
+import { useEffect } from "preact/hooks";
+import { IS_BROWSER } from "fresh/runtime";
+import { notifApi } from "@/lib/api.ts";
+import type {
+  NotifChannel,
+  NotifRule,
+  NotifRuleInput,
+  NotifSeverity,
+  NotifSource,
+} from "@/lib/notif-center-types.ts";
+import {
+  NOTIF_SEVERITIES,
+  NOTIF_SOURCES,
+  SOURCE_LABELS,
+} from "@/lib/notif-center-types.ts";
+
+/** Capitalize first letter of a severity for display. */
+function capFirst(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+export default function NotificationRules() {
+  const rules = useSignal<NotifRule[]>([]);
+  const channels = useSignal<NotifChannel[]>([]);
+  const loading = useSignal(true);
+  const error = useSignal("");
+
+  // Modal state
+  const showModal = useSignal(false);
+  const editingId = useSignal<string | null>(null);
+  const formName = useSignal("");
+  const formSources = useSignal<NotifSource[]>([]);
+  const formSeverities = useSignal<NotifSeverity[]>([]);
+  const formChannelId = useSignal("");
+  const formEnabled = useSignal(true);
+  const saving = useSignal(false);
+
+  // Delete confirmation
+  const confirmDeleteId = useSignal<string | null>(null);
+
+  const fetchRules = async () => {
+    try {
+      const res = await notifApi.listRules();
+      rules.value = res.data ?? [];
+    } catch {
+      error.value = "Failed to load rules";
+    }
+    loading.value = false;
+  };
+
+  const fetchChannels = async () => {
+    try {
+      const res = await notifApi.listChannels();
+      channels.value = res.data ?? [];
+    } catch {
+      // channels will be empty — dropdown shows nothing
+    }
+  };
+
+  useEffect(() => {
+    if (!IS_BROWSER) return;
+    fetchRules();
+    fetchChannels();
+  }, []);
+
+  const openCreate = () => {
+    editingId.value = null;
+    formName.value = "";
+    formSources.value = [];
+    formSeverities.value = [];
+    formChannelId.value = channels.value.length > 0 ? channels.value[0].id : "";
+    formEnabled.value = true;
+    showModal.value = true;
+  };
+
+  const openEdit = (rule: NotifRule) => {
+    editingId.value = rule.id;
+    formName.value = rule.name;
+    formSources.value = [...rule.sourceFilter];
+    formSeverities.value = [...rule.severityFilter];
+    formChannelId.value = rule.channelId;
+    formEnabled.value = rule.enabled;
+    showModal.value = true;
+  };
+
+  const closeModal = () => {
+    showModal.value = false;
+    editingId.value = null;
+  };
+
+  const handleSave = async () => {
+    if (!formName.value.trim() || !formChannelId.value) return;
+    saving.value = true;
+    const input: NotifRuleInput = {
+      name: formName.value.trim(),
+      sourceFilter: formSources.value,
+      severityFilter: formSeverities.value,
+      channelId: formChannelId.value,
+      enabled: formEnabled.value,
+    };
+    try {
+      if (editingId.value) {
+        await notifApi.updateRule(editingId.value, input);
+      } else {
+        await notifApi.createRule(input);
+      }
+      closeModal();
+      loading.value = true;
+      await fetchRules();
+    } catch {
+      error.value = "Failed to save rule";
+    }
+    saving.value = false;
+  };
+
+  const handleToggle = async (rule: NotifRule) => {
+    try {
+      await notifApi.updateRule(rule.id, {
+        name: rule.name,
+        sourceFilter: rule.sourceFilter,
+        severityFilter: rule.severityFilter,
+        channelId: rule.channelId,
+        enabled: !rule.enabled,
+      });
+      await fetchRules();
+    } catch {
+      error.value = "Failed to toggle rule";
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      await notifApi.deleteRule(id);
+      confirmDeleteId.value = null;
+      loading.value = true;
+      await fetchRules();
+    } catch {
+      error.value = "Failed to delete rule";
+    }
+  };
+
+  const toggleSource = (src: NotifSource) => {
+    const cur = formSources.value;
+    formSources.value = cur.includes(src)
+      ? cur.filter((s) => s !== src)
+      : [...cur, src];
+  };
+
+  const toggleSeverity = (sev: NotifSeverity) => {
+    const cur = formSeverities.value;
+    formSeverities.value = cur.includes(sev)
+      ? cur.filter((s) => s !== sev)
+      : [...cur, sev];
+  };
+
+  // --- Styles ---
+
+  const pillStyle = (color: string): Record<string, string> => ({
+    display: "inline-block",
+    padding: "2px 8px",
+    borderRadius: "9999px",
+    fontSize: "11px",
+    fontWeight: "500",
+    background: `color-mix(in srgb, ${color} 15%, transparent)`,
+    color: color,
+    marginRight: "4px",
+    marginBottom: "2px",
+  });
+
+  const btnStyle: Record<string, string> = {
+    padding: "6px 14px",
+    borderRadius: "6px",
+    border: "1px solid var(--border-primary)",
+    background: "var(--surface)",
+    color: "var(--text-primary)",
+    fontSize: "13px",
+    cursor: "pointer",
+  };
+
+  const primaryBtnStyle: Record<string, string> = {
+    ...btnStyle,
+    background: "var(--accent)",
+    color: "#fff",
+    border: "1px solid var(--accent)",
+  };
+
+  const dangerBtnStyle: Record<string, string> = {
+    ...btnStyle,
+    background: "var(--danger)",
+    color: "#fff",
+    border: "1px solid var(--danger)",
+  };
+
+  // --- Render ---
+
+  if (loading.value) {
+    return (
+      <div
+        style={{
+          padding: "24px",
+          textAlign: "center",
+          color: "var(--text-muted)",
+        }}
+      >
+        Loading rules...
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {/* Header */}
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: "16px",
+        }}
+      >
+        <h3
+          style={{
+            margin: 0,
+            fontSize: "16px",
+            fontWeight: 600,
+            color: "var(--text-primary)",
+          }}
+        >
+          Routing Rules
+        </h3>
+        <button type="button" style={primaryBtnStyle} onClick={openCreate}>
+          Create Rule
+        </button>
+      </div>
+
+      {/* Error banner */}
+      {error.value && (
+        <div
+          style={{
+            padding: "8px 12px",
+            marginBottom: "12px",
+            borderRadius: "6px",
+            background: "color-mix(in srgb, var(--danger) 10%, transparent)",
+            color: "var(--danger)",
+            fontSize: "13px",
+          }}
+        >
+          {error.value}
+        </div>
+      )}
+
+      {/* Empty state */}
+      {rules.value.length === 0
+        ? (
+          <div
+            style={{
+              padding: "32px",
+              textAlign: "center",
+              color: "var(--text-muted)",
+              fontSize: "13px",
+              border: "1px dashed var(--border-primary)",
+              borderRadius: "8px",
+            }}
+          >
+            No rules configured — notifications will only appear in-app
+          </div>
+        )
+        : (
+          /* Rules table */
+          <div
+            style={{
+              border: "1px solid var(--border-primary)",
+              borderRadius: "8px",
+              overflow: "hidden",
+            }}
+          >
+            <table
+              style={{
+                width: "100%",
+                borderCollapse: "collapse",
+                fontSize: "13px",
+              }}
+            >
+              <thead>
+                <tr
+                  style={{
+                    background: "var(--surface)",
+                    borderBottom: "1px solid var(--border-primary)",
+                  }}
+                >
+                  {["Name", "Sources", "Severities", "Channel", "Enabled", ""]
+                    .map(
+                      (h) => (
+                        <th
+                          key={h}
+                          style={{
+                            padding: "8px 12px",
+                            textAlign: "left",
+                            fontWeight: 500,
+                            color: "var(--text-muted)",
+                            fontSize: "12px",
+                          }}
+                        >
+                          {h}
+                        </th>
+                      ),
+                    )}
+                </tr>
+              </thead>
+              <tbody>
+                {rules.value.map((rule) => (
+                  <tr
+                    key={rule.id}
+                    style={{
+                      borderBottom: "1px solid var(--border-primary)",
+                    }}
+                  >
+                    {/* Name */}
+                    <td
+                      style={{
+                        padding: "10px 12px",
+                        color: "var(--text-primary)",
+                        fontWeight: 500,
+                      }}
+                    >
+                      {rule.name}
+                    </td>
+
+                    {/* Sources */}
+                    <td style={{ padding: "10px 12px" }}>
+                      {rule.sourceFilter.length === 0
+                        ? (
+                          <span style={{ color: "var(--text-muted)" }}>
+                            All
+                          </span>
+                        )
+                        : rule.sourceFilter.map((src) => (
+                          <span key={src} style={pillStyle("var(--accent)")}>
+                            {SOURCE_LABELS[src]}
+                          </span>
+                        ))}
+                    </td>
+
+                    {/* Severities */}
+                    <td style={{ padding: "10px 12px" }}>
+                      {rule.severityFilter.length === 0
+                        ? (
+                          <span style={{ color: "var(--text-muted)" }}>
+                            All
+                          </span>
+                        )
+                        : rule.severityFilter.map((sev) => {
+                          const color = sev === "critical"
+                            ? "var(--danger)"
+                            : sev === "warning"
+                            ? "var(--warning)"
+                            : "var(--accent)";
+                          return (
+                            <span key={sev} style={pillStyle(color)}>
+                              {capFirst(sev)}
+                            </span>
+                          );
+                        })}
+                    </td>
+
+                    {/* Channel */}
+                    <td
+                      style={{
+                        padding: "10px 12px",
+                        color: "var(--text-primary)",
+                      }}
+                    >
+                      {rule.channelName ?? rule.channelId}
+                    </td>
+
+                    {/* Toggle */}
+                    <td style={{ padding: "10px 12px" }}>
+                      <button
+                        type="button"
+                        onClick={() => handleToggle(rule)}
+                        style={{
+                          padding: "2px 10px",
+                          borderRadius: "9999px",
+                          border: "none",
+                          fontSize: "12px",
+                          fontWeight: 500,
+                          cursor: "pointer",
+                          background: rule.enabled
+                            ? "color-mix(in srgb, var(--success) 15%, transparent)"
+                            : "color-mix(in srgb, var(--text-muted) 15%, transparent)",
+                          color: rule.enabled
+                            ? "var(--success)"
+                            : "var(--text-muted)",
+                        }}
+                      >
+                        {rule.enabled ? "On" : "Off"}
+                      </button>
+                    </td>
+
+                    {/* Actions */}
+                    <td
+                      style={{
+                        padding: "10px 12px",
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      <button
+                        type="button"
+                        style={{
+                          ...btnStyle,
+                          padding: "4px 10px",
+                          marginRight: "6px",
+                        }}
+                        onClick={() => openEdit(rule)}
+                      >
+                        Edit
+                      </button>
+                      {confirmDeleteId.value === rule.id
+                        ? (
+                          <>
+                            <button
+                              type="button"
+                              style={{
+                                ...dangerBtnStyle,
+                                padding: "4px 10px",
+                                marginRight: "4px",
+                              }}
+                              onClick={() => handleDelete(rule.id)}
+                            >
+                              Confirm
+                            </button>
+                            <button
+                              type="button"
+                              style={{ ...btnStyle, padding: "4px 10px" }}
+                              onClick={() => confirmDeleteId.value = null}
+                            >
+                              Cancel
+                            </button>
+                          </>
+                        )
+                        : (
+                          <button
+                            type="button"
+                            style={{
+                              ...btnStyle,
+                              padding: "4px 10px",
+                              color: "var(--danger)",
+                            }}
+                            onClick={() => confirmDeleteId.value = rule.id}
+                          >
+                            Delete
+                          </button>
+                        )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+      {/* Modal overlay */}
+      {showModal.value && (
+        <div
+          style={{
+            position: "fixed",
+            inset: 0,
+            background: "rgba(0,0,0,0.5)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            zIndex: 1000,
+          }}
+          onClick={(e) => {
+            if (e.target === e.currentTarget) closeModal();
+          }}
+        >
+          <div
+            style={{
+              background: "var(--bg-elevated)",
+              border: "1px solid var(--border-primary)",
+              borderRadius: "10px",
+              padding: "24px",
+              width: "100%",
+              maxWidth: "480px",
+              maxHeight: "80vh",
+              overflowY: "auto",
+            }}
+          >
+            <h3
+              style={{
+                margin: "0 0 16px",
+                fontSize: "16px",
+                fontWeight: 600,
+                color: "var(--text-primary)",
+              }}
+            >
+              {editingId.value ? "Edit Rule" : "Create Rule"}
+            </h3>
+
+            {/* Name */}
+            <div style={{ marginBottom: "14px" }}>
+              <label
+                style={{
+                  display: "block",
+                  fontSize: "12px",
+                  fontWeight: 500,
+                  color: "var(--text-muted)",
+                  marginBottom: "4px",
+                }}
+              >
+                Name
+              </label>
+              <input
+                type="text"
+                value={formName.value}
+                onInput={(e) =>
+                  formName.value = (e.target as HTMLInputElement).value}
+                placeholder="e.g. Critical alerts to Slack"
+                style={{
+                  width: "100%",
+                  padding: "8px 10px",
+                  borderRadius: "6px",
+                  border: "1px solid var(--border-primary)",
+                  background: "var(--surface)",
+                  color: "var(--text-primary)",
+                  fontSize: "13px",
+                  boxSizing: "border-box",
+                }}
+              />
+            </div>
+
+            {/* Source filter */}
+            <div style={{ marginBottom: "14px" }}>
+              <label
+                style={{
+                  display: "block",
+                  fontSize: "12px",
+                  fontWeight: 500,
+                  color: "var(--text-muted)",
+                  marginBottom: "6px",
+                }}
+              >
+                Source filter{" "}
+                <span style={{ fontWeight: 400 }}>
+                  (empty = all sources)
+                </span>
+              </label>
+              <div style={{ display: "flex", flexWrap: "wrap", gap: "8px" }}>
+                {NOTIF_SOURCES.map((src) => (
+                  <label
+                    key={src}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: "4px",
+                      fontSize: "13px",
+                      color: "var(--text-primary)",
+                      cursor: "pointer",
+                    }}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={formSources.value.includes(src)}
+                      onChange={() => toggleSource(src)}
+                    />
+                    {SOURCE_LABELS[src]}
+                  </label>
+                ))}
+              </div>
+            </div>
+
+            {/* Severity filter */}
+            <div style={{ marginBottom: "14px" }}>
+              <label
+                style={{
+                  display: "block",
+                  fontSize: "12px",
+                  fontWeight: 500,
+                  color: "var(--text-muted)",
+                  marginBottom: "6px",
+                }}
+              >
+                Severity filter{" "}
+                <span style={{ fontWeight: 400 }}>
+                  (empty = all severities)
+                </span>
+              </label>
+              <div style={{ display: "flex", gap: "12px" }}>
+                {NOTIF_SEVERITIES.map((sev) => (
+                  <label
+                    key={sev}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: "4px",
+                      fontSize: "13px",
+                      color: "var(--text-primary)",
+                      cursor: "pointer",
+                    }}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={formSeverities.value.includes(sev)}
+                      onChange={() => toggleSeverity(sev)}
+                    />
+                    {capFirst(sev)}
+                  </label>
+                ))}
+              </div>
+            </div>
+
+            {/* Channel */}
+            <div style={{ marginBottom: "14px" }}>
+              <label
+                style={{
+                  display: "block",
+                  fontSize: "12px",
+                  fontWeight: 500,
+                  color: "var(--text-muted)",
+                  marginBottom: "4px",
+                }}
+              >
+                Channel
+              </label>
+              <select
+                value={formChannelId.value}
+                onChange={(e) =>
+                  formChannelId.value = (e.target as HTMLSelectElement).value}
+                style={{
+                  width: "100%",
+                  padding: "8px 10px",
+                  borderRadius: "6px",
+                  border: "1px solid var(--border-primary)",
+                  background: "var(--surface)",
+                  color: "var(--text-primary)",
+                  fontSize: "13px",
+                  boxSizing: "border-box",
+                }}
+              >
+                {channels.value.length === 0 && (
+                  <option value="">No channels available</option>
+                )}
+                {channels.value.map((ch) => (
+                  <option key={ch.id} value={ch.id}>
+                    {ch.name} ({ch.type})
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* Enabled */}
+            <div style={{ marginBottom: "20px" }}>
+              <label
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "6px",
+                  fontSize: "13px",
+                  color: "var(--text-primary)",
+                  cursor: "pointer",
+                }}
+              >
+                <input
+                  type="checkbox"
+                  checked={formEnabled.value}
+                  onChange={() => formEnabled.value = !formEnabled.value}
+                />
+                Enabled
+              </label>
+            </div>
+
+            {/* Actions */}
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "flex-end",
+                gap: "8px",
+              }}
+            >
+              <button type="button" style={btnStyle} onClick={closeModal}>
+                Cancel
+              </button>
+              <button
+                type="button"
+                style={{
+                  ...primaryBtnStyle,
+                  opacity: saving.value ? 0.6 : 1,
+                }}
+                disabled={saving.value || !formName.value.trim() ||
+                  !formChannelId.value}
+                onClick={handleSave}
+              >
+                {saving.value
+                  ? "Saving..."
+                  : editingId.value
+                  ? "Update"
+                  : "Create"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Delete confirmation dialog */}
+      {/* (inline in table row — no separate overlay needed) */}
+    </div>
+  );
+}

--- a/frontend/islands/TopBarV2.tsx
+++ b/frontend/islands/TopBarV2.tsx
@@ -8,6 +8,7 @@ import { initTheme } from "@/lib/themes.ts";
 import { initAnimationPrefs } from "@/lib/animation-prefs.ts";
 import { selectedCluster } from "@/lib/cluster.ts";
 import ThemeSelector from "@/islands/ThemeSelector.tsx";
+import NotificationBell from "@/islands/NotificationBell.tsx";
 
 export default function TopBarV2() {
   const { user, logout, fetchCurrentUser, refreshPermissions } = useAuth();
@@ -170,36 +171,7 @@ export default function TopBarV2() {
         <ThemeSelector />
 
         {/* Notification bell */}
-        <button
-          type="button"
-          aria-label="Notifications"
-          style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            width: "32px",
-            height: "32px",
-            borderRadius: "6px",
-            background: "transparent",
-            border: "none",
-            color: "var(--text-muted)",
-            cursor: "pointer",
-          }}
-        >
-          <svg
-            width="18"
-            height="18"
-            viewBox="0 0 20 20"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="1.5"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          >
-            <path d="M10 2a5 5 0 00-5 5v3l-1.5 2.5h13L15 10V7a5 5 0 00-5-5Z" />
-            <path d="M8 16a2 2 0 004 0" />
-          </svg>
-        </button>
+        <NotificationBell />
 
         {/* Divider */}
         <div

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -6,6 +6,14 @@
  */
 import { selectedCluster } from "@/lib/cluster.ts";
 import type { APIError, APIResponse } from "@/lib/k8s-types.ts";
+import type {
+  AppNotification,
+  NotifChannel,
+  NotifChannelInput,
+  NotifListParams,
+  NotifRule,
+  NotifRuleInput,
+} from "@/lib/notif-center-types.ts";
 
 /** In-memory access token. Never stored in localStorage. */
 let accessToken: string | null = null;
@@ -182,13 +190,6 @@ export const apiPostRaw = <T>(
 
 // --- Notification Center API ---
 
-import type {
-  AppNotification,
-  NotifChannel,
-  NotifListParams,
-  NotifRule,
-} from "@/lib/notif-center-types.ts";
-
 function notifQueryString(params: NotifListParams): string {
   const p = new URLSearchParams();
   if (params.source) p.set("source", params.source);
@@ -196,8 +197,8 @@ function notifQueryString(params: NotifListParams): string {
   if (params.read) p.set("read", params.read);
   if (params.since) p.set("since", params.since);
   if (params.until) p.set("until", params.until);
-  if (params.limit) p.set("limit", String(params.limit));
-  if (params.offset) p.set("offset", String(params.offset));
+  if (params.limit !== undefined) p.set("limit", String(params.limit));
+  if (params.offset !== undefined) p.set("offset", String(params.offset));
   const qs = p.toString();
   return qs ? `?${qs}` : "";
 }
@@ -216,9 +217,9 @@ export const notifApi = {
   // Channels (admin)
   listChannels: () =>
     apiGet<{ data: NotifChannel[] }>("/v1/notifications/channels"),
-  createChannel: (ch: Partial<NotifChannel>) =>
+  createChannel: (ch: NotifChannelInput) =>
     apiPost<{ data: { id: string } }>("/v1/notifications/channels", ch),
-  updateChannel: (id: string, ch: Partial<NotifChannel>) =>
+  updateChannel: (id: string, ch: NotifChannelInput) =>
     apiPut<void>(`/v1/notifications/channels/${id}`, ch),
   deleteChannel: (id: string) => apiDelete(`/v1/notifications/channels/${id}`),
   testChannel: (id: string) =>
@@ -228,9 +229,9 @@ export const notifApi = {
 
   // Rules (admin)
   listRules: () => apiGet<{ data: NotifRule[] }>("/v1/notifications/rules"),
-  createRule: (rule: Partial<NotifRule>) =>
+  createRule: (rule: NotifRuleInput) =>
     apiPost<{ data: { id: string } }>("/v1/notifications/rules", rule),
-  updateRule: (id: string, rule: Partial<NotifRule>) =>
+  updateRule: (id: string, rule: NotifRuleInput) =>
     apiPut<void>(`/v1/notifications/rules/${id}`, rule),
   deleteRule: (id: string) => apiDelete(`/v1/notifications/rules/${id}`),
 };

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -179,3 +179,58 @@ export const apiPostRaw = <T>(
     body,
     headers: { "Content-Type": contentType },
   });
+
+// --- Notification Center API ---
+
+import type {
+  AppNotification,
+  NotifChannel,
+  NotifListParams,
+  NotifRule,
+} from "@/lib/notif-center-types.ts";
+
+function notifQueryString(params: NotifListParams): string {
+  const p = new URLSearchParams();
+  if (params.source) p.set("source", params.source);
+  if (params.severity) p.set("severity", params.severity);
+  if (params.read) p.set("read", params.read);
+  if (params.since) p.set("since", params.since);
+  if (params.until) p.set("until", params.until);
+  if (params.limit) p.set("limit", String(params.limit));
+  if (params.offset) p.set("offset", String(params.offset));
+  const qs = p.toString();
+  return qs ? `?${qs}` : "";
+}
+
+export const notifApi = {
+  // Feed
+  list: (params: NotifListParams = {}) =>
+    apiGet<{ data: AppNotification[]; metadata: { total: number } }>(
+      `/v1/notifications${notifQueryString(params)}`,
+    ),
+  unreadCount: () =>
+    apiGet<{ data: { count: number } }>("/v1/notifications/unread-count"),
+  markRead: (id: string) => apiPost<void>(`/v1/notifications/${id}/read`),
+  markAllRead: () => apiPost<void>("/v1/notifications/read-all"),
+
+  // Channels (admin)
+  listChannels: () =>
+    apiGet<{ data: NotifChannel[] }>("/v1/notifications/channels"),
+  createChannel: (ch: Partial<NotifChannel>) =>
+    apiPost<{ data: { id: string } }>("/v1/notifications/channels", ch),
+  updateChannel: (id: string, ch: Partial<NotifChannel>) =>
+    apiPut<void>(`/v1/notifications/channels/${id}`, ch),
+  deleteChannel: (id: string) => apiDelete(`/v1/notifications/channels/${id}`),
+  testChannel: (id: string) =>
+    apiPost<{ data: { status: string } }>(
+      `/v1/notifications/channels/${id}/test`,
+    ),
+
+  // Rules (admin)
+  listRules: () => apiGet<{ data: NotifRule[] }>("/v1/notifications/rules"),
+  createRule: (rule: Partial<NotifRule>) =>
+    apiPost<{ data: { id: string } }>("/v1/notifications/rules", rule),
+  updateRule: (id: string, rule: Partial<NotifRule>) =>
+    apiPut<void>(`/v1/notifications/rules/${id}`, rule),
+  deleteRule: (id: string) => apiDelete(`/v1/notifications/rules/${id}`),
+};

--- a/frontend/lib/notif-center-types.ts
+++ b/frontend/lib/notif-center-types.ts
@@ -87,6 +87,13 @@ export interface NotifListParams {
   offset?: number;
 }
 
+/** SubNav tabs for the admin notification center pages. */
+export const NOTIF_ADMIN_TABS = [
+  { label: "Feed", href: "/admin/notifications/feed" },
+  { label: "Channels", href: "/admin/notifications/channels" },
+  { label: "Rules", href: "/admin/notifications/rules" },
+];
+
 /** All known notification sources for filter dropdowns. */
 export const NOTIF_SOURCES: NotifSource[] = [
   "alert",

--- a/frontend/lib/notif-center-types.ts
+++ b/frontend/lib/notif-center-types.ts
@@ -1,0 +1,107 @@
+/** Notification severity levels matching backend notifications.Severity */
+export type NotifSeverity = "critical" | "warning" | "info";
+
+/** Notification source subsystems matching backend notifications.Source */
+export type NotifSource =
+  | "alert"
+  | "policy"
+  | "gitops"
+  | "diagnostic"
+  | "scan"
+  | "cluster"
+  | "audit";
+
+/** Notification channel types matching backend notifications.ChannelType */
+export type NotifChannelType = "slack" | "email" | "webhook";
+
+/** A single notification from the backend feed. */
+export interface AppNotification {
+  id: string;
+  source: NotifSource;
+  severity: NotifSeverity;
+  title: string;
+  message: string;
+  resourceKind?: string;
+  resourceNamespace?: string;
+  resourceName?: string;
+  clusterId?: string;
+  createdAt: string;
+  read?: boolean;
+}
+
+/** External dispatch channel configuration. */
+export interface NotifChannel {
+  id: string;
+  name: string;
+  type: NotifChannelType;
+  config: Record<string, unknown>;
+  createdBy: string;
+  createdAt: string;
+  updatedAt?: string;
+  updatedBy?: string;
+  lastSentAt?: string;
+  lastError?: string;
+  lastErrorAt?: string;
+}
+
+/** Routing rule that maps notifications to channels. */
+export interface NotifRule {
+  id: string;
+  name: string;
+  sourceFilter: NotifSource[];
+  severityFilter: NotifSeverity[];
+  channelId: string;
+  channelName?: string;
+  enabled: boolean;
+  createdBy: string;
+  createdAt: string;
+  updatedAt?: string;
+  updatedBy?: string;
+}
+
+/** Query parameters for the notification feed endpoint. */
+export interface NotifListParams {
+  source?: NotifSource;
+  severity?: NotifSeverity;
+  read?: "read" | "unread";
+  since?: string;
+  until?: string;
+  limit?: number;
+  offset?: number;
+}
+
+/** All known notification sources for filter dropdowns. */
+export const NOTIF_SOURCES: NotifSource[] = [
+  "alert",
+  "policy",
+  "gitops",
+  "diagnostic",
+  "scan",
+  "cluster",
+  "audit",
+];
+
+/** All known notification severities for filter dropdowns. */
+export const NOTIF_SEVERITIES: NotifSeverity[] = [
+  "critical",
+  "warning",
+  "info",
+];
+
+/** Severity → CSS color variable mapping. */
+export const SEVERITY_COLORS: Record<NotifSeverity, string> = {
+  critical: "var(--danger)",
+  warning: "var(--warning)",
+  info: "var(--accent)",
+};
+
+/** Source → display label mapping. */
+export const SOURCE_LABELS: Record<NotifSource, string> = {
+  alert: "Alert",
+  policy: "Policy",
+  gitops: "GitOps",
+  diagnostic: "Diagnostic",
+  scan: "Security",
+  cluster: "Cluster",
+  audit: "Audit",
+};

--- a/frontend/lib/notif-center-types.ts
+++ b/frontend/lib/notif-center-types.ts
@@ -26,6 +26,7 @@ export interface AppNotification {
   resourceName?: string;
   clusterId?: string;
   createdAt: string;
+  /** Absent means unread (Go omitempty omits false). Treat undefined as false. */
   read?: boolean;
 }
 
@@ -59,6 +60,22 @@ export interface NotifRule {
   updatedBy?: string;
 }
 
+/** Input for creating/updating a channel (only mutable fields). */
+export interface NotifChannelInput {
+  name: string;
+  type: NotifChannelType;
+  config: Record<string, unknown>;
+}
+
+/** Input for creating/updating a rule (only mutable fields). */
+export interface NotifRuleInput {
+  name: string;
+  sourceFilter: NotifSource[];
+  severityFilter: NotifSeverity[];
+  channelId: string;
+  enabled: boolean;
+}
+
 /** Query parameters for the notification feed endpoint. */
 export interface NotifListParams {
   source?: NotifSource;
@@ -89,7 +106,7 @@ export const NOTIF_SEVERITIES: NotifSeverity[] = [
 ];
 
 /** Severity → CSS color variable mapping. */
-export const SEVERITY_COLORS: Record<NotifSeverity, string> = {
+export const NOTIF_SEVERITY_COLORS: Record<NotifSeverity, string> = {
   critical: "var(--danger)",
   warning: "var(--warning)",
   info: "var(--accent)",

--- a/frontend/routes/admin/notifications/channels.tsx
+++ b/frontend/routes/admin/notifications/channels.tsx
@@ -1,17 +1,12 @@
 import { define } from "@/utils.ts";
 import SubNav from "@/islands/SubNav.tsx";
 import NotificationChannels from "@/islands/NotificationChannels.tsx";
-
-const tabs = [
-  { label: "Feed", href: "/admin/notifications/feed" },
-  { label: "Channels", href: "/admin/notifications/channels" },
-  { label: "Rules", href: "/admin/notifications/rules" },
-];
+import { NOTIF_ADMIN_TABS } from "@/lib/notif-center-types.ts";
 
 export default define.page(function NotificationChannelsPage(ctx) {
   return (
     <>
-      <SubNav tabs={tabs} currentPath={ctx.url.pathname} />
+      <SubNav tabs={NOTIF_ADMIN_TABS} currentPath={ctx.url.pathname} />
       <NotificationChannels />
     </>
   );

--- a/frontend/routes/admin/notifications/channels.tsx
+++ b/frontend/routes/admin/notifications/channels.tsx
@@ -1,0 +1,18 @@
+import { define } from "@/utils.ts";
+import SubNav from "@/islands/SubNav.tsx";
+import NotificationChannels from "@/islands/NotificationChannels.tsx";
+
+const tabs = [
+  { label: "Feed", href: "/admin/notifications/feed" },
+  { label: "Channels", href: "/admin/notifications/channels" },
+  { label: "Rules", href: "/admin/notifications/rules" },
+];
+
+export default define.page(function NotificationChannelsPage(ctx) {
+  return (
+    <>
+      <SubNav tabs={tabs} currentPath={ctx.url.pathname} />
+      <NotificationChannels />
+    </>
+  );
+});

--- a/frontend/routes/admin/notifications/feed.tsx
+++ b/frontend/routes/admin/notifications/feed.tsx
@@ -1,17 +1,12 @@
 import { define } from "@/utils.ts";
 import SubNav from "@/islands/SubNav.tsx";
 import NotificationFeed from "@/islands/NotificationFeed.tsx";
-
-const tabs = [
-  { label: "Feed", href: "/admin/notifications/feed" },
-  { label: "Channels", href: "/admin/notifications/channels" },
-  { label: "Rules", href: "/admin/notifications/rules" },
-];
+import { NOTIF_ADMIN_TABS } from "@/lib/notif-center-types.ts";
 
 export default define.page(function NotificationFeedPage(ctx) {
   return (
     <>
-      <SubNav tabs={tabs} currentPath={ctx.url.pathname} />
+      <SubNav tabs={NOTIF_ADMIN_TABS} currentPath={ctx.url.pathname} />
       <NotificationFeed />
     </>
   );

--- a/frontend/routes/admin/notifications/feed.tsx
+++ b/frontend/routes/admin/notifications/feed.tsx
@@ -1,0 +1,18 @@
+import { define } from "@/utils.ts";
+import SubNav from "@/islands/SubNav.tsx";
+import NotificationFeed from "@/islands/NotificationFeed.tsx";
+
+const tabs = [
+  { label: "Feed", href: "/admin/notifications/feed" },
+  { label: "Channels", href: "/admin/notifications/channels" },
+  { label: "Rules", href: "/admin/notifications/rules" },
+];
+
+export default define.page(function NotificationFeedPage(ctx) {
+  return (
+    <>
+      <SubNav tabs={tabs} currentPath={ctx.url.pathname} />
+      <NotificationFeed />
+    </>
+  );
+});

--- a/frontend/routes/admin/notifications/index.tsx
+++ b/frontend/routes/admin/notifications/index.tsx
@@ -1,0 +1,10 @@
+import { define } from "@/utils.ts";
+
+export const handler = define.handlers({
+  GET(_ctx) {
+    return new Response(null, {
+      status: 302,
+      headers: { Location: "/admin/notifications/feed" },
+    });
+  },
+});

--- a/frontend/routes/admin/notifications/rules.tsx
+++ b/frontend/routes/admin/notifications/rules.tsx
@@ -1,17 +1,12 @@
 import { define } from "@/utils.ts";
 import SubNav from "@/islands/SubNav.tsx";
 import NotificationRules from "@/islands/NotificationRules.tsx";
-
-const tabs = [
-  { label: "Feed", href: "/admin/notifications/feed" },
-  { label: "Channels", href: "/admin/notifications/channels" },
-  { label: "Rules", href: "/admin/notifications/rules" },
-];
+import { NOTIF_ADMIN_TABS } from "@/lib/notif-center-types.ts";
 
 export default define.page(function NotificationRulesPage(ctx) {
   return (
     <>
-      <SubNav tabs={tabs} currentPath={ctx.url.pathname} />
+      <SubNav tabs={NOTIF_ADMIN_TABS} currentPath={ctx.url.pathname} />
       <NotificationRules />
     </>
   );

--- a/frontend/routes/admin/notifications/rules.tsx
+++ b/frontend/routes/admin/notifications/rules.tsx
@@ -1,0 +1,18 @@
+import { define } from "@/utils.ts";
+import SubNav from "@/islands/SubNav.tsx";
+import NotificationRules from "@/islands/NotificationRules.tsx";
+
+const tabs = [
+  { label: "Feed", href: "/admin/notifications/feed" },
+  { label: "Channels", href: "/admin/notifications/channels" },
+  { label: "Rules", href: "/admin/notifications/rules" },
+];
+
+export default define.page(function NotificationRulesPage(ctx) {
+  return (
+    <>
+      <SubNav tabs={tabs} currentPath={ctx.url.pathname} />
+      <NotificationRules />
+    </>
+  );
+});

--- a/frontend/routes/notifications/index.tsx
+++ b/frontend/routes/notifications/index.tsx
@@ -1,0 +1,6 @@
+import { define } from "@/utils.ts";
+import NotificationFeed from "@/islands/NotificationFeed.tsx";
+
+export default define.page(function NotificationFeedPage() {
+  return <NotificationFeed />;
+});


### PR DESCRIPTION
## Summary

- **Migration 000007**: 4 tables (`nc_notifications`, `nc_reads`, `nc_channels`, `nc_rules`) with dedup index, cascade deletes, channel error tracking columns, and encrypted config storage
- **types.go**: `Notification`, `Channel`, `Rule` structs with `Source`/`Severity`/`ChannelType` constants and `ListOpts` for paginated RBAC-filtered queries
- **store.go**: Concrete `Store` struct (no interface per review) with full CRUD, 15-min dedup check, RBAC-filtered list with namespace `ANY()` filtering, unread count, mark read/all, retention pruning, AES-256-GCM encrypted channel config, digest query

This is Step 1 of 8 for the Notification Center feature. See `plans/notification-center.md` for the full plan and `docs/superpowers/specs/2026-04-10-notification-center-design.md` for the design spec.

## Design Decisions (from review)

- No `Store` interface — concrete struct, one PostgreSQL implementation
- No `Dispatcher` interface — switch-based dispatch in service (Step 2)
- No SMTP extraction — reuse `*alerting.Notifier` directly (Step 2)
- Channel config stored as encrypted `BYTEA` (not JSONB) via AES-256-GCM
- `last_error`/`last_error_at` on channels for admin visibility of broken channels
- `last_sent_at` on channels for email digest tracking
- Dedup index for 15-min suppression window
- Index on `nc_reads(notification_id)` for cascade delete performance

## Test plan

- [ ] Migration applies cleanly (`make dev-db` + backend start)
- [ ] `go vet ./internal/notifications/...` passes
- [ ] Store methods tested in Step 8 (unit tests with real PostgreSQL)
- [ ] Encrypted config round-trips verified in integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)