### PR TITLE
feat(velero): Backup & Restore integration with Velero

### DIFF
--- a/backend/cmd/kubecenter/main.go
+++ b/backend/cmd/kubecenter/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/kubecenter/kubecenter/internal/storage"
 	appstore "github.com/kubecenter/kubecenter/internal/store"
 	"github.com/kubecenter/kubecenter/internal/topology"
+	"github.com/kubecenter/kubecenter/internal/velero"
 	"github.com/kubecenter/kubecenter/internal/websocket"
 	"github.com/kubecenter/kubecenter/pkg/version"
 )
@@ -608,6 +609,10 @@ func main() {
 	// Note: Limits checker is created after notification center to enable threshold alerts
 	limitsHandler := limits.NewHandler(informerMgr, accessChecker, logger)
 
+	// Velero backup/restore handler
+	veleroDiscoverer := velero.NewDiscoverer(k8sClient, logger)
+	veleroHandler := velero.NewHandler(k8sClient, veleroDiscoverer, accessChecker, auditLogger, nil, logger)
+
 	// Notification center — aggregates events from all subsystems
 	var notifService *notifications.NotificationService
 	var notifCenterHandler *notifications.Handler
@@ -648,6 +653,7 @@ func main() {
 		gitopsHandler.NotifService = notifService
 		scanHandler.NotifService = notifService
 		diagHandler.NotifService = notifService
+		veleroHandler.NotifService = notifService
 
 		// Limits checker — monitors quotas and dispatches threshold notifications
 		limitsChecker = limits.NewChecker(limitsHandler, notifService, limits.DefaultCheckInterval, logger)
@@ -692,6 +698,7 @@ func main() {
 		NotifCenterService: notifService,
 		ScanningHandler:    scanHandler,
 		LimitsHandler:      limitsHandler,
+		VeleroHandler:      veleroHandler,
 		CRDHandler:         crdHandler,
 		LogQueryLimiter:    logQueryLimiter,
 		WebhookRateLimiter: webhookRateLimiter,

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -65,6 +65,7 @@ require (
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
+	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -190,6 +190,8 @@ github.com/prometheus/common v0.66.1 h1:h5E0h5/Y8niHc5DlaLlWLArTQI7tMrsfQjHV+d9Z
 github.com/prometheus/common v0.66.1/go.mod h1:gcaUsgf3KfRSwHY4dIMXLPV0K/Wg1oZ8+SbZk/HH/dA=
 github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzMyRg=
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=

--- a/backend/internal/audit/logger.go
+++ b/backend/internal/audit/logger.go
@@ -30,6 +30,15 @@ const (
 	ActionGitOpsSuspend       Action = "gitops_suspend"
 	ActionGitOpsResume        Action = "gitops_resume"
 	ActionGitOpsRollback      Action = "gitops_rollback"
+
+	// Velero actions
+	ActionVeleroBackupCreate    Action = "velero_backup_create"
+	ActionVeleroBackupDelete    Action = "velero_backup_delete"
+	ActionVeleroRestoreCreate   Action = "velero_restore_create"
+	ActionVeleroScheduleCreate  Action = "velero_schedule_create"
+	ActionVeleroScheduleUpdate  Action = "velero_schedule_update"
+	ActionVeleroScheduleDelete  Action = "velero_schedule_delete"
+	ActionVeleroScheduleTrigger Action = "velero_schedule_trigger"
 )
 
 // Result represents the outcome of an auditable operation.

--- a/backend/internal/notifications/types.go
+++ b/backend/internal/notifications/types.go
@@ -14,6 +14,7 @@ const (
 	SourceCluster    Source = "cluster"
 	SourceAudit      Source = "audit"
 	SourceLimits     Source = "limits"
+	SourceVelero     Source = "velero"
 )
 
 // Severity indicates how critical a notification is.

--- a/backend/internal/server/routes.go
+++ b/backend/internal/server/routes.go
@@ -161,6 +161,11 @@ func (s *Server) registerRoutes() {
 				s.registerLimitsRoutes(ar)
 			}
 
+			// Velero backup/restore routes — only registered if velero handler is available
+			if s.VeleroHandler != nil {
+				s.registerVeleroRoutes(ar)
+			}
+
 			// Notification center routes
 			if s.NotifCenterHandler != nil {
 				s.registerNotifCenterRoutes(ar)
@@ -270,6 +275,9 @@ func (s *Server) registerWizardRoutes(ar chi.Router) {
 		wr.Post("/pdb/preview", h.HandlePreview(func() wizard.WizardInput { return &wizard.PDBInput{} }))
 		wr.Post("/policy/preview", h.HandlePreview(func() wizard.WizardInput { return &wizard.PolicyWizardInput{} }))
 		wr.Post("/namespace-limits/preview", h.HandlePreview(func() wizard.WizardInput { return &wizard.NamespaceLimitsInput{} }))
+		wr.Post("/velero-backup/preview", h.HandlePreview(func() wizard.WizardInput { return &wizard.VeleroBackupInput{} }))
+		wr.Post("/velero-restore/preview", h.HandlePreview(func() wizard.WizardInput { return &wizard.VeleroRestoreInput{} }))
+		wr.Post("/velero-schedule/preview", h.HandlePreview(func() wizard.WizardInput { return &wizard.VeleroScheduleInput{} }))
 	})
 }
 
@@ -524,6 +532,41 @@ func (s *Server) registerLimitsRoutes(ar chi.Router) {
 		lr.Get("/status", h.HandleStatus)
 		lr.Get("/namespaces", h.HandleListNamespaces)
 		lr.With(resources.ValidateURLParams).Get("/namespaces/{namespace}", h.HandleGetNamespace)
+	})
+}
+
+func (s *Server) registerVeleroRoutes(ar chi.Router) {
+	h := s.VeleroHandler
+	ar.Route("/velero", func(vr chi.Router) {
+		yamlRL := s.YAMLRateLimiter
+		if yamlRL == nil {
+			yamlRL = s.RateLimiter
+		}
+		// Status (read-only, no rate limit needed)
+		vr.Get("/status", h.HandleStatus)
+
+		// Backups
+		vr.Get("/backups", h.HandleListBackups)
+		vr.With(resources.ValidateURLParams).Get("/backups/{namespace}/{name}", h.HandleGetBackup)
+		vr.With(middleware.RateLimit(yamlRL)).Post("/backups", h.HandleCreateBackup)
+		vr.With(middleware.RateLimit(yamlRL), resources.ValidateURLParams).Delete("/backups/{namespace}/{name}", h.HandleDeleteBackup)
+		vr.With(resources.ValidateURLParams).Get("/backups/{namespace}/{name}/logs", h.HandleGetBackupLogs)
+
+		// Restores
+		vr.Get("/restores", h.HandleListRestores)
+		vr.With(resources.ValidateURLParams).Get("/restores/{namespace}/{name}", h.HandleGetRestore)
+		vr.With(middleware.RateLimit(yamlRL)).Post("/restores", h.HandleCreateRestore)
+
+		// Schedules
+		vr.Get("/schedules", h.HandleListSchedules)
+		vr.With(resources.ValidateURLParams).Get("/schedules/{namespace}/{name}", h.HandleGetSchedule)
+		vr.With(middleware.RateLimit(yamlRL)).Post("/schedules", h.HandleCreateSchedule)
+		vr.With(middleware.RateLimit(yamlRL), resources.ValidateURLParams).Put("/schedules/{namespace}/{name}", h.HandleUpdateSchedule)
+		vr.With(middleware.RateLimit(yamlRL), resources.ValidateURLParams).Delete("/schedules/{namespace}/{name}", h.HandleDeleteSchedule)
+		vr.With(middleware.RateLimit(yamlRL), resources.ValidateURLParams).Post("/schedules/{namespace}/{name}/trigger", h.HandleTriggerSchedule)
+
+		// Locations (read-only)
+		vr.Get("/locations", h.HandleListLocations)
 	})
 }
 

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -29,6 +29,7 @@ import (
 	"github.com/kubecenter/kubecenter/internal/storage"
 	"github.com/kubecenter/kubecenter/internal/store"
 	"github.com/kubecenter/kubecenter/internal/topology"
+	"github.com/kubecenter/kubecenter/internal/velero"
 	"github.com/kubecenter/kubecenter/internal/websocket"
 	"github.com/kubecenter/kubecenter/internal/wizard"
 	yamlpkg "github.com/kubecenter/kubecenter/internal/yaml"
@@ -69,6 +70,7 @@ type Server struct {
 	FluxNotifHandler   *notification.Handler
 	ScanningHandler    *scanning.Handler
 	LimitsHandler      *limits.Handler
+	VeleroHandler      *velero.Handler
 	CRDHandler         *resources.GenericCRDHandler
 	NotifCenterHandler *notifications.Handler
 	NotifCenterService *notifications.NotificationService
@@ -111,6 +113,7 @@ type Deps struct {
 	FluxNotifHandler   *notification.Handler
 	ScanningHandler    *scanning.Handler
 	LimitsHandler      *limits.Handler
+	VeleroHandler      *velero.Handler
 	CRDHandler         *resources.GenericCRDHandler
 	NotifCenterHandler *notifications.Handler
 	NotifCenterService *notifications.NotificationService
@@ -251,6 +254,11 @@ func New(deps Deps) *Server {
 	// Limits handler (namespace quota/limit range management)
 	if deps.LimitsHandler != nil {
 		s.LimitsHandler = deps.LimitsHandler
+	}
+
+	// Velero handler (backup/restore)
+	if deps.VeleroHandler != nil {
+		s.VeleroHandler = deps.VeleroHandler
 	}
 
 	// Notification center

--- a/backend/internal/velero/discovery.go
+++ b/backend/internal/velero/discovery.go
@@ -1,0 +1,145 @@
+package velero
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/kubecenter/kubecenter/internal/k8s"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// staleDuration is how long before cached status is considered stale.
+	staleDuration = 5 * time.Minute
+	// veleroNamespace is the default namespace where Velero is installed.
+	veleroNamespace = "velero"
+)
+
+// Discoverer probes the cluster for Velero CRDs and maintains cached discovery state.
+type Discoverer struct {
+	k8sClient *k8s.ClientFactory
+	logger    *slog.Logger
+
+	mu     sync.RWMutex
+	status VeleroStatus
+}
+
+// NewDiscoverer creates a new Velero discoverer.
+func NewDiscoverer(k8sClient *k8s.ClientFactory, logger *slog.Logger) *Discoverer {
+	return &Discoverer{
+		k8sClient: k8sClient,
+		logger:    logger,
+		status: VeleroStatus{
+			LastChecked: time.Now().UTC(),
+		},
+	}
+}
+
+// Status returns a copy of the cached Velero status.
+// If the cache is stale (older than staleDuration), it triggers a re-probe.
+func (d *Discoverer) Status(ctx context.Context) VeleroStatus {
+	d.mu.RLock()
+	if time.Since(d.status.LastChecked) < staleDuration {
+		status := d.status
+		d.mu.RUnlock()
+		return status
+	}
+	d.mu.RUnlock()
+
+	// Cache is stale, re-probe
+	return d.Probe(ctx)
+}
+
+// Probe checks if velero.io/v1 CRDs exist and updates cached state.
+func (d *Discoverer) Probe(ctx context.Context) VeleroStatus {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	now := time.Now().UTC()
+	disco := d.k8sClient.DiscoveryClient()
+
+	status := VeleroStatus{
+		LastChecked: now,
+	}
+
+	// Check for Velero CRDs: look for Backup kind in velero.io/v1
+	veleroResources, err := disco.ServerResourcesForGroupVersion("velero.io/v1")
+	if err != nil || veleroResources == nil {
+		d.logger.Debug("Velero CRDs not found", "error", err)
+		d.status = status
+		return status
+	}
+
+	// Check if Backup resource exists
+	hasBackup := false
+	for _, r := range veleroResources.APIResources {
+		if r.Kind == "Backup" {
+			hasBackup = true
+			break
+		}
+	}
+
+	if !hasBackup {
+		d.logger.Debug("Velero Backup CRD not found")
+		d.status = status
+		return status
+	}
+
+	status.Detected = true
+
+	// Probe the velero namespace for deployment and version
+	cs := d.k8sClient.BaseClientset()
+	deps, err := cs.AppsV1().Deployments(veleroNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "component=velero",
+	})
+	if err == nil && len(deps.Items) > 0 {
+		status.Namespace = veleroNamespace
+		// Extract version from deployment labels or container image
+		dep := deps.Items[0]
+		if v, ok := dep.Labels["app.kubernetes.io/version"]; ok {
+			status.Version = v
+		} else if len(dep.Spec.Template.Spec.Containers) > 0 {
+			// Try to extract version from image tag
+			img := dep.Spec.Template.Spec.Containers[0].Image
+			if idx := len(img) - 1; idx > 0 {
+				for i := len(img) - 1; i >= 0; i-- {
+					if img[i] == ':' {
+						status.Version = img[i+1:]
+						break
+					}
+				}
+			}
+		}
+	}
+
+	// Count BSLs
+	dynClient := d.k8sClient.BaseDynamicClient()
+	bslList, err := dynClient.Resource(BackupStorageLocationGVR).Namespace(veleroNamespace).List(ctx, metav1.ListOptions{})
+	if err == nil {
+		status.BSLCount = len(bslList.Items)
+	}
+
+	// Count VSLs
+	vslList, err := dynClient.Resource(VolumeSnapshotLocationGVR).Namespace(veleroNamespace).List(ctx, metav1.ListOptions{})
+	if err == nil {
+		status.VSLCount = len(vslList.Items)
+	}
+
+	d.status = status
+	d.logger.Info("Velero discovery completed",
+		"detected", status.Detected,
+		"namespace", status.Namespace,
+		"version", status.Version,
+		"bslCount", status.BSLCount,
+		"vslCount", status.VSLCount,
+	)
+
+	return status
+}
+
+// IsAvailable returns true if Velero was detected.
+func (d *Discoverer) IsAvailable(ctx context.Context) bool {
+	return d.Status(ctx).Detected
+}

--- a/backend/internal/velero/discovery_test.go
+++ b/backend/internal/velero/discovery_test.go
@@ -1,0 +1,75 @@
+package velero
+
+import (
+	"testing"
+)
+
+func TestPhaseHelpers(t *testing.T) {
+	tests := []struct {
+		phase      string
+		isFailed   bool
+		isWarning  bool
+		isSuccess  bool
+		isProgress bool
+	}{
+		{"Failed", true, false, false, false},
+		{"FailedValidation", true, false, false, false},
+		{"PartiallyFailed", false, true, false, false},
+		{"Completed", false, false, true, false},
+		{"Available", false, false, true, false},
+		{"Enabled", false, false, true, false},
+		{"InProgress", false, false, false, true},
+		{"New", false, false, false, true},
+		{"WaitingForPluginOperations", false, false, false, true},
+		{"Finalizing", false, false, false, true},
+		{"Queued", false, false, false, true},
+		{"ReadyToStart", false, false, false, true},
+		{"Unknown", false, false, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.phase, func(t *testing.T) {
+			if got := IsFailedPhase(tt.phase); got != tt.isFailed {
+				t.Errorf("IsFailedPhase(%q) = %v, want %v", tt.phase, got, tt.isFailed)
+			}
+			if got := IsWarningPhase(tt.phase); got != tt.isWarning {
+				t.Errorf("IsWarningPhase(%q) = %v, want %v", tt.phase, got, tt.isWarning)
+			}
+			if got := IsSuccessPhase(tt.phase); got != tt.isSuccess {
+				t.Errorf("IsSuccessPhase(%q) = %v, want %v", tt.phase, got, tt.isSuccess)
+			}
+			if got := IsProgressPhase(tt.phase); got != tt.isProgress {
+				t.Errorf("IsProgressPhase(%q) = %v, want %v", tt.phase, got, tt.isProgress)
+			}
+		})
+	}
+}
+
+func TestGVRs(t *testing.T) {
+	// Verify GVR constants are correctly defined
+	if BackupGVR.Group != "velero.io" {
+		t.Errorf("BackupGVR.Group = %q, want %q", BackupGVR.Group, "velero.io")
+	}
+	if BackupGVR.Version != "v1" {
+		t.Errorf("BackupGVR.Version = %q, want %q", BackupGVR.Version, "v1")
+	}
+	if BackupGVR.Resource != "backups" {
+		t.Errorf("BackupGVR.Resource = %q, want %q", BackupGVR.Resource, "backups")
+	}
+
+	if RestoreGVR.Resource != "restores" {
+		t.Errorf("RestoreGVR.Resource = %q, want %q", RestoreGVR.Resource, "restores")
+	}
+
+	if ScheduleGVR.Resource != "schedules" {
+		t.Errorf("ScheduleGVR.Resource = %q, want %q", ScheduleGVR.Resource, "schedules")
+	}
+
+	if BackupStorageLocationGVR.Resource != "backupstoragelocations" {
+		t.Errorf("BackupStorageLocationGVR.Resource = %q, want %q", BackupStorageLocationGVR.Resource, "backupstoragelocations")
+	}
+
+	if VolumeSnapshotLocationGVR.Resource != "volumesnapshotlocations" {
+		t.Errorf("VolumeSnapshotLocationGVR.Resource = %q, want %q", VolumeSnapshotLocationGVR.Resource, "volumesnapshotlocations")
+	}
+}

--- a/backend/internal/velero/handler.go
+++ b/backend/internal/velero/handler.go
@@ -1,0 +1,1310 @@
+package velero
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/robfig/cron/v3"
+	"golang.org/x/sync/singleflight"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/kubecenter/kubecenter/internal/audit"
+	"github.com/kubecenter/kubecenter/internal/auth"
+	"github.com/kubecenter/kubecenter/internal/httputil"
+	"github.com/kubecenter/kubecenter/internal/k8s"
+	"github.com/kubecenter/kubecenter/internal/k8s/resources"
+	"github.com/kubecenter/kubecenter/internal/server/middleware"
+)
+
+const cacheTTL = 30 * time.Second
+
+// Handler serves Velero HTTP endpoints.
+type Handler struct {
+	K8sClient     *k8s.ClientFactory
+	Discoverer    *Discoverer
+	AccessChecker *resources.AccessChecker
+	AuditLogger   audit.Logger
+	Logger        *slog.Logger
+
+	fetchGroup singleflight.Group
+	cacheMu    sync.RWMutex
+	cachedData *cachedVeleroData
+	cacheGen   uint64
+}
+
+type cachedVeleroData struct {
+	backups   []Backup
+	restores  []Restore
+	schedules []Schedule
+	locations *LocationsResponse
+	fetchedAt time.Time
+}
+
+// NewHandler creates a new Velero handler.
+func NewHandler(
+	k8sClient *k8s.ClientFactory,
+	discoverer *Discoverer,
+	accessChecker *resources.AccessChecker,
+	auditLogger audit.Logger,
+	logger *slog.Logger,
+) *Handler {
+	return &Handler{
+		K8sClient:     k8sClient,
+		Discoverer:    discoverer,
+		AccessChecker: accessChecker,
+		AuditLogger:   auditLogger,
+		Logger:        logger,
+	}
+}
+
+// InvalidateCache clears the cached data.
+func (h *Handler) InvalidateCache() {
+	h.cacheMu.Lock()
+	h.cacheGen++
+	h.cachedData = nil
+	h.cacheMu.Unlock()
+}
+
+// canAccess checks if the user can access a Velero resource.
+func (h *Handler) canAccess(ctx context.Context, user *auth.User, verb, resource, namespace string) bool {
+	can, err := h.AccessChecker.CanAccessGroupResource(
+		ctx,
+		user.KubernetesUsername,
+		user.KubernetesGroups,
+		verb,
+		"velero.io",
+		resource,
+		namespace,
+	)
+	return err == nil && can
+}
+
+// auditLog writes an audit entry for a Velero action.
+func (h *Handler) auditLog(r *http.Request, user *auth.User, action audit.Action, kind, ns, name string, result audit.Result) {
+	if h.AuditLogger == nil {
+		return
+	}
+	_ = h.AuditLogger.Log(r.Context(), audit.Entry{
+		Timestamp:         time.Now(),
+		ClusterID:         middleware.ClusterIDFromContext(r.Context()),
+		User:              user.Username,
+		SourceIP:          r.RemoteAddr,
+		Action:            action,
+		ResourceKind:      kind,
+		ResourceNamespace: ns,
+		ResourceName:      name,
+		Result:            result,
+	})
+}
+
+// ============================================================================
+// Status
+// ============================================================================
+
+// HandleStatus returns the Velero detection status.
+func (h *Handler) HandleStatus(w http.ResponseWriter, r *http.Request) {
+	_, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	status := h.Discoverer.Status(r.Context())
+	httputil.WriteData(w, status)
+}
+
+// ============================================================================
+// Backups
+// ============================================================================
+
+// HandleListBackups returns all Velero backups.
+func (h *Handler) HandleListBackups(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	status := h.Discoverer.Status(r.Context())
+	if !status.Detected {
+		httputil.WriteData(w, []Backup{})
+		return
+	}
+
+	backups, err := h.fetchBackups(r.Context())
+	if err != nil {
+		h.Logger.Error("failed to fetch backups", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to fetch backups", "")
+		return
+	}
+
+	// RBAC filter
+	if !h.canAccess(r.Context(), user, "list", "backups", "") {
+		httputil.WriteData(w, []Backup{})
+		return
+	}
+
+	// Sort by start time descending (newest first)
+	sort.Slice(backups, func(i, j int) bool {
+		if backups[i].StartTime == nil {
+			return false
+		}
+		if backups[j].StartTime == nil {
+			return true
+		}
+		return backups[i].StartTime.After(*backups[j].StartTime)
+	})
+
+	httputil.WriteData(w, backups)
+}
+
+// HandleGetBackup returns a single backup.
+func (h *Handler) HandleGetBackup(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	namespace := chi.URLParam(r, "namespace")
+	name := chi.URLParam(r, "name")
+
+	if !h.canAccess(r.Context(), user, "get", "backups", namespace) {
+		httputil.WriteError(w, http.StatusForbidden, "access denied", "")
+		return
+	}
+
+	dynClient, err := h.K8sClient.DynamicClientForUser(user.KubernetesUsername, user.KubernetesGroups)
+	if err != nil {
+		h.Logger.Error("failed to create impersonating client", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "internal error", "")
+		return
+	}
+
+	backup, err := h.getBackup(r.Context(), dynClient, namespace, name)
+	if err != nil {
+		h.Logger.Error("failed to get backup", "namespace", namespace, "name", name, "error", err)
+		httputil.WriteError(w, http.StatusNotFound, "backup not found", "")
+		return
+	}
+
+	httputil.WriteData(w, backup)
+}
+
+// HandleCreateBackup creates a new backup.
+func (h *Handler) HandleCreateBackup(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	var input struct {
+		Name               string            `json:"name"`
+		Namespace          string            `json:"namespace"`
+		IncludedNamespaces []string          `json:"includedNamespaces"`
+		ExcludedNamespaces []string          `json:"excludedNamespaces"`
+		StorageLocation    string            `json:"storageLocation"`
+		TTL                string            `json:"ttl"`
+		SnapshotVolumes    *bool             `json:"snapshotVolumes"`
+		Labels             map[string]string `json:"labels"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		httputil.WriteError(w, http.StatusBadRequest, "invalid request body", err.Error())
+		return
+	}
+
+	if input.Name == "" {
+		httputil.WriteError(w, http.StatusBadRequest, "name is required", "")
+		return
+	}
+	if input.Namespace == "" {
+		input.Namespace = "velero"
+	}
+
+	dynClient, err := h.K8sClient.DynamicClientForUser(user.KubernetesUsername, user.KubernetesGroups)
+	if err != nil {
+		h.Logger.Error("failed to create impersonating client", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "internal error", "")
+		return
+	}
+
+	spec := map[string]any{}
+	if len(input.IncludedNamespaces) > 0 {
+		spec["includedNamespaces"] = input.IncludedNamespaces
+	}
+	if len(input.ExcludedNamespaces) > 0 {
+		spec["excludedNamespaces"] = input.ExcludedNamespaces
+	}
+	if input.StorageLocation != "" {
+		spec["storageLocation"] = input.StorageLocation
+	}
+	if input.TTL != "" {
+		spec["ttl"] = input.TTL
+	}
+	if input.SnapshotVolumes != nil {
+		spec["snapshotVolumes"] = *input.SnapshotVolumes
+	}
+
+	obj := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "velero.io/v1",
+			"kind":       "Backup",
+			"metadata": map[string]any{
+				"name":      input.Name,
+				"namespace": input.Namespace,
+				"labels":    input.Labels,
+			},
+			"spec": spec,
+		},
+	}
+
+	created, err := dynClient.Resource(BackupGVR).Namespace(input.Namespace).Create(r.Context(), obj, metav1.CreateOptions{})
+	if err != nil {
+		h.Logger.Error("failed to create backup", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to create backup", err.Error())
+		return
+	}
+
+	h.InvalidateCache()
+	h.auditLog(r, user, audit.ActionVeleroBackupCreate, "Backup", input.Namespace, input.Name, audit.ResultSuccess)
+
+	backup := parseBackup(created)
+	httputil.WriteData(w, backup)
+}
+
+// HandleDeleteBackup deletes a backup by creating a DeleteBackupRequest.
+func (h *Handler) HandleDeleteBackup(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	namespace := chi.URLParam(r, "namespace")
+	name := chi.URLParam(r, "name")
+
+	dynClient, err := h.K8sClient.DynamicClientForUser(user.KubernetesUsername, user.KubernetesGroups)
+	if err != nil {
+		h.Logger.Error("failed to create impersonating client", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "internal error", "")
+		return
+	}
+
+	// Create a DeleteBackupRequest to gracefully delete the backup
+	deleteRequest := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "velero.io/v1",
+			"kind":       "DeleteBackupRequest",
+			"metadata": map[string]any{
+				"name":      name + "-delete-" + time.Now().Format("20060102150405"),
+				"namespace": namespace,
+			},
+			"spec": map[string]any{
+				"backupName": name,
+			},
+		},
+	}
+
+	_, err = dynClient.Resource(DeleteBackupRequestGVR).Namespace(namespace).Create(r.Context(), deleteRequest, metav1.CreateOptions{})
+	if err != nil {
+		h.Logger.Error("failed to create delete backup request", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to delete backup", err.Error())
+		return
+	}
+
+	h.InvalidateCache()
+	h.auditLog(r, user, audit.ActionVeleroBackupDelete, "Backup", namespace, name, audit.ResultSuccess)
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// HandleGetBackupLogs creates a DownloadRequest and returns the presigned URL.
+func (h *Handler) HandleGetBackupLogs(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	namespace := chi.URLParam(r, "namespace")
+	name := chi.URLParam(r, "name")
+
+	if !h.canAccess(r.Context(), user, "get", "backups", namespace) {
+		httputil.WriteError(w, http.StatusForbidden, "access denied", "")
+		return
+	}
+
+	dynClient, err := h.K8sClient.DynamicClientForUser(user.KubernetesUsername, user.KubernetesGroups)
+	if err != nil {
+		h.Logger.Error("failed to create impersonating client", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "internal error", "")
+		return
+	}
+
+	url, err := h.requestBackupLogs(r.Context(), dynClient, namespace, name)
+	if err != nil {
+		h.Logger.Error("failed to get backup logs", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to get backup logs", err.Error())
+		return
+	}
+
+	httputil.WriteData(w, map[string]string{"url": url})
+}
+
+// ============================================================================
+// Restores
+// ============================================================================
+
+// HandleListRestores returns all Velero restores.
+func (h *Handler) HandleListRestores(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	status := h.Discoverer.Status(r.Context())
+	if !status.Detected {
+		httputil.WriteData(w, []Restore{})
+		return
+	}
+
+	restores, err := h.fetchRestores(r.Context())
+	if err != nil {
+		h.Logger.Error("failed to fetch restores", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to fetch restores", "")
+		return
+	}
+
+	// RBAC filter
+	if !h.canAccess(r.Context(), user, "list", "restores", "") {
+		httputil.WriteData(w, []Restore{})
+		return
+	}
+
+	// Sort by start time descending
+	sort.Slice(restores, func(i, j int) bool {
+		if restores[i].StartTime == nil {
+			return false
+		}
+		if restores[j].StartTime == nil {
+			return true
+		}
+		return restores[i].StartTime.After(*restores[j].StartTime)
+	})
+
+	httputil.WriteData(w, restores)
+}
+
+// HandleGetRestore returns a single restore.
+func (h *Handler) HandleGetRestore(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	namespace := chi.URLParam(r, "namespace")
+	name := chi.URLParam(r, "name")
+
+	if !h.canAccess(r.Context(), user, "get", "restores", namespace) {
+		httputil.WriteError(w, http.StatusForbidden, "access denied", "")
+		return
+	}
+
+	dynClient, err := h.K8sClient.DynamicClientForUser(user.KubernetesUsername, user.KubernetesGroups)
+	if err != nil {
+		h.Logger.Error("failed to create impersonating client", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "internal error", "")
+		return
+	}
+
+	restore, err := h.getRestore(r.Context(), dynClient, namespace, name)
+	if err != nil {
+		h.Logger.Error("failed to get restore", "namespace", namespace, "name", name, "error", err)
+		httputil.WriteError(w, http.StatusNotFound, "restore not found", "")
+		return
+	}
+
+	httputil.WriteData(w, restore)
+}
+
+// HandleCreateRestore creates a new restore.
+func (h *Handler) HandleCreateRestore(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	var input struct {
+		Name                   string            `json:"name"`
+		Namespace              string            `json:"namespace"`
+		BackupName             string            `json:"backupName"`
+		ScheduleName           string            `json:"scheduleName"`
+		IncludedNamespaces     []string          `json:"includedNamespaces"`
+		ExcludedNamespaces     []string          `json:"excludedNamespaces"`
+		NamespaceMapping       map[string]string `json:"namespaceMapping"`
+		ExistingResourcePolicy string            `json:"existingResourcePolicy"`
+		RestorePVs             *bool             `json:"restorePVs"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		httputil.WriteError(w, http.StatusBadRequest, "invalid request body", err.Error())
+		return
+	}
+
+	if input.Name == "" {
+		httputil.WriteError(w, http.StatusBadRequest, "name is required", "")
+		return
+	}
+	if input.BackupName == "" && input.ScheduleName == "" {
+		httputil.WriteError(w, http.StatusBadRequest, "backupName or scheduleName is required", "")
+		return
+	}
+	if input.Namespace == "" {
+		input.Namespace = "velero"
+	}
+
+	dynClient, err := h.K8sClient.DynamicClientForUser(user.KubernetesUsername, user.KubernetesGroups)
+	if err != nil {
+		h.Logger.Error("failed to create impersonating client", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "internal error", "")
+		return
+	}
+
+	spec := map[string]any{}
+	if input.BackupName != "" {
+		spec["backupName"] = input.BackupName
+	}
+	if input.ScheduleName != "" {
+		spec["scheduleName"] = input.ScheduleName
+	}
+	if len(input.IncludedNamespaces) > 0 {
+		spec["includedNamespaces"] = input.IncludedNamespaces
+	}
+	if len(input.ExcludedNamespaces) > 0 {
+		spec["excludedNamespaces"] = input.ExcludedNamespaces
+	}
+	if len(input.NamespaceMapping) > 0 {
+		spec["namespaceMapping"] = input.NamespaceMapping
+	}
+	if input.ExistingResourcePolicy != "" {
+		spec["existingResourcePolicy"] = input.ExistingResourcePolicy
+	}
+	if input.RestorePVs != nil {
+		spec["restorePVs"] = *input.RestorePVs
+	}
+
+	obj := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "velero.io/v1",
+			"kind":       "Restore",
+			"metadata": map[string]any{
+				"name":      input.Name,
+				"namespace": input.Namespace,
+			},
+			"spec": spec,
+		},
+	}
+
+	created, err := dynClient.Resource(RestoreGVR).Namespace(input.Namespace).Create(r.Context(), obj, metav1.CreateOptions{})
+	if err != nil {
+		h.Logger.Error("failed to create restore", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to create restore", err.Error())
+		return
+	}
+
+	h.InvalidateCache()
+	h.auditLog(r, user, audit.ActionVeleroRestoreCreate, "Restore", input.Namespace, input.Name, audit.ResultSuccess)
+
+	restore := parseRestore(created)
+	httputil.WriteData(w, restore)
+}
+
+// ============================================================================
+// Schedules
+// ============================================================================
+
+// HandleListSchedules returns all Velero schedules.
+func (h *Handler) HandleListSchedules(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	status := h.Discoverer.Status(r.Context())
+	if !status.Detected {
+		httputil.WriteData(w, []Schedule{})
+		return
+	}
+
+	schedules, err := h.fetchSchedules(r.Context())
+	if err != nil {
+		h.Logger.Error("failed to fetch schedules", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to fetch schedules", "")
+		return
+	}
+
+	// RBAC filter
+	if !h.canAccess(r.Context(), user, "list", "schedules", "") {
+		httputil.WriteData(w, []Schedule{})
+		return
+	}
+
+	// Sort by name
+	sort.Slice(schedules, func(i, j int) bool {
+		return schedules[i].Name < schedules[j].Name
+	})
+
+	httputil.WriteData(w, schedules)
+}
+
+// HandleGetSchedule returns a single schedule.
+func (h *Handler) HandleGetSchedule(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	namespace := chi.URLParam(r, "namespace")
+	name := chi.URLParam(r, "name")
+
+	if !h.canAccess(r.Context(), user, "get", "schedules", namespace) {
+		httputil.WriteError(w, http.StatusForbidden, "access denied", "")
+		return
+	}
+
+	dynClient, err := h.K8sClient.DynamicClientForUser(user.KubernetesUsername, user.KubernetesGroups)
+	if err != nil {
+		h.Logger.Error("failed to create impersonating client", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "internal error", "")
+		return
+	}
+
+	schedule, err := h.getSchedule(r.Context(), dynClient, namespace, name)
+	if err != nil {
+		h.Logger.Error("failed to get schedule", "namespace", namespace, "name", name, "error", err)
+		httputil.WriteError(w, http.StatusNotFound, "schedule not found", "")
+		return
+	}
+
+	httputil.WriteData(w, schedule)
+}
+
+// HandleCreateSchedule creates a new schedule.
+func (h *Handler) HandleCreateSchedule(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	var input struct {
+		Name               string   `json:"name"`
+		Namespace          string   `json:"namespace"`
+		Schedule           string   `json:"schedule"`
+		IncludedNamespaces []string `json:"includedNamespaces"`
+		ExcludedNamespaces []string `json:"excludedNamespaces"`
+		StorageLocation    string   `json:"storageLocation"`
+		TTL                string   `json:"ttl"`
+		SnapshotVolumes    *bool    `json:"snapshotVolumes"`
+		Paused             bool     `json:"paused"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		httputil.WriteError(w, http.StatusBadRequest, "invalid request body", err.Error())
+		return
+	}
+
+	if input.Name == "" {
+		httputil.WriteError(w, http.StatusBadRequest, "name is required", "")
+		return
+	}
+	if input.Schedule == "" {
+		httputil.WriteError(w, http.StatusBadRequest, "schedule is required", "")
+		return
+	}
+	if input.Namespace == "" {
+		input.Namespace = "velero"
+	}
+
+	// Validate cron expression
+	if _, err := cron.ParseStandard(input.Schedule); err != nil {
+		httputil.WriteError(w, http.StatusBadRequest, "invalid cron expression", err.Error())
+		return
+	}
+
+	dynClient, err := h.K8sClient.DynamicClientForUser(user.KubernetesUsername, user.KubernetesGroups)
+	if err != nil {
+		h.Logger.Error("failed to create impersonating client", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "internal error", "")
+		return
+	}
+
+	template := map[string]any{}
+	if len(input.IncludedNamespaces) > 0 {
+		template["includedNamespaces"] = input.IncludedNamespaces
+	}
+	if len(input.ExcludedNamespaces) > 0 {
+		template["excludedNamespaces"] = input.ExcludedNamespaces
+	}
+	if input.StorageLocation != "" {
+		template["storageLocation"] = input.StorageLocation
+	}
+	if input.TTL != "" {
+		template["ttl"] = input.TTL
+	}
+	if input.SnapshotVolumes != nil {
+		template["snapshotVolumes"] = *input.SnapshotVolumes
+	}
+
+	obj := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "velero.io/v1",
+			"kind":       "Schedule",
+			"metadata": map[string]any{
+				"name":      input.Name,
+				"namespace": input.Namespace,
+			},
+			"spec": map[string]any{
+				"schedule": input.Schedule,
+				"paused":   input.Paused,
+				"template": template,
+			},
+		},
+	}
+
+	created, err := dynClient.Resource(ScheduleGVR).Namespace(input.Namespace).Create(r.Context(), obj, metav1.CreateOptions{})
+	if err != nil {
+		h.Logger.Error("failed to create schedule", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to create schedule", err.Error())
+		return
+	}
+
+	h.InvalidateCache()
+	h.auditLog(r, user, audit.ActionVeleroScheduleCreate, "Schedule", input.Namespace, input.Name, audit.ResultSuccess)
+
+	schedule := parseSchedule(created)
+	httputil.WriteData(w, schedule)
+}
+
+// HandleUpdateSchedule updates a schedule (pause/resume or full update).
+func (h *Handler) HandleUpdateSchedule(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	namespace := chi.URLParam(r, "namespace")
+	name := chi.URLParam(r, "name")
+
+	var input struct {
+		Paused   *bool  `json:"paused"`
+		Schedule string `json:"schedule"`
+		TTL      string `json:"ttl"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		httputil.WriteError(w, http.StatusBadRequest, "invalid request body", err.Error())
+		return
+	}
+
+	dynClient, err := h.K8sClient.DynamicClientForUser(user.KubernetesUsername, user.KubernetesGroups)
+	if err != nil {
+		h.Logger.Error("failed to create impersonating client", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "internal error", "")
+		return
+	}
+
+	// Get existing schedule
+	existing, err := dynClient.Resource(ScheduleGVR).Namespace(namespace).Get(r.Context(), name, metav1.GetOptions{})
+	if err != nil {
+		h.Logger.Error("failed to get schedule", "error", err)
+		httputil.WriteError(w, http.StatusNotFound, "schedule not found", "")
+		return
+	}
+
+	spec, _, _ := unstructured.NestedMap(existing.Object, "spec")
+	if spec == nil {
+		spec = map[string]any{}
+	}
+
+	if input.Paused != nil {
+		spec["paused"] = *input.Paused
+	}
+	if input.Schedule != "" {
+		if _, err := cron.ParseStandard(input.Schedule); err != nil {
+			httputil.WriteError(w, http.StatusBadRequest, "invalid cron expression", err.Error())
+			return
+		}
+		spec["schedule"] = input.Schedule
+	}
+	if input.TTL != "" {
+		template, _, _ := unstructured.NestedMap(spec, "template")
+		if template == nil {
+			template = map[string]any{}
+		}
+		template["ttl"] = input.TTL
+		spec["template"] = template
+	}
+
+	if err := unstructured.SetNestedMap(existing.Object, spec, "spec"); err != nil {
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to update spec", err.Error())
+		return
+	}
+
+	updated, err := dynClient.Resource(ScheduleGVR).Namespace(namespace).Update(r.Context(), existing, metav1.UpdateOptions{})
+	if err != nil {
+		h.Logger.Error("failed to update schedule", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to update schedule", err.Error())
+		return
+	}
+
+	h.InvalidateCache()
+	h.auditLog(r, user, audit.ActionVeleroScheduleUpdate, "Schedule", namespace, name, audit.ResultSuccess)
+
+	schedule := parseSchedule(updated)
+	httputil.WriteData(w, schedule)
+}
+
+// HandleDeleteSchedule deletes a schedule.
+func (h *Handler) HandleDeleteSchedule(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	namespace := chi.URLParam(r, "namespace")
+	name := chi.URLParam(r, "name")
+
+	dynClient, err := h.K8sClient.DynamicClientForUser(user.KubernetesUsername, user.KubernetesGroups)
+	if err != nil {
+		h.Logger.Error("failed to create impersonating client", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "internal error", "")
+		return
+	}
+
+	err = dynClient.Resource(ScheduleGVR).Namespace(namespace).Delete(r.Context(), name, metav1.DeleteOptions{})
+	if err != nil {
+		h.Logger.Error("failed to delete schedule", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to delete schedule", err.Error())
+		return
+	}
+
+	h.InvalidateCache()
+	h.auditLog(r, user, audit.ActionVeleroScheduleDelete, "Schedule", namespace, name, audit.ResultSuccess)
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// HandleTriggerSchedule creates an on-demand backup from a schedule.
+func (h *Handler) HandleTriggerSchedule(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	namespace := chi.URLParam(r, "namespace")
+	name := chi.URLParam(r, "name")
+
+	dynClient, err := h.K8sClient.DynamicClientForUser(user.KubernetesUsername, user.KubernetesGroups)
+	if err != nil {
+		h.Logger.Error("failed to create impersonating client", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "internal error", "")
+		return
+	}
+
+	// Get schedule to copy template
+	scheduleObj, err := dynClient.Resource(ScheduleGVR).Namespace(namespace).Get(r.Context(), name, metav1.GetOptions{})
+	if err != nil {
+		h.Logger.Error("failed to get schedule", "error", err)
+		httputil.WriteError(w, http.StatusNotFound, "schedule not found", "")
+		return
+	}
+
+	template, _, _ := unstructured.NestedMap(scheduleObj.Object, "spec", "template")
+	if template == nil {
+		template = map[string]any{}
+	}
+
+	backupName := fmt.Sprintf("%s-manual-%s", name, time.Now().Format("20060102150405"))
+
+	backupObj := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "velero.io/v1",
+			"kind":       "Backup",
+			"metadata": map[string]any{
+				"name":      backupName,
+				"namespace": namespace,
+				"labels": map[string]any{
+					"velero.io/schedule-name": name,
+				},
+			},
+			"spec": template,
+		},
+	}
+
+	created, err := dynClient.Resource(BackupGVR).Namespace(namespace).Create(r.Context(), backupObj, metav1.CreateOptions{})
+	if err != nil {
+		h.Logger.Error("failed to trigger backup", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to trigger backup", err.Error())
+		return
+	}
+
+	h.InvalidateCache()
+	h.auditLog(r, user, audit.ActionVeleroScheduleTrigger, "Backup", namespace, name, audit.ResultSuccess)
+
+	backup := parseBackup(created)
+	httputil.WriteData(w, backup)
+}
+
+// ============================================================================
+// Locations
+// ============================================================================
+
+// HandleListLocations returns BSLs and VSLs.
+func (h *Handler) HandleListLocations(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	status := h.Discoverer.Status(r.Context())
+	if !status.Detected {
+		httputil.WriteData(w, &LocationsResponse{
+			BackupStorageLocations:  []BackupStorageLocation{},
+			VolumeSnapshotLocations: []VolumeSnapshotLocation{},
+		})
+		return
+	}
+
+	locations, err := h.fetchLocations(r.Context())
+	if err != nil {
+		h.Logger.Error("failed to fetch locations", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to fetch locations", "")
+		return
+	}
+
+	// RBAC filter
+	if !h.canAccess(r.Context(), user, "list", "backupstoragelocations", "") {
+		locations.BackupStorageLocations = []BackupStorageLocation{}
+	}
+	if !h.canAccess(r.Context(), user, "list", "volumesnapshotlocations", "") {
+		locations.VolumeSnapshotLocations = []VolumeSnapshotLocation{}
+	}
+
+	httputil.WriteData(w, locations)
+}
+
+// ============================================================================
+// Fetch helpers with caching
+// ============================================================================
+
+func (h *Handler) fetchBackups(ctx context.Context) ([]Backup, error) {
+	h.cacheMu.RLock()
+	if h.cachedData != nil && time.Since(h.cachedData.fetchedAt) < cacheTTL {
+		backups := h.cachedData.backups
+		h.cacheMu.RUnlock()
+		return backups, nil
+	}
+	h.cacheMu.RUnlock()
+
+	result, err, _ := h.fetchGroup.Do("backups", func() (any, error) {
+		return h.doFetchBackups(ctx)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.([]Backup), nil
+}
+
+func (h *Handler) doFetchBackups(ctx context.Context) ([]Backup, error) {
+	dynClient := h.K8sClient.BaseDynamicClient()
+
+	list, err := dynClient.Resource(BackupGVR).Namespace("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	backups := make([]Backup, 0, len(list.Items))
+	for _, item := range list.Items {
+		backups = append(backups, parseBackup(&item))
+	}
+
+	return backups, nil
+}
+
+func (h *Handler) fetchRestores(ctx context.Context) ([]Restore, error) {
+	result, err, _ := h.fetchGroup.Do("restores", func() (any, error) {
+		dynClient := h.K8sClient.BaseDynamicClient()
+		list, err := dynClient.Resource(RestoreGVR).Namespace("").List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return nil, err
+		}
+		restores := make([]Restore, 0, len(list.Items))
+		for _, item := range list.Items {
+			restores = append(restores, parseRestore(&item))
+		}
+		return restores, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.([]Restore), nil
+}
+
+func (h *Handler) fetchSchedules(ctx context.Context) ([]Schedule, error) {
+	result, err, _ := h.fetchGroup.Do("schedules", func() (any, error) {
+		dynClient := h.K8sClient.BaseDynamicClient()
+		list, err := dynClient.Resource(ScheduleGVR).Namespace("").List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return nil, err
+		}
+		schedules := make([]Schedule, 0, len(list.Items))
+		for _, item := range list.Items {
+			schedules = append(schedules, parseSchedule(&item))
+		}
+		return schedules, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.([]Schedule), nil
+}
+
+func (h *Handler) fetchLocations(ctx context.Context) (*LocationsResponse, error) {
+	result, err, _ := h.fetchGroup.Do("locations", func() (any, error) {
+		dynClient := h.K8sClient.BaseDynamicClient()
+
+		bslList, err := dynClient.Resource(BackupStorageLocationGVR).Namespace("").List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return nil, err
+		}
+		bsls := make([]BackupStorageLocation, 0, len(bslList.Items))
+		for _, item := range bslList.Items {
+			bsls = append(bsls, parseBSL(&item))
+		}
+
+		vslList, err := dynClient.Resource(VolumeSnapshotLocationGVR).Namespace("").List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return nil, err
+		}
+		vsls := make([]VolumeSnapshotLocation, 0, len(vslList.Items))
+		for _, item := range vslList.Items {
+			vsls = append(vsls, parseVSL(&item))
+		}
+
+		return &LocationsResponse{
+			BackupStorageLocations:  bsls,
+			VolumeSnapshotLocations: vsls,
+		}, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*LocationsResponse), nil
+}
+
+// ============================================================================
+// Single-item fetchers with impersonation
+// ============================================================================
+
+func (h *Handler) getBackup(ctx context.Context, client dynamic.Interface, namespace, name string) (*Backup, error) {
+	obj, err := client.Resource(BackupGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	backup := parseBackup(obj)
+	return &backup, nil
+}
+
+func (h *Handler) getRestore(ctx context.Context, client dynamic.Interface, namespace, name string) (*Restore, error) {
+	obj, err := client.Resource(RestoreGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	restore := parseRestore(obj)
+	return &restore, nil
+}
+
+func (h *Handler) getSchedule(ctx context.Context, client dynamic.Interface, namespace, name string) (*Schedule, error) {
+	obj, err := client.Resource(ScheduleGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	schedule := parseSchedule(obj)
+	return &schedule, nil
+}
+
+func (h *Handler) requestBackupLogs(ctx context.Context, client dynamic.Interface, namespace, backupName string) (string, error) {
+	// Create a DownloadRequest
+	requestName := fmt.Sprintf("%s-logs-%s", backupName, time.Now().Format("20060102150405"))
+
+	downloadReq := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "velero.io/v1",
+			"kind":       "DownloadRequest",
+			"metadata": map[string]any{
+				"name":      requestName,
+				"namespace": namespace,
+			},
+			"spec": map[string]any{
+				"target": map[string]any{
+					"kind": "BackupLog",
+					"name": backupName,
+				},
+			},
+		},
+	}
+
+	_, err := client.Resource(DownloadRequestGVR).Namespace(namespace).Create(ctx, downloadReq, metav1.CreateOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to create download request: %w", err)
+	}
+
+	// Poll for completion (max 30 seconds)
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		req, err := client.Resource(DownloadRequestGVR).Namespace(namespace).Get(ctx, requestName, metav1.GetOptions{})
+		if err != nil {
+			return "", err
+		}
+
+		phase, _, _ := unstructured.NestedString(req.Object, "status", "phase")
+		if phase == "Processed" {
+			url, _, _ := unstructured.NestedString(req.Object, "status", "downloadURL")
+			return url, nil
+		}
+
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	return "", fmt.Errorf("timeout waiting for download request to be processed")
+}
+
+// ============================================================================
+// Parse helpers
+// ============================================================================
+
+func parseBackup(obj *unstructured.Unstructured) Backup {
+	spec, _, _ := unstructured.NestedMap(obj.Object, "spec")
+	status, _, _ := unstructured.NestedMap(obj.Object, "status")
+
+	backup := Backup{
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+		Labels:    obj.GetLabels(),
+	}
+
+	// Spec fields
+	if spec != nil {
+		backup.IncludedNamespaces = getStringSlice(spec, "includedNamespaces")
+		backup.ExcludedNamespaces = getStringSlice(spec, "excludedNamespaces")
+		backup.StorageLocation, _, _ = unstructured.NestedString(spec, "storageLocation")
+		backup.TTL, _, _ = unstructured.NestedString(spec, "ttl")
+		backup.SnapshotVolumes, _, _ = unstructured.NestedBool(spec, "snapshotVolumes")
+	}
+
+	// Status fields
+	if status != nil {
+		backup.Phase, _, _ = unstructured.NestedString(status, "phase")
+		backup.StartTime = getTime(status, "startTimestamp")
+		backup.CompletionTime = getTime(status, "completionTimestamp")
+		backup.Expiration = getTime(status, "expiration")
+		backup.ItemsBackedUp = getInt(status, "progress", "itemsBackedUp")
+		backup.TotalItems = getInt(status, "progress", "totalItems")
+		backup.Warnings = getInt(status, "warnings")
+		backup.Errors = getInt(status, "errors")
+	}
+
+	// Schedule name from label
+	if labels := obj.GetLabels(); labels != nil {
+		backup.ScheduleName = labels["velero.io/schedule-name"]
+	}
+
+	return backup
+}
+
+func parseRestore(obj *unstructured.Unstructured) Restore {
+	spec, _, _ := unstructured.NestedMap(obj.Object, "spec")
+	status, _, _ := unstructured.NestedMap(obj.Object, "status")
+
+	restore := Restore{
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+	}
+
+	// Spec fields
+	if spec != nil {
+		restore.BackupName, _, _ = unstructured.NestedString(spec, "backupName")
+		restore.ScheduleName, _, _ = unstructured.NestedString(spec, "scheduleName")
+		restore.IncludedNamespaces = getStringSlice(spec, "includedNamespaces")
+		nsMapping, _, _ := unstructured.NestedStringMap(spec, "namespaceMapping")
+		if len(nsMapping) > 0 {
+			restore.NamespaceMapping = nsMapping
+		}
+	}
+
+	// Status fields
+	if status != nil {
+		restore.Phase, _, _ = unstructured.NestedString(status, "phase")
+		restore.StartTime = getTime(status, "startTimestamp")
+		restore.CompletionTime = getTime(status, "completionTimestamp")
+		restore.ItemsRestored = getInt(status, "progress", "itemsRestored")
+		restore.TotalItems = getInt(status, "progress", "totalItems")
+		restore.Warnings = getInt(status, "warnings")
+		restore.Errors = getInt(status, "errors")
+		restore.FailureReason, _, _ = unstructured.NestedString(status, "failureReason")
+	}
+
+	return restore
+}
+
+func parseSchedule(obj *unstructured.Unstructured) Schedule {
+	spec, _, _ := unstructured.NestedMap(obj.Object, "spec")
+	status, _, _ := unstructured.NestedMap(obj.Object, "status")
+
+	schedule := Schedule{
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+	}
+
+	// Spec fields
+	if spec != nil {
+		schedule.Schedule, _, _ = unstructured.NestedString(spec, "schedule")
+		schedule.Paused, _, _ = unstructured.NestedBool(spec, "paused")
+
+		template, _, _ := unstructured.NestedMap(spec, "template")
+		if template != nil {
+			schedule.IncludedNamespaces = getStringSlice(template, "includedNamespaces")
+			schedule.TTL, _, _ = unstructured.NestedString(template, "ttl")
+			schedule.StorageLocation, _, _ = unstructured.NestedString(template, "storageLocation")
+		}
+	}
+
+	// Status fields
+	if status != nil {
+		schedule.Phase, _, _ = unstructured.NestedString(status, "phase")
+		schedule.LastBackup = getTime(status, "lastBackup")
+
+		validationErrors, _, _ := unstructured.NestedStringSlice(status, "validationErrors")
+		if len(validationErrors) > 0 {
+			schedule.ValidationErrors = validationErrors
+		}
+	}
+
+	// Compute next run time
+	if schedule.Schedule != "" && !schedule.Paused && schedule.Phase == "Enabled" {
+		schedule.NextRunTime = computeNextRun(schedule.Schedule, schedule.LastBackup)
+	}
+
+	return schedule
+}
+
+func parseBSL(obj *unstructured.Unstructured) BackupStorageLocation {
+	spec, _, _ := unstructured.NestedMap(obj.Object, "spec")
+	status, _, _ := unstructured.NestedMap(obj.Object, "status")
+
+	bsl := BackupStorageLocation{
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+	}
+
+	if spec != nil {
+		bsl.Provider, _, _ = unstructured.NestedString(spec, "provider")
+		bsl.Bucket, _, _ = unstructured.NestedString(spec, "objectStorage", "bucket")
+		bsl.Prefix, _, _ = unstructured.NestedString(spec, "objectStorage", "prefix")
+		bsl.Default, _, _ = unstructured.NestedBool(spec, "default")
+	}
+
+	if status != nil {
+		bsl.Phase, _, _ = unstructured.NestedString(status, "phase")
+		bsl.LastSyncedTime = getTime(status, "lastSyncedTime")
+		bsl.Message, _, _ = unstructured.NestedString(status, "message")
+	}
+
+	return bsl
+}
+
+func parseVSL(obj *unstructured.Unstructured) VolumeSnapshotLocation {
+	spec, _, _ := unstructured.NestedMap(obj.Object, "spec")
+
+	vsl := VolumeSnapshotLocation{
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+	}
+
+	if spec != nil {
+		vsl.Provider, _, _ = unstructured.NestedString(spec, "provider")
+	}
+
+	return vsl
+}
+
+// ============================================================================
+// Utility functions
+// ============================================================================
+
+func getStringSlice(m map[string]any, key string) []string {
+	val, found, _ := unstructured.NestedStringSlice(m, key)
+	if !found {
+		return nil
+	}
+	return val
+}
+
+func getInt(m map[string]any, keys ...string) int {
+	val, found, _ := unstructured.NestedInt64(m, keys...)
+	if !found {
+		return 0
+	}
+	return int(val)
+}
+
+func getTime(m map[string]any, key string) *time.Time {
+	val, found, _ := unstructured.NestedString(m, key)
+	if !found || val == "" {
+		return nil
+	}
+	t, err := time.Parse(time.RFC3339, val)
+	if err != nil {
+		return nil
+	}
+	return &t
+}
+
+func computeNextRun(cronExpr string, lastRun *time.Time) *time.Time {
+	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+	sched, err := parser.Parse(cronExpr)
+	if err != nil {
+		// Try standard parser
+		sched, err = cron.ParseStandard(cronExpr)
+		if err != nil {
+			return nil
+		}
+	}
+
+	var from time.Time
+	if lastRun != nil {
+		from = *lastRun
+	} else {
+		from = time.Now()
+	}
+
+	// Ensure we start from at least now
+	if from.Before(time.Now()) {
+		from = time.Now()
+	}
+
+	next := sched.Next(from)
+	return &next
+}
+
+// stringSliceContains checks if a string slice contains a value.
+func stringSliceContains(slice []string, val string) bool {
+	for _, s := range slice {
+		if strings.EqualFold(s, val) {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/velero/handler.go
+++ b/backend/internal/velero/handler.go
@@ -6,13 +6,15 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"regexp"
+	"slices"
 	"sort"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/robfig/cron/v3"
+	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/singleflight"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -23,8 +25,12 @@ import (
 	"github.com/kubecenter/kubecenter/internal/httputil"
 	"github.com/kubecenter/kubecenter/internal/k8s"
 	"github.com/kubecenter/kubecenter/internal/k8s/resources"
+	"github.com/kubecenter/kubecenter/internal/notifications"
 	"github.com/kubecenter/kubecenter/internal/server/middleware"
 )
+
+// dnsLabelRegex validates DNS label names (RFC 1123).
+var dnsLabelRegex = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
 
 const cacheTTL = 30 * time.Second
 
@@ -34,6 +40,7 @@ type Handler struct {
 	Discoverer    *Discoverer
 	AccessChecker *resources.AccessChecker
 	AuditLogger   audit.Logger
+	NotifService  *notifications.NotificationService
 	Logger        *slog.Logger
 
 	fetchGroup singleflight.Group
@@ -56,6 +63,7 @@ func NewHandler(
 	discoverer *Discoverer,
 	accessChecker *resources.AccessChecker,
 	auditLogger audit.Logger,
+	notifService *notifications.NotificationService,
 	logger *slog.Logger,
 ) *Handler {
 	return &Handler{
@@ -63,16 +71,42 @@ func NewHandler(
 		Discoverer:    discoverer,
 		AccessChecker: accessChecker,
 		AuditLogger:   auditLogger,
+		NotifService:  notifService,
 		Logger:        logger,
 	}
 }
 
-// InvalidateCache clears the cached data.
+// InvalidateCache clears the cached data and emits a notification.
 func (h *Handler) InvalidateCache() {
 	h.cacheMu.Lock()
 	h.cacheGen++
 	h.cachedData = nil
 	h.cacheMu.Unlock()
+
+	if h.NotifService != nil {
+		go h.NotifService.Emit(context.Background(), notifications.Notification{
+			Source:   notifications.SourceVelero,
+			Severity: notifications.SeverityInfo,
+			Title:    "Velero data updated",
+			Message:  "Backup or restore data has changed",
+		})
+	}
+}
+
+// getImpersonatingClient creates a dynamic client impersonating the user and handles errors.
+func (h *Handler) getImpersonatingClient(w http.ResponseWriter, user *auth.User) (dynamic.Interface, bool) {
+	client, err := h.K8sClient.DynamicClientForUser(user.KubernetesUsername, user.KubernetesGroups)
+	if err != nil {
+		h.Logger.Error("failed to create impersonating client", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "internal error", "")
+		return nil, false
+	}
+	return client, true
+}
+
+// validateDNSLabel validates that a string is a valid DNS label.
+func validateDNSLabel(s string) bool {
+	return len(s) > 0 && len(s) <= 63 && dnsLabelRegex.MatchString(s)
 }
 
 // canAccess checks if the user can access a Velero resource.
@@ -220,18 +254,27 @@ func (h *Handler) HandleCreateBackup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if input.Name == "" {
-		httputil.WriteError(w, http.StatusBadRequest, "name is required", "")
+	// Validate DNS label names
+	if !validateDNSLabel(input.Name) {
+		httputil.WriteError(w, http.StatusBadRequest, "name must be a valid DNS label (lowercase, 1-63 chars)", "")
 		return
 	}
 	if input.Namespace == "" {
 		input.Namespace = "velero"
 	}
+	if !validateDNSLabel(input.Namespace) {
+		httputil.WriteError(w, http.StatusBadRequest, "namespace must be a valid DNS label", "")
+		return
+	}
 
-	dynClient, err := h.K8sClient.DynamicClientForUser(user.KubernetesUsername, user.KubernetesGroups)
-	if err != nil {
-		h.Logger.Error("failed to create impersonating client", "error", err)
-		httputil.WriteError(w, http.StatusInternalServerError, "internal error", "")
+	// RBAC pre-check
+	if !h.canAccess(r.Context(), user, "create", "backups", input.Namespace) {
+		httputil.WriteError(w, http.StatusForbidden, "access denied", "")
+		return
+	}
+
+	dynClient, ok := h.getImpersonatingClient(w, user)
+	if !ok {
 		return
 	}
 
@@ -289,11 +332,31 @@ func (h *Handler) HandleDeleteBackup(w http.ResponseWriter, r *http.Request) {
 	namespace := chi.URLParam(r, "namespace")
 	name := chi.URLParam(r, "name")
 
-	dynClient, err := h.K8sClient.DynamicClientForUser(user.KubernetesUsername, user.KubernetesGroups)
-	if err != nil {
-		h.Logger.Error("failed to create impersonating client", "error", err)
-		httputil.WriteError(w, http.StatusInternalServerError, "internal error", "")
+	// RBAC pre-check
+	if !h.canAccess(r.Context(), user, "delete", "backups", namespace) {
+		httputil.WriteError(w, http.StatusForbidden, "access denied", "")
 		return
+	}
+
+	dynClient, ok := h.getImpersonatingClient(w, user)
+	if !ok {
+		return
+	}
+
+	// Check for dependent restores that reference this backup
+	restores, err := h.fetchRestores(r.Context())
+	if err == nil {
+		for _, restore := range restores {
+			if restore.BackupName == name && restore.Namespace == namespace {
+				// Only block if restore is in progress
+				if restore.Phase == "InProgress" || restore.Phase == "New" || restore.Phase == "WaitingForPluginOperations" {
+					httputil.WriteError(w, http.StatusConflict,
+						"cannot delete backup with in-progress restore",
+						fmt.Sprintf("restore %s/%s is using this backup", restore.Namespace, restore.Name))
+					return
+				}
+			}
+		}
 	}
 
 	// Create a DeleteBackupRequest to gracefully delete the backup
@@ -455,8 +518,9 @@ func (h *Handler) HandleCreateRestore(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if input.Name == "" {
-		httputil.WriteError(w, http.StatusBadRequest, "name is required", "")
+	// Validate DNS label names
+	if !validateDNSLabel(input.Name) {
+		httputil.WriteError(w, http.StatusBadRequest, "name must be a valid DNS label (lowercase, 1-63 chars)", "")
 		return
 	}
 	if input.BackupName == "" && input.ScheduleName == "" {
@@ -466,12 +530,39 @@ func (h *Handler) HandleCreateRestore(w http.ResponseWriter, r *http.Request) {
 	if input.Namespace == "" {
 		input.Namespace = "velero"
 	}
-
-	dynClient, err := h.K8sClient.DynamicClientForUser(user.KubernetesUsername, user.KubernetesGroups)
-	if err != nil {
-		h.Logger.Error("failed to create impersonating client", "error", err)
-		httputil.WriteError(w, http.StatusInternalServerError, "internal error", "")
+	if !validateDNSLabel(input.Namespace) {
+		httputil.WriteError(w, http.StatusBadRequest, "namespace must be a valid DNS label", "")
 		return
+	}
+
+	// Validate existingResourcePolicy enum
+	if input.ExistingResourcePolicy != "" && !slices.Contains([]string{"none", "update"}, input.ExistingResourcePolicy) {
+		httputil.WriteError(w, http.StatusBadRequest, "existingResourcePolicy must be 'none' or 'update'", "")
+		return
+	}
+
+	// RBAC pre-check
+	if !h.canAccess(r.Context(), user, "create", "restores", input.Namespace) {
+		httputil.WriteError(w, http.StatusForbidden, "access denied", "")
+		return
+	}
+
+	dynClient, ok := h.getImpersonatingClient(w, user)
+	if !ok {
+		return
+	}
+
+	// Validate backup exists and is completed (if backupName is specified)
+	if input.BackupName != "" {
+		backup, err := h.getBackup(r.Context(), dynClient, input.Namespace, input.BackupName)
+		if err != nil {
+			httputil.WriteError(w, http.StatusBadRequest, "backup not found", input.BackupName)
+			return
+		}
+		if backup.Phase != "Completed" && backup.Phase != "PartiallyFailed" {
+			httputil.WriteError(w, http.StatusBadRequest, "backup must be Completed or PartiallyFailed", backup.Phase)
+			return
+		}
 	}
 
 	spec := map[string]any{}
@@ -616,8 +707,9 @@ func (h *Handler) HandleCreateSchedule(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if input.Name == "" {
-		httputil.WriteError(w, http.StatusBadRequest, "name is required", "")
+	// Validate DNS label names
+	if !validateDNSLabel(input.Name) {
+		httputil.WriteError(w, http.StatusBadRequest, "name must be a valid DNS label (lowercase, 1-63 chars)", "")
 		return
 	}
 	if input.Schedule == "" {
@@ -627,6 +719,10 @@ func (h *Handler) HandleCreateSchedule(w http.ResponseWriter, r *http.Request) {
 	if input.Namespace == "" {
 		input.Namespace = "velero"
 	}
+	if !validateDNSLabel(input.Namespace) {
+		httputil.WriteError(w, http.StatusBadRequest, "namespace must be a valid DNS label", "")
+		return
+	}
 
 	// Validate cron expression
 	if _, err := cron.ParseStandard(input.Schedule); err != nil {
@@ -634,10 +730,14 @@ func (h *Handler) HandleCreateSchedule(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	dynClient, err := h.K8sClient.DynamicClientForUser(user.KubernetesUsername, user.KubernetesGroups)
-	if err != nil {
-		h.Logger.Error("failed to create impersonating client", "error", err)
-		httputil.WriteError(w, http.StatusInternalServerError, "internal error", "")
+	// RBAC pre-check
+	if !h.canAccess(r.Context(), user, "create", "schedules", input.Namespace) {
+		httputil.WriteError(w, http.StatusForbidden, "access denied", "")
+		return
+	}
+
+	dynClient, ok := h.getImpersonatingClient(w, user)
+	if !ok {
 		return
 	}
 
@@ -899,109 +999,158 @@ func (h *Handler) HandleListLocations(w http.ResponseWriter, r *http.Request) {
 // Fetch helpers with caching
 // ============================================================================
 
-func (h *Handler) fetchBackups(ctx context.Context) ([]Backup, error) {
+// fetchAll fetches all Velero data in parallel and caches the result.
+func (h *Handler) fetchAll(ctx context.Context) (*cachedVeleroData, error) {
 	h.cacheMu.RLock()
 	if h.cachedData != nil && time.Since(h.cachedData.fetchedAt) < cacheTTL {
-		backups := h.cachedData.backups
+		data := h.cachedData
 		h.cacheMu.RUnlock()
-		return backups, nil
+		return data, nil
 	}
+	gen := h.cacheGen
 	h.cacheMu.RUnlock()
 
-	result, err, _ := h.fetchGroup.Do("backups", func() (any, error) {
-		return h.doFetchBackups(ctx)
+	result, err, _ := h.fetchGroup.Do("all", func() (any, error) {
+		return h.doFetchAll(ctx, gen)
 	})
 	if err != nil {
 		return nil, err
 	}
-	return result.([]Backup), nil
+	return result.(*cachedVeleroData), nil
 }
 
-func (h *Handler) doFetchBackups(ctx context.Context) ([]Backup, error) {
+func (h *Handler) doFetchAll(ctx context.Context, gen uint64) (*cachedVeleroData, error) {
+	// Add timeout to prevent hanging on slow k8s API
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
 	dynClient := h.K8sClient.BaseDynamicClient()
 
-	list, err := dynClient.Resource(BackupGVR).Namespace("").List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
+	var (
+		backups   []Backup
+		restores  []Restore
+		schedules []Schedule
+		bsls      []BackupStorageLocation
+		vsls      []VolumeSnapshotLocation
+	)
 
-	backups := make([]Backup, 0, len(list.Items))
-	for _, item := range list.Items {
-		backups = append(backups, parseBackup(&item))
-	}
+	g, gctx := errgroup.WithContext(ctx)
 
-	return backups, nil
-}
-
-func (h *Handler) fetchRestores(ctx context.Context) ([]Restore, error) {
-	result, err, _ := h.fetchGroup.Do("restores", func() (any, error) {
-		dynClient := h.K8sClient.BaseDynamicClient()
-		list, err := dynClient.Resource(RestoreGVR).Namespace("").List(ctx, metav1.ListOptions{})
+	g.Go(func() error {
+		list, err := dynClient.Resource(BackupGVR).Namespace("").List(gctx, metav1.ListOptions{})
 		if err != nil {
-			return nil, err
+			return err
 		}
-		restores := make([]Restore, 0, len(list.Items))
+		backups = make([]Backup, 0, len(list.Items))
+		for _, item := range list.Items {
+			backups = append(backups, parseBackup(&item))
+		}
+		return nil
+	})
+
+	g.Go(func() error {
+		list, err := dynClient.Resource(RestoreGVR).Namespace("").List(gctx, metav1.ListOptions{})
+		if err != nil {
+			return err
+		}
+		restores = make([]Restore, 0, len(list.Items))
 		for _, item := range list.Items {
 			restores = append(restores, parseRestore(&item))
 		}
-		return restores, nil
+		return nil
 	})
-	if err != nil {
-		return nil, err
-	}
-	return result.([]Restore), nil
-}
 
-func (h *Handler) fetchSchedules(ctx context.Context) ([]Schedule, error) {
-	result, err, _ := h.fetchGroup.Do("schedules", func() (any, error) {
-		dynClient := h.K8sClient.BaseDynamicClient()
-		list, err := dynClient.Resource(ScheduleGVR).Namespace("").List(ctx, metav1.ListOptions{})
+	g.Go(func() error {
+		list, err := dynClient.Resource(ScheduleGVR).Namespace("").List(gctx, metav1.ListOptions{})
 		if err != nil {
-			return nil, err
+			return err
 		}
-		schedules := make([]Schedule, 0, len(list.Items))
+		schedules = make([]Schedule, 0, len(list.Items))
 		for _, item := range list.Items {
 			schedules = append(schedules, parseSchedule(&item))
 		}
-		return schedules, nil
+		return nil
 	})
+
+	g.Go(func() error {
+		list, err := dynClient.Resource(BackupStorageLocationGVR).Namespace("").List(gctx, metav1.ListOptions{})
+		if err != nil {
+			return err
+		}
+		bsls = make([]BackupStorageLocation, 0, len(list.Items))
+		for _, item := range list.Items {
+			bsls = append(bsls, parseBSL(&item))
+		}
+		return nil
+	})
+
+	g.Go(func() error {
+		list, err := dynClient.Resource(VolumeSnapshotLocationGVR).Namespace("").List(gctx, metav1.ListOptions{})
+		if err != nil {
+			return err
+		}
+		vsls = make([]VolumeSnapshotLocation, 0, len(list.Items))
+		for _, item := range list.Items {
+			vsls = append(vsls, parseVSL(&item))
+		}
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	data := &cachedVeleroData{
+		backups:   backups,
+		restores:  restores,
+		schedules: schedules,
+		locations: &LocationsResponse{
+			BackupStorageLocations:  bsls,
+			VolumeSnapshotLocations: vsls,
+		},
+		fetchedAt: time.Now(),
+	}
+
+	// Store in cache if not invalidated
+	h.cacheMu.Lock()
+	if h.cacheGen == gen {
+		h.cachedData = data
+	}
+	h.cacheMu.Unlock()
+
+	return data, nil
+}
+
+func (h *Handler) fetchBackups(ctx context.Context) ([]Backup, error) {
+	data, err := h.fetchAll(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return result.([]Schedule), nil
+	return data.backups, nil
+}
+
+func (h *Handler) fetchRestores(ctx context.Context) ([]Restore, error) {
+	data, err := h.fetchAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return data.restores, nil
+}
+
+func (h *Handler) fetchSchedules(ctx context.Context) ([]Schedule, error) {
+	data, err := h.fetchAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return data.schedules, nil
 }
 
 func (h *Handler) fetchLocations(ctx context.Context) (*LocationsResponse, error) {
-	result, err, _ := h.fetchGroup.Do("locations", func() (any, error) {
-		dynClient := h.K8sClient.BaseDynamicClient()
-
-		bslList, err := dynClient.Resource(BackupStorageLocationGVR).Namespace("").List(ctx, metav1.ListOptions{})
-		if err != nil {
-			return nil, err
-		}
-		bsls := make([]BackupStorageLocation, 0, len(bslList.Items))
-		for _, item := range bslList.Items {
-			bsls = append(bsls, parseBSL(&item))
-		}
-
-		vslList, err := dynClient.Resource(VolumeSnapshotLocationGVR).Namespace("").List(ctx, metav1.ListOptions{})
-		if err != nil {
-			return nil, err
-		}
-		vsls := make([]VolumeSnapshotLocation, 0, len(vslList.Items))
-		for _, item := range vslList.Items {
-			vsls = append(vsls, parseVSL(&item))
-		}
-
-		return &LocationsResponse{
-			BackupStorageLocations:  bsls,
-			VolumeSnapshotLocations: vsls,
-		}, nil
-	})
+	data, err := h.fetchAll(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return result.(*LocationsResponse), nil
+	return data.locations, nil
 }
 
 // ============================================================================
@@ -1297,14 +1446,4 @@ func computeNextRun(cronExpr string, lastRun *time.Time) *time.Time {
 
 	next := sched.Next(from)
 	return &next
-}
-
-// stringSliceContains checks if a string slice contains a value.
-func stringSliceContains(slice []string, val string) bool {
-	for _, s := range slice {
-		if strings.EqualFold(s, val) {
-			return true
-		}
-	}
-	return false
 }

--- a/backend/internal/velero/types.go
+++ b/backend/internal/velero/types.go
@@ -1,0 +1,161 @@
+// Package velero provides Velero backup/restore integration for k8sCenter.
+package velero
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// GVR constants for Velero CRDs
+var (
+	BackupGVR = schema.GroupVersionResource{
+		Group: "velero.io", Version: "v1", Resource: "backups",
+	}
+	RestoreGVR = schema.GroupVersionResource{
+		Group: "velero.io", Version: "v1", Resource: "restores",
+	}
+	ScheduleGVR = schema.GroupVersionResource{
+		Group: "velero.io", Version: "v1", Resource: "schedules",
+	}
+	BackupStorageLocationGVR = schema.GroupVersionResource{
+		Group: "velero.io", Version: "v1", Resource: "backupstoragelocations",
+	}
+	VolumeSnapshotLocationGVR = schema.GroupVersionResource{
+		Group: "velero.io", Version: "v1", Resource: "volumesnapshotlocations",
+	}
+	DeleteBackupRequestGVR = schema.GroupVersionResource{
+		Group: "velero.io", Version: "v1", Resource: "deletebackuprequests",
+	}
+	DownloadRequestGVR = schema.GroupVersionResource{
+		Group: "velero.io", Version: "v1", Resource: "downloadrequests",
+	}
+)
+
+// VeleroStatus is returned by GET /velero/status
+type VeleroStatus struct {
+	Detected    bool      `json:"detected"`
+	Namespace   string    `json:"namespace,omitempty"`
+	Version     string    `json:"version,omitempty"`
+	BSLCount    int       `json:"bslCount"`
+	VSLCount    int       `json:"vslCount"`
+	LastChecked time.Time `json:"lastChecked"`
+}
+
+// Backup is the API response for a Velero backup.
+// Phase is passed through from Velero's native phases.
+type Backup struct {
+	Name               string            `json:"name"`
+	Namespace          string            `json:"namespace"`
+	Phase              string            `json:"phase"`
+	IncludedNamespaces []string          `json:"includedNamespaces"`
+	ExcludedNamespaces []string          `json:"excludedNamespaces"`
+	StorageLocation    string            `json:"storageLocation"`
+	TTL                string            `json:"ttl"`
+	StartTime          *time.Time        `json:"startTime,omitempty"`
+	CompletionTime     *time.Time        `json:"completionTime,omitempty"`
+	Expiration         *time.Time        `json:"expiration,omitempty"`
+	ItemsBackedUp      int               `json:"itemsBackedUp"`
+	TotalItems         int               `json:"totalItems"`
+	Warnings           int               `json:"warnings"`
+	Errors             int               `json:"errors"`
+	ScheduleName       string            `json:"scheduleName,omitempty"`
+	SnapshotVolumes    bool              `json:"snapshotVolumes"`
+	Labels             map[string]string `json:"labels,omitempty"`
+}
+
+// Restore is the API response for a Velero restore.
+type Restore struct {
+	Name               string            `json:"name"`
+	Namespace          string            `json:"namespace"`
+	Phase              string            `json:"phase"`
+	BackupName         string            `json:"backupName"`
+	ScheduleName       string            `json:"scheduleName,omitempty"`
+	IncludedNamespaces []string          `json:"includedNamespaces"`
+	NamespaceMapping   map[string]string `json:"namespaceMapping,omitempty"`
+	StartTime          *time.Time        `json:"startTime,omitempty"`
+	CompletionTime     *time.Time        `json:"completionTime,omitempty"`
+	ItemsRestored      int               `json:"itemsRestored"`
+	TotalItems         int               `json:"totalItems"`
+	Warnings           int               `json:"warnings"`
+	Errors             int               `json:"errors"`
+	FailureReason      string            `json:"failureReason,omitempty"`
+}
+
+// Schedule is the API response for a Velero schedule.
+type Schedule struct {
+	Name               string     `json:"name"`
+	Namespace          string     `json:"namespace"`
+	Phase              string     `json:"phase"`
+	Schedule           string     `json:"schedule"`
+	Paused             bool       `json:"paused"`
+	LastBackup         *time.Time `json:"lastBackup,omitempty"`
+	NextRunTime        *time.Time `json:"nextRunTime,omitempty"`
+	IncludedNamespaces []string   `json:"includedNamespaces"`
+	TTL                string     `json:"ttl"`
+	StorageLocation    string     `json:"storageLocation"`
+	LastBackupPhase    string     `json:"lastBackupPhase,omitempty"`
+	ValidationErrors   []string   `json:"validationErrors,omitempty"`
+}
+
+// BackupStorageLocation is the API response for a BSL.
+type BackupStorageLocation struct {
+	Name           string     `json:"name"`
+	Namespace      string     `json:"namespace"`
+	Provider       string     `json:"provider"`
+	Bucket         string     `json:"bucket"`
+	Prefix         string     `json:"prefix,omitempty"`
+	Phase          string     `json:"phase"`
+	Default        bool       `json:"default"`
+	LastSyncedTime *time.Time `json:"lastSyncedTime,omitempty"`
+	Message        string     `json:"message,omitempty"`
+}
+
+// VolumeSnapshotLocation is the API response for a VSL.
+type VolumeSnapshotLocation struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	Provider  string `json:"provider"`
+}
+
+// LocationsResponse combines BSL and VSL lists.
+type LocationsResponse struct {
+	BackupStorageLocations  []BackupStorageLocation  `json:"backupStorageLocations"`
+	VolumeSnapshotLocations []VolumeSnapshotLocation `json:"volumeSnapshotLocations"`
+}
+
+// Phase helper functions for UI badge coloring
+
+// IsFailedPhase returns true for failed phases.
+func IsFailedPhase(phase string) bool {
+	switch phase {
+	case "Failed", "FailedValidation":
+		return true
+	}
+	return false
+}
+
+// IsWarningPhase returns true for partial failure phases.
+func IsWarningPhase(phase string) bool {
+	return phase == "PartiallyFailed"
+}
+
+// IsSuccessPhase returns true for success phases.
+func IsSuccessPhase(phase string) bool {
+	switch phase {
+	case "Completed", "Available", "Enabled":
+		return true
+	}
+	return false
+}
+
+// IsProgressPhase returns true for in-progress phases.
+func IsProgressPhase(phase string) bool {
+	switch phase {
+	case "InProgress", "New", "WaitingForPluginOperations", "Finalizing",
+		"Queued", "ReadyToStart", "FinalizingPartiallyFailed",
+		"WaitingForPluginOperationsPartiallyFailed":
+		return true
+	}
+	return false
+}

--- a/backend/internal/wizard/velero.go
+++ b/backend/internal/wizard/velero.go
@@ -53,7 +53,7 @@ func (v *VeleroBackupInput) Validate() []FieldError {
 
 // ToBackup converts the input to an unstructured Velero Backup resource.
 func (v *VeleroBackupInput) ToBackup() *unstructured.Unstructured {
-	spec := map[string]interface{}{}
+	spec := map[string]any{}
 
 	if len(v.IncludedNamespaces) > 0 {
 		spec["includedNamespaces"] = v.IncludedNamespaces
@@ -71,7 +71,7 @@ func (v *VeleroBackupInput) ToBackup() *unstructured.Unstructured {
 		spec["snapshotVolumes"] = *v.SnapshotVolumes
 	}
 
-	metadata := map[string]interface{}{
+	metadata := map[string]any{
 		"name":      v.Name,
 		"namespace": v.Namespace,
 	}
@@ -80,7 +80,7 @@ func (v *VeleroBackupInput) ToBackup() *unstructured.Unstructured {
 	}
 
 	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "velero.io/v1",
 			"kind":       "Backup",
 			"metadata":   metadata,
@@ -139,7 +139,7 @@ func (v *VeleroRestoreInput) Validate() []FieldError {
 
 // ToRestore converts the input to an unstructured Velero Restore resource.
 func (v *VeleroRestoreInput) ToRestore() *unstructured.Unstructured {
-	spec := map[string]interface{}{}
+	spec := map[string]any{}
 
 	if v.BackupName != "" {
 		spec["backupName"] = v.BackupName
@@ -161,10 +161,10 @@ func (v *VeleroRestoreInput) ToRestore() *unstructured.Unstructured {
 	}
 
 	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "velero.io/v1",
 			"kind":       "Restore",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      v.Name,
 				"namespace": v.Namespace,
 			},
@@ -221,7 +221,7 @@ func (v *VeleroScheduleInput) Validate() []FieldError {
 
 // ToSchedule converts the input to an unstructured Velero Schedule resource.
 func (v *VeleroScheduleInput) ToSchedule() *unstructured.Unstructured {
-	template := map[string]interface{}{}
+	template := map[string]any{}
 	if len(v.IncludedNamespaces) > 0 {
 		template["includedNamespaces"] = v.IncludedNamespaces
 	}
@@ -238,7 +238,7 @@ func (v *VeleroScheduleInput) ToSchedule() *unstructured.Unstructured {
 		template["snapshotVolumes"] = *v.SnapshotVolumes
 	}
 
-	spec := map[string]interface{}{
+	spec := map[string]any{
 		"schedule": v.Schedule,
 	}
 	if v.Paused {
@@ -249,10 +249,10 @@ func (v *VeleroScheduleInput) ToSchedule() *unstructured.Unstructured {
 	}
 
 	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "velero.io/v1",
 			"kind":       "Schedule",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      v.Name,
 				"namespace": v.Namespace,
 			},

--- a/backend/internal/wizard/velero.go
+++ b/backend/internal/wizard/velero.go
@@ -1,0 +1,272 @@
+package wizard
+
+import (
+	"github.com/robfig/cron/v3"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	sigsyaml "sigs.k8s.io/yaml"
+)
+
+// VeleroBackupInput represents the wizard form data for creating a Velero Backup.
+type VeleroBackupInput struct {
+	Name               string            `json:"name"`
+	Namespace          string            `json:"namespace"`
+	IncludedNamespaces []string          `json:"includedNamespaces,omitempty"`
+	ExcludedNamespaces []string          `json:"excludedNamespaces,omitempty"`
+	StorageLocation    string            `json:"storageLocation,omitempty"`
+	TTL                string            `json:"ttl,omitempty"`
+	SnapshotVolumes    *bool             `json:"snapshotVolumes,omitempty"`
+	Labels             map[string]string `json:"labels,omitempty"`
+}
+
+// Validate checks the VeleroBackupInput and returns field-level errors.
+func (v *VeleroBackupInput) Validate() []FieldError {
+	var errs []FieldError
+
+	if !dnsLabelRegex.MatchString(v.Name) {
+		errs = append(errs, FieldError{Field: "name", Message: "must be a valid DNS label (lowercase alphanumeric and hyphens, 1-63 chars)"})
+	}
+
+	if v.Namespace == "" {
+		v.Namespace = "velero" // Default to velero namespace
+	} else if !dnsLabelRegex.MatchString(v.Namespace) {
+		errs = append(errs, FieldError{Field: "namespace", Message: "must be a valid DNS label"})
+	}
+
+	for i, ns := range v.IncludedNamespaces {
+		if ns != "*" && !dnsLabelRegex.MatchString(ns) {
+			errs = append(errs, FieldError{Field: "includedNamespaces", Message: "each namespace must be a valid DNS label or '*'"})
+			break
+		}
+		_ = i
+	}
+
+	for i, ns := range v.ExcludedNamespaces {
+		if !dnsLabelRegex.MatchString(ns) {
+			errs = append(errs, FieldError{Field: "excludedNamespaces", Message: "each namespace must be a valid DNS label"})
+			break
+		}
+		_ = i
+	}
+
+	return errs
+}
+
+// ToBackup converts the input to an unstructured Velero Backup resource.
+func (v *VeleroBackupInput) ToBackup() *unstructured.Unstructured {
+	spec := map[string]interface{}{}
+
+	if len(v.IncludedNamespaces) > 0 {
+		spec["includedNamespaces"] = v.IncludedNamespaces
+	}
+	if len(v.ExcludedNamespaces) > 0 {
+		spec["excludedNamespaces"] = v.ExcludedNamespaces
+	}
+	if v.StorageLocation != "" {
+		spec["storageLocation"] = v.StorageLocation
+	}
+	if v.TTL != "" {
+		spec["ttl"] = v.TTL
+	}
+	if v.SnapshotVolumes != nil {
+		spec["snapshotVolumes"] = *v.SnapshotVolumes
+	}
+
+	metadata := map[string]interface{}{
+		"name":      v.Name,
+		"namespace": v.Namespace,
+	}
+	if len(v.Labels) > 0 {
+		metadata["labels"] = v.Labels
+	}
+
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "velero.io/v1",
+			"kind":       "Backup",
+			"metadata":   metadata,
+			"spec":       spec,
+		},
+	}
+}
+
+// ToYAML implements WizardInput by marshaling the unstructured Backup.
+func (v *VeleroBackupInput) ToYAML() (string, error) {
+	obj := v.ToBackup()
+	yamlBytes, err := sigsyaml.Marshal(obj.Object)
+	if err != nil {
+		return "", err
+	}
+	return string(yamlBytes), nil
+}
+
+// VeleroRestoreInput represents the wizard form data for creating a Velero Restore.
+type VeleroRestoreInput struct {
+	Name               string            `json:"name"`
+	Namespace          string            `json:"namespace"`
+	BackupName         string            `json:"backupName"`
+	ScheduleName       string            `json:"scheduleName,omitempty"`
+	IncludedNamespaces []string          `json:"includedNamespaces,omitempty"`
+	ExcludedNamespaces []string          `json:"excludedNamespaces,omitempty"`
+	NamespaceMapping   map[string]string `json:"namespaceMapping,omitempty"`
+	RestorePVs         *bool             `json:"restorePVs,omitempty"`
+}
+
+// Validate checks the VeleroRestoreInput and returns field-level errors.
+func (v *VeleroRestoreInput) Validate() []FieldError {
+	var errs []FieldError
+
+	if !dnsLabelRegex.MatchString(v.Name) {
+		errs = append(errs, FieldError{Field: "name", Message: "must be a valid DNS label (lowercase alphanumeric and hyphens, 1-63 chars)"})
+	}
+
+	if v.Namespace == "" {
+		v.Namespace = "velero"
+	} else if !dnsLabelRegex.MatchString(v.Namespace) {
+		errs = append(errs, FieldError{Field: "namespace", Message: "must be a valid DNS label"})
+	}
+
+	// Must have either backupName or scheduleName
+	if v.BackupName == "" && v.ScheduleName == "" {
+		errs = append(errs, FieldError{Field: "backupName", Message: "backupName or scheduleName is required"})
+	}
+
+	if v.BackupName != "" && v.ScheduleName != "" {
+		errs = append(errs, FieldError{Field: "backupName", Message: "cannot specify both backupName and scheduleName"})
+	}
+
+	return errs
+}
+
+// ToRestore converts the input to an unstructured Velero Restore resource.
+func (v *VeleroRestoreInput) ToRestore() *unstructured.Unstructured {
+	spec := map[string]interface{}{}
+
+	if v.BackupName != "" {
+		spec["backupName"] = v.BackupName
+	}
+	if v.ScheduleName != "" {
+		spec["scheduleName"] = v.ScheduleName
+	}
+	if len(v.IncludedNamespaces) > 0 {
+		spec["includedNamespaces"] = v.IncludedNamespaces
+	}
+	if len(v.ExcludedNamespaces) > 0 {
+		spec["excludedNamespaces"] = v.ExcludedNamespaces
+	}
+	if len(v.NamespaceMapping) > 0 {
+		spec["namespaceMapping"] = v.NamespaceMapping
+	}
+	if v.RestorePVs != nil {
+		spec["restorePVs"] = *v.RestorePVs
+	}
+
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "velero.io/v1",
+			"kind":       "Restore",
+			"metadata": map[string]interface{}{
+				"name":      v.Name,
+				"namespace": v.Namespace,
+			},
+			"spec": spec,
+		},
+	}
+}
+
+// ToYAML implements WizardInput by marshaling the unstructured Restore.
+func (v *VeleroRestoreInput) ToYAML() (string, error) {
+	obj := v.ToRestore()
+	yamlBytes, err := sigsyaml.Marshal(obj.Object)
+	if err != nil {
+		return "", err
+	}
+	return string(yamlBytes), nil
+}
+
+// VeleroScheduleInput represents the wizard form data for creating a Velero Schedule.
+type VeleroScheduleInput struct {
+	Name               string   `json:"name"`
+	Namespace          string   `json:"namespace"`
+	Schedule           string   `json:"schedule"` // Cron expression
+	Paused             bool     `json:"paused,omitempty"`
+	IncludedNamespaces []string `json:"includedNamespaces,omitempty"`
+	ExcludedNamespaces []string `json:"excludedNamespaces,omitempty"`
+	StorageLocation    string   `json:"storageLocation,omitempty"`
+	TTL                string   `json:"ttl,omitempty"`
+	SnapshotVolumes    *bool    `json:"snapshotVolumes,omitempty"`
+}
+
+// Validate checks the VeleroScheduleInput and returns field-level errors.
+func (v *VeleroScheduleInput) Validate() []FieldError {
+	var errs []FieldError
+
+	if !dnsLabelRegex.MatchString(v.Name) {
+		errs = append(errs, FieldError{Field: "name", Message: "must be a valid DNS label (lowercase alphanumeric and hyphens, 1-63 chars)"})
+	}
+
+	if v.Namespace == "" {
+		v.Namespace = "velero"
+	} else if !dnsLabelRegex.MatchString(v.Namespace) {
+		errs = append(errs, FieldError{Field: "namespace", Message: "must be a valid DNS label"})
+	}
+
+	if v.Schedule == "" {
+		errs = append(errs, FieldError{Field: "schedule", Message: "cron schedule is required"})
+	} else if _, err := cron.ParseStandard(v.Schedule); err != nil {
+		errs = append(errs, FieldError{Field: "schedule", Message: "must be a valid cron expression (e.g., '0 * * * *' for hourly)"})
+	}
+
+	return errs
+}
+
+// ToSchedule converts the input to an unstructured Velero Schedule resource.
+func (v *VeleroScheduleInput) ToSchedule() *unstructured.Unstructured {
+	template := map[string]interface{}{}
+	if len(v.IncludedNamespaces) > 0 {
+		template["includedNamespaces"] = v.IncludedNamespaces
+	}
+	if len(v.ExcludedNamespaces) > 0 {
+		template["excludedNamespaces"] = v.ExcludedNamespaces
+	}
+	if v.StorageLocation != "" {
+		template["storageLocation"] = v.StorageLocation
+	}
+	if v.TTL != "" {
+		template["ttl"] = v.TTL
+	}
+	if v.SnapshotVolumes != nil {
+		template["snapshotVolumes"] = *v.SnapshotVolumes
+	}
+
+	spec := map[string]interface{}{
+		"schedule": v.Schedule,
+	}
+	if v.Paused {
+		spec["paused"] = true
+	}
+	if len(template) > 0 {
+		spec["template"] = template
+	}
+
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "velero.io/v1",
+			"kind":       "Schedule",
+			"metadata": map[string]interface{}{
+				"name":      v.Name,
+				"namespace": v.Namespace,
+			},
+			"spec": spec,
+		},
+	}
+}
+
+// ToYAML implements WizardInput by marshaling the unstructured Schedule.
+func (v *VeleroScheduleInput) ToYAML() (string, error) {
+	obj := v.ToSchedule()
+	yamlBytes, err := sigsyaml.Marshal(obj.Object)
+	if err != nil {
+		return "", err
+	}
+	return string(yamlBytes), nil
+}

--- a/e2e/velero.spec.ts
+++ b/e2e/velero.spec.ts
@@ -1,0 +1,134 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Velero integration E2E tests.
+ *
+ * NOTE: These tests require Velero to be installed in the cluster.
+ * If Velero is not installed, tests will verify graceful degradation.
+ */
+
+test.describe("Velero Backup Section", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/backup");
+  });
+
+  test("redirects /backup to /backup/backups", async ({ page }) => {
+    await expect(page).toHaveURL(/\/backup\/backups$/);
+  });
+
+  test("shows backup section in navigation", async ({ page }) => {
+    // Verify the backup icon is visible in the icon rail
+    const backupIcon = page.locator('[data-section="backup"]');
+    // Icon rail items may be rendered as tooltips, check the href
+    const backupLink = page.locator('a[href="/backup"]');
+    await expect(backupLink.or(backupIcon).first()).toBeVisible();
+  });
+
+  test("shows sub-navigation tabs", async ({ page }) => {
+    await expect(page.getByRole("link", { name: "Backups" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Restores" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Schedules" })).toBeVisible();
+  });
+
+  test("can navigate to restores tab", async ({ page }) => {
+    await page.getByRole("link", { name: "Restores" }).click();
+    await expect(page).toHaveURL(/\/backup\/restores$/);
+  });
+
+  test("can navigate to schedules tab", async ({ page }) => {
+    await page.getByRole("link", { name: "Schedules" }).click();
+    await expect(page).toHaveURL(/\/backup\/schedules$/);
+  });
+
+  test("shows New Backup button", async ({ page }) => {
+    const newBackupButton = page.getByRole("link", { name: /New Backup/i });
+    await expect(newBackupButton).toBeVisible();
+  });
+
+  test("can navigate to new backup wizard", async ({ page }) => {
+    await page.getByRole("link", { name: /New Backup/i }).click();
+    await expect(page).toHaveURL(/\/backup\/backups\/new$/);
+    await expect(page.getByRole("heading", { name: "New Backup" })).toBeVisible();
+  });
+});
+
+test.describe("Velero Backup Wizard", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/backup/backups/new");
+  });
+
+  test("shows wizard stepper", async ({ page }) => {
+    await expect(page.getByText("Configure")).toBeVisible();
+    await expect(page.getByText("Review & Apply")).toBeVisible();
+  });
+
+  test("shows backup name field", async ({ page }) => {
+    await expect(page.getByLabel(/Backup Name/i)).toBeVisible();
+  });
+
+  test("shows storage location dropdown", async ({ page }) => {
+    await expect(page.getByText(/Storage Location/i)).toBeVisible();
+  });
+
+  test("shows retention TTL dropdown", async ({ page }) => {
+    await expect(page.getByText(/Retention/i)).toBeVisible();
+  });
+
+  test("shows snapshot volumes checkbox", async ({ page }) => {
+    await expect(page.getByLabel(/Snapshot persistent volumes/i)).toBeVisible();
+  });
+
+  test("can cancel wizard", async ({ page }) => {
+    await page.getByRole("button", { name: "Cancel" }).click();
+    await expect(page).toHaveURL(/\/backup\/backups$/);
+  });
+});
+
+test.describe("Velero Restore Wizard", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/backup/restores/new");
+  });
+
+  test("shows wizard stepper", async ({ page }) => {
+    await expect(page.getByText("Configure")).toBeVisible();
+    await expect(page.getByText("Review & Apply")).toBeVisible();
+  });
+
+  test("shows source backup dropdown", async ({ page }) => {
+    await expect(page.getByText(/Source Backup/i)).toBeVisible();
+  });
+
+  test("shows restore PVs checkbox", async ({ page }) => {
+    await expect(page.getByLabel(/Restore persistent volumes/i)).toBeVisible();
+  });
+});
+
+test.describe("Velero Schedule Wizard", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/backup/schedules/new");
+  });
+
+  test("shows wizard stepper", async ({ page }) => {
+    await expect(page.getByText("Configure")).toBeVisible();
+    await expect(page.getByText("Review")).toBeVisible();
+  });
+
+  test("shows schedule name field", async ({ page }) => {
+    await expect(page.getByLabel(/Schedule Name/i)).toBeVisible();
+  });
+
+  test("shows cron schedule input", async ({ page }) => {
+    await expect(page.getByText(/Schedule \(Cron\)/i)).toBeVisible();
+  });
+
+  test("shows cron preset buttons", async ({ page }) => {
+    await expect(page.getByRole("button", { name: /Hourly/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /Daily/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /Weekly/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /Monthly/i })).toBeVisible();
+  });
+
+  test("shows paused checkbox", async ({ page }) => {
+    await expect(page.getByLabel(/Create paused/i)).toBeVisible();
+  });
+});

--- a/frontend/islands/IconRail.tsx
+++ b/frontend/islands/IconRail.tsx
@@ -27,6 +27,8 @@ const ICONS: Record<string, string> = {
     '<path d="M12.5 3.5a2.5 2.5 0 0 0-5 0V5H5a2.5 2.5 0 0 0-2.5 2.5V10H4a2.5 2.5 0 1 1 0 5H2.5V17.5A2.5 2.5 0 0 0 5 20h2.5v-1.5a2.5 2.5 0 1 1 5 0V20H15a2.5 2.5 0 0 0 2.5-2.5V15H16a2.5 2.5 0 1 1 0-5h1.5V7.5A2.5 2.5 0 0 0 15 5h-2.5V3.5z"/>',
   "git-branch":
     '<line x1="7" y1="7" x2="7" y2="17"/><circle cx="7" cy="5" r="2"/><circle cx="13" cy="7" r="2"/><path d="M7 7c0 3 6 3 6 0"/>',
+  archive:
+    '<rect x="3" y="7" width="14" height="10" rx="1"/><path d="M3 10h14"/><path d="M5 4h10v3H5z"/><rect x="8" y="12" width="4" height="2" rx="0.5"/>',
   settings:
     '<circle cx="10" cy="10" r="7"/><circle cx="10" cy="10" r="3"/><path d="M13 10h4M3 10h4M10 3v4M10 13v4"/>',
 };

--- a/frontend/islands/VeleroBackupWizard.tsx
+++ b/frontend/islands/VeleroBackupWizard.tsx
@@ -1,0 +1,306 @@
+import { useSignal } from "@preact/signals";
+import { useCallback, useEffect } from "preact/hooks";
+import { IS_BROWSER } from "fresh/runtime";
+import { apiGet, apiPost } from "@/lib/api.ts";
+import { DNS_LABEL_REGEX, WIZARD_INPUT_CLASS } from "@/lib/wizard-constants.ts";
+import { useNamespaces } from "@/lib/hooks/use-namespaces.ts";
+import { useDirtyGuard } from "@/lib/hooks/use-dirty-guard.ts";
+import { WizardStepper } from "@/components/wizard/WizardStepper.tsx";
+import { WizardReviewStep } from "@/components/wizard/WizardReviewStep.tsx";
+import { Button } from "@/components/ui/Button.tsx";
+import type { BackupStorageLocation } from "@/lib/velero-types.ts";
+
+interface BackupFormState {
+  name: string;
+  namespace: string;
+  includedNamespaces: string[];
+  excludedNamespaces: string[];
+  storageLocation: string;
+  ttl: string;
+  snapshotVolumes: boolean;
+}
+
+const STEPS = [{ title: "Configure" }, { title: "Review & Apply" }];
+
+const TTL_OPTIONS = [
+  { value: "", label: "Default" },
+  { value: "24h", label: "1 day" },
+  { value: "168h", label: "7 days" },
+  { value: "720h", label: "30 days" },
+  { value: "2160h", label: "90 days" },
+  { value: "8760h", label: "1 year" },
+];
+
+function generateBackupName(): string {
+  const now = new Date();
+  const ts = now.getFullYear().toString() +
+    (now.getMonth() + 1).toString().padStart(2, "0") +
+    now.getDate().toString().padStart(2, "0") + "-" +
+    now.getHours().toString().padStart(2, "0") +
+    now.getMinutes().toString().padStart(2, "0") +
+    now.getSeconds().toString().padStart(2, "0");
+  return `backup-${ts}`;
+}
+
+function initialState(): BackupFormState {
+  return {
+    name: generateBackupName(),
+    namespace: "velero",
+    includedNamespaces: [],
+    excludedNamespaces: [],
+    storageLocation: "",
+    ttl: "",
+    snapshotVolumes: true,
+  };
+}
+
+export default function VeleroBackupWizard() {
+  const currentStep = useSignal(0);
+  const form = useSignal<BackupFormState>(initialState());
+  const errors = useSignal<Record<string, string>>({});
+  const dirty = useSignal(false);
+
+  const namespaces = useNamespaces();
+  const bsls = useSignal<BackupStorageLocation[]>([]);
+
+  const previewYaml = useSignal("");
+  const previewLoading = useSignal(false);
+  const previewError = useSignal<string | null>(null);
+
+  // Fetch BSLs
+  useEffect(() => {
+    if (!IS_BROWSER) return;
+    apiGet<{ backupStorageLocations: BackupStorageLocation[] }>(
+      "/v1/velero/locations",
+    )
+      .then((resp) => {
+        if (resp.data?.backupStorageLocations) {
+          bsls.value = resp.data.backupStorageLocations;
+          const defaultBsl = resp.data.backupStorageLocations.find((b) =>
+            b.default
+          );
+          if (defaultBsl && !form.value.storageLocation) {
+            form.value = { ...form.value, storageLocation: defaultBsl.name };
+          }
+        }
+      })
+      .catch(() => {});
+  }, []);
+
+  useDirtyGuard(dirty);
+
+  const updateField = useCallback((field: string, value: unknown) => {
+    dirty.value = true;
+    form.value = { ...form.value, [field]: value };
+  }, []);
+
+  const validate = useCallback((): boolean => {
+    const newErrors: Record<string, string> = {};
+    if (!DNS_LABEL_REGEX.test(form.value.name)) {
+      newErrors.name = "Must be a valid DNS label (lowercase, hyphens allowed)";
+    }
+    errors.value = newErrors;
+    return Object.keys(newErrors).length === 0;
+  }, []);
+
+  const fetchPreview = useCallback(async () => {
+    previewLoading.value = true;
+    previewError.value = null;
+    try {
+      const body = {
+        name: form.value.name,
+        namespace: form.value.namespace,
+        includedNamespaces: form.value.includedNamespaces.length > 0
+          ? form.value.includedNamespaces
+          : undefined,
+        excludedNamespaces: form.value.excludedNamespaces.length > 0
+          ? form.value.excludedNamespaces
+          : undefined,
+        storageLocation: form.value.storageLocation || undefined,
+        ttl: form.value.ttl || undefined,
+        snapshotVolumes: form.value.snapshotVolumes,
+      };
+      const resp = await apiPost<{ yaml: string }>(
+        "/v1/wizards/velero-backup/preview",
+        body,
+      );
+      previewYaml.value = resp.data.yaml;
+    } catch (e: unknown) {
+      previewError.value = e instanceof Error ? e.message : "Preview failed";
+    }
+    previewLoading.value = false;
+  }, []);
+
+  const goNext = useCallback(async () => {
+    if (currentStep.value === 0) {
+      if (!validate()) return;
+      await fetchPreview();
+    }
+    currentStep.value++;
+  }, []);
+
+  const goBack = useCallback(() => {
+    currentStep.value--;
+  }, []);
+
+  if (!IS_BROWSER) return null;
+
+  return (
+    <div class="max-w-3xl mx-auto p-6">
+      <h1 class="text-2xl font-bold text-text-primary mb-2">New Backup</h1>
+      <p class="text-sm text-text-muted mb-6">
+        Create a one-time Velero backup of cluster resources.
+      </p>
+
+      <WizardStepper steps={STEPS} currentStep={currentStep.value} />
+
+      <div class="mt-6">
+        {currentStep.value === 0 && (
+          <div class="space-y-6">
+            {/* Name */}
+            <div>
+              <label class="block text-sm font-medium text-text-primary mb-1">
+                Backup Name
+              </label>
+              <input
+                type="text"
+                value={form.value.name}
+                onInput={(e) =>
+                  updateField("name", (e.target as HTMLInputElement).value)}
+                class={WIZARD_INPUT_CLASS}
+                placeholder="my-backup"
+              />
+              {errors.value.name && (
+                <p class="text-xs text-error mt-1">{errors.value.name}</p>
+              )}
+            </div>
+
+            {/* Included Namespaces */}
+            <div>
+              <label class="block text-sm font-medium text-text-primary mb-1">
+                Include Namespaces
+              </label>
+              <p class="text-xs text-text-muted mb-2">
+                Leave empty to back up all namespaces. Use Ctrl/Cmd+click to
+                select multiple.
+              </p>
+              <select
+                multiple
+                onChange={(e) => {
+                  const select = e.target as HTMLSelectElement;
+                  const selected = Array.from(select.selectedOptions).map((o) =>
+                    o.value
+                  );
+                  updateField("includedNamespaces", selected);
+                }}
+                class={`${WIZARD_INPUT_CLASS} h-32`}
+              >
+                {namespaces.value.map((ns) => (
+                  <option
+                    key={ns}
+                    value={ns}
+                    selected={form.value.includedNamespaces.includes(ns)}
+                  >
+                    {ns}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* Storage Location */}
+            <div>
+              <label class="block text-sm font-medium text-text-primary mb-1">
+                Storage Location
+              </label>
+              <select
+                value={form.value.storageLocation}
+                onChange={(e) =>
+                  updateField(
+                    "storageLocation",
+                    (e.target as HTMLSelectElement).value,
+                  )}
+                class={WIZARD_INPUT_CLASS}
+              >
+                <option value="">Default</option>
+                {bsls.value.map((bsl) => (
+                  <option key={bsl.name} value={bsl.name}>
+                    {bsl.name} ({bsl.provider})
+                    {bsl.default ? " - default" : ""}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* TTL */}
+            <div>
+              <label class="block text-sm font-medium text-text-primary mb-1">
+                Retention (TTL)
+              </label>
+              <select
+                value={form.value.ttl}
+                onChange={(e) =>
+                  updateField("ttl", (e.target as HTMLSelectElement).value)}
+                class={WIZARD_INPUT_CLASS}
+              >
+                {TTL_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>{opt.label}</option>
+                ))}
+              </select>
+            </div>
+
+            {/* Snapshot Volumes */}
+            <div class="flex items-center gap-2">
+              <input
+                type="checkbox"
+                id="snapshotVolumes"
+                checked={form.value.snapshotVolumes}
+                onChange={(e) =>
+                  updateField(
+                    "snapshotVolumes",
+                    (e.target as HTMLInputElement).checked,
+                  )}
+                class="rounded border-border"
+              />
+              <label
+                for="snapshotVolumes"
+                class="text-sm font-medium text-text-primary"
+              >
+                Snapshot persistent volumes
+              </label>
+            </div>
+          </div>
+        )}
+
+        {currentStep.value === 1 && (
+          <WizardReviewStep
+            yaml={previewYaml.value}
+            onYamlChange={(v) => (previewYaml.value = v)}
+            loading={previewLoading.value}
+            error={previewError.value}
+            detailBasePath="/backup/backups"
+          />
+        )}
+      </div>
+
+      {currentStep.value === 0 && (
+        <div class="mt-8 flex justify-between">
+          <a href="/backup/backups">
+            <Button type="button" variant="ghost">Cancel</Button>
+          </a>
+          <Button type="button" variant="primary" onClick={goNext}>
+            Preview YAML
+          </Button>
+        </div>
+      )}
+
+      {currentStep.value === 1 && !previewLoading.value &&
+        previewError.value === null && (
+        <div class="mt-4 flex justify-start">
+          <Button type="button" variant="ghost" onClick={goBack}>
+            Back
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/islands/VeleroDashboard.tsx
+++ b/frontend/islands/VeleroDashboard.tsx
@@ -1,0 +1,580 @@
+import { useSignal } from "@preact/signals";
+import { IS_BROWSER } from "fresh/runtime";
+import { useEffect } from "preact/hooks";
+import { apiDelete, apiGet } from "@/lib/api.ts";
+import { SearchBar } from "@/components/ui/SearchBar.tsx";
+import { Spinner } from "@/components/ui/Spinner.tsx";
+import { Button } from "@/components/ui/Button.tsx";
+import { age } from "@/lib/format.ts";
+import type {
+  Backup,
+  LocationsResponse,
+  Restore,
+  Schedule,
+  VeleroStatus,
+} from "@/lib/velero-types.ts";
+import { getPhaseCategory as getPhaseCat } from "@/lib/velero-types.ts";
+
+type Tab = "backups" | "restores" | "schedules";
+
+interface Props {
+  initialTab?: Tab;
+}
+
+export default function VeleroDashboard({ initialTab = "backups" }: Props) {
+  const status = useSignal<VeleroStatus | null>(null);
+  const backups = useSignal<Backup[]>([]);
+  const restores = useSignal<Restore[]>([]);
+  const schedules = useSignal<Schedule[]>([]);
+  const locations = useSignal<LocationsResponse | null>(null);
+  const loading = useSignal(true);
+  const error = useSignal<string | null>(null);
+  const search = useSignal("");
+  const tab = useSignal<Tab>(initialTab);
+  const refreshing = useSignal(false);
+  const deleting = useSignal<string | null>(null);
+
+  async function fetchData() {
+    try {
+      const [statusRes, backupsRes, restoresRes, schedulesRes, locationsRes] =
+        await Promise.all([
+          apiGet<VeleroStatus>("/v1/velero/status"),
+          apiGet<Backup[]>("/v1/velero/backups"),
+          apiGet<Restore[]>("/v1/velero/restores"),
+          apiGet<Schedule[]>("/v1/velero/schedules"),
+          apiGet<LocationsResponse>("/v1/velero/locations"),
+        ]);
+      status.value = statusRes.data;
+      backups.value = Array.isArray(backupsRes.data) ? backupsRes.data : [];
+      restores.value = Array.isArray(restoresRes.data) ? restoresRes.data : [];
+      schedules.value = Array.isArray(schedulesRes.data)
+        ? schedulesRes.data
+        : [];
+      locations.value = locationsRes.data;
+      error.value = null;
+    } catch {
+      error.value = "Failed to load Velero data";
+    }
+  }
+
+  useEffect(() => {
+    if (!IS_BROWSER) return;
+    fetchData().then(() => {
+      loading.value = false;
+    });
+  }, []);
+
+  async function handleRefresh() {
+    refreshing.value = true;
+    await fetchData();
+    refreshing.value = false;
+  }
+
+  async function handleDeleteBackup(ns: string, name: string) {
+    if (
+      !confirm(`Delete backup "${name}"? This will remove the backup data.`)
+    ) {
+      return;
+    }
+    deleting.value = `backup-${ns}-${name}`;
+    try {
+      await apiDelete(`/v1/velero/backups/${ns}/${name}`);
+      await fetchData();
+    } catch {
+      alert("Failed to delete backup");
+    }
+    deleting.value = null;
+  }
+
+  async function handleDeleteSchedule(ns: string, name: string) {
+    if (!confirm(`Delete schedule "${name}"?`)) return;
+    deleting.value = `schedule-${ns}-${name}`;
+    try {
+      await apiDelete(`/v1/velero/schedules/${ns}/${name}`);
+      await fetchData();
+    } catch {
+      alert("Failed to delete schedule");
+    }
+    deleting.value = null;
+  }
+
+  if (!IS_BROWSER) return null;
+
+  const notDetected = status.value && !status.value.detected;
+
+  // Filter items by search
+  const filteredBackups = backups.value.filter((b) =>
+    !search.value ||
+    b.name.toLowerCase().includes(search.value.toLowerCase()) ||
+    (b.scheduleName ?? "").toLowerCase().includes(search.value.toLowerCase())
+  );
+  const filteredRestores = restores.value.filter((r) =>
+    !search.value ||
+    r.name.toLowerCase().includes(search.value.toLowerCase()) ||
+    (r.backupName ?? "").toLowerCase().includes(search.value.toLowerCase())
+  );
+  const filteredSchedules = schedules.value.filter((s) =>
+    !search.value || s.name.toLowerCase().includes(search.value.toLowerCase())
+  );
+
+  return (
+    <div class="p-6">
+      <div class="flex items-center justify-between mb-1">
+        <h1 class="text-2xl font-bold text-text-primary">Backup & Restore</h1>
+        {!loading.value && (
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={handleRefresh}
+            disabled={refreshing.value}
+          >
+            {refreshing.value ? "Refreshing..." : "Refresh"}
+          </Button>
+        )}
+      </div>
+      <p class="text-sm text-text-muted mb-6">
+        Velero backup and restore management.
+      </p>
+
+      {loading.value && (
+        <div class="flex items-center justify-center py-12">
+          <Spinner />
+        </div>
+      )}
+
+      {error.value && (
+        <div class="rounded-lg border border-error/30 bg-error/10 p-4 text-error">
+          {error.value}
+        </div>
+      )}
+
+      {notDetected && !loading.value && (
+        <div class="rounded-lg border border-warning/30 bg-warning/10 p-6 text-center">
+          <h3 class="font-semibold text-lg text-text-primary mb-2">
+            Velero Not Detected
+          </h3>
+          <p class="text-text-muted mb-4">
+            Velero CRDs were not found in this cluster. Install Velero to enable
+            backup and restore functionality.
+          </p>
+          <a
+            href="https://velero.io/docs/v1.12/basic-install/"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex items-center gap-1 text-accent hover:underline"
+          >
+            View Velero Installation Docs
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="h-4 w-4"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                clip-rule="evenodd"
+              />
+            </svg>
+          </a>
+        </div>
+      )}
+
+      {!loading.value && !error.value && status.value?.detected && (
+        <>
+          {/* Status summary */}
+          <div class="mb-6 flex flex-wrap gap-3">
+            <SummaryCard
+              label="Backups"
+              value={backups.value.length}
+              color="text-accent"
+            />
+            <SummaryCard
+              label="Restores"
+              value={restores.value.length}
+              color="text-success"
+            />
+            <SummaryCard
+              label="Schedules"
+              value={schedules.value.length}
+              color="text-warning"
+            />
+            <SummaryCard
+              label="Storage Locations"
+              value={locations.value?.backupStorageLocations.length ?? 0}
+              color="text-text-muted"
+            />
+          </div>
+
+          {/* Tabs */}
+          <div class="flex items-center gap-2 mb-4 border-b border-border">
+            <TabButton
+              active={tab.value === "backups"}
+              onClick={() => (tab.value = "backups")}
+              count={backups.value.length}
+            >
+              Backups
+            </TabButton>
+            <TabButton
+              active={tab.value === "restores"}
+              onClick={() => (tab.value = "restores")}
+              count={restores.value.length}
+            >
+              Restores
+            </TabButton>
+            <TabButton
+              active={tab.value === "schedules"}
+              onClick={() => (tab.value = "schedules")}
+              count={schedules.value.length}
+            >
+              Schedules
+            </TabButton>
+          </div>
+
+          {/* Search and actions */}
+          <div class="flex items-center justify-between gap-4 mb-4">
+            <div class="w-64">
+              <SearchBar
+                value={search.value}
+                onInput={(v) => (search.value = v)}
+                placeholder="Search..."
+              />
+            </div>
+            <div class="flex gap-2">
+              {tab.value === "backups" && (
+                <a href="/backup/backups/new">
+                  <Button type="button" variant="primary">
+                    + New Backup
+                  </Button>
+                </a>
+              )}
+              {tab.value === "restores" && (
+                <a href="/backup/restores/new">
+                  <Button type="button" variant="primary">
+                    + New Restore
+                  </Button>
+                </a>
+              )}
+              {tab.value === "schedules" && (
+                <a href="/backup/schedules/new">
+                  <Button type="button" variant="primary">
+                    + New Schedule
+                  </Button>
+                </a>
+              )}
+            </div>
+          </div>
+
+          {/* Tables */}
+          {tab.value === "backups" && (
+            <BackupsTable
+              backups={filteredBackups}
+              deleting={deleting.value}
+              onDelete={handleDeleteBackup}
+            />
+          )}
+          {tab.value === "restores" && (
+            <RestoresTable restores={filteredRestores} />
+          )}
+          {tab.value === "schedules" && (
+            <SchedulesTable
+              schedules={filteredSchedules}
+              deleting={deleting.value}
+              onDelete={handleDeleteSchedule}
+            />
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function SummaryCard(
+  { label, value, color }: { label: string; value: number; color: string },
+) {
+  return (
+    <div class="rounded-lg border border-border bg-bg-secondary px-4 py-2">
+      <div class={`text-2xl font-bold ${color}`}>{value}</div>
+      <div class="text-xs text-text-muted">{label}</div>
+    </div>
+  );
+}
+
+function TabButton(
+  { active, onClick, count, children }: {
+    active: boolean;
+    onClick: () => void;
+    count: number;
+    children: preact.ComponentChildren;
+  },
+) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      class={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+        active
+          ? "border-accent text-accent"
+          : "border-transparent text-text-muted hover:text-text-primary"
+      }`}
+    >
+      {children}
+      <span
+        class={`ml-1 px-1.5 py-0.5 text-xs rounded-full ${
+          active ? "bg-accent/20" : "bg-bg-tertiary"
+        }`}
+      >
+        {count}
+      </span>
+    </button>
+  );
+}
+
+function PhaseBadge({ phase }: { phase: string }) {
+  const cat = getPhaseCat(phase);
+  const colors: Record<string, string> = {
+    success: "bg-success/20 text-success",
+    warning: "bg-warning/20 text-warning",
+    error: "bg-error/20 text-error",
+    progress: "bg-accent/20 text-accent",
+    unknown: "bg-text-muted/20 text-text-muted",
+  };
+  return (
+    <span
+      class={`inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-full ${
+        colors[cat]
+      }`}
+    >
+      {phase}
+    </span>
+  );
+}
+
+function BackupsTable(
+  { backups, deleting, onDelete }: {
+    backups: Backup[];
+    deleting: string | null;
+    onDelete: (ns: string, name: string) => void;
+  },
+) {
+  if (backups.length === 0) {
+    return (
+      <div class="text-center py-8 text-text-muted">No backups found.</div>
+    );
+  }
+
+  return (
+    <div class="overflow-x-auto">
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="border-b border-border text-left text-text-muted">
+            <th class="px-3 py-2 font-medium">Name</th>
+            <th class="px-3 py-2 font-medium">Status</th>
+            <th class="px-3 py-2 font-medium">Schedule</th>
+            <th class="px-3 py-2 font-medium">Started</th>
+            <th class="px-3 py-2 font-medium">Items</th>
+            <th class="px-3 py-2 font-medium">Issues</th>
+            <th class="px-3 py-2 font-medium"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {backups.map((b) => (
+            <tr
+              key={`${b.namespace}/${b.name}`}
+              class="border-b border-border hover:bg-bg-secondary"
+            >
+              <td class="px-3 py-2">
+                <a
+                  href={`/backup/backups/${b.namespace}/${b.name}`}
+                  class="text-accent hover:underline font-medium"
+                >
+                  {b.name}
+                </a>
+                <div class="text-xs text-text-muted">{b.namespace}</div>
+              </td>
+              <td class="px-3 py-2">
+                <PhaseBadge phase={b.phase} />
+              </td>
+              <td class="px-3 py-2 text-text-muted">
+                {b.scheduleName || "-"}
+              </td>
+              <td class="px-3 py-2 text-text-muted">
+                {b.startTime ? age(b.startTime) : "-"}
+              </td>
+              <td class="px-3 py-2 text-text-muted">
+                {b.itemsBackedUp} / {b.totalItems}
+              </td>
+              <td class="px-3 py-2">
+                {(b.warnings > 0 || b.errors > 0)
+                  ? (
+                    <span class="text-warning">
+                      {b.warnings}W / {b.errors}E
+                    </span>
+                  )
+                  : <span class="text-success">0</span>}
+              </td>
+              <td class="px-3 py-2">
+                <div class="flex gap-1">
+                  <a href={`/backup/restores/new?backup=${b.name}`}>
+                    <Button type="button" variant="ghost" size="sm">
+                      Restore
+                    </Button>
+                  </a>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => onDelete(b.namespace, b.name)}
+                    disabled={deleting === `backup-${b.namespace}-${b.name}`}
+                  >
+                    {deleting === `backup-${b.namespace}-${b.name}`
+                      ? "..."
+                      : "Delete"}
+                  </Button>
+                </div>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function RestoresTable({ restores }: { restores: Restore[] }) {
+  if (restores.length === 0) {
+    return (
+      <div class="text-center py-8 text-text-muted">No restores found.</div>
+    );
+  }
+
+  return (
+    <div class="overflow-x-auto">
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="border-b border-border text-left text-text-muted">
+            <th class="px-3 py-2 font-medium">Name</th>
+            <th class="px-3 py-2 font-medium">Status</th>
+            <th class="px-3 py-2 font-medium">Backup</th>
+            <th class="px-3 py-2 font-medium">Started</th>
+            <th class="px-3 py-2 font-medium">Items</th>
+            <th class="px-3 py-2 font-medium">Issues</th>
+          </tr>
+        </thead>
+        <tbody>
+          {restores.map((r) => (
+            <tr
+              key={`${r.namespace}/${r.name}`}
+              class="border-b border-border hover:bg-bg-secondary"
+            >
+              <td class="px-3 py-2">
+                <a
+                  href={`/backup/restores/${r.namespace}/${r.name}`}
+                  class="text-accent hover:underline font-medium"
+                >
+                  {r.name}
+                </a>
+                <div class="text-xs text-text-muted">{r.namespace}</div>
+              </td>
+              <td class="px-3 py-2">
+                <PhaseBadge phase={r.phase} />
+              </td>
+              <td class="px-3 py-2 text-text-muted">
+                {r.backupName || r.scheduleName || "-"}
+              </td>
+              <td class="px-3 py-2 text-text-muted">
+                {r.startTime ? age(r.startTime) : "-"}
+              </td>
+              <td class="px-3 py-2 text-text-muted">
+                {r.itemsRestored} / {r.totalItems}
+              </td>
+              <td class="px-3 py-2">
+                {(r.warnings > 0 || r.errors > 0)
+                  ? (
+                    <span class="text-warning">
+                      {r.warnings}W / {r.errors}E
+                    </span>
+                  )
+                  : <span class="text-success">0</span>}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function SchedulesTable(
+  { schedules, deleting, onDelete }: {
+    schedules: Schedule[];
+    deleting: string | null;
+    onDelete: (ns: string, name: string) => void;
+  },
+) {
+  if (schedules.length === 0) {
+    return (
+      <div class="text-center py-8 text-text-muted">No schedules found.</div>
+    );
+  }
+
+  return (
+    <div class="overflow-x-auto">
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="border-b border-border text-left text-text-muted">
+            <th class="px-3 py-2 font-medium">Name</th>
+            <th class="px-3 py-2 font-medium">Status</th>
+            <th class="px-3 py-2 font-medium">Schedule</th>
+            <th class="px-3 py-2 font-medium">Last Backup</th>
+            <th class="px-3 py-2 font-medium">Next Run</th>
+            <th class="px-3 py-2 font-medium"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {schedules.map((s) => (
+            <tr
+              key={`${s.namespace}/${s.name}`}
+              class="border-b border-border hover:bg-bg-secondary"
+            >
+              <td class="px-3 py-2">
+                <a
+                  href={`/backup/schedules/${s.namespace}/${s.name}`}
+                  class="text-accent hover:underline font-medium"
+                >
+                  {s.name}
+                </a>
+                <div class="text-xs text-text-muted">{s.namespace}</div>
+              </td>
+              <td class="px-3 py-2">
+                <PhaseBadge phase={s.paused ? "Paused" : s.phase} />
+              </td>
+              <td class="px-3 py-2 font-mono text-xs text-text-muted">
+                {s.schedule}
+              </td>
+              <td class="px-3 py-2 text-text-muted">
+                {s.lastBackup ? age(s.lastBackup) : "Never"}
+              </td>
+              <td class="px-3 py-2 text-text-muted">
+                {s.nextRunTime ? age(s.nextRunTime) : "-"}
+              </td>
+              <td class="px-3 py-2">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => onDelete(s.namespace, s.name)}
+                  disabled={deleting === `schedule-${s.namespace}-${s.name}`}
+                >
+                  {deleting === `schedule-${s.namespace}-${s.name}`
+                    ? "..."
+                    : "Delete"}
+                </Button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/islands/VeleroRestoreWizard.tsx
+++ b/frontend/islands/VeleroRestoreWizard.tsx
@@ -1,0 +1,285 @@
+import { useSignal } from "@preact/signals";
+import { useCallback, useEffect } from "preact/hooks";
+import { IS_BROWSER } from "fresh/runtime";
+import { apiGet, apiPost } from "@/lib/api.ts";
+import { DNS_LABEL_REGEX, WIZARD_INPUT_CLASS } from "@/lib/wizard-constants.ts";
+import { useNamespaces } from "@/lib/hooks/use-namespaces.ts";
+import { useDirtyGuard } from "@/lib/hooks/use-dirty-guard.ts";
+import { WizardStepper } from "@/components/wizard/WizardStepper.tsx";
+import { WizardReviewStep } from "@/components/wizard/WizardReviewStep.tsx";
+import { Button } from "@/components/ui/Button.tsx";
+import type { Backup } from "@/lib/velero-types.ts";
+
+interface RestoreFormState {
+  name: string;
+  namespace: string;
+  backupName: string;
+  includedNamespaces: string[];
+  restorePVs: boolean;
+}
+
+const STEPS = [{ title: "Configure" }, { title: "Review & Apply" }];
+
+function generateRestoreName(backupName: string): string {
+  const now = new Date();
+  const ts = now.getFullYear().toString() +
+    (now.getMonth() + 1).toString().padStart(2, "0") +
+    now.getDate().toString().padStart(2, "0") + "-" +
+    now.getHours().toString().padStart(2, "0") +
+    now.getMinutes().toString().padStart(2, "0") +
+    now.getSeconds().toString().padStart(2, "0");
+  return `${backupName}-restore-${ts}`;
+}
+
+function initialState(preselectedBackup?: string): RestoreFormState {
+  return {
+    name: preselectedBackup ? generateRestoreName(preselectedBackup) : "",
+    namespace: "velero",
+    backupName: preselectedBackup || "",
+    includedNamespaces: [],
+    restorePVs: true,
+  };
+}
+
+export default function VeleroRestoreWizard() {
+  const urlParams = IS_BROWSER
+    ? new URLSearchParams(globalThis.location.search)
+    : null;
+  const preselectedBackup = urlParams?.get("backup") || undefined;
+
+  const currentStep = useSignal(0);
+  const form = useSignal<RestoreFormState>(initialState(preselectedBackup));
+  const errors = useSignal<Record<string, string>>({});
+  const dirty = useSignal(false);
+
+  const namespaces = useNamespaces();
+  const backups = useSignal<Backup[]>([]);
+
+  const previewYaml = useSignal("");
+  const previewLoading = useSignal(false);
+  const previewError = useSignal<string | null>(null);
+
+  // Fetch backups
+  useEffect(() => {
+    if (!IS_BROWSER) return;
+    apiGet<Backup[]>("/v1/velero/backups")
+      .then((resp) => {
+        if (Array.isArray(resp.data)) {
+          backups.value = resp.data.filter((b) =>
+            b.phase === "Completed" || b.phase === "PartiallyFailed"
+          );
+        }
+      })
+      .catch(() => {});
+  }, []);
+
+  // Update name when backup changes
+  useEffect(() => {
+    if (form.value.backupName && !form.value.name) {
+      form.value = {
+        ...form.value,
+        name: generateRestoreName(form.value.backupName),
+      };
+    }
+  }, [form.value.backupName]);
+
+  useDirtyGuard(dirty);
+
+  const updateField = useCallback((field: string, value: unknown) => {
+    dirty.value = true;
+    form.value = { ...form.value, [field]: value };
+  }, []);
+
+  const validate = useCallback((): boolean => {
+    const newErrors: Record<string, string> = {};
+    if (!DNS_LABEL_REGEX.test(form.value.name)) {
+      newErrors.name = "Must be a valid DNS label";
+    }
+    if (!form.value.backupName) {
+      newErrors.backupName = "Backup is required";
+    }
+    errors.value = newErrors;
+    return Object.keys(newErrors).length === 0;
+  }, []);
+
+  const fetchPreview = useCallback(async () => {
+    previewLoading.value = true;
+    previewError.value = null;
+    try {
+      const body = {
+        name: form.value.name,
+        namespace: form.value.namespace,
+        backupName: form.value.backupName,
+        includedNamespaces: form.value.includedNamespaces.length > 0
+          ? form.value.includedNamespaces
+          : undefined,
+        restorePVs: form.value.restorePVs,
+      };
+      const resp = await apiPost<{ yaml: string }>(
+        "/v1/wizards/velero-restore/preview",
+        body,
+      );
+      previewYaml.value = resp.data.yaml;
+    } catch (e: unknown) {
+      previewError.value = e instanceof Error ? e.message : "Preview failed";
+    }
+    previewLoading.value = false;
+  }, []);
+
+  const goNext = useCallback(async () => {
+    if (currentStep.value === 0) {
+      if (!validate()) return;
+      await fetchPreview();
+    }
+    currentStep.value++;
+  }, []);
+
+  const goBack = useCallback(() => {
+    currentStep.value--;
+  }, []);
+
+  if (!IS_BROWSER) return null;
+
+  return (
+    <div class="max-w-3xl mx-auto p-6">
+      <h1 class="text-2xl font-bold text-text-primary mb-2">New Restore</h1>
+      <p class="text-sm text-text-muted mb-6">
+        Restore cluster resources from a Velero backup.
+      </p>
+
+      <WizardStepper steps={STEPS} currentStep={currentStep.value} />
+
+      <div class="mt-6">
+        {currentStep.value === 0 && (
+          <div class="space-y-6">
+            {/* Backup Selection */}
+            <div>
+              <label class="block text-sm font-medium text-text-primary mb-1">
+                Source Backup *
+              </label>
+              <select
+                value={form.value.backupName}
+                onChange={(e) =>
+                  updateField(
+                    "backupName",
+                    (e.target as HTMLSelectElement).value,
+                  )}
+                class={WIZARD_INPUT_CLASS}
+              >
+                <option value="">Select a backup...</option>
+                {backups.value.map((b) => (
+                  <option key={b.name} value={b.name}>
+                    {b.name} ({b.phase})
+                  </option>
+                ))}
+              </select>
+              {errors.value.backupName && (
+                <p class="text-xs text-error mt-1">{errors.value.backupName}</p>
+              )}
+            </div>
+
+            {/* Restore Name */}
+            <div>
+              <label class="block text-sm font-medium text-text-primary mb-1">
+                Restore Name
+              </label>
+              <input
+                type="text"
+                value={form.value.name}
+                onInput={(e) =>
+                  updateField("name", (e.target as HTMLInputElement).value)}
+                class={WIZARD_INPUT_CLASS}
+                placeholder="my-restore"
+              />
+              {errors.value.name && (
+                <p class="text-xs text-error mt-1">{errors.value.name}</p>
+              )}
+            </div>
+
+            {/* Included Namespaces */}
+            <div>
+              <label class="block text-sm font-medium text-text-primary mb-1">
+                Include Namespaces (optional)
+              </label>
+              <p class="text-xs text-text-muted mb-2">
+                Leave empty to restore all namespaces from the backup.
+              </p>
+              <select
+                multiple
+                onChange={(e) => {
+                  const select = e.target as HTMLSelectElement;
+                  const selected = Array.from(select.selectedOptions).map((o) =>
+                    o.value
+                  );
+                  updateField("includedNamespaces", selected);
+                }}
+                class={`${WIZARD_INPUT_CLASS} h-32`}
+              >
+                {namespaces.value.map((ns) => (
+                  <option
+                    key={ns}
+                    value={ns}
+                    selected={form.value.includedNamespaces.includes(ns)}
+                  >
+                    {ns}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* Restore PVs */}
+            <div class="flex items-center gap-2">
+              <input
+                type="checkbox"
+                id="restorePVs"
+                checked={form.value.restorePVs}
+                onChange={(e) =>
+                  updateField(
+                    "restorePVs",
+                    (e.target as HTMLInputElement).checked,
+                  )}
+                class="rounded border-border"
+              />
+              <label
+                for="restorePVs"
+                class="text-sm font-medium text-text-primary"
+              >
+                Restore persistent volumes
+              </label>
+            </div>
+          </div>
+        )}
+
+        {currentStep.value === 1 && (
+          <WizardReviewStep
+            yaml={previewYaml.value}
+            onYamlChange={(v) => (previewYaml.value = v)}
+            loading={previewLoading.value}
+            error={previewError.value}
+            detailBasePath="/backup/restores"
+          />
+        )}
+      </div>
+
+      {currentStep.value === 0 && (
+        <div class="mt-8 flex justify-between">
+          <a href="/backup/restores">
+            <Button type="button" variant="ghost">Cancel</Button>
+          </a>
+          <Button type="button" variant="primary" onClick={goNext}>
+            Preview YAML
+          </Button>
+        </div>
+      )}
+
+      {currentStep.value === 1 && !previewLoading.value &&
+        previewError.value === null && (
+        <div class="mt-4 flex justify-start">
+          <Button type="button" variant="ghost" onClick={goBack}>
+            Back
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/islands/VeleroScheduleWizard.tsx
+++ b/frontend/islands/VeleroScheduleWizard.tsx
@@ -1,0 +1,371 @@
+import { useSignal } from "@preact/signals";
+import { useCallback, useEffect } from "preact/hooks";
+import { IS_BROWSER } from "fresh/runtime";
+import { apiGet, apiPost } from "@/lib/api.ts";
+import { DNS_LABEL_REGEX, WIZARD_INPUT_CLASS } from "@/lib/wizard-constants.ts";
+import { useNamespaces } from "@/lib/hooks/use-namespaces.ts";
+import { useDirtyGuard } from "@/lib/hooks/use-dirty-guard.ts";
+import { WizardStepper } from "@/components/wizard/WizardStepper.tsx";
+import { WizardReviewStep } from "@/components/wizard/WizardReviewStep.tsx";
+import { Button } from "@/components/ui/Button.tsx";
+import type { BackupStorageLocation } from "@/lib/velero-types.ts";
+
+interface ScheduleFormState {
+  name: string;
+  namespace: string;
+  schedule: string;
+  includedNamespaces: string[];
+  excludedNamespaces: string[];
+  storageLocation: string;
+  ttl: string;
+  snapshotVolumes: boolean;
+  paused: boolean;
+}
+
+const STEPS = [{ title: "Configure" }, { title: "Review" }];
+
+const CRON_PRESETS = [
+  { value: "0 * * * *", label: "Hourly (at minute 0)" },
+  { value: "0 0 * * *", label: "Daily (at midnight UTC)" },
+  { value: "0 0 * * 0", label: "Weekly (Sunday at midnight)" },
+  { value: "0 0 1 * *", label: "Monthly (1st at midnight)" },
+];
+
+const TTL_OPTIONS = [
+  { value: "", label: "Default" },
+  { value: "24h", label: "1 day" },
+  { value: "168h", label: "7 days" },
+  { value: "720h", label: "30 days" },
+  { value: "2160h", label: "90 days" },
+  { value: "8760h", label: "1 year" },
+];
+
+function initialState(): ScheduleFormState {
+  return {
+    name: "",
+    namespace: "velero",
+    schedule: "0 0 * * *", // Daily at midnight
+    includedNamespaces: [],
+    excludedNamespaces: [],
+    storageLocation: "",
+    ttl: "720h", // 30 days default
+    snapshotVolumes: true,
+    paused: false,
+  };
+}
+
+export default function VeleroScheduleWizard() {
+  const currentStep = useSignal(0);
+  const form = useSignal<ScheduleFormState>(initialState());
+  const errors = useSignal<Record<string, string>>({});
+  const dirty = useSignal(false);
+
+  const namespaces = useNamespaces();
+  const bsls = useSignal<BackupStorageLocation[]>([]);
+
+  const previewYaml = useSignal("");
+  const previewLoading = useSignal(false);
+  const previewError = useSignal<string | null>(null);
+
+  // Fetch BSLs
+  useEffect(() => {
+    if (!IS_BROWSER) return;
+    apiGet<{ backupStorageLocations: BackupStorageLocation[] }>(
+      "/v1/velero/locations",
+    )
+      .then((resp) => {
+        if (resp.data?.backupStorageLocations) {
+          bsls.value = resp.data.backupStorageLocations;
+          const defaultBsl = resp.data.backupStorageLocations.find((b) =>
+            b.default
+          );
+          if (defaultBsl && !form.value.storageLocation) {
+            form.value = { ...form.value, storageLocation: defaultBsl.name };
+          }
+        }
+      })
+      .catch(() => {});
+  }, []);
+
+  useDirtyGuard(dirty);
+
+  const updateField = useCallback((field: string, value: unknown) => {
+    dirty.value = true;
+    form.value = { ...form.value, [field]: value };
+  }, []);
+
+  const validate = useCallback((): boolean => {
+    const newErrors: Record<string, string> = {};
+    if (!DNS_LABEL_REGEX.test(form.value.name)) {
+      newErrors.name =
+        "Must be a valid DNS label (lowercase, hyphens allowed, 1-63 chars)";
+    }
+    if (!form.value.schedule) {
+      newErrors.schedule = "Cron schedule is required";
+    } else {
+      // Basic cron validation (5 fields)
+      const parts = form.value.schedule.trim().split(/\s+/);
+      if (parts.length !== 5) {
+        newErrors.schedule = "Must be a valid cron expression (5 fields)";
+      }
+    }
+    errors.value = newErrors;
+    return Object.keys(newErrors).length === 0;
+  }, []);
+
+  const fetchPreview = useCallback(async () => {
+    previewLoading.value = true;
+    previewError.value = null;
+    try {
+      const body = {
+        name: form.value.name,
+        namespace: form.value.namespace,
+        schedule: form.value.schedule,
+        includedNamespaces: form.value.includedNamespaces.length > 0
+          ? form.value.includedNamespaces
+          : undefined,
+        excludedNamespaces: form.value.excludedNamespaces.length > 0
+          ? form.value.excludedNamespaces
+          : undefined,
+        storageLocation: form.value.storageLocation || undefined,
+        ttl: form.value.ttl || undefined,
+        snapshotVolumes: form.value.snapshotVolumes,
+        paused: form.value.paused || undefined,
+      };
+      const resp = await apiPost<{ yaml: string }>(
+        "/v1/wizards/velero-schedule/preview",
+        body,
+      );
+      previewYaml.value = resp.data.yaml;
+    } catch (e: unknown) {
+      previewError.value = e instanceof Error ? e.message : "Preview failed";
+    }
+    previewLoading.value = false;
+  }, []);
+
+  const handleNext = useCallback(async () => {
+    if (currentStep.value === 0) {
+      if (!validate()) return;
+      await fetchPreview();
+    }
+    currentStep.value++;
+  }, []);
+
+  const handleBack = useCallback(() => {
+    currentStep.value--;
+  }, []);
+
+  if (!IS_BROWSER) return null;
+
+  return (
+    <div class="max-w-3xl mx-auto p-6">
+      <h1 class="text-2xl font-bold text-text-primary mb-2">New Schedule</h1>
+      <p class="text-sm text-text-muted mb-6">
+        Create a scheduled Velero backup that runs automatically.
+      </p>
+
+      <WizardStepper steps={STEPS} currentStep={currentStep.value} />
+
+      {currentStep.value === 0 && (
+        <div class="mt-6 space-y-6">
+          {/* Name */}
+          <div>
+            <label class="block text-sm font-medium text-text-primary mb-1">
+              Schedule Name *
+            </label>
+            <input
+              type="text"
+              value={form.value.name}
+              onInput={(e) =>
+                updateField("name", (e.target as HTMLInputElement).value)}
+              class={WIZARD_INPUT_CLASS}
+              placeholder="daily-backup"
+            />
+            {errors.value.name && (
+              <p class="text-xs text-error mt-1">{errors.value.name}</p>
+            )}
+          </div>
+
+          {/* Cron Schedule */}
+          <div>
+            <label class="block text-sm font-medium text-text-primary mb-1">
+              Schedule (Cron) *
+            </label>
+            <div class="flex gap-2 mb-2">
+              {CRON_PRESETS.map((preset) => (
+                <button
+                  key={preset.value}
+                  type="button"
+                  onClick={() => updateField("schedule", preset.value)}
+                  class={`px-2 py-1 text-xs rounded border ${
+                    form.value.schedule === preset.value
+                      ? "border-accent bg-accent/10 text-accent"
+                      : "border-border text-text-muted hover:border-text-muted"
+                  }`}
+                >
+                  {preset.label}
+                </button>
+              ))}
+            </div>
+            <input
+              type="text"
+              value={form.value.schedule}
+              onInput={(e) =>
+                updateField("schedule", (e.target as HTMLInputElement).value)}
+              class={`${WIZARD_INPUT_CLASS} font-mono`}
+              placeholder="0 0 * * *"
+            />
+            {errors.value.schedule && (
+              <p class="text-xs text-error mt-1">{errors.value.schedule}</p>
+            )}
+            <p class="text-xs text-text-muted mt-1">
+              Format: minute hour day-of-month month day-of-week
+            </p>
+          </div>
+
+          {/* Included Namespaces */}
+          <div>
+            <label class="block text-sm font-medium text-text-primary mb-1">
+              Include Namespaces
+            </label>
+            <p class="text-xs text-text-muted mb-2">
+              Leave empty to back up all namespaces.
+            </p>
+            <select
+              multiple
+              onChange={(e) => {
+                const select = e.target as HTMLSelectElement;
+                const selected = Array.from(select.selectedOptions).map((o) =>
+                  o.value
+                );
+                updateField("includedNamespaces", selected);
+              }}
+              class={`${WIZARD_INPUT_CLASS} h-32`}
+            >
+              {namespaces.value.map((ns) => (
+                <option
+                  key={ns}
+                  value={ns}
+                  selected={form.value.includedNamespaces.includes(ns)}
+                >
+                  {ns}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Storage Location */}
+          <div>
+            <label class="block text-sm font-medium text-text-primary mb-1">
+              Storage Location
+            </label>
+            <select
+              value={form.value.storageLocation}
+              onChange={(e) =>
+                updateField(
+                  "storageLocation",
+                  (e.target as HTMLSelectElement).value,
+                )}
+              class={WIZARD_INPUT_CLASS}
+            >
+              <option value="">Default</option>
+              {bsls.value.map((bsl) => (
+                <option key={bsl.name} value={bsl.name}>
+                  {bsl.name} ({bsl.provider})
+                  {bsl.default ? " - default" : ""}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* TTL */}
+          <div>
+            <label class="block text-sm font-medium text-text-primary mb-1">
+              Retention (TTL)
+            </label>
+            <select
+              value={form.value.ttl}
+              onChange={(e) =>
+                updateField("ttl", (e.target as HTMLSelectElement).value)}
+              class={WIZARD_INPUT_CLASS}
+            >
+              {TTL_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
+              ))}
+            </select>
+          </div>
+
+          {/* Checkboxes */}
+          <div class="space-y-2">
+            <div class="flex items-center gap-2">
+              <input
+                type="checkbox"
+                id="snapshotVolumes"
+                checked={form.value.snapshotVolumes}
+                onChange={(e) =>
+                  updateField(
+                    "snapshotVolumes",
+                    (e.target as HTMLInputElement).checked,
+                  )}
+                class="rounded border-border"
+              />
+              <label
+                for="snapshotVolumes"
+                class="text-sm font-medium text-text-primary"
+              >
+                Snapshot persistent volumes
+              </label>
+            </div>
+            <div class="flex items-center gap-2">
+              <input
+                type="checkbox"
+                id="paused"
+                checked={form.value.paused}
+                onChange={(e) =>
+                  updateField(
+                    "paused",
+                    (e.target as HTMLInputElement).checked,
+                  )}
+                class="rounded border-border"
+              />
+              <label
+                for="paused"
+                class="text-sm font-medium text-text-primary"
+              >
+                Create paused (won't run until unpaused)
+              </label>
+            </div>
+          </div>
+
+          <div class="flex justify-end gap-2 pt-4 border-t border-border">
+            <a href="/backup/schedules">
+              <Button type="button" variant="ghost">Cancel</Button>
+            </a>
+            <Button type="button" variant="primary" onClick={handleNext}>
+              Next
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {currentStep.value === 1 && (
+        <WizardReviewStep
+          yaml={previewYaml.value}
+          onYamlChange={(v) => (previewYaml.value = v)}
+          loading={previewLoading.value}
+          error={previewError.value}
+          detailBasePath="/backup/schedules"
+        />
+      )}
+
+      {currentStep.value === 1 && !previewLoading.value &&
+        previewError.value === null && (
+        <div class="mt-4 flex justify-start">
+          <Button type="button" variant="ghost" onClick={handleBack}>
+            Back
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/lib/constants.ts
+++ b/frontend/lib/constants.ts
@@ -574,6 +574,17 @@ export const DOMAIN_SECTIONS: DomainSection[] = [
     ],
   },
   {
+    id: "backup",
+    label: "Backup",
+    icon: "archive",
+    href: "/backup",
+    tabs: [
+      { label: "Backups", href: "/backup/backups" },
+      { label: "Restores", href: "/backup/restores" },
+      { label: "Schedules", href: "/backup/schedules" },
+    ],
+  },
+  {
     id: "tools",
     label: "Tools",
     icon: "wrench",

--- a/frontend/lib/velero-types.ts
+++ b/frontend/lib/velero-types.ts
@@ -1,0 +1,165 @@
+/** VeleroStatus is the status response from the velero status API. */
+export interface VeleroStatus {
+  detected: boolean;
+  namespace?: string;
+  version?: string;
+  bslCount: number;
+  vslCount: number;
+  lastChecked: string;
+}
+
+/** Backup represents a Velero backup. */
+export interface Backup {
+  name: string;
+  namespace: string;
+  phase: string;
+  includedNamespaces?: string[];
+  excludedNamespaces?: string[];
+  storageLocation?: string;
+  ttl?: string;
+  snapshotVolumes: boolean;
+  startTime?: string;
+  completionTime?: string;
+  expiration?: string;
+  itemsBackedUp: number;
+  totalItems: number;
+  warnings: number;
+  errors: number;
+  scheduleName?: string;
+  labels?: Record<string, string>;
+}
+
+/** Restore represents a Velero restore. */
+export interface Restore {
+  name: string;
+  namespace: string;
+  phase: string;
+  backupName?: string;
+  scheduleName?: string;
+  includedNamespaces?: string[];
+  namespaceMapping?: Record<string, string>;
+  startTime?: string;
+  completionTime?: string;
+  itemsRestored: number;
+  totalItems: number;
+  warnings: number;
+  errors: number;
+  failureReason?: string;
+}
+
+/** Schedule represents a Velero backup schedule. */
+export interface Schedule {
+  name: string;
+  namespace: string;
+  phase: string;
+  schedule: string;
+  paused: boolean;
+  includedNamespaces?: string[];
+  storageLocation?: string;
+  ttl?: string;
+  lastBackup?: string;
+  nextRunTime?: string;
+  validationErrors?: string[];
+}
+
+/** BackupStorageLocation represents a Velero BSL. */
+export interface BackupStorageLocation {
+  name: string;
+  namespace: string;
+  provider: string;
+  bucket: string;
+  prefix?: string;
+  phase: string;
+  default: boolean;
+  lastSyncedTime?: string;
+  message?: string;
+}
+
+/** VolumeSnapshotLocation represents a Velero VSL. */
+export interface VolumeSnapshotLocation {
+  name: string;
+  namespace: string;
+  provider: string;
+}
+
+/** LocationsResponse is the response from the locations endpoint. */
+export interface LocationsResponse {
+  backupStorageLocations: BackupStorageLocation[];
+  volumeSnapshotLocations: VolumeSnapshotLocation[];
+}
+
+/** Phase helper types for UI styling. */
+export type PhaseCategory =
+  | "success"
+  | "warning"
+  | "error"
+  | "progress"
+  | "unknown";
+
+/** Get the category of a Velero phase for UI styling. */
+export function getPhaseCategory(phase: string): PhaseCategory {
+  const lowerPhase = phase.toLowerCase();
+
+  // Failed states
+  if (lowerPhase.includes("failed")) return "error";
+
+  // Partial failure / warning states
+  if (lowerPhase === "partiallyfailed") return "warning";
+
+  // Success states
+  if (["completed", "available", "enabled"].includes(lowerPhase)) {
+    return "success";
+  }
+
+  // In-progress states
+  if (
+    [
+      "inprogress",
+      "new",
+      "waitingforpluginoperations",
+      "finalizing",
+      "queued",
+      "readytostart",
+    ].includes(lowerPhase)
+  ) {
+    return "progress";
+  }
+
+  return "unknown";
+}
+
+/** Wizard input types for creating resources. */
+
+export interface BackupInput {
+  name: string;
+  namespace: string;
+  includedNamespaces?: string[];
+  excludedNamespaces?: string[];
+  storageLocation?: string;
+  ttl?: string;
+  snapshotVolumes?: boolean;
+  labels?: Record<string, string>;
+}
+
+export interface RestoreInput {
+  name: string;
+  namespace: string;
+  backupName?: string;
+  scheduleName?: string;
+  includedNamespaces?: string[];
+  excludedNamespaces?: string[];
+  namespaceMapping?: Record<string, string>;
+  restorePVs?: boolean;
+}
+
+export interface ScheduleInput {
+  name: string;
+  namespace: string;
+  schedule: string;
+  paused?: boolean;
+  includedNamespaces?: string[];
+  excludedNamespaces?: string[];
+  storageLocation?: string;
+  ttl?: string;
+  snapshotVolumes?: boolean;
+}

--- a/frontend/routes/backup/backups.tsx
+++ b/frontend/routes/backup/backups.tsx
@@ -1,0 +1,15 @@
+import { define } from "@/utils.ts";
+import SubNav from "@/islands/SubNav.tsx";
+import { DOMAIN_SECTIONS } from "@/lib/constants.ts";
+import VeleroDashboard from "@/islands/VeleroDashboard.tsx";
+
+const section = DOMAIN_SECTIONS.find((s) => s.id === "backup")!;
+
+export default define.page(function BackupsPage(ctx) {
+  return (
+    <>
+      <SubNav tabs={section.tabs ?? []} currentPath={ctx.url.pathname} />
+      <VeleroDashboard initialTab="backups" />
+    </>
+  );
+});

--- a/frontend/routes/backup/backups/new.tsx
+++ b/frontend/routes/backup/backups/new.tsx
@@ -1,0 +1,15 @@
+import { define } from "@/utils.ts";
+import SubNav from "@/islands/SubNav.tsx";
+import { DOMAIN_SECTIONS } from "@/lib/constants.ts";
+import VeleroBackupWizard from "@/islands/VeleroBackupWizard.tsx";
+
+const section = DOMAIN_SECTIONS.find((s) => s.id === "backup")!;
+
+export default define.page(function NewBackupPage(ctx) {
+  return (
+    <>
+      <SubNav tabs={section.tabs ?? []} currentPath={ctx.url.pathname} />
+      <VeleroBackupWizard />
+    </>
+  );
+});

--- a/frontend/routes/backup/index.tsx
+++ b/frontend/routes/backup/index.tsx
@@ -1,0 +1,10 @@
+import { define } from "@/utils.ts";
+
+export const handler = define.handlers({
+  GET(_ctx) {
+    return new Response(null, {
+      status: 302,
+      headers: { Location: "/backup/backups" },
+    });
+  },
+});

--- a/frontend/routes/backup/restores.tsx
+++ b/frontend/routes/backup/restores.tsx
@@ -1,0 +1,15 @@
+import { define } from "@/utils.ts";
+import SubNav from "@/islands/SubNav.tsx";
+import { DOMAIN_SECTIONS } from "@/lib/constants.ts";
+import VeleroDashboard from "@/islands/VeleroDashboard.tsx";
+
+const section = DOMAIN_SECTIONS.find((s) => s.id === "backup")!;
+
+export default define.page(function RestoresPage(ctx) {
+  return (
+    <>
+      <SubNav tabs={section.tabs ?? []} currentPath={ctx.url.pathname} />
+      <VeleroDashboard initialTab="restores" />
+    </>
+  );
+});

--- a/frontend/routes/backup/restores/new.tsx
+++ b/frontend/routes/backup/restores/new.tsx
@@ -1,0 +1,15 @@
+import { define } from "@/utils.ts";
+import SubNav from "@/islands/SubNav.tsx";
+import { DOMAIN_SECTIONS } from "@/lib/constants.ts";
+import VeleroRestoreWizard from "@/islands/VeleroRestoreWizard.tsx";
+
+const section = DOMAIN_SECTIONS.find((s) => s.id === "backup")!;
+
+export default define.page(function NewRestorePage(ctx) {
+  return (
+    <>
+      <SubNav tabs={section.tabs ?? []} currentPath={ctx.url.pathname} />
+      <VeleroRestoreWizard />
+    </>
+  );
+});

--- a/frontend/routes/backup/schedules.tsx
+++ b/frontend/routes/backup/schedules.tsx
@@ -1,0 +1,15 @@
+import { define } from "@/utils.ts";
+import SubNav from "@/islands/SubNav.tsx";
+import { DOMAIN_SECTIONS } from "@/lib/constants.ts";
+import VeleroDashboard from "@/islands/VeleroDashboard.tsx";
+
+const section = DOMAIN_SECTIONS.find((s) => s.id === "backup")!;
+
+export default define.page(function SchedulesPage(ctx) {
+  return (
+    <>
+      <SubNav tabs={section.tabs ?? []} currentPath={ctx.url.pathname} />
+      <VeleroDashboard initialTab="schedules" />
+    </>
+  );
+});

--- a/frontend/routes/backup/schedules/new.tsx
+++ b/frontend/routes/backup/schedules/new.tsx
@@ -1,0 +1,15 @@
+import { define } from "@/utils.ts";
+import SubNav from "@/islands/SubNav.tsx";
+import { DOMAIN_SECTIONS } from "@/lib/constants.ts";
+import VeleroScheduleWizard from "@/islands/VeleroScheduleWizard.tsx";
+
+const section = DOMAIN_SECTIONS.find((s) => s.id === "backup")!;
+
+export default define.page(function NewSchedulePage(ctx) {
+  return (
+    <>
+      <SubNav tabs={section.tabs ?? []} currentPath={ctx.url.pathname} />
+      <VeleroScheduleWizard />
+    </>
+  );
+});


### PR DESCRIPTION
## Summary

- Add comprehensive Velero backup/restore management to k8sCenter
- New `internal/velero` package with CRD-based Velero detection and CRUD operations
- VeleroDashboard island with tabs for backups, restores, and schedules
- Three wizard islands for creating backups, restores, and schedules
- Routes under `/backup/*` with sub-navigation
- Basic E2E tests for navigation and wizard UI

## Features

**Backend:**
- Velero CRD discovery (Backup, Restore, Schedule, BSL, VSL)
- Full CRUD with user impersonation and RBAC enforcement
- Audit logging for all mutating operations
- Singleflight + 30s cache pattern for list endpoints
- Wizard input types for YAML preview generation

**Frontend:**
- Dashboard with summary cards, search, and tabbed resource tables
- Backup wizard: name, included/excluded namespaces, storage location, TTL, volume snapshots
- Restore wizard: source backup selection, namespace filtering, PV restore toggle
- Schedule wizard: cron presets, validation, paused creation option
- Archive icon in IconRail navigation

**E2E:**
- Navigation tests for backup section
- Wizard UI element tests

## Test plan

- [ ] Backend: `go test ./internal/velero/...` passes
- [ ] Frontend: `deno lint` and `deno check` pass
- [ ] E2E: New tests cover backup section navigation and wizards
- [ ] Manual: Verify backup section appears in navigation when Velero is installed

## Screenshots

_(Velero must be installed in cluster to see populated data)_

Closes #165

Generated with [Claude Code](https://claude.com/claude-code)