### PR TITLE
feat(security): Vulnerability detail view — backend (Phase 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ e2e/test-results/
 *.tmp
 *.png
 .superpowers/
+.worktrees

--- a/backend/internal/scanning/handler.go
+++ b/backend/internal/scanning/handler.go
@@ -2,7 +2,6 @@ package scanning
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -10,7 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-chi/chi/v5"
 	"golang.org/x/sync/singleflight"
 
 	"github.com/kubecenter/kubecenter/internal/auth"
@@ -21,6 +19,14 @@ import (
 )
 
 // Handler serves security scanning HTTP endpoints.
+//
+// Known limitations carried from existing scanning endpoints (tracked for
+// follow-up; see todos/297 and todos/304):
+//   - Reads use the service account (BaseDynamicClient) plus an SSAR precheck
+//     rather than user impersonation. Stale-authorization window up to the
+//     AccessChecker cache TTL (~5 min).
+//   - Multi-cluster routing (X-Cluster-ID) is not threaded through — all reads
+//     hit the local cluster.
 type Handler struct {
 	K8sClient     *k8s.ClientFactory
 	Discoverer    *ScannerDiscoverer
@@ -28,9 +34,10 @@ type Handler struct {
 	NotifService  *notifications.NotificationService
 	Logger        *slog.Logger
 
-	fetchGroup singleflight.Group
-	cacheMu    sync.RWMutex
-	nsCache    map[string]*cachedNSData // initialized eagerly, never nil
+	fetchGroup  singleflight.Group
+	cacheMu     sync.RWMutex
+	nsCache     map[string]*cachedNSData     // namespace-scoped summary cache
+	detailCache map[string]*cachedDetailData // per-workload detail cache
 }
 
 type cachedNSData struct {
@@ -38,23 +45,31 @@ type cachedNSData struct {
 	fetchedAt time.Time
 }
 
+type cachedDetailData struct {
+	detail    *WorkloadVulnDetail
+	fetchedAt time.Time
+}
+
 const (
-	cacheTTL        = 30 * time.Second
-	cacheMaxEntries = 200 // evict oldest entries beyond this
+	cacheTTL              = 30 * time.Second
+	cacheMaxEntries       = 200 // evict oldest entries beyond this
+	detailCacheMaxEntries = 200
 )
 
 var validNamespace = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`)
 
-// InitCache must be called after construction to initialize the cache map.
+// InitCache must be called after construction to initialize the cache maps.
 // This avoids lazy init under locks.
 func (h *Handler) InitCache() {
 	h.nsCache = make(map[string]*cachedNSData)
+	h.detailCache = make(map[string]*cachedDetailData)
 }
 
 // InvalidateCache clears all cached scan data so subsequent requests re-fetch.
 func (h *Handler) InvalidateCache() {
 	h.cacheMu.Lock()
 	h.nsCache = make(map[string]*cachedNSData)
+	h.detailCache = make(map[string]*cachedDetailData)
 	h.cacheMu.Unlock()
 	if h.NotifService != nil {
 		go h.NotifService.Emit(context.Background(), notifications.Notification{
@@ -249,75 +264,6 @@ func (h *Handler) HandleVulnerabilities(w http.ResponseWriter, r *http.Request) 
 		Vulnerabilities: vulns,
 		Summary:         computeMetadata(vulns),
 	})
-}
-
-// validWorkloadKind limits accepted resource kinds in the detail endpoint to prevent
-// free-form path injection into the Kubernetes API.
-var validWorkloadKind = regexp.MustCompile(`^[A-Z][A-Za-z0-9]{1,62}$`)
-
-// validWorkloadName matches standard DNS-1123 subdomain (Kubernetes resource name).
-var validWorkloadName = regexp.MustCompile(`^[a-z0-9]([a-z0-9.\-]{0,251}[a-z0-9])?$`)
-
-// HandleVulnerabilityDetail returns full CVE details for a specific workload.
-// Route: GET /v1/scanning/vulnerabilities/{namespace}/{kind}/{name}
-func (h *Handler) HandleVulnerabilityDetail(w http.ResponseWriter, r *http.Request) {
-	user, ok := httputil.RequireUser(w, r)
-	if !ok {
-		return
-	}
-
-	namespace := chi.URLParam(r, "namespace")
-	kind := chi.URLParam(r, "kind")
-	name := chi.URLParam(r, "name")
-
-	if !validNamespace.MatchString(namespace) {
-		httputil.WriteError(w, http.StatusBadRequest, "invalid namespace", "")
-		return
-	}
-	if !validWorkloadKind.MatchString(kind) {
-		httputil.WriteError(w, http.StatusBadRequest, "invalid resource kind", "")
-		return
-	}
-	if !validWorkloadName.MatchString(name) {
-		httputil.WriteError(w, http.StatusBadRequest, "invalid resource name", "")
-		return
-	}
-
-	// RBAC: require Trivy access. Kubescape CVE-level detail is not supported.
-	if !h.canAccessTrivy(r.Context(), user, namespace) {
-		httputil.WriteError(w, http.StatusForbidden,
-			fmt.Sprintf("access denied to vulnerability reports in namespace %q", namespace), "")
-		return
-	}
-
-	// Check scanner status. If only Kubescape is available, return a helpful message.
-	status := h.Discoverer.Status()
-	if status.Trivy == nil || !status.Trivy.Available {
-		httputil.WriteError(w, http.StatusNotImplemented,
-			"CVE-level detail requires Trivy Operator; Kubescape summaries only expose severity totals", "")
-		return
-	}
-
-	// Add 30s timeout to prevent hanging on slow API servers.
-	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
-	defer cancel()
-
-	dynClient := h.K8sClient.BaseDynamicClient()
-	detail, err := GetTrivyWorkloadVulnDetails(ctx, dynClient, namespace, kind, name)
-	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) {
-			h.Logger.Warn("vulnerability detail fetch timed out",
-				"namespace", namespace, "kind", kind, "name", name)
-			httputil.WriteError(w, http.StatusGatewayTimeout, "timed out fetching vulnerability details", "")
-			return
-		}
-		h.Logger.Error("failed to fetch vulnerability detail",
-			"namespace", namespace, "kind", kind, "name", name, "error", err)
-		httputil.WriteError(w, http.StatusInternalServerError, "failed to fetch vulnerability details", "")
-		return
-	}
-
-	httputil.WriteData(w, detail)
 }
 
 // canAccessTrivy checks if the user can list Trivy VulnerabilityReports in the namespace.

--- a/backend/internal/scanning/handler.go
+++ b/backend/internal/scanning/handler.go
@@ -2,6 +2,7 @@ package scanning
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -9,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-chi/chi/v5"
 	"golang.org/x/sync/singleflight"
 
 	"github.com/kubecenter/kubecenter/internal/auth"
@@ -247,6 +249,75 @@ func (h *Handler) HandleVulnerabilities(w http.ResponseWriter, r *http.Request) 
 		Vulnerabilities: vulns,
 		Summary:         computeMetadata(vulns),
 	})
+}
+
+// validWorkloadKind limits accepted resource kinds in the detail endpoint to prevent
+// free-form path injection into the Kubernetes API.
+var validWorkloadKind = regexp.MustCompile(`^[A-Z][A-Za-z0-9]{1,62}$`)
+
+// validWorkloadName matches standard DNS-1123 subdomain (Kubernetes resource name).
+var validWorkloadName = regexp.MustCompile(`^[a-z0-9]([a-z0-9.\-]{0,251}[a-z0-9])?$`)
+
+// HandleVulnerabilityDetail returns full CVE details for a specific workload.
+// Route: GET /v1/scanning/vulnerabilities/{namespace}/{kind}/{name}
+func (h *Handler) HandleVulnerabilityDetail(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	namespace := chi.URLParam(r, "namespace")
+	kind := chi.URLParam(r, "kind")
+	name := chi.URLParam(r, "name")
+
+	if !validNamespace.MatchString(namespace) {
+		httputil.WriteError(w, http.StatusBadRequest, "invalid namespace", "")
+		return
+	}
+	if !validWorkloadKind.MatchString(kind) {
+		httputil.WriteError(w, http.StatusBadRequest, "invalid resource kind", "")
+		return
+	}
+	if !validWorkloadName.MatchString(name) {
+		httputil.WriteError(w, http.StatusBadRequest, "invalid resource name", "")
+		return
+	}
+
+	// RBAC: require Trivy access. Kubescape CVE-level detail is not supported.
+	if !h.canAccessTrivy(r.Context(), user, namespace) {
+		httputil.WriteError(w, http.StatusForbidden,
+			fmt.Sprintf("access denied to vulnerability reports in namespace %q", namespace), "")
+		return
+	}
+
+	// Check scanner status. If only Kubescape is available, return a helpful message.
+	status := h.Discoverer.Status()
+	if status.Trivy == nil || !status.Trivy.Available {
+		httputil.WriteError(w, http.StatusNotImplemented,
+			"CVE-level detail requires Trivy Operator; Kubescape summaries only expose severity totals", "")
+		return
+	}
+
+	// Add 30s timeout to prevent hanging on slow API servers.
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+
+	dynClient := h.K8sClient.BaseDynamicClient()
+	detail, err := GetTrivyWorkloadVulnDetails(ctx, dynClient, namespace, kind, name)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			h.Logger.Warn("vulnerability detail fetch timed out",
+				"namespace", namespace, "kind", kind, "name", name)
+			httputil.WriteError(w, http.StatusGatewayTimeout, "timed out fetching vulnerability details", "")
+			return
+		}
+		h.Logger.Error("failed to fetch vulnerability detail",
+			"namespace", namespace, "kind", kind, "name", name, "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to fetch vulnerability details", "")
+		return
+	}
+
+	httputil.WriteData(w, detail)
 }
 
 // canAccessTrivy checks if the user can list Trivy VulnerabilityReports in the namespace.

--- a/backend/internal/scanning/handler_vulnerability_detail.go
+++ b/backend/internal/scanning/handler_vulnerability_detail.go
@@ -1,0 +1,131 @@
+package scanning
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"regexp"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/kubecenter/kubecenter/internal/httputil"
+)
+
+// validWorkloadKind limits accepted resource kinds in the detail endpoint.
+// Resource-name and namespace validation is handled by resources.ValidateURLParams
+// middleware on the route; kinds are not validated by that middleware so we
+// enforce a PascalCase identifier regex here.
+var validWorkloadKind = regexp.MustCompile(`^[A-Z][A-Za-z0-9]{1,62}$`)
+
+// fetchVulnDetail returns cached CVE detail for a workload, refreshing if stale.
+// Uses singleflight to coalesce concurrent identical requests and a 30s TTL cache
+// to protect the apiserver from rapid-click scenarios (same pattern as fetchVulns).
+func (h *Handler) fetchVulnDetail(ctx context.Context, namespace, kind, name string) (*WorkloadVulnDetail, error) {
+	cacheKey := namespace + "/" + kind + "/" + name
+
+	h.cacheMu.RLock()
+	if entry := h.detailCache[cacheKey]; entry != nil && time.Since(entry.fetchedAt) < cacheTTL {
+		detail := entry.detail
+		h.cacheMu.RUnlock()
+		return detail, nil
+	}
+	h.cacheMu.RUnlock()
+
+	key := "vuln-detail:" + cacheKey
+	result, err, _ := h.fetchGroup.Do(key, func() (any, error) {
+		dynClient := h.K8sClient.BaseDynamicClient()
+		return GetTrivyWorkloadVulnDetails(ctx, dynClient, namespace, kind, name)
+	})
+	if err != nil {
+		return nil, err
+	}
+	detail := result.(*WorkloadVulnDetail)
+
+	h.cacheMu.Lock()
+	h.detailCache[cacheKey] = &cachedDetailData{detail: detail, fetchedAt: time.Now()}
+	if len(h.detailCache) > detailCacheMaxEntries {
+		h.evictOldestDetailLocked()
+	}
+	h.cacheMu.Unlock()
+
+	return detail, nil
+}
+
+// evictOldestDetailLocked removes the oldest detail cache entry. Call under write lock.
+func (h *Handler) evictOldestDetailLocked() {
+	var oldestKey string
+	var oldestTime time.Time
+	for k, v := range h.detailCache {
+		if oldestKey == "" || v.fetchedAt.Before(oldestTime) {
+			oldestKey = k
+			oldestTime = v.fetchedAt
+		}
+	}
+	if oldestKey != "" {
+		delete(h.detailCache, oldestKey)
+	}
+}
+
+// HandleVulnerabilityDetail returns full CVE details for a specific workload.
+// Route: GET /v1/scanning/vulnerabilities/{namespace}/{kind}/{name}
+//
+// Input validation: resources.ValidateURLParams middleware validates {namespace}
+// and {name}; this handler validates {kind}.
+func (h *Handler) HandleVulnerabilityDetail(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	namespace := chi.URLParam(r, "namespace")
+	kind := chi.URLParam(r, "kind")
+	name := chi.URLParam(r, "name")
+
+	if !validWorkloadKind.MatchString(kind) {
+		httputil.WriteError(w, http.StatusBadRequest, "invalid resource kind", "")
+		return
+	}
+
+	// Check scanner availability first — if Trivy isn't installed, the RBAC
+	// error would be misleading ("access denied" when the real fix is
+	// installing Trivy Operator).
+	status := h.Discoverer.Status()
+	if status.Trivy == nil || !status.Trivy.Available {
+		httputil.WriteError(w, http.StatusNotImplemented,
+			"CVE-level detail requires Trivy Operator", "")
+		return
+	}
+
+	// RBAC: require Trivy list access in the target namespace.
+	// Kubescape CVE-level detail is not supported — its detail CRDs live in
+	// the kubescape namespace and aren't accessible under user impersonation.
+	if !h.canAccessTrivy(r.Context(), user, namespace) {
+		httputil.WriteError(w, http.StatusForbidden,
+			fmt.Sprintf("access denied to vulnerability reports in namespace %q", namespace), "")
+		return
+	}
+
+	// 10s timeout: healthy apiservers return label-selector List in <500ms.
+	// A degraded apiserver tying up handler goroutines for 30s amplifies
+	// partial outages into full ones.
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	detail, err := h.fetchVulnDetail(ctx, namespace, kind, name)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			h.Logger.Warn("vulnerability detail fetch timed out",
+				"namespace", namespace, "kind", kind, "name", name)
+			httputil.WriteError(w, http.StatusGatewayTimeout, "timed out fetching vulnerability details", "")
+			return
+		}
+		h.Logger.Error("failed to fetch vulnerability detail",
+			"namespace", namespace, "kind", kind, "name", name, "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to fetch vulnerability details", "")
+		return
+	}
+
+	httputil.WriteData(w, detail)
+}

--- a/backend/internal/scanning/trivy.go
+++ b/backend/internal/scanning/trivy.go
@@ -3,6 +3,8 @@ package scanning
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -122,4 +124,196 @@ func ListTrivyVulnSummaries(ctx context.Context, dynClient dynamic.Interface, na
 	}
 
 	return results, nil
+}
+
+// severityRank returns a numeric rank for sorting (lower = more severe).
+func severityRank(severity string) int {
+	switch strings.ToUpper(severity) {
+	case "CRITICAL":
+		return 0
+	case "HIGH":
+		return 1
+	case "MEDIUM":
+		return 2
+	case "LOW":
+		return 3
+	default:
+		return 4 // UNKNOWN and anything unexpected
+	}
+}
+
+// selectCVSSScore picks the best CVSS v3 score from Trivy's vendor-keyed CVSS map.
+// Prefers NVD, falls back to known vendors, then to the first available.
+// Returns nil when no CVSS data is present.
+func selectCVSSScore(cvss map[string]interface{}) *float64 {
+	if len(cvss) == 0 {
+		return nil
+	}
+	preferred := []string{"nvd", "redhat", "ubuntu", "debian"}
+	for _, vendor := range preferred {
+		if score := extractV3Score(cvss, vendor); score != nil {
+			return score
+		}
+	}
+	// Fall back to the first vendor with a score.
+	for vendor := range cvss {
+		if score := extractV3Score(cvss, vendor); score != nil {
+			return score
+		}
+	}
+	return nil
+}
+
+// extractV3Score pulls V3Score from a nested CVSS vendor map.
+func extractV3Score(cvss map[string]interface{}, vendor string) *float64 {
+	vendorMap, ok := cvss[vendor].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	raw, ok := vendorMap["V3Score"]
+	if !ok {
+		return nil
+	}
+	switch v := raw.(type) {
+	case float64:
+		return &v
+	case int64:
+		f := float64(v)
+		return &f
+	case int:
+		f := float64(v)
+		return &f
+	}
+	return nil
+}
+
+// GetTrivyWorkloadVulnDetails fetches full CVE details for a specific workload
+// from Trivy VulnerabilityReport CRDs. Returns grouped-by-image results sorted
+// by severity (CRITICAL→LOW→UNKNOWN) then by CVSS score descending.
+func GetTrivyWorkloadVulnDetails(
+	ctx context.Context,
+	dynClient dynamic.Interface,
+	namespace, kind, name string,
+) (*WorkloadVulnDetail, error) {
+	// Filter reports via label selectors. Trivy labels use these keys:
+	//   trivy-operator.resource.namespace
+	//   trivy-operator.resource.kind
+	//   trivy-operator.resource.name
+	labelSelector := fmt.Sprintf(
+		"trivy-operator.resource.namespace=%s,trivy-operator.resource.kind=%s,trivy-operator.resource.name=%s",
+		namespace, kind, name,
+	)
+
+	list, err := dynClient.Resource(trivyVulnReportGVR).Namespace(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing trivy vulnerability reports for %s/%s/%s: %w", namespace, kind, name, err)
+	}
+
+	detail := &WorkloadVulnDetail{
+		Namespace: namespace,
+		Kind:      kind,
+		Name:      name,
+		Scanner:   ScannerTrivy,
+		Images:    []ImageVulnDetail{},
+	}
+
+	for i := range list.Items {
+		obj := &list.Items[i]
+		labels := obj.GetLabels()
+		container := labels["trivy-operator.container.name"]
+
+		// Build image reference from artifact.
+		repo, _, _ := unstructured.NestedString(obj.Object, "report", "artifact", "repository")
+		tag, _, _ := unstructured.NestedString(obj.Object, "report", "artifact", "tag")
+		image := repo
+		if tag != "" {
+			image = repo + ":" + tag
+		}
+		if image == "" {
+			image = container
+		}
+
+		scanTime, _, _ := unstructured.NestedString(obj.Object, "report", "updateTimestamp")
+		if scanTime > detail.LastScanned {
+			detail.LastScanned = scanTime
+		}
+
+		// Extract the vulnerabilities[] array.
+		vulnsRaw, _, _ := unstructured.NestedSlice(obj.Object, "report", "vulnerabilities")
+		cves := make([]CVEDetail, 0, len(vulnsRaw))
+		for _, v := range vulnsRaw {
+			vmap, ok := v.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			cve := extractCVEDetail(vmap)
+			if cve.ID == "" {
+				continue
+			}
+			cves = append(cves, cve)
+		}
+
+		// Sort CVEs: severity asc (0=critical first), CVSS desc, ID asc.
+		sort.SliceStable(cves, func(i, j int) bool {
+			si, sj := severityRank(cves[i].Severity), severityRank(cves[j].Severity)
+			if si != sj {
+				return si < sj
+			}
+			ci := float64(0)
+			if cves[i].CVSSScore != nil {
+				ci = *cves[i].CVSSScore
+			}
+			cj := float64(0)
+			if cves[j].CVSSScore != nil {
+				cj = *cves[j].CVSSScore
+			}
+			if ci != cj {
+				return ci > cj
+			}
+			return cves[i].ID < cves[j].ID
+		})
+
+		detail.Images = append(detail.Images, ImageVulnDetail{
+			Name:            image,
+			Container:       container,
+			Vulnerabilities: cves,
+		})
+	}
+
+	return detail, nil
+}
+
+// extractCVEDetail maps a single Trivy vulnerability map to a CVEDetail.
+func extractCVEDetail(v map[string]interface{}) CVEDetail {
+	getStr := func(key string) string {
+		s, _ := v[key].(string)
+		return s
+	}
+
+	cve := CVEDetail{
+		ID:               getStr("vulnerabilityID"),
+		Severity:         strings.ToUpper(getStr("severity")),
+		Package:          getStr("resource"),
+		InstalledVersion: getStr("installedVersion"),
+		FixedVersion:     getStr("fixedVersion"),
+		Title:            getStr("title"),
+		PrimaryLink:      getStr("primaryLink"),
+	}
+	if cve.Severity == "" {
+		cve.Severity = "UNKNOWN"
+	}
+
+	// Prefer nested CVSS map; fall back to top-level "score" field.
+	if cvssMap, ok := v["cvss"].(map[string]interface{}); ok {
+		cve.CVSSScore = selectCVSSScore(cvssMap)
+	}
+	if cve.CVSSScore == nil {
+		if score, ok := v["score"].(float64); ok {
+			cve.CVSSScore = &score
+		}
+	}
+
+	return cve
 }

--- a/backend/internal/scanning/trivy.go
+++ b/backend/internal/scanning/trivy.go
@@ -1,16 +1,33 @@
 package scanning
 
 import (
+	"cmp"
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 )
+
+// imageRefFromArtifact builds a container image reference from a Trivy report's
+// report.artifact fields, falling back to the container name when repository is empty.
+func imageRefFromArtifact(obj map[string]interface{}, containerName string) string {
+	repo, _, _ := unstructured.NestedString(obj, "report", "artifact", "repository")
+	tag, _, _ := unstructured.NestedString(obj, "report", "artifact", "tag")
+	if repo == "" {
+		return containerName
+	}
+	if tag == "" {
+		return repo
+	}
+	return repo + ":" + tag
+}
 
 var trivyVulnReportGVR = schema.GroupVersionResource{
 	Group:    "aquasecurity.github.io",
@@ -58,18 +75,7 @@ func ListTrivyVulnSummaries(ctx context.Context, dynClient dynamic.Interface, na
 		medium, _, _ := unstructured.NestedInt64(obj.Object, "report", "summary", "mediumCount")
 		low, _, _ := unstructured.NestedInt64(obj.Object, "report", "summary", "lowCount")
 
-		// Build image reference from artifact.
-		repo, _, _ := unstructured.NestedString(obj.Object, "report", "artifact", "repository")
-		tag, _, _ := unstructured.NestedString(obj.Object, "report", "artifact", "tag")
-		image := repo
-		if tag != "" {
-			image = repo + ":" + tag
-		}
-
-		// Use container name as fallback image label when artifact is missing.
-		if image == "" {
-			image = container
-		}
+		image := imageRefFromArtifact(obj.Object, container)
 
 		scanTime, _, _ := unstructured.NestedString(obj.Object, "report", "updateTimestamp")
 
@@ -143,46 +149,38 @@ func severityRank(severity string) int {
 }
 
 // selectCVSSScore picks the best CVSS v3 score from Trivy's vendor-keyed CVSS map.
-// Prefers NVD, falls back to known vendors, then to the first available.
-// Returns nil when no CVSS data is present.
+// Prefers NVD, falls back to RedHat/Ubuntu/Debian, then to any remaining vendor
+// in alphabetical order for determinism. Returns nil when no V3Score is present.
+//
+// Trivy's report.vulnerabilities[].cvss is serialized as YAML and decoded via
+// unstructured, so numeric values arrive as float64 — int branches are dead.
 func selectCVSSScore(cvss map[string]interface{}) *float64 {
 	if len(cvss) == 0 {
 		return nil
 	}
-	preferred := []string{"nvd", "redhat", "ubuntu", "debian"}
-	for _, vendor := range preferred {
-		if score := extractV3Score(cvss, vendor); score != nil {
-			return score
+	get := func(vendor string) *float64 {
+		m, _ := cvss[vendor].(map[string]interface{})
+		if f, ok := m["V3Score"].(float64); ok {
+			return &f
+		}
+		return nil
+	}
+	for _, vendor := range []string{"nvd", "redhat", "ubuntu", "debian"} {
+		if s := get(vendor); s != nil {
+			return s
 		}
 	}
-	// Fall back to the first vendor with a score.
+	// Deterministic fallback: sort remaining vendors so the same input always
+	// yields the same output regardless of Go's map iteration order.
+	remaining := make([]string, 0, len(cvss))
 	for vendor := range cvss {
-		if score := extractV3Score(cvss, vendor); score != nil {
-			return score
+		remaining = append(remaining, vendor)
+	}
+	sort.Strings(remaining)
+	for _, vendor := range remaining {
+		if s := get(vendor); s != nil {
+			return s
 		}
-	}
-	return nil
-}
-
-// extractV3Score pulls V3Score from a nested CVSS vendor map.
-func extractV3Score(cvss map[string]interface{}, vendor string) *float64 {
-	vendorMap, ok := cvss[vendor].(map[string]interface{})
-	if !ok {
-		return nil
-	}
-	raw, ok := vendorMap["V3Score"]
-	if !ok {
-		return nil
-	}
-	switch v := raw.(type) {
-	case float64:
-		return &v
-	case int64:
-		f := float64(v)
-		return &f
-	case int:
-		f := float64(v)
-		return &f
 	}
 	return nil
 }
@@ -190,22 +188,25 @@ func extractV3Score(cvss map[string]interface{}, vendor string) *float64 {
 // GetTrivyWorkloadVulnDetails fetches full CVE details for a specific workload
 // from Trivy VulnerabilityReport CRDs. Returns grouped-by-image results sorted
 // by severity (CRITICAL→LOW→UNKNOWN) then by CVSS score descending.
+//
+// Callers must validate namespace/kind/name before invoking — inputs flow into
+// a label selector and must not contain selector metacharacters. In practice,
+// scanning/handler.go applies regex validation and the resources.ValidateURLParams
+// middleware before this function is reached.
 func GetTrivyWorkloadVulnDetails(
 	ctx context.Context,
 	dynClient dynamic.Interface,
 	namespace, kind, name string,
 ) (*WorkloadVulnDetail, error) {
-	// Filter reports via label selectors. Trivy labels use these keys:
-	//   trivy-operator.resource.namespace
-	//   trivy-operator.resource.kind
-	//   trivy-operator.resource.name
-	labelSelector := fmt.Sprintf(
-		"trivy-operator.resource.namespace=%s,trivy-operator.resource.kind=%s,trivy-operator.resource.name=%s",
-		namespace, kind, name,
-	)
+	// Build the label selector via the typed API so it can't be mis-escaped.
+	selector := labels.SelectorFromSet(labels.Set{
+		"trivy-operator.resource.namespace": namespace,
+		"trivy-operator.resource.kind":      kind,
+		"trivy-operator.resource.name":      name,
+	}).String()
 
 	list, err := dynClient.Resource(trivyVulnReportGVR).Namespace(namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: labelSelector,
+		LabelSelector: selector,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("listing trivy vulnerability reports for %s/%s/%s: %w", namespace, kind, name, err)
@@ -216,24 +217,15 @@ func GetTrivyWorkloadVulnDetails(
 		Kind:      kind,
 		Name:      name,
 		Scanner:   ScannerTrivy,
-		Images:    []ImageVulnDetail{},
+		Images:    make([]ImageVulnDetail, 0, len(list.Items)),
 	}
 
 	for i := range list.Items {
 		obj := &list.Items[i]
-		labels := obj.GetLabels()
-		container := labels["trivy-operator.container.name"]
+		reportLabels := obj.GetLabels()
+		container := reportLabels["trivy-operator.container.name"]
 
-		// Build image reference from artifact.
-		repo, _, _ := unstructured.NestedString(obj.Object, "report", "artifact", "repository")
-		tag, _, _ := unstructured.NestedString(obj.Object, "report", "artifact", "tag")
-		image := repo
-		if tag != "" {
-			image = repo + ":" + tag
-		}
-		if image == "" {
-			image = container
-		}
+		image := imageRefFromArtifact(obj.Object, container)
 
 		scanTime, _, _ := unstructured.NestedString(obj.Object, "report", "updateTimestamp")
 		if scanTime > detail.LastScanned {
@@ -256,23 +248,22 @@ func GetTrivyWorkloadVulnDetails(
 		}
 
 		// Sort CVEs: severity asc (0=critical first), CVSS desc, ID asc.
-		sort.SliceStable(cves, func(i, j int) bool {
-			si, sj := severityRank(cves[i].Severity), severityRank(cves[j].Severity)
-			if si != sj {
-				return si < sj
+		// Comparator defines a total order so stability isn't required.
+		slices.SortFunc(cves, func(a, b CVEDetail) int {
+			if n := cmp.Compare(severityRank(a.Severity), severityRank(b.Severity)); n != 0 {
+				return n
 			}
-			ci := float64(0)
-			if cves[i].CVSSScore != nil {
-				ci = *cves[i].CVSSScore
+			ai, bi := float64(0), float64(0)
+			if a.CVSSScore != nil {
+				ai = *a.CVSSScore
 			}
-			cj := float64(0)
-			if cves[j].CVSSScore != nil {
-				cj = *cves[j].CVSSScore
+			if b.CVSSScore != nil {
+				bi = *b.CVSSScore
 			}
-			if ci != cj {
-				return ci > cj
+			if n := cmp.Compare(bi, ai); n != 0 { // descending on score
+				return n
 			}
-			return cves[i].ID < cves[j].ID
+			return cmp.Compare(a.ID, b.ID)
 		})
 
 		detail.Images = append(detail.Images, ImageVulnDetail{
@@ -292,9 +283,11 @@ func extractCVEDetail(v map[string]interface{}) CVEDetail {
 		return s
 	}
 
+	// Trivy emits severities in uppercase; severityRank normalizes case at
+	// sort time as defense-in-depth, so ToUpper here would be redundant.
 	cve := CVEDetail{
 		ID:               getStr("vulnerabilityID"),
-		Severity:         strings.ToUpper(getStr("severity")),
+		Severity:         getStr("severity"),
 		Package:          getStr("resource"),
 		InstalledVersion: getStr("installedVersion"),
 		FixedVersion:     getStr("fixedVersion"),

--- a/backend/internal/scanning/trivy_test.go
+++ b/backend/internal/scanning/trivy_test.go
@@ -514,6 +514,168 @@ func TestGetTrivyWorkloadVulnDetails_MultipleImages(t *testing.T) {
 	if len(detail.Images) != 2 {
 		t.Fatalf("expected 2 images, got %d", len(detail.Images))
 	}
+
+	// Assert per-image identity: CVE ID should match its container.
+	byContainer := map[string]ImageVulnDetail{}
+	for _, img := range detail.Images {
+		byContainer[img.Container] = img
+	}
+	main, ok := byContainer["main"]
+	if !ok {
+		t.Fatalf("expected image for container 'main', got containers: %v", keys(byContainer))
+	}
+	if main.Name != "myrepo/app:v1" {
+		t.Errorf("main image name: expected %q, got %q", "myrepo/app:v1", main.Name)
+	}
+	if len(main.Vulnerabilities) != 1 || main.Vulnerabilities[0].ID != "CVE-A" {
+		t.Errorf("main CVE: expected [CVE-A], got %+v", main.Vulnerabilities)
+	}
+	sidecar, ok := byContainer["sidecar"]
+	if !ok {
+		t.Fatalf("expected image for container 'sidecar', got containers: %v", keys(byContainer))
+	}
+	if sidecar.Name != "envoy:v1.28" {
+		t.Errorf("sidecar image name: expected %q, got %q", "envoy:v1.28", sidecar.Name)
+	}
+	if len(sidecar.Vulnerabilities) != 1 || sidecar.Vulnerabilities[0].ID != "CVE-B" {
+		t.Errorf("sidecar CVE: expected [CVE-B], got %+v", sidecar.Vulnerabilities)
+	}
+}
+
+func keys(m map[string]ImageVulnDetail) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// TestGetTrivyWorkloadVulnDetails_TopLevelScoreFallback verifies that when a
+// vulnerability has no nested cvss map but carries a top-level "score" field,
+// that value is used as the CVSS score.
+func TestGetTrivyWorkloadVulnDetails_TopLevelScoreFallback(t *testing.T) {
+	report := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "aquasecurity.github.io/v1alpha1",
+			"kind":       "VulnerabilityReport",
+			"metadata": map[string]interface{}{
+				"name":      "ds-node-agent",
+				"namespace": "default",
+				"labels": map[string]interface{}{
+					"trivy-operator.resource.kind":      "DaemonSet",
+					"trivy-operator.resource.name":      "node-agent",
+					"trivy-operator.resource.namespace": "default",
+					"trivy-operator.container.name":     "agent",
+				},
+			},
+			"report": map[string]interface{}{
+				"artifact": map[string]interface{}{"repository": "agent", "tag": "v1"},
+				"vulnerabilities": []interface{}{
+					map[string]interface{}{
+						"vulnerabilityID": "CVE-TOP",
+						"severity":        "MEDIUM",
+						"resource":        "glibc",
+						"score":           5.5, // top-level, no nested cvss map
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{trivyVulnReportGVR: "VulnerabilityReportList"},
+		report,
+	)
+
+	detail, err := GetTrivyWorkloadVulnDetails(context.Background(), dynClient, "default", "DaemonSet", "node-agent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(detail.Images) != 1 || len(detail.Images[0].Vulnerabilities) != 1 {
+		t.Fatalf("expected 1 image with 1 CVE, got %+v", detail.Images)
+	}
+	cve := detail.Images[0].Vulnerabilities[0]
+	if cve.CVSSScore == nil || *cve.CVSSScore != 5.5 {
+		t.Errorf("expected CVSS 5.5 from top-level score, got %v", cve.CVSSScore)
+	}
+}
+
+// TestGetTrivyWorkloadVulnDetails_SkipsMalformedEntries ensures the loop
+// silently drops non-map entries and entries missing vulnerabilityID.
+func TestGetTrivyWorkloadVulnDetails_SkipsMalformedEntries(t *testing.T) {
+	report := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "aquasecurity.github.io/v1alpha1",
+			"kind":       "VulnerabilityReport",
+			"metadata": map[string]interface{}{
+				"name":      "deploy-app-main",
+				"namespace": "default",
+				"labels": map[string]interface{}{
+					"trivy-operator.resource.kind":      "Deployment",
+					"trivy-operator.resource.name":      "app",
+					"trivy-operator.resource.namespace": "default",
+					"trivy-operator.container.name":     "main",
+				},
+			},
+			"report": map[string]interface{}{
+				"artifact": map[string]interface{}{"repository": "app", "tag": "v1"},
+				"vulnerabilities": []interface{}{
+					"not-a-map", // non-map entry, should be skipped
+					map[string]interface{}{
+						// missing vulnerabilityID, should be skipped
+						"severity": "HIGH",
+						"resource": "x",
+					},
+					map[string]interface{}{
+						"vulnerabilityID": "CVE-OK",
+						"severity":        "LOW",
+						"resource":        "pkg",
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{trivyVulnReportGVR: "VulnerabilityReportList"},
+		report,
+	)
+
+	detail, err := GetTrivyWorkloadVulnDetails(context.Background(), dynClient, "default", "Deployment", "app")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(detail.Images) != 1 {
+		t.Fatalf("expected 1 image, got %d", len(detail.Images))
+	}
+	cves := detail.Images[0].Vulnerabilities
+	if len(cves) != 1 {
+		t.Fatalf("expected 1 CVE (malformed entries skipped), got %d: %+v", len(cves), cves)
+	}
+	if cves[0].ID != "CVE-OK" {
+		t.Errorf("expected CVE-OK, got %q", cves[0].ID)
+	}
+}
+
+// TestSelectCVSSScore_DeterministicFallback verifies that when no preferred
+// vendor is present, alphabetical ordering of remaining vendors yields
+// deterministic results regardless of Go's map iteration order.
+func TestSelectCVSSScore_DeterministicFallback(t *testing.T) {
+	cvss := map[string]interface{}{
+		"zzz":    map[string]interface{}{"V3Score": 9.0},
+		"alpine": map[string]interface{}{"V3Score": 5.0},
+		"custom": map[string]interface{}{"V3Score": 7.0},
+	}
+	// Expected: alphabetical first with V3Score = "alpine" → 5.0
+	got := selectCVSSScore(cvss)
+	if got == nil {
+		t.Fatalf("expected non-nil score")
+	}
+	if *got != 5.0 {
+		t.Errorf("expected 5.0 (alpine) via deterministic fallback, got %v", *got)
+	}
 }
 
 func TestGetTrivyWorkloadVulnDetails_EmptyReports(t *testing.T) {

--- a/backend/internal/scanning/trivy_test.go
+++ b/backend/internal/scanning/trivy_test.go
@@ -268,3 +268,275 @@ func TestListTrivyVulnSummaries_NamespaceScoped(t *testing.T) {
 		t.Errorf("expected namespace %q, got %q", "specific-ns", listAction.GetNamespace())
 	}
 }
+
+func TestSelectCVSSScore(t *testing.T) {
+	tests := []struct {
+		name  string
+		cvss  map[string]interface{}
+		want  *float64
+	}{
+		{
+			name: "prefers nvd",
+			cvss: map[string]interface{}{
+				"nvd":    map[string]interface{}{"V3Score": 9.8},
+				"redhat": map[string]interface{}{"V3Score": 7.5},
+			},
+			want: ptrFloat(9.8),
+		},
+		{
+			name: "falls back to redhat",
+			cvss: map[string]interface{}{
+				"redhat": map[string]interface{}{"V3Score": 7.5},
+			},
+			want: ptrFloat(7.5),
+		},
+		{
+			name: "falls back to any vendor",
+			cvss: map[string]interface{}{
+				"alpine": map[string]interface{}{"V3Score": 5.0},
+			},
+			want: ptrFloat(5.0),
+		},
+		{
+			name: "nil when empty",
+			cvss: map[string]interface{}{},
+			want: nil,
+		},
+		{
+			name: "nil when vendor has no V3Score",
+			cvss: map[string]interface{}{
+				"nvd": map[string]interface{}{"V2Score": 4.0},
+			},
+			want: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := selectCVSSScore(tc.cvss)
+			if tc.want == nil && got != nil {
+				t.Errorf("expected nil, got %v", *got)
+			}
+			if tc.want != nil && got == nil {
+				t.Errorf("expected %v, got nil", *tc.want)
+			}
+			if tc.want != nil && got != nil && *tc.want != *got {
+				t.Errorf("expected %v, got %v", *tc.want, *got)
+			}
+		})
+	}
+}
+
+func TestSeverityRank(t *testing.T) {
+	cases := map[string]int{
+		"CRITICAL": 0,
+		"HIGH":     1,
+		"MEDIUM":   2,
+		"LOW":      3,
+		"UNKNOWN":  4,
+		"":         4,
+		"weird":    4,
+		"critical": 0, // case-insensitive
+	}
+	for input, want := range cases {
+		if got := severityRank(input); got != want {
+			t.Errorf("severityRank(%q) = %d, want %d", input, got, want)
+		}
+	}
+}
+
+func TestGetTrivyWorkloadVulnDetails_SortsAndGroups(t *testing.T) {
+	// Report with multiple CVEs of mixed severity and one without a CVSS score.
+	report := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "aquasecurity.github.io/v1alpha1",
+			"kind":       "VulnerabilityReport",
+			"metadata": map[string]interface{}{
+				"name":      "deploy-nginx-app",
+				"namespace": "default",
+				"labels": map[string]interface{}{
+					"trivy-operator.resource.kind":      "Deployment",
+					"trivy-operator.resource.name":      "nginx",
+					"trivy-operator.resource.namespace": "default",
+					"trivy-operator.container.name":     "app",
+				},
+			},
+			"report": map[string]interface{}{
+				"artifact": map[string]interface{}{
+					"repository": "nginx",
+					"tag":        "1.25",
+				},
+				"updateTimestamp": "2026-04-01T10:00:00Z",
+				"vulnerabilities": []interface{}{
+					map[string]interface{}{
+						"vulnerabilityID":  "CVE-2024-0002",
+						"severity":         "HIGH",
+						"resource":         "curl",
+						"installedVersion": "7.68.0",
+						"fixedVersion":     "",
+						"title":            "curl flaw",
+						"primaryLink":      "https://avd.aquasec.com/nvd/cve-2024-0002",
+						"cvss": map[string]interface{}{
+							"nvd": map[string]interface{}{"V3Score": 7.5},
+						},
+					},
+					map[string]interface{}{
+						"vulnerabilityID":  "CVE-2024-0001",
+						"severity":         "CRITICAL",
+						"resource":         "openssl",
+						"installedVersion": "1.1.1k-1",
+						"fixedVersion":     "1.1.1n-1",
+						"title":            "openssl flaw",
+						"primaryLink":      "https://avd.aquasec.com/nvd/cve-2024-0001",
+						"cvss": map[string]interface{}{
+							"nvd": map[string]interface{}{"V3Score": 9.8},
+						},
+					},
+					map[string]interface{}{
+						"vulnerabilityID":  "CVE-2024-0003",
+						"severity":         "LOW",
+						"resource":         "zlib",
+						"installedVersion": "1.2.11",
+						"fixedVersion":     "1.2.13",
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{
+			trivyVulnReportGVR: "VulnerabilityReportList",
+		},
+		report,
+	)
+
+	detail, err := GetTrivyWorkloadVulnDetails(context.Background(), dynClient, "default", "Deployment", "nginx")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if detail.Scanner != ScannerTrivy {
+		t.Errorf("expected scanner trivy, got %q", detail.Scanner)
+	}
+	if detail.LastScanned != "2026-04-01T10:00:00Z" {
+		t.Errorf("unexpected lastScanned: %q", detail.LastScanned)
+	}
+	if len(detail.Images) != 1 {
+		t.Fatalf("expected 1 image, got %d", len(detail.Images))
+	}
+
+	img := detail.Images[0]
+	if img.Name != "nginx:1.25" {
+		t.Errorf("expected image nginx:1.25, got %q", img.Name)
+	}
+	if img.Container != "app" {
+		t.Errorf("expected container app, got %q", img.Container)
+	}
+	if len(img.Vulnerabilities) != 3 {
+		t.Fatalf("expected 3 CVEs, got %d", len(img.Vulnerabilities))
+	}
+
+	// Expected order: CRITICAL (9.8), HIGH (7.5), LOW (no score).
+	wantOrder := []string{"CVE-2024-0001", "CVE-2024-0002", "CVE-2024-0003"}
+	for i, want := range wantOrder {
+		if img.Vulnerabilities[i].ID != want {
+			t.Errorf("position %d: expected %s, got %s", i, want, img.Vulnerabilities[i].ID)
+		}
+	}
+
+	// First CVE should have CVSS score, last CVE should be nil.
+	if img.Vulnerabilities[0].CVSSScore == nil || *img.Vulnerabilities[0].CVSSScore != 9.8 {
+		t.Errorf("expected CVE-2024-0001 CVSS 9.8, got %v", img.Vulnerabilities[0].CVSSScore)
+	}
+	if img.Vulnerabilities[2].CVSSScore != nil {
+		t.Errorf("expected CVE-2024-0003 to have nil CVSS, got %v", *img.Vulnerabilities[2].CVSSScore)
+	}
+
+	// Fix availability: CVE-0001 and CVE-0003 have fixes, CVE-0002 doesn't.
+	if img.Vulnerabilities[0].FixedVersion != "1.1.1n-1" {
+		t.Errorf("expected CVE-0001 fixedVersion set, got %q", img.Vulnerabilities[0].FixedVersion)
+	}
+	if img.Vulnerabilities[1].FixedVersion != "" {
+		t.Errorf("expected CVE-0002 fixedVersion empty, got %q", img.Vulnerabilities[1].FixedVersion)
+	}
+}
+
+func TestGetTrivyWorkloadVulnDetails_MultipleImages(t *testing.T) {
+	makeReport := func(container, repo, tag, cveID string) *unstructured.Unstructured {
+		return &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "aquasecurity.github.io/v1alpha1",
+				"kind":       "VulnerabilityReport",
+				"metadata": map[string]interface{}{
+					"name":      "deploy-app-" + container,
+					"namespace": "default",
+					"labels": map[string]interface{}{
+						"trivy-operator.resource.kind":      "Deployment",
+						"trivy-operator.resource.name":      "app",
+						"trivy-operator.resource.namespace": "default",
+						"trivy-operator.container.name":     container,
+					},
+				},
+				"report": map[string]interface{}{
+					"artifact": map[string]interface{}{
+						"repository": repo,
+						"tag":        tag,
+					},
+					"updateTimestamp": "2026-04-01T10:00:00Z",
+					"vulnerabilities": []interface{}{
+						map[string]interface{}{
+							"vulnerabilityID": cveID,
+							"severity":        "HIGH",
+							"resource":        "pkg",
+						},
+					},
+				},
+			},
+		}
+	}
+
+	scheme := runtime.NewScheme()
+	dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{
+			trivyVulnReportGVR: "VulnerabilityReportList",
+		},
+		makeReport("main", "myrepo/app", "v1", "CVE-A"),
+		makeReport("sidecar", "envoy", "v1.28", "CVE-B"),
+	)
+
+	detail, err := GetTrivyWorkloadVulnDetails(context.Background(), dynClient, "default", "Deployment", "app")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(detail.Images) != 2 {
+		t.Fatalf("expected 2 images, got %d", len(detail.Images))
+	}
+}
+
+func TestGetTrivyWorkloadVulnDetails_EmptyReports(t *testing.T) {
+	scheme := runtime.NewScheme()
+	dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{
+			trivyVulnReportGVR: "VulnerabilityReportList",
+		},
+	)
+
+	detail, err := GetTrivyWorkloadVulnDetails(context.Background(), dynClient, "default", "Deployment", "nothing")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if detail == nil {
+		t.Fatalf("expected non-nil detail")
+	}
+	if len(detail.Images) != 0 {
+		t.Errorf("expected 0 images for empty report, got %d", len(detail.Images))
+	}
+	if detail.Namespace != "default" || detail.Kind != "Deployment" || detail.Name != "nothing" {
+		t.Errorf("unexpected identity: %s/%s/%s", detail.Namespace, detail.Kind, detail.Name)
+	}
+}
+
+func ptrFloat(f float64) *float64 { return &f }

--- a/backend/internal/scanning/types.go
+++ b/backend/internal/scanning/types.go
@@ -54,3 +54,33 @@ type VulnListMetadata struct {
 	Total    int             `json:"total"`
 	Severity SeveritySummary `json:"severity"`
 }
+
+// CVEDetail represents an individual vulnerability finding with full metadata.
+type CVEDetail struct {
+	ID               string   `json:"id"`
+	Severity         string   `json:"severity"` // CRITICAL, HIGH, MEDIUM, LOW, UNKNOWN
+	CVSSScore        *float64 `json:"cvssScore"` // nil when unavailable
+	Package          string   `json:"package"`
+	InstalledVersion string   `json:"installedVersion"`
+	FixedVersion     string   `json:"fixedVersion"` // empty = no fix available
+	Title            string   `json:"title"`
+	PrimaryLink      string   `json:"primaryLink"`
+}
+
+// ImageVulnDetail holds detailed vulnerabilities for a single container image.
+type ImageVulnDetail struct {
+	Name            string      `json:"name"`      // image reference (repo:tag)
+	Container       string      `json:"container"` // container name in workload
+	Vulnerabilities []CVEDetail `json:"vulnerabilities"`
+}
+
+// WorkloadVulnDetail is the full detail response for a workload.
+// Summary counts are computed client-side from the vulnerabilities array.
+type WorkloadVulnDetail struct {
+	Namespace   string            `json:"namespace"`
+	Kind        string            `json:"kind"`
+	Name        string            `json:"name"`
+	Scanner     Scanner           `json:"scanner"`
+	LastScanned string            `json:"lastScanned"`
+	Images      []ImageVulnDetail `json:"images"`
+}

--- a/backend/internal/server/routes.go
+++ b/backend/internal/server/routes.go
@@ -518,6 +518,7 @@ func (s *Server) registerScanningRoutes(ar chi.Router) {
 		sr.Use(middleware.RateLimit(yamlRL))
 		sr.Get("/status", h.HandleStatus)
 		sr.Get("/vulnerabilities", h.HandleVulnerabilities)
+		sr.Get("/vulnerabilities/{namespace}/{kind}/{name}", h.HandleVulnerabilityDetail)
 	})
 }
 

--- a/backend/internal/server/routes.go
+++ b/backend/internal/server/routes.go
@@ -518,7 +518,7 @@ func (s *Server) registerScanningRoutes(ar chi.Router) {
 		sr.Use(middleware.RateLimit(yamlRL))
 		sr.Get("/status", h.HandleStatus)
 		sr.Get("/vulnerabilities", h.HandleVulnerabilities)
-		sr.Get("/vulnerabilities/{namespace}/{kind}/{name}", h.HandleVulnerabilityDetail)
+		sr.With(resources.ValidateURLParams).Get("/vulnerabilities/{namespace}/{kind}/{name}", h.HandleVulnerabilityDetail)
 	})
 }
 

--- a/frontend/components/k8s/detail/DeploymentOverview.tsx
+++ b/frontend/components/k8s/detail/DeploymentOverview.tsx
@@ -3,6 +3,7 @@ import { age } from "@/lib/format.ts";
 import { InfoGrid } from "./InfoGrid.tsx";
 import type { InfoGridItem } from "./InfoGrid.tsx";
 import { ConditionsGrid, SectionTitle } from "./ConditionsGrid.tsx";
+import { VulnerabilityLink } from "./VulnerabilityLink.tsx";
 
 function parseCpuMillis(val: string | undefined): number {
   if (!val || val === "-") return 0;
@@ -98,6 +99,12 @@ export function DeploymentOverview({ resource }: { resource: K8sResource }) {
   return (
     <div>
       <InfoGrid items={items} />
+
+      <VulnerabilityLink
+        namespace={dep.metadata.namespace}
+        kind="Deployment"
+        name={dep.metadata.name}
+      />
 
       {dep.status?.conditions && (
         <ConditionsGrid conditions={dep.status.conditions} />

--- a/frontend/components/k8s/detail/PodOverview.tsx
+++ b/frontend/components/k8s/detail/PodOverview.tsx
@@ -3,6 +3,7 @@ import { statusColor } from "@/lib/status-colors.ts";
 import { Field, SectionHeader } from "@/components/ui/Field.tsx";
 import { ConditionsTable } from "./ConditionsTable.tsx";
 import { ContainerResourcesTable } from "./ContainerResourcesTable.tsx";
+import { VulnerabilityLink } from "./VulnerabilityLink.tsx";
 
 function containerStateLabel(state: Record<string, unknown>): string {
   if (state.running) return "Running";
@@ -34,6 +35,12 @@ export function PodOverview({ resource }: { resource: K8sResource }) {
 
   return (
     <div class="space-y-4">
+      <VulnerabilityLink
+        namespace={p.metadata.namespace}
+        kind="Pod"
+        name={p.metadata.name}
+      />
+
       {/* Summary */}
       <div>
         <SectionHeader>Summary</SectionHeader>

--- a/frontend/components/k8s/detail/VulnerabilityLink.tsx
+++ b/frontend/components/k8s/detail/VulnerabilityLink.tsx
@@ -1,0 +1,41 @@
+/**
+ * Cross-link from a workload detail page to its vulnerability detail view.
+ * Rendered as a simple section header + link. The detail page itself handles
+ * the "Trivy not installed" / "no results" empty states, so this component
+ * intentionally does not pre-fetch a count.
+ */
+interface Props {
+  namespace: string | undefined;
+  kind: string;
+  name: string | undefined;
+}
+
+export function VulnerabilityLink({ namespace, kind, name }: Props) {
+  if (!namespace || !name) return null;
+
+  const href = `/security/vulnerabilities/${encodeURIComponent(namespace)}/${
+    encodeURIComponent(kind)
+  }/${encodeURIComponent(name)}`;
+
+  return (
+    <div style={{ marginBottom: "20px" }}>
+      <div
+        style={{
+          fontSize: "14px",
+          fontWeight: 600,
+          color: "var(--text-primary)",
+          marginBottom: "8px",
+        }}
+      >
+        Security
+      </div>
+      <a
+        href={href}
+        class="text-sm text-brand hover:underline inline-flex items-center gap-1"
+      >
+        View vulnerability scan results
+        <span aria-hidden="true">&rarr;</span>
+      </a>
+    </div>
+  );
+}

--- a/frontend/components/k8s/detail/VulnerabilityLink.tsx
+++ b/frontend/components/k8s/detail/VulnerabilityLink.tsx
@@ -18,17 +18,8 @@ export function VulnerabilityLink({ namespace, kind, name }: Props) {
   }/${encodeURIComponent(name)}`;
 
   return (
-    <div style={{ marginBottom: "20px" }}>
-      <div
-        style={{
-          fontSize: "14px",
-          fontWeight: 600,
-          color: "var(--text-primary)",
-          marginBottom: "8px",
-        }}
-      >
-        Security
-      </div>
+    <div class="mb-5">
+      <div class="text-sm font-semibold text-text-primary mb-2">Security</div>
       <a
         href={href}
         class="text-sm text-brand hover:underline inline-flex items-center gap-1"

--- a/frontend/components/ui/ScanBadges.tsx
+++ b/frontend/components/ui/ScanBadges.tsx
@@ -10,7 +10,34 @@ export const SEVERITY_COLORS: Record<string, string> = {
   high: "var(--warning)",
   medium: "var(--accent)",
   low: "var(--text-muted)",
+  unknown: "var(--text-muted)",
 };
+
+/** Badge for a CVE severity with consistent coloring and text labels. */
+export function CVESeverityBadge({ severity }: { severity: string }) {
+  const key = severity.toLowerCase();
+  const color = SEVERITY_COLORS[key] ?? "var(--text-muted)";
+  const label = severity.charAt(0).toUpperCase() +
+    severity.slice(1).toLowerCase();
+  return <ColorBadge label={label} color={color} />;
+}
+
+/** Indicator shown when a CVE's fixedVersion is non-empty. */
+export function FixAvailableBadge({ fixedVersion }: { fixedVersion: string }) {
+  if (!fixedVersion) {
+    return <span class="text-text-muted">&mdash;</span>;
+  }
+  return (
+    <span
+      class="inline-flex items-center gap-1 font-mono text-xs"
+      style={{ color: "var(--success)" }}
+      title="Upgrade available"
+    >
+      <span aria-hidden="true">✓</span>
+      {fixedVersion}
+    </span>
+  );
+}
 
 export function ScannerBadge({ scanner }: { scanner: string }) {
   const labels: Record<string, string> = {

--- a/frontend/islands/VulnerabilityDashboard.tsx
+++ b/frontend/islands/VulnerabilityDashboard.tsx
@@ -299,43 +299,22 @@ export default function VulnerabilityDashboard() {
                 </tr>
               </thead>
               <tbody class="divide-y divide-border-subtle">
-                {displayed.map((w) => (
-                  <tr key={`${w.kind}/${w.name}`} class="hover:bg-hover/30">
-                    <td class="px-3 py-2">
-                      <div class="font-medium text-text-primary">{w.name}</div>
-                      <div class="text-xs text-text-muted">{w.kind}</div>
-                    </td>
-                    <td class="px-3 py-2 text-text-secondary text-xs">
-                      {w.images.length > 1
-                        ? `${w.images.length} images`
-                        : w.images.length === 1
-                        ? (
-                          <span
-                            class="truncate inline-block max-w-[180px]"
-                            title={w.images[0].image}
-                          >
-                            {w.images[0].image}
-                          </span>
-                        )
-                        : "-"}
-                    </td>
-                    <SeverityCell
-                      count={w.total.critical}
-                      severity="critical"
+                {displayed.map((w) => {
+                  const href = w.scanner === "trivy"
+                    ? `/security/vulnerabilities/${
+                      encodeURIComponent(w.namespace)
+                    }/${encodeURIComponent(w.kind)}/${
+                      encodeURIComponent(w.name)
+                    }`
+                    : null;
+                  return (
+                    <WorkloadRow
+                      key={`${w.namespace}/${w.kind}/${w.name}`}
+                      w={w}
+                      href={href}
                     />
-                    <SeverityCell count={w.total.high} severity="high" />
-                    <SeverityCell count={w.total.medium} severity="medium" />
-                    <SeverityCell count={w.total.low} severity="low" />
-                    <td class="px-3 py-2">
-                      <ScannerBadge scanner={w.scanner} />
-                    </td>
-                    <td class="px-3 py-2 text-text-secondary text-xs">
-                      {w.lastScanned
-                        ? new Date(w.lastScanned).toLocaleString()
-                        : "-"}
-                    </td>
-                  </tr>
-                ))}
+                  );
+                })}
               </tbody>
             </table>
           </div>
@@ -397,4 +376,87 @@ function SeverityCell(
       {count}
     </td>
   );
+}
+
+/**
+ * Workload row. Wraps the row content in an <a> tag (full-row click target) for
+ * Trivy-scanned workloads so keyboard navigation, right-click, and middle-click
+ * work. Kubescape rows are rendered as plain rows since the detail endpoint
+ * only supports Trivy.
+ */
+function WorkloadRow(
+  { w, href }: { w: WorkloadVulnSummary; href: string | null },
+) {
+  const imageCell = w.images.length > 1
+    ? `${w.images.length} images`
+    : w.images.length === 1
+    ? (
+      <span
+        class="truncate inline-block max-w-[180px]"
+        title={w.images[0].image}
+      >
+        {w.images[0].image}
+      </span>
+    )
+    : "-";
+
+  const content = (
+    <>
+      <td class="px-3 py-2">
+        <div class="font-medium text-text-primary">{w.name}</div>
+        <div class="text-xs text-text-muted">{w.kind}</div>
+      </td>
+      <td class="px-3 py-2 text-text-secondary text-xs">{imageCell}</td>
+      <SeverityCell count={w.total.critical} severity="critical" />
+      <SeverityCell count={w.total.high} severity="high" />
+      <SeverityCell count={w.total.medium} severity="medium" />
+      <SeverityCell count={w.total.low} severity="low" />
+      <td class="px-3 py-2">
+        <ScannerBadge scanner={w.scanner} />
+      </td>
+      <td class="px-3 py-2 text-text-secondary text-xs">
+        {w.lastScanned ? new Date(w.lastScanned).toLocaleString() : "-"}
+      </td>
+    </>
+  );
+
+  if (href) {
+    // Wrap the row in a link by making <tr> a clickable surface.
+    // Navigating via `window.location` keeps table semantics intact while
+    // also allowing keyboard activation via the inner <a>.
+    return (
+      <tr
+        class="hover:bg-hover/30 cursor-pointer focus-within:bg-hover/30"
+        onClick={(e) => {
+          // Ignore clicks on links inside the row (none today, but future-proof).
+          const target = e.target as HTMLElement;
+          if (target.closest("a")) return;
+          globalThis.location.href = href;
+        }}
+      >
+        <td class="px-3 py-2 relative">
+          {/* Invisible full-row anchor for accessibility: keyboard + middle-click + right-click */}
+          <a
+            href={href}
+            class="absolute inset-0"
+            aria-label={`View vulnerability details for ${w.kind} ${w.name}`}
+          />
+          <div class="font-medium text-text-primary relative">{w.name}</div>
+          <div class="text-xs text-text-muted relative">{w.kind}</div>
+        </td>
+        <td class="px-3 py-2 text-text-secondary text-xs">{imageCell}</td>
+        <SeverityCell count={w.total.critical} severity="critical" />
+        <SeverityCell count={w.total.high} severity="high" />
+        <SeverityCell count={w.total.medium} severity="medium" />
+        <SeverityCell count={w.total.low} severity="low" />
+        <td class="px-3 py-2">
+          <ScannerBadge scanner={w.scanner} />
+        </td>
+        <td class="px-3 py-2 text-text-secondary text-xs">
+          {w.lastScanned ? new Date(w.lastScanned).toLocaleString() : "-"}
+        </td>
+      </tr>
+    );
+  }
+  return <tr class="hover:bg-hover/30">{content}</tr>;
 }

--- a/frontend/islands/VulnerabilityDashboard.tsx
+++ b/frontend/islands/VulnerabilityDashboard.tsx
@@ -2,6 +2,7 @@ import { useSignal } from "@preact/signals";
 import { IS_BROWSER } from "fresh/runtime";
 import { useEffect } from "preact/hooks";
 import { apiGet } from "@/lib/api.ts";
+import { age } from "@/lib/format.ts";
 import { SearchBar } from "@/components/ui/SearchBar.tsx";
 import { Spinner } from "@/components/ui/Spinner.tsx";
 import { Button } from "@/components/ui/Button.tsx";
@@ -16,6 +17,8 @@ import type {
   WorkloadVulnSummary,
 } from "@/lib/scanning-types.ts";
 import { selectedNamespace } from "@/lib/namespace.ts";
+
+const STALE_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 const PAGE_SIZE = 100;
 
@@ -299,22 +302,12 @@ export default function VulnerabilityDashboard() {
                 </tr>
               </thead>
               <tbody class="divide-y divide-border-subtle">
-                {displayed.map((w) => {
-                  const href = w.scanner === "trivy"
-                    ? `/security/vulnerabilities/${
-                      encodeURIComponent(w.namespace)
-                    }/${encodeURIComponent(w.kind)}/${
-                      encodeURIComponent(w.name)
-                    }`
-                    : null;
-                  return (
-                    <WorkloadRow
-                      key={`${w.namespace}/${w.kind}/${w.name}`}
-                      w={w}
-                      href={href}
-                    />
-                  );
-                })}
+                {displayed.map((w) => (
+                  <WorkloadRow
+                    key={`${w.namespace}/${w.kind}/${w.name}`}
+                    w={w}
+                  />
+                ))}
               </tbody>
             </table>
           </div>
@@ -366,27 +359,44 @@ export default function VulnerabilityDashboard() {
   );
 }
 
-/** Table cell for a severity count — colored if > 0, gray "0" otherwise. */
+/**
+ * Severity cell — count + weight + color. Font weight and opacity carry
+ * information in addition to color so colorblind users can distinguish
+ * "has issues" from "clean".
+ */
 function SeverityCell(
   { count, severity }: { count: number; severity: string },
 ) {
-  const color = count > 0 ? SEVERITY_COLORS[severity] : "var(--text-muted)";
+  const hasIssues = count > 0;
+  const color = hasIssues ? SEVERITY_COLORS[severity] : "var(--text-muted)";
   return (
-    <td class="px-3 py-2 text-center text-xs font-medium" style={{ color }}>
+    <td
+      class={`px-3 py-2 text-center text-xs ${
+        hasIssues ? "font-bold" : "font-normal opacity-60"
+      }`}
+      style={{ color }}
+    >
       {count}
     </td>
   );
 }
 
 /**
- * Workload row. Wraps the row content in an <a> tag (full-row click target) for
- * Trivy-scanned workloads so keyboard navigation, right-click, and middle-click
- * work. Kubescape rows are rendered as plain rows since the detail endpoint
- * only supports Trivy.
+ * Workload row. Trivy-scanned rows are clickable (navigate to the detail page).
+ * Kubescape rows render with a not-allowed cursor and a tooltip explaining
+ * why they're not actionable — the detail endpoint is Trivy-only.
+ *
+ * Uses the plain `tr` + `onClick` pattern that matches GitOpsApplications and
+ * every other clickable-row table in the project.
  */
-function WorkloadRow(
-  { w, href }: { w: WorkloadVulnSummary; href: string | null },
-) {
+function WorkloadRow({ w }: { w: WorkloadVulnSummary }) {
+  const isTrivy = w.scanner === "trivy";
+  const href = isTrivy
+    ? `/security/vulnerabilities/${encodeURIComponent(w.namespace)}/${
+      encodeURIComponent(w.kind)
+    }/${encodeURIComponent(w.name)}`
+    : null;
+
   const imageCell = w.images.length > 1
     ? `${w.images.length} images`
     : w.images.length === 1
@@ -400,8 +410,23 @@ function WorkloadRow(
     )
     : "-";
 
-  const content = (
-    <>
+  const stale = w.lastScanned
+    ? Date.now() - new Date(w.lastScanned).getTime() > STALE_THRESHOLD_MS
+    : false;
+
+  const rowClass = href
+    ? "hover:bg-hover/30 cursor-pointer"
+    : "cursor-not-allowed opacity-70";
+  const rowTitle = href
+    ? undefined
+    : "CVE-level detail requires Trivy Operator";
+
+  return (
+    <tr
+      class={rowClass}
+      title={rowTitle}
+      onClick={href ? () => (globalThis.location.href = href) : undefined}
+    >
       <td class="px-3 py-2">
         <div class="font-medium text-text-primary">{w.name}</div>
         <div class="text-xs text-text-muted">{w.kind}</div>
@@ -415,48 +440,23 @@ function WorkloadRow(
         <ScannerBadge scanner={w.scanner} />
       </td>
       <td class="px-3 py-2 text-text-secondary text-xs">
-        {w.lastScanned ? new Date(w.lastScanned).toLocaleString() : "-"}
+        {w.lastScanned
+          ? (
+            <span title={new Date(w.lastScanned).toLocaleString()}>
+              {age(w.lastScanned)} ago
+              {stale && (
+                <span
+                  class="ml-1 font-semibold"
+                  style={{ color: "var(--warning)" }}
+                  title="Scan data is more than 7 days old"
+                >
+                  (stale)
+                </span>
+              )}
+            </span>
+          )
+          : "-"}
       </td>
-    </>
+    </tr>
   );
-
-  if (href) {
-    // Wrap the row in a link by making <tr> a clickable surface.
-    // Navigating via `window.location` keeps table semantics intact while
-    // also allowing keyboard activation via the inner <a>.
-    return (
-      <tr
-        class="hover:bg-hover/30 cursor-pointer focus-within:bg-hover/30"
-        onClick={(e) => {
-          // Ignore clicks on links inside the row (none today, but future-proof).
-          const target = e.target as HTMLElement;
-          if (target.closest("a")) return;
-          globalThis.location.href = href;
-        }}
-      >
-        <td class="px-3 py-2 relative">
-          {/* Invisible full-row anchor for accessibility: keyboard + middle-click + right-click */}
-          <a
-            href={href}
-            class="absolute inset-0"
-            aria-label={`View vulnerability details for ${w.kind} ${w.name}`}
-          />
-          <div class="font-medium text-text-primary relative">{w.name}</div>
-          <div class="text-xs text-text-muted relative">{w.kind}</div>
-        </td>
-        <td class="px-3 py-2 text-text-secondary text-xs">{imageCell}</td>
-        <SeverityCell count={w.total.critical} severity="critical" />
-        <SeverityCell count={w.total.high} severity="high" />
-        <SeverityCell count={w.total.medium} severity="medium" />
-        <SeverityCell count={w.total.low} severity="low" />
-        <td class="px-3 py-2">
-          <ScannerBadge scanner={w.scanner} />
-        </td>
-        <td class="px-3 py-2 text-text-secondary text-xs">
-          {w.lastScanned ? new Date(w.lastScanned).toLocaleString() : "-"}
-        </td>
-      </tr>
-    );
-  }
-  return <tr class="hover:bg-hover/30">{content}</tr>;
 }

--- a/frontend/islands/VulnerabilityDetail.tsx
+++ b/frontend/islands/VulnerabilityDetail.tsx
@@ -1,7 +1,8 @@
-import { useComputed, useSignal } from "@preact/signals";
+import { useSignal } from "@preact/signals";
 import { IS_BROWSER } from "fresh/runtime";
 import { useEffect } from "preact/hooks";
-import { apiGet } from "@/lib/api.ts";
+import { ApiError, apiGet } from "@/lib/api.ts";
+import { age } from "@/lib/format.ts";
 import { Button } from "@/components/ui/Button.tsx";
 import { Spinner } from "@/components/ui/Spinner.tsx";
 import {
@@ -14,12 +15,11 @@ import {
 import {
   computeVulnSummary,
   type CVEDetail,
-  type ImageVulnDetail,
-  severityRank,
   type WorkloadVulnDetail,
 } from "@/lib/scanning-types.ts";
 
 const PAGE_SIZE = 100;
+const STALE_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 interface Props {
   namespace: string;
@@ -27,23 +27,36 @@ interface Props {
   name: string;
 }
 
-interface FlatCVE extends CVEDetail {
-  image: string;
-  container: string;
+type FlatCVE = CVEDetail & { image: string; container: string };
+
+/**
+ * Validates a URL string and returns it only if it uses http(s).
+ * External CVE data (Trivy → NVD/Aqua/GHSA) can contain any string, including
+ * `javascript:` or `data:` URLs that would execute script in our origin when
+ * used as href. Falls back to a safe NVD URL constructed from the CVE ID.
+ */
+function safeHttpUrl(raw: string, fallback: string): string {
+  if (!raw) return fallback;
+  try {
+    const u = new URL(raw);
+    if (u.protocol === "https:" || u.protocol === "http:") return u.href;
+  } catch { /* malformed — fall through */ }
+  return fallback;
 }
 
 /**
- * Flatten the per-image CVE lists into a single array so the table can display
- * the image column inline rather than using collapsible sections.
+ * Strips the registry host prefix from an image reference so the more
+ * informative path+tag stays visible when the column is truncated.
  */
-function flattenCVEs(images: ImageVulnDetail[]): FlatCVE[] {
-  const out: FlatCVE[] = [];
-  for (const img of images) {
-    for (const v of img.vulnerabilities) {
-      out.push({ ...v, image: img.name, container: img.container });
-    }
+function displayImage(ref: string): string {
+  const firstSlash = ref.indexOf("/");
+  if (firstSlash === -1) return ref;
+  const before = ref.slice(0, firstSlash);
+  // If the first segment looks like a registry host (contains "." or ":"), drop it.
+  if (before.includes(".") || before.includes(":")) {
+    return ref.slice(firstSlash + 1);
   }
-  return out;
+  return ref;
 }
 
 export default function VulnerabilityDetail(
@@ -55,9 +68,9 @@ export default function VulnerabilityDetail(
   const severityFilter = useSignal<string>("all");
   const fixableOnly = useSignal(false);
   const page = useSignal(1);
+  const refreshing = useSignal(false);
 
   async function fetchDetail() {
-    loading.value = true;
     error.value = null;
     try {
       const path = `/v1/scanning/vulnerabilities/${
@@ -66,57 +79,116 @@ export default function VulnerabilityDetail(
       const res = await apiGet<WorkloadVulnDetail>(path);
       detail.value = res.data;
     } catch (e) {
-      const err = e as { status?: number; message?: string };
-      if (err.status === 501) {
-        error.value =
-          "CVE-level detail requires Trivy Operator. This cluster does not have Trivy installed.";
-      } else if (err.status === 403) {
-        error.value =
-          "Access denied. You don't have permission to view vulnerability reports in this namespace.";
+      if (e instanceof ApiError) {
+        if (e.status === 501) {
+          error.value =
+            "CVE-level detail requires Trivy Operator. This workload was scanned by Kubescape, which does not expose per-CVE data under user impersonation.";
+        } else if (e.status === 403) {
+          error.value =
+            "Access denied. You don't have permission to view vulnerability reports in this namespace.";
+        } else {
+          error.value = e.message || "Failed to load vulnerability details";
+        }
       } else {
-        error.value = err.message ?? "Failed to load vulnerability details";
+        error.value = "Failed to load vulnerability details";
       }
-    } finally {
-      loading.value = false;
     }
   }
 
   useEffect(() => {
-    if (!IS_BROWSER) return;
-    fetchDetail();
+    loading.value = true;
+    fetchDetail().then(() => {
+      loading.value = false;
+    });
   }, [namespace, kind, name]);
 
-  const summary = useComputed(() => {
-    return detail.value ? computeVulnSummary(detail.value.images) : null;
-  });
+  async function handleRefresh() {
+    refreshing.value = true;
+    await fetchDetail();
+    refreshing.value = false;
+  }
 
-  const allCVEs = useComputed(() => {
-    return detail.value ? flattenCVEs(detail.value.images) : [];
-  });
+  function onSeverityChange(next: string) {
+    severityFilter.value = next;
+    page.value = 1;
+  }
 
-  const filtered = useComputed(() => {
-    let cves = allCVEs.value;
-    if (severityFilter.value !== "all") {
-      const target = severityFilter.value.toUpperCase();
-      cves = cves.filter((c) => c.severity === target);
-    }
-    if (fixableOnly.value) {
-      cves = cves.filter((c) => c.fixedVersion !== "");
-    }
-    return cves;
-  });
+  function onFixableChange(next: boolean) {
+    fixableOnly.value = next;
+    page.value = 1;
+  }
 
   if (!IS_BROWSER) return null;
 
-  const totalPages = Math.max(
-    1,
-    Math.ceil(filtered.value.length / PAGE_SIZE),
+  // Early return: loading
+  if (loading.value && !detail.value) {
+    return (
+      <div class="p-6">
+        <div class="mb-4">
+          <a
+            href="/security/vulnerabilities"
+            class="text-sm text-brand hover:underline inline-flex items-center gap-1"
+          >
+            <span aria-hidden="true">&larr;</span> Back to Vulnerabilities
+          </a>
+        </div>
+        <div class="flex justify-center py-12">
+          <Spinner class="text-brand" />
+        </div>
+      </div>
+    );
+  }
+
+  // Early return: error state (no data available at all)
+  if (error.value && !detail.value) {
+    return (
+      <div class="p-6">
+        <div class="mb-4">
+          <a
+            href="/security/vulnerabilities"
+            class="text-sm text-brand hover:underline inline-flex items-center gap-1"
+          >
+            <span aria-hidden="true">&larr;</span> Back to Vulnerabilities
+          </a>
+        </div>
+        <div class="rounded-lg border border-border-primary bg-bg-elevated p-6 text-center">
+          <p class="text-sm text-danger">{error.value}</p>
+        </div>
+      </div>
+    );
+  }
+
+  const d = detail.value!;
+  const summary = computeVulnSummary(d.images);
+  const allCVEs: FlatCVE[] = d.images.flatMap((img) =>
+    img.vulnerabilities.map((v) => ({
+      ...v,
+      image: img.name,
+      container: img.container,
+    }))
   );
-  if (page.value > totalPages) page.value = totalPages;
-  const displayed = filtered.value.slice(
-    (page.value - 1) * PAGE_SIZE,
-    page.value * PAGE_SIZE,
+
+  // Apply filters.
+  let filtered = allCVEs;
+  if (severityFilter.value !== "all") {
+    const target = severityFilter.value.toUpperCase();
+    filtered = filtered.filter((c) => c.severity === target);
+  }
+  if (fixableOnly.value) {
+    filtered = filtered.filter((c) => c.fixedVersion !== "");
+  }
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const currentPage = Math.min(page.value, totalPages);
+  const displayed = filtered.slice(
+    (currentPage - 1) * PAGE_SIZE,
+    currentPage * PAGE_SIZE,
   );
+
+  const scanStaleMs = d.lastScanned
+    ? Date.now() - new Date(d.lastScanned).getTime()
+    : 0;
+  const isStale = scanStaleMs > STALE_THRESHOLD_MS;
 
   return (
     <div class="p-6">
@@ -141,209 +213,301 @@ export default function VulnerabilityDetail(
           </p>
         </div>
         <div class="flex items-center gap-3">
-          {detail.value && <ScannerBadge scanner={detail.value.scanner} />}
-          {detail.value?.lastScanned && (
-            <span class="text-xs text-text-muted">
-              Last scanned:{" "}
-              {new Date(detail.value.lastScanned).toLocaleString()}
+          <ScannerBadge scanner={d.scanner} />
+          {d.lastScanned && (
+            <span
+              class="text-xs text-text-muted"
+              title={new Date(d.lastScanned).toLocaleString()}
+            >
+              Last scanned {age(d.lastScanned)} ago
+              {isStale && (
+                <span
+                  class="ml-1 font-semibold"
+                  style={{ color: "var(--warning)" }}
+                  title="Scan data is more than 7 days old"
+                >
+                  (stale)
+                </span>
+              )}
             </span>
           )}
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={handleRefresh}
+            disabled={refreshing.value}
+          >
+            {refreshing.value ? "Refreshing..." : "Refresh"}
+          </Button>
         </div>
       </div>
 
-      {loading.value && (
-        <div class="flex justify-center py-12">
-          <Spinner class="text-brand" />
+      {/* Inline error (non-blocking — we still have stale data to show) */}
+      {error.value && (
+        <div class="mb-4 rounded-lg border border-danger bg-bg-elevated p-3 text-sm text-danger">
+          {error.value}
         </div>
       )}
 
-      {error.value && !loading.value && (
-        <div class="rounded-lg border border-border-primary bg-bg-elevated p-6 text-center">
-          <p class="text-sm text-danger">{error.value}</p>
-        </div>
-      )}
-
-      {!loading.value && !error.value && detail.value && summary.value && (
-        <>
-          {/* Summary cards */}
-          <div class="mb-6 flex flex-wrap gap-3">
-            <SeverityCount
-              label="Critical"
-              count={summary.value.critical}
-              color={SEVERITY_COLORS.critical}
-            />
-            <SeverityCount
-              label="High"
-              count={summary.value.high}
-              color={SEVERITY_COLORS.high}
-            />
-            <SeverityCount
-              label="Medium"
-              count={summary.value.medium}
-              color={SEVERITY_COLORS.medium}
-            />
-            <SeverityCount
-              label="Low"
-              count={summary.value.low}
-              color={SEVERITY_COLORS.low}
-            />
-            {summary.value.unknown > 0 && (
-              <SeverityCount
-                label="Unknown"
-                count={summary.value.unknown}
-                color={SEVERITY_COLORS.unknown}
-              />
+      {/* Summary cards — clickable to filter */}
+      <div class="mb-6 flex flex-wrap gap-3">
+        <ClickableCount
+          label="Critical"
+          count={summary.critical}
+          color={SEVERITY_COLORS.critical}
+          active={severityFilter.value === "critical"}
+          onClick={() =>
+            onSeverityChange(
+              severityFilter.value === "critical" ? "all" : "critical",
             )}
-            <SeverityCount
-              label="Fixable"
-              count={summary.value.fixable}
-              color="var(--success)"
+        />
+        <ClickableCount
+          label="High"
+          count={summary.high}
+          color={SEVERITY_COLORS.high}
+          active={severityFilter.value === "high"}
+          onClick={() =>
+            onSeverityChange(
+              severityFilter.value === "high" ? "all" : "high",
+            )}
+        />
+        <ClickableCount
+          label="Medium"
+          count={summary.medium}
+          color={SEVERITY_COLORS.medium}
+          active={severityFilter.value === "medium"}
+          onClick={() =>
+            onSeverityChange(
+              severityFilter.value === "medium" ? "all" : "medium",
+            )}
+        />
+        <ClickableCount
+          label="Low"
+          count={summary.low}
+          color={SEVERITY_COLORS.low}
+          active={severityFilter.value === "low"}
+          onClick={() =>
+            onSeverityChange(
+              severityFilter.value === "low" ? "all" : "low",
+            )}
+        />
+        {summary.unknown > 0 && (
+          <SeverityCount
+            label="Unknown"
+            count={summary.unknown}
+            color={SEVERITY_COLORS.unknown}
+          />
+        )}
+        <SeverityCount
+          label="Fixable"
+          count={summary.fixable}
+          color="var(--success)"
+        />
+      </div>
+
+      {/* Empty state: no CVEs at all */}
+      {summary.total === 0 && (
+        <div class="rounded-lg border border-border-primary bg-bg-elevated p-12 text-center">
+          <p class="text-lg font-medium text-text-primary mb-2">
+            No vulnerabilities found
+          </p>
+          <p class="text-sm text-text-muted">
+            Trivy has scanned this workload and found no CVEs. Results may lag
+            image changes by a few minutes.
+          </p>
+        </div>
+      )}
+
+      {/* Filters */}
+      {summary.total > 0 && (
+        <div class="mb-4 flex flex-wrap items-center gap-4">
+          <select
+            class="rounded border border-border-primary px-2 py-1.5 text-sm bg-bg-base text-text-primary"
+            value={severityFilter.value}
+            onChange={(e) =>
+              onSeverityChange((e.target as HTMLSelectElement).value)}
+          >
+            <option value="all">All Severities</option>
+            <option value="critical">Critical</option>
+            <option value="high">High</option>
+            <option value="medium">Medium</option>
+            <option value="low">Low</option>
+            <option value="unknown">Unknown</option>
+          </select>
+          <label class="flex items-center gap-2 text-sm text-text-primary cursor-pointer">
+            <input
+              type="checkbox"
+              checked={fixableOnly.value}
+              onChange={(e) =>
+                onFixableChange((e.target as HTMLInputElement).checked)}
             />
-          </div>
+            Fixable only
+          </label>
+          <span class="text-xs text-text-muted ml-auto">
+            {filtered.length} of {summary.total} CVEs
+          </span>
+        </div>
+      )}
 
-          {/* Empty state: no CVEs */}
-          {summary.value.total === 0 && (
-            <div class="rounded-lg border border-border-primary bg-bg-elevated p-12 text-center">
-              <p class="text-lg font-medium text-text-primary mb-2">
-                No vulnerabilities found
-              </p>
-              <p class="text-sm text-text-muted">
-                Trivy has scanned this workload and found no CVEs. Results may
-                lag image changes by a few minutes.
-              </p>
-            </div>
-          )}
-
-          {/* Filters */}
-          {summary.value.total > 0 && (
-            <div class="mb-4 flex flex-wrap items-center gap-4">
-              <select
-                class="rounded border border-border-primary px-2 py-1.5 text-sm bg-bg-base text-text-primary"
-                value={severityFilter.value}
-                onChange={(e) => {
-                  severityFilter.value = (e.target as HTMLSelectElement).value;
-                  page.value = 1;
-                }}
-              >
-                <option value="all">All Severities</option>
-                <option value="critical">Critical</option>
-                <option value="high">High</option>
-                <option value="medium">Medium</option>
-                <option value="low">Low</option>
-                <option value="unknown">Unknown</option>
-              </select>
-              <label class="flex items-center gap-2 text-sm text-text-primary cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={fixableOnly.value}
-                  onChange={(e) => {
-                    fixableOnly.value = (e.target as HTMLInputElement).checked;
-                    page.value = 1;
-                  }}
+      {/* CVE table */}
+      {filtered.length > 0 && (
+        <div
+          class="overflow-x-auto rounded-lg border border-border-primary"
+          style={{
+            opacity: refreshing.value ? 0.5 : 1,
+            transition: "opacity 0.2s",
+          }}
+        >
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="border-b border-border-primary bg-surface">
+                <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
+                  CVE
+                </th>
+                <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
+                  Severity
+                </th>
+                <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
+                  CVSS
+                </th>
+                <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
+                  Image
+                </th>
+                <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
+                  Package
+                </th>
+                <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
+                  Installed
+                </th>
+                <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
+                  Fixed
+                </th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-border-subtle">
+              {displayed.map((cve) => (
+                <CVERow
+                  key={`${cve.image}/${cve.id}/${cve.package}`}
+                  cve={cve}
                 />
-                Fixable only
-              </label>
-              <span class="text-xs text-text-muted ml-auto">
-                {filtered.value.length} of {summary.value.total} CVEs
-              </span>
-            </div>
-          )}
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
 
-          {/* CVE table */}
-          {filtered.value.length > 0 && (
-            <div class="overflow-x-auto rounded-lg border border-border-primary">
-              <table class="w-full text-sm">
-                <thead>
-                  <tr class="border-b border-border-primary bg-surface">
-                    <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
-                      CVE
-                    </th>
-                    <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
-                      Severity
-                    </th>
-                    <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
-                      CVSS
-                    </th>
-                    <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
-                      Image
-                    </th>
-                    <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
-                      Package
-                    </th>
-                    <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
-                      Installed
-                    </th>
-                    <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
-                      Fixed
-                    </th>
-                  </tr>
-                </thead>
-                <tbody class="divide-y divide-border-subtle">
-                  {displayed.map((cve) => (
-                    <CVERow
-                      key={`${cve.image}/${cve.id}/${cve.package}`}
-                      cve={cve}
-                    />
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
+      {/* Empty-filtered state */}
+      {summary.total > 0 && filtered.length === 0 && (
+        <div class="rounded-lg border border-border-primary bg-bg-elevated p-8 text-center">
+          <p class="text-sm text-text-muted">No CVEs match your filters.</p>
+        </div>
+      )}
 
-          {/* Empty-filtered state */}
-          {summary.value.total > 0 && filtered.value.length === 0 && (
-            <div class="rounded-lg border border-border-primary bg-bg-elevated p-8 text-center">
-              <p class="text-sm text-text-muted">
-                No CVEs match your filters.
-              </p>
-            </div>
-          )}
-
-          {/* Pagination */}
-          {filtered.value.length > PAGE_SIZE && (
-            <div class="mt-4 flex items-center justify-between">
-              <p class="text-sm text-text-muted">
-                {filtered.value.length} CVEs &middot; Page {page.value} of{"  "}
-                {totalPages}
-              </p>
-              <div class="flex gap-2">
-                <Button
-                  type="button"
-                  variant="ghost"
-                  onClick={() => {
-                    page.value--;
-                  }}
-                  disabled={page.value <= 1}
-                >
-                  Previous
-                </Button>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  onClick={() => {
-                    page.value++;
-                  }}
-                  disabled={page.value >= totalPages}
-                >
-                  Next
-                </Button>
-              </div>
-            </div>
-          )}
-        </>
+      {/* Pagination */}
+      {filtered.length > PAGE_SIZE && (
+        <div class="mt-4 flex items-center justify-between flex-wrap gap-2">
+          <p class="text-sm text-text-muted">
+            {filtered.length} CVEs &middot; Page {currentPage} of {totalPages}
+          </p>
+          <div class="flex gap-2 items-center">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => {
+                page.value = 1;
+              }}
+              disabled={currentPage <= 1}
+            >
+              &laquo; First
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => {
+                page.value = currentPage - 1;
+              }}
+              disabled={currentPage <= 1}
+            >
+              Previous
+            </Button>
+            <input
+              type="number"
+              min={1}
+              max={totalPages}
+              value={currentPage}
+              onChange={(e) => {
+                const n = parseInt((e.target as HTMLInputElement).value, 10);
+                if (!isNaN(n) && n >= 1 && n <= totalPages) page.value = n;
+              }}
+              class="w-16 rounded border border-border-primary px-2 py-1 text-sm bg-bg-base text-text-primary text-center"
+              aria-label="Go to page"
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => {
+                page.value = currentPage + 1;
+              }}
+              disabled={currentPage >= totalPages}
+            >
+              Next
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => {
+                page.value = totalPages;
+              }}
+              disabled={currentPage >= totalPages}
+            >
+              Last &raquo;
+            </Button>
+          </div>
+        </div>
       )}
     </div>
   );
 }
 
+/** Summary-count pill that doubles as a severity filter toggle. */
+function ClickableCount(
+  { label, count, color, active, onClick }: {
+    label: string;
+    count: number;
+    color: string;
+    active: boolean;
+    onClick: () => void;
+  },
+) {
+  if (count === 0) return null;
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium cursor-pointer transition-all"
+      style={{
+        color,
+        backgroundColor: `color-mix(in srgb, ${color} ${
+          active ? "30%" : "15%"
+        }, transparent)`,
+        border: active ? `1px solid ${color}` : "1px solid transparent",
+      }}
+      aria-pressed={active}
+    >
+      <span class="font-bold">{count}</span>
+      {label}
+    </button>
+  );
+}
+
 /** Single row in the CVE table. */
 function CVERow({ cve }: { cve: FlatCVE }) {
-  // Sort order is guaranteed by the backend (severity asc → CVSS desc → ID asc),
-  // so severityRank is used here only as defense when rendering.
-  void severityRank;
-
-  const cveLink = cve.primaryLink ||
-    `https://nvd.nist.gov/vuln/detail/${cve.id}`;
+  // External CVE data must be URL-validated before use as href.
+  const cveLink = safeHttpUrl(
+    cve.primaryLink,
+    `https://nvd.nist.gov/vuln/detail/${encodeURIComponent(cve.id)}`,
+  );
+  const imageShort = displayImage(cve.image);
 
   return (
     <tr class="hover:bg-hover/30">
@@ -353,10 +517,17 @@ function CVERow({ cve }: { cve: FlatCVE }) {
           target="_blank"
           rel="noopener noreferrer"
           class="font-mono text-xs text-brand hover:underline"
-          title={cve.title || cve.id}
         >
           {cve.id}
         </a>
+        {cve.title && (
+          <div
+            class="text-[11px] text-text-muted truncate max-w-[240px]"
+            title={cve.title}
+          >
+            {cve.title}
+          </div>
+        )}
       </td>
       <td class="px-3 py-2">
         <CVESeverityBadge severity={cve.severity} />
@@ -366,9 +537,9 @@ function CVERow({ cve }: { cve: FlatCVE }) {
       </td>
       <td class="px-3 py-2 text-xs text-text-secondary">
         <span class="truncate inline-block max-w-[180px]" title={cve.image}>
-          {cve.image}
+          {imageShort}
         </span>
-        {cve.container && cve.container !== cve.image && (
+        {cve.container && cve.container !== imageShort && (
           <div class="text-[10px] text-text-muted">{cve.container}</div>
         )}
       </td>

--- a/frontend/islands/VulnerabilityDetail.tsx
+++ b/frontend/islands/VulnerabilityDetail.tsx
@@ -1,0 +1,386 @@
+import { useComputed, useSignal } from "@preact/signals";
+import { IS_BROWSER } from "fresh/runtime";
+import { useEffect } from "preact/hooks";
+import { apiGet } from "@/lib/api.ts";
+import { Button } from "@/components/ui/Button.tsx";
+import { Spinner } from "@/components/ui/Spinner.tsx";
+import {
+  CVESeverityBadge,
+  FixAvailableBadge,
+  ScannerBadge,
+  SEVERITY_COLORS,
+  SeverityCount,
+} from "@/components/ui/ScanBadges.tsx";
+import {
+  computeVulnSummary,
+  type CVEDetail,
+  type ImageVulnDetail,
+  severityRank,
+  type WorkloadVulnDetail,
+} from "@/lib/scanning-types.ts";
+
+const PAGE_SIZE = 100;
+
+interface Props {
+  namespace: string;
+  kind: string;
+  name: string;
+}
+
+interface FlatCVE extends CVEDetail {
+  image: string;
+  container: string;
+}
+
+/**
+ * Flatten the per-image CVE lists into a single array so the table can display
+ * the image column inline rather than using collapsible sections.
+ */
+function flattenCVEs(images: ImageVulnDetail[]): FlatCVE[] {
+  const out: FlatCVE[] = [];
+  for (const img of images) {
+    for (const v of img.vulnerabilities) {
+      out.push({ ...v, image: img.name, container: img.container });
+    }
+  }
+  return out;
+}
+
+export default function VulnerabilityDetail(
+  { namespace, kind, name }: Props,
+) {
+  const detail = useSignal<WorkloadVulnDetail | null>(null);
+  const loading = useSignal(true);
+  const error = useSignal<string | null>(null);
+  const severityFilter = useSignal<string>("all");
+  const fixableOnly = useSignal(false);
+  const page = useSignal(1);
+
+  async function fetchDetail() {
+    loading.value = true;
+    error.value = null;
+    try {
+      const path = `/v1/scanning/vulnerabilities/${
+        encodeURIComponent(namespace)
+      }/${encodeURIComponent(kind)}/${encodeURIComponent(name)}`;
+      const res = await apiGet<WorkloadVulnDetail>(path);
+      detail.value = res.data;
+    } catch (e) {
+      const err = e as { status?: number; message?: string };
+      if (err.status === 501) {
+        error.value =
+          "CVE-level detail requires Trivy Operator. This cluster does not have Trivy installed.";
+      } else if (err.status === 403) {
+        error.value =
+          "Access denied. You don't have permission to view vulnerability reports in this namespace.";
+      } else {
+        error.value = err.message ?? "Failed to load vulnerability details";
+      }
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  useEffect(() => {
+    if (!IS_BROWSER) return;
+    fetchDetail();
+  }, [namespace, kind, name]);
+
+  const summary = useComputed(() => {
+    return detail.value ? computeVulnSummary(detail.value.images) : null;
+  });
+
+  const allCVEs = useComputed(() => {
+    return detail.value ? flattenCVEs(detail.value.images) : [];
+  });
+
+  const filtered = useComputed(() => {
+    let cves = allCVEs.value;
+    if (severityFilter.value !== "all") {
+      const target = severityFilter.value.toUpperCase();
+      cves = cves.filter((c) => c.severity === target);
+    }
+    if (fixableOnly.value) {
+      cves = cves.filter((c) => c.fixedVersion !== "");
+    }
+    return cves;
+  });
+
+  if (!IS_BROWSER) return null;
+
+  const totalPages = Math.max(
+    1,
+    Math.ceil(filtered.value.length / PAGE_SIZE),
+  );
+  if (page.value > totalPages) page.value = totalPages;
+  const displayed = filtered.value.slice(
+    (page.value - 1) * PAGE_SIZE,
+    page.value * PAGE_SIZE,
+  );
+
+  return (
+    <div class="p-6">
+      {/* Back link */}
+      <div class="mb-4">
+        <a
+          href="/security/vulnerabilities"
+          class="text-sm text-brand hover:underline inline-flex items-center gap-1"
+        >
+          <span aria-hidden="true">&larr;</span> Back to Vulnerabilities
+        </a>
+      </div>
+
+      {/* Header */}
+      <div class="mb-6 flex items-start justify-between gap-4">
+        <div>
+          <h1 class="text-2xl font-bold text-text-primary">
+            {kind}/{name}
+          </h1>
+          <p class="text-sm text-text-muted mt-1">
+            Namespace: <span class="font-mono">{namespace}</span>
+          </p>
+        </div>
+        <div class="flex items-center gap-3">
+          {detail.value && <ScannerBadge scanner={detail.value.scanner} />}
+          {detail.value?.lastScanned && (
+            <span class="text-xs text-text-muted">
+              Last scanned:{" "}
+              {new Date(detail.value.lastScanned).toLocaleString()}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {loading.value && (
+        <div class="flex justify-center py-12">
+          <Spinner class="text-brand" />
+        </div>
+      )}
+
+      {error.value && !loading.value && (
+        <div class="rounded-lg border border-border-primary bg-bg-elevated p-6 text-center">
+          <p class="text-sm text-danger">{error.value}</p>
+        </div>
+      )}
+
+      {!loading.value && !error.value && detail.value && summary.value && (
+        <>
+          {/* Summary cards */}
+          <div class="mb-6 flex flex-wrap gap-3">
+            <SeverityCount
+              label="Critical"
+              count={summary.value.critical}
+              color={SEVERITY_COLORS.critical}
+            />
+            <SeverityCount
+              label="High"
+              count={summary.value.high}
+              color={SEVERITY_COLORS.high}
+            />
+            <SeverityCount
+              label="Medium"
+              count={summary.value.medium}
+              color={SEVERITY_COLORS.medium}
+            />
+            <SeverityCount
+              label="Low"
+              count={summary.value.low}
+              color={SEVERITY_COLORS.low}
+            />
+            {summary.value.unknown > 0 && (
+              <SeverityCount
+                label="Unknown"
+                count={summary.value.unknown}
+                color={SEVERITY_COLORS.unknown}
+              />
+            )}
+            <SeverityCount
+              label="Fixable"
+              count={summary.value.fixable}
+              color="var(--success)"
+            />
+          </div>
+
+          {/* Empty state: no CVEs */}
+          {summary.value.total === 0 && (
+            <div class="rounded-lg border border-border-primary bg-bg-elevated p-12 text-center">
+              <p class="text-lg font-medium text-text-primary mb-2">
+                No vulnerabilities found
+              </p>
+              <p class="text-sm text-text-muted">
+                Trivy has scanned this workload and found no CVEs. Results may
+                lag image changes by a few minutes.
+              </p>
+            </div>
+          )}
+
+          {/* Filters */}
+          {summary.value.total > 0 && (
+            <div class="mb-4 flex flex-wrap items-center gap-4">
+              <select
+                class="rounded border border-border-primary px-2 py-1.5 text-sm bg-bg-base text-text-primary"
+                value={severityFilter.value}
+                onChange={(e) => {
+                  severityFilter.value = (e.target as HTMLSelectElement).value;
+                  page.value = 1;
+                }}
+              >
+                <option value="all">All Severities</option>
+                <option value="critical">Critical</option>
+                <option value="high">High</option>
+                <option value="medium">Medium</option>
+                <option value="low">Low</option>
+                <option value="unknown">Unknown</option>
+              </select>
+              <label class="flex items-center gap-2 text-sm text-text-primary cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={fixableOnly.value}
+                  onChange={(e) => {
+                    fixableOnly.value = (e.target as HTMLInputElement).checked;
+                    page.value = 1;
+                  }}
+                />
+                Fixable only
+              </label>
+              <span class="text-xs text-text-muted ml-auto">
+                {filtered.value.length} of {summary.value.total} CVEs
+              </span>
+            </div>
+          )}
+
+          {/* CVE table */}
+          {filtered.value.length > 0 && (
+            <div class="overflow-x-auto rounded-lg border border-border-primary">
+              <table class="w-full text-sm">
+                <thead>
+                  <tr class="border-b border-border-primary bg-surface">
+                    <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
+                      CVE
+                    </th>
+                    <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
+                      Severity
+                    </th>
+                    <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
+                      CVSS
+                    </th>
+                    <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
+                      Image
+                    </th>
+                    <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
+                      Package
+                    </th>
+                    <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
+                      Installed
+                    </th>
+                    <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
+                      Fixed
+                    </th>
+                  </tr>
+                </thead>
+                <tbody class="divide-y divide-border-subtle">
+                  {displayed.map((cve) => (
+                    <CVERow
+                      key={`${cve.image}/${cve.id}/${cve.package}`}
+                      cve={cve}
+                    />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          {/* Empty-filtered state */}
+          {summary.value.total > 0 && filtered.value.length === 0 && (
+            <div class="rounded-lg border border-border-primary bg-bg-elevated p-8 text-center">
+              <p class="text-sm text-text-muted">
+                No CVEs match your filters.
+              </p>
+            </div>
+          )}
+
+          {/* Pagination */}
+          {filtered.value.length > PAGE_SIZE && (
+            <div class="mt-4 flex items-center justify-between">
+              <p class="text-sm text-text-muted">
+                {filtered.value.length} CVEs &middot; Page {page.value} of{"  "}
+                {totalPages}
+              </p>
+              <div class="flex gap-2">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={() => {
+                    page.value--;
+                  }}
+                  disabled={page.value <= 1}
+                >
+                  Previous
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={() => {
+                    page.value++;
+                  }}
+                  disabled={page.value >= totalPages}
+                >
+                  Next
+                </Button>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+/** Single row in the CVE table. */
+function CVERow({ cve }: { cve: FlatCVE }) {
+  // Sort order is guaranteed by the backend (severity asc → CVSS desc → ID asc),
+  // so severityRank is used here only as defense when rendering.
+  void severityRank;
+
+  const cveLink = cve.primaryLink ||
+    `https://nvd.nist.gov/vuln/detail/${cve.id}`;
+
+  return (
+    <tr class="hover:bg-hover/30">
+      <td class="px-3 py-2">
+        <a
+          href={cveLink}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="font-mono text-xs text-brand hover:underline"
+          title={cve.title || cve.id}
+        >
+          {cve.id}
+        </a>
+      </td>
+      <td class="px-3 py-2">
+        <CVESeverityBadge severity={cve.severity} />
+      </td>
+      <td class="px-3 py-2 text-xs font-mono text-text-secondary">
+        {cve.cvssScore !== null ? cve.cvssScore.toFixed(1) : "—"}
+      </td>
+      <td class="px-3 py-2 text-xs text-text-secondary">
+        <span class="truncate inline-block max-w-[180px]" title={cve.image}>
+          {cve.image}
+        </span>
+        {cve.container && cve.container !== cve.image && (
+          <div class="text-[10px] text-text-muted">{cve.container}</div>
+        )}
+      </td>
+      <td class="px-3 py-2 text-xs font-mono text-text-primary">
+        {cve.package}
+      </td>
+      <td class="px-3 py-2 text-xs font-mono text-text-secondary">
+        {cve.installedVersion || "—"}
+      </td>
+      <td class="px-3 py-2 text-xs">
+        <FixAvailableBadge fixedVersion={cve.fixedVersion} />
+      </td>
+    </tr>
+  );
+}

--- a/frontend/lib/scanning-types.ts
+++ b/frontend/lib/scanning-types.ts
@@ -44,3 +44,106 @@ export interface VulnListResponse {
   vulnerabilities: WorkloadVulnSummary[];
   summary: VulnListMetadata;
 }
+
+// --- Vulnerability detail view (per-workload CVEs) ---
+
+export type Severity = "CRITICAL" | "HIGH" | "MEDIUM" | "LOW" | "UNKNOWN";
+
+/** An individual CVE finding with full metadata. */
+export interface CVEDetail {
+  id: string;
+  severity: Severity;
+  /** CVSS v3 score (0-10). `null` when unavailable. */
+  cvssScore: number | null;
+  package: string;
+  installedVersion: string;
+  /** Empty string = no fix available. */
+  fixedVersion: string;
+  title: string;
+  primaryLink: string;
+}
+
+/** Detailed vulnerabilities for a single container image. */
+export interface ImageVulnDetail {
+  name: string;
+  container: string;
+  vulnerabilities: CVEDetail[];
+}
+
+/** Full detail response for a workload. Summary counts are computed client-side. */
+export interface WorkloadVulnDetail {
+  namespace: string;
+  kind: string;
+  name: string;
+  scanner: Scanner;
+  lastScanned: string;
+  images: ImageVulnDetail[];
+}
+
+/** Aggregated counts computed from the vulnerabilities array. */
+export interface VulnDetailSummary {
+  critical: number;
+  high: number;
+  medium: number;
+  low: number;
+  unknown: number;
+  fixable: number;
+  unfixable: number;
+  total: number;
+}
+
+/** Compute severity and fix-availability counts from an images array. */
+export function computeVulnSummary(
+  images: ImageVulnDetail[],
+): VulnDetailSummary {
+  const s: VulnDetailSummary = {
+    critical: 0,
+    high: 0,
+    medium: 0,
+    low: 0,
+    unknown: 0,
+    fixable: 0,
+    unfixable: 0,
+    total: 0,
+  };
+  for (const img of images) {
+    for (const v of img.vulnerabilities) {
+      s.total++;
+      switch (v.severity) {
+        case "CRITICAL":
+          s.critical++;
+          break;
+        case "HIGH":
+          s.high++;
+          break;
+        case "MEDIUM":
+          s.medium++;
+          break;
+        case "LOW":
+          s.low++;
+          break;
+        default:
+          s.unknown++;
+      }
+      if (v.fixedVersion) {
+        s.fixable++;
+      } else {
+        s.unfixable++;
+      }
+    }
+  }
+  return s;
+}
+
+const SEVERITY_RANK: Record<Severity, number> = {
+  CRITICAL: 0,
+  HIGH: 1,
+  MEDIUM: 2,
+  LOW: 3,
+  UNKNOWN: 4,
+};
+
+/** Severity rank for sorting (lower = more severe). Handles unknown values. */
+export function severityRank(severity: string): number {
+  return SEVERITY_RANK[severity as Severity] ?? 4;
+}

--- a/frontend/lib/scanning-types.ts
+++ b/frontend/lib/scanning-types.ts
@@ -88,7 +88,6 @@ export interface VulnDetailSummary {
   low: number;
   unknown: number;
   fixable: number;
-  unfixable: number;
   total: number;
 }
 
@@ -103,7 +102,6 @@ export function computeVulnSummary(
     low: 0,
     unknown: 0,
     fixable: 0,
-    unfixable: 0,
     total: 0,
   };
   for (const img of images) {
@@ -125,25 +123,8 @@ export function computeVulnSummary(
         default:
           s.unknown++;
       }
-      if (v.fixedVersion) {
-        s.fixable++;
-      } else {
-        s.unfixable++;
-      }
+      if (v.fixedVersion) s.fixable++;
     }
   }
   return s;
-}
-
-const SEVERITY_RANK: Record<Severity, number> = {
-  CRITICAL: 0,
-  HIGH: 1,
-  MEDIUM: 2,
-  LOW: 3,
-  UNKNOWN: 4,
-};
-
-/** Severity rank for sorting (lower = more severe). Handles unknown values. */
-export function severityRank(severity: string): number {
-  return SEVERITY_RANK[severity as Severity] ?? 4;
 }

--- a/frontend/routes/security/vulnerabilities/[namespace]/[kind]/[name].tsx
+++ b/frontend/routes/security/vulnerabilities/[namespace]/[kind]/[name].tsx
@@ -1,0 +1,23 @@
+import { define } from "@/utils.ts";
+import SubNav from "@/islands/SubNav.tsx";
+import { DOMAIN_SECTIONS } from "@/lib/constants.ts";
+import VulnerabilityDetail from "@/islands/VulnerabilityDetail.tsx";
+
+const section = DOMAIN_SECTIONS.find((s) => s.id === "security")!;
+
+export default define.page(function VulnerabilityDetailPage(ctx) {
+  const { namespace, kind, name } = ctx.params;
+  return (
+    <>
+      <SubNav
+        tabs={section.tabs ?? []}
+        currentPath="/security/vulnerabilities"
+      />
+      <VulnerabilityDetail
+        namespace={namespace}
+        kind={kind}
+        name={name}
+      />
+    </>
+  );
+});

--- a/plans/security-vulnerability-detail-view.md
+++ b/plans/security-vulnerability-detail-view.md
@@ -1,0 +1,614 @@
+# feat: Security Vulnerability Detail View
+
+## Overview
+
+Expand the security vulnerability functionality to provide clickable workload rows that open a detail view showing all individual CVE findings. The detail page displays CVEs sorted by criticality with links to vulnerability databases and shows "Fix Available" indicators when upgrades would resolve vulnerabilities.
+
+## Problem Statement / Motivation
+
+The current vulnerability dashboard (Phase 10) shows only aggregate severity counts per workload. Security teams need to:
+
+1. **Investigate specific CVEs** — understand which packages are affected and what fixes are available
+2. **Prioritize remediation** — sort by criticality to address highest-risk vulnerabilities first
+3. **Research vulnerabilities** — quick access to NVD/AVD pages for CVE details
+4. **Plan upgrades** — know which vulnerabilities have available fixes vs. those without remediation paths
+
+Currently, users must manually query the Trivy VulnerabilityReport CRDs via kubectl to get this information.
+
+## Proposed Solution
+
+### Core Features (MVP)
+
+1. **Clickable workload rows** — Link from VulnerabilityDashboard to detail page (using `<a>` tags for accessibility)
+2. **CVE detail table** — Flat table with image column, displaying:
+   - CVE ID (clickable link to primary source)
+   - Image name (for multi-container workloads)
+   - Affected package name
+   - Installed version
+   - Fixed version (with "Fix Available" indicator when present)
+   - Severity badge with CVSS score
+3. **Sorting** — Primary: severity (Critical → Low → Unknown), Secondary: CVSS score descending
+4. **Filtering** — Severity dropdown + "Fixable only" checkbox
+5. **Pagination** — Client-side, 100 CVEs per page (consistent with existing patterns)
+6. **Cross-links** — "View Vulnerabilities" link from workload detail pages (Deployment, Pod, etc.)
+
+### Deferred Features (Future)
+
+1. **EPSS scores** — Requires external API integration (api.first.org)
+2. **CISA KEV status** — Requires external API integration
+3. **Kubescape CVE details** — Blocked by impersonation constraints (see Technical Decisions)
+
+---
+
+## Technical Approach
+
+### Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                        VulnerabilityDashboard                           │
+│  (existing - add clickable rows → href to detail page)                  │
+└─────────────────────────────────────────┬───────────────────────────────┘
+                                          │ click workload row
+                                          ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│             /security/vulnerabilities/[namespace]/[kind]/[name]         │
+│                                                                         │
+│  ┌──────────────────┐   GET /v1/scanning/vulnerabilities/{ns}/{k}/{n}  │
+│  │ SubNav (Security)│◄──────────────────────────────────────────────── │
+│  └──────────────────┘                                                   │
+│  ┌──────────────────────────────────────────────────────────────────┐  │
+│  │ VulnerabilityDetail island                                        │  │
+│  │  - Back link + breadcrumb                                         │  │
+│  │  - Workload header (name, kind, namespace, last scanned)          │  │
+│  │  - Summary cards (computed client-side from vulnerabilities)      │  │
+│  │  - Filter bar (severity dropdown, fixable checkbox)               │  │
+│  │  - Flat CVE table with image column (sorted by severity → CVSS)   │  │
+│  │    - CVE ID link, image, package, versions, severity badge        │  │
+│  │  - Pagination controls                                            │  │
+│  └──────────────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### URL Structure
+
+```
+/security/vulnerabilities/{namespace}/{kind}/{name}
+```
+
+- Fresh 2.x route: `routes/security/vulnerabilities/[namespace]/[kind]/[name].tsx`
+- Example: `/security/vulnerabilities/production/Deployment/nginx`
+- Parameters are URL-encoded to handle special characters in names
+
+### API Design
+
+**New Endpoint:**
+
+```
+GET /api/v1/scanning/vulnerabilities/{namespace}/{kind}/{name}
+```
+
+**Request:**
+- Path params: `namespace`, `kind`, `name`
+- Query params: none (all filtering done client-side)
+- Headers: `Authorization: Bearer <jwt>`, `X-Requested-With: XMLHttpRequest`
+
+**Response:**
+
+```json
+{
+  "data": {
+    "namespace": "production",
+    "kind": "Deployment",
+    "name": "nginx",
+    "scanner": "trivy",
+    "lastScanned": "2026-04-10T14:30:00Z",
+    "images": [
+      {
+        "name": "nginx:1.25",
+        "container": "nginx",
+        "vulnerabilities": [
+          {
+            "id": "CVE-2024-1234",
+            "severity": "CRITICAL",
+            "cvssScore": 9.8,
+            "package": "openssl",
+            "installedVersion": "1.1.1k-1",
+            "fixedVersion": "1.1.1n-1",
+            "title": "Buffer overflow in X.509 certificate verification",
+            "primaryLink": "https://avd.aquasec.com/nvd/cve-2024-1234"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Note:** Summary counts (critical, high, medium, low, unknown, fixable, unfixable) are computed client-side from the vulnerabilities array to avoid duplication.
+```
+
+**RBAC:** Same check as list endpoint — `list` verb on `aquasecurity.github.io/vulnerabilityreports`
+
+**Caching:** No caching for detail endpoint (fresh fetch each request). Existing 30s namespace cache for summaries remains unchanged.
+
+---
+
+### Implementation Phases
+
+#### Phase 1: Backend Detail Endpoint
+
+**Files to modify:**
+
+| File | Changes |
+|------|---------|
+| `backend/internal/scanning/types.go` | Add `WorkloadVulnDetail`, `ImageVulnDetail`, `CVEDetail` types |
+| `backend/internal/scanning/trivy.go` | Add `GetWorkloadVulnDetails()` function |
+| `backend/internal/scanning/handler.go` | Add `HandleVulnerabilityDetail()` handler |
+| `backend/internal/server/routes.go` | Register new route |
+
+**New Types (`types.go`):**
+
+```go
+// CVEDetail represents an individual vulnerability finding
+type CVEDetail struct {
+    ID               string   `json:"id"`
+    Severity         string   `json:"severity"`          // CRITICAL, HIGH, MEDIUM, LOW, UNKNOWN
+    CVSSScore        *float64 `json:"cvssScore"`         // 0-10 scale, nil if unavailable
+    Package          string   `json:"package"`           // Affected package name
+    InstalledVersion string   `json:"installedVersion"`
+    FixedVersion     string   `json:"fixedVersion"`      // Empty string = no fix available
+    Title            string   `json:"title"`
+    PrimaryLink      string   `json:"primaryLink"`       // URL to CVE page
+}
+
+// ImageVulnDetail represents vulnerabilities for a single container image
+type ImageVulnDetail struct {
+    Name            string      `json:"name"`            // Image reference (repo:tag)
+    Container       string      `json:"container"`       // Container name in workload
+    Vulnerabilities []CVEDetail `json:"vulnerabilities"` // Sorted by severity
+}
+
+// WorkloadVulnDetail is the full detail response for a workload
+// Note: Summary counts are computed client-side from vulnerabilities array
+type WorkloadVulnDetail struct {
+    Namespace   string            `json:"namespace"`
+    Kind        string            `json:"kind"`
+    Name        string            `json:"name"`
+    Scanner     Scanner           `json:"scanner"`
+    LastScanned string            `json:"lastScanned"`
+    Images      []ImageVulnDetail `json:"images"`
+}
+```
+
+**Trivy Adapter (`trivy.go`):**
+
+```go
+// GetWorkloadVulnDetails fetches full CVE details for a specific workload
+func GetWorkloadVulnDetails(
+    ctx context.Context,
+    dynClient dynamic.Interface,
+    namespace, kind, name string,
+) (*WorkloadVulnDetail, error) {
+    // 1. List VulnerabilityReports with label selectors:
+    //    trivy-operator.resource.namespace=<namespace>
+    //    trivy-operator.resource.kind=<kind>
+    //    trivy-operator.resource.name=<name>
+    // 2. For each report, extract report.vulnerabilities[] array
+    // 3. Map to CVEDetail structs, picking CVSS score from nvd > redhat > first available
+    // 4. Sort by severity (CRITICAL=0, HIGH=1, MEDIUM=2, LOW=3, UNKNOWN=4), then by CVSS desc
+    // 5. Group by image/container
+    // Note: Summary counts computed client-side, not here
+}
+```
+
+**Handler (`handler.go`):**
+
+```go
+// HandleVulnerabilityDetail handles GET /v1/scanning/vulnerabilities/{namespace}/{kind}/{name}
+func (h *Handler) HandleVulnerabilityDetail(w http.ResponseWriter, r *http.Request) {
+    namespace := chi.URLParam(r, "namespace")
+    kind := chi.URLParam(r, "kind")
+    name := chi.URLParam(r, "name")
+
+    // RBAC check (same as list endpoint)
+    if !h.canAccessTrivy(r.Context()) {
+        writeError(w, 403, "Access denied", "You don't have permission to view vulnerability reports")
+        return
+    }
+
+    // Add 30s timeout to prevent hanging on slow API servers
+    ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+    defer cancel()
+
+    // Fetch details (bypass namespace cache, direct API call)
+    detail, err := GetWorkloadVulnDetails(ctx, h.dynClient, namespace, kind, name)
+    if err != nil {
+        // Handle not found (empty images) vs other errors (500)
+        if errors.Is(err, context.DeadlineExceeded) {
+            writeError(w, 504, "Timeout", "Request timed out fetching vulnerability details")
+            return
+        }
+        // ... other error handling
+    }
+
+    writeJSON(w, http.StatusOK, envelope{Data: detail})
+}
+```
+
+**Route (`routes.go`):**
+
+```go
+// Inside the scanning routes group (line ~520)
+sr.Get("/vulnerabilities/{namespace}/{kind}/{name}", h.HandleVulnerabilityDetail)
+```
+
+**Success Criteria:**
+- [ ] New endpoint returns CVE details for Trivy-scanned workloads
+- [ ] RBAC filtering prevents unauthorized access
+- [ ] Response includes all fields from VulnerabilityReport.report.vulnerabilities[]
+- [ ] Empty response (no reports) returns 200 with empty images array
+- [ ] `go vet` and `go test` pass
+
+---
+
+#### Phase 2: Frontend Detail Page + Cross-links
+
+**Files to create/modify:**
+
+| File | Changes |
+|------|---------|
+| `frontend/lib/scanning-types.ts` | Add `WorkloadVulnDetail`, `ImageVulnDetail`, `CVEDetail` interfaces + `computeVulnSummary` helper |
+| `frontend/lib/api.ts` | Add `getWorkloadVulnDetails()` function |
+| `frontend/islands/VulnerabilityDetail.tsx` | NEW: Detail island component (flat table) |
+| `frontend/routes/security/vulnerabilities/[namespace]/[kind]/[name].tsx` | NEW: Route file |
+| `frontend/islands/VulnerabilityDashboard.tsx` | Make workload rows clickable (using `<a>` tags) |
+| `frontend/components/ui/ScanBadges.tsx` | Add `FixAvailableBadge` component |
+| `frontend/components/k8s/DeploymentOverview.tsx` | Add "View Vulnerabilities" link |
+| `frontend/components/k8s/PodOverview.tsx` | Add "View Vulnerabilities" link |
+
+**Types (`scanning-types.ts`):**
+
+```typescript
+export interface CVEDetail {
+  id: string;
+  severity: "CRITICAL" | "HIGH" | "MEDIUM" | "LOW" | "UNKNOWN";
+  cvssScore: number | null;  // null if unavailable
+  package: string;
+  installedVersion: string;
+  fixedVersion: string;  // empty string = no fix available
+  title: string;
+  primaryLink: string;
+}
+
+export interface ImageVulnDetail {
+  name: string;
+  container: string;
+  vulnerabilities: CVEDetail[];
+}
+
+// Note: Summary computed client-side from vulnerabilities array
+export interface WorkloadVulnDetail {
+  namespace: string;
+  kind: string;
+  name: string;
+  scanner: Scanner;
+  lastScanned: string;
+  images: ImageVulnDetail[];
+}
+
+// Helper to compute summary from vulnerabilities (client-side)
+export function computeVulnSummary(images: ImageVulnDetail[]): {
+  critical: number; high: number; medium: number; low: number; unknown: number;
+  fixable: number; unfixable: number;
+} {
+  const summary = { critical: 0, high: 0, medium: 0, low: 0, unknown: 0, fixable: 0, unfixable: 0 };
+  for (const img of images) {
+    for (const v of img.vulnerabilities) {
+      summary[v.severity.toLowerCase() as keyof typeof summary]++;
+      if (v.fixedVersion) summary.fixable++;
+      else summary.unfixable++;
+    }
+  }
+  return summary;
+}
+```
+
+**VulnerabilityDetail Island:**
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│ ← Back to Vulnerabilities                                               │
+├─────────────────────────────────────────────────────────────────────────┤
+│ Deployment/nginx                                      Last scanned: 2h ago │
+│ production                                            🛡️ Trivy           │
+├─────────────────────────────────────────────────────────────────────────┤
+│ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────────────┐│
+│ │ 5 Critical│ │ 12 High  │ │ 45 Medium│ │ 23 Low   │ │ 52 Fixable      ││
+│ └──────────┘ └──────────┘ └──────────┘ └──────────┘ └──────────────────┘│
+├─────────────────────────────────────────────────────────────────────────┤
+│ Filter: [All Severities ▼]  [✓] Fixable only                           │
+├─────────────────────────────────────────────────────────────────────────┤
+│ ┌───────────────────────────────────────────────────────────────────┐  │
+│ │ CVE ID         │ Image      │ Package   │ Installed │ Fixed     │  │
+│ │────────────────│────────────│───────────│───────────│───────────│  │
+│ │ CVE-2024-1234  │ nginx:1.25 │ openssl   │ 1.1.1k-1  │ 1.1.1n-1 ✓│  │
+│ │ CVE-2024-5678  │ nginx:1.25 │ curl      │ 7.68.0    │ —         │  │
+│ │ CVE-2024-9999  │ envoy:1.0  │ zlib      │ 1.2.11    │ 1.2.13 ✓  │  │
+│ └───────────────────────────────────────────────────────────────────┘  │
+├─────────────────────────────────────────────────────────────────────────┤
+│ Page 1 of 5   [Previous] [1] [2] [3] ... [5] [Next]                    │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+**Key UI Patterns:**
+- **Flat table with image column** — No collapsible sections; image name shown per row
+- Severity badges use existing `SeverityBadge` component from `components/ui/PolicyBadges.tsx`
+- Fixed version column: show version in `--success` color with checkmark when present, show "—" when absent
+- CVE ID links use `primaryLink` from API response (falls back to NVD URL if empty)
+- Summary cards computed client-side via `computeVulnSummary()` helper
+
+**VulnerabilityDashboard modifications:**
+
+```tsx
+// In the table row (around line 302-338)
+// Use <a> tags for accessibility (keyboard nav, right-click, middle-click)
+<tr key={`${w.namespace}/${w.kind}/${w.name}`}>
+  <td colSpan={8} class="p-0">
+    <a
+      href={`/security/vulnerabilities/${encodeURIComponent(w.namespace)}/${encodeURIComponent(w.kind)}/${encodeURIComponent(w.name)}`}
+      class="flex items-center gap-4 px-4 py-3 hover:bg-[var(--surface-hover)]"
+    >
+      {/* Row content rendered inside the anchor */}
+    </a>
+  </td>
+</tr>
+```
+
+**Accessibility note:** Using `<a>` tags instead of `onClick` handlers ensures:
+- Keyboard navigation (Tab + Enter)
+- Right-click context menu (Open in new tab)
+- Middle-click to open in new tab
+- Screen reader compatibility
+
+**Success Criteria:**
+- [ ] Clicking a workload row navigates to detail page
+- [ ] Detail page shows all CVEs grouped by image
+- [ ] Severity filter works correctly
+- [ ] Fixable filter shows only CVEs with non-empty fixedVersion
+- [ ] Pagination works with 100 items per page
+- [ ] Back link returns to vulnerabilities list
+- [ ] Empty state shows helpful message when no scan results exist
+- [ ] Kubescape workloads show summary-only message
+- [ ] `deno lint` and `deno fmt --check` pass
+
+**Cross-linking from workload detail pages:**
+
+Also modify workload overview components to add "View Vulnerabilities" links:
+
+| File | Changes |
+|------|---------|
+| `frontend/components/k8s/DeploymentOverview.tsx` | Add "View Vulnerabilities" link |
+| `frontend/components/k8s/PodOverview.tsx` | Add "View Vulnerabilities" link |
+
+```tsx
+// In DeploymentOverview.tsx - add Security section
+{vulnCount !== undefined && (
+  <div class="mt-4 border-t border-[var(--border)] pt-4">
+    <h4 class="text-sm font-medium text-[var(--muted)]">Security</h4>
+    <a
+      href={`/security/vulnerabilities/${namespace}/Deployment/${name}`}
+      class="flex items-center gap-2 mt-2 text-[var(--accent)] hover:underline"
+    >
+      <span>{vulnCount} vulnerabilities</span>
+      <span class="text-xs">→</span>
+    </a>
+  </div>
+)}
+```
+
+**Implementation:** Client-side fetch from the new detail endpoint to get vulnerability count. Load lazily (on expand or via IntersectionObserver) to avoid adding latency to page load.
+
+---
+
+## Technical Decisions
+
+### Kubescape Limitation
+
+**Decision:** CVE-level detail is Trivy-only for this implementation.
+
+**Rationale:**
+- Kubescape's `VulnerabilitySummary` CRD (in workload namespace) contains only severity counts
+- Kubescape's `VulnerabilityManifest` CRD (in `kubescape` namespace) contains CVE details but is inaccessible via user impersonation for non-admin users
+- Fetching from `kubescape` namespace with service account credentials violates the project's core security principle that all k8s API calls use impersonation
+
+**UX:** When a Kubescape-scanned workload is clicked:
+- Show severity counts from summary
+- Display message: "Individual CVE details are not available for Kubescape scans. Severity totals are shown above."
+- Link to Kubescape dashboard URL if available (from status endpoint)
+
+### CVSS Score Selection
+
+**Decision:** Prefer NVD score, fall back to vendor-specific scores. Return the score only (not the source).
+
+**Logic:**
+```go
+func selectCVSSScore(cvss map[string]CVSSDetail) *float64 {
+    preferred := []string{"nvd", "redhat", "ubuntu", "debian"}
+    for _, vendor := range preferred {
+        if detail, ok := cvss[vendor]; ok {
+            return &detail.V3Score
+        }
+    }
+    // Return first available if none of preferred exist
+    for _, detail := range cvss {
+        return &detail.V3Score
+    }
+    return nil  // No CVSS data available
+}
+```
+
+### Namespace Selector Behavior
+
+**Decision:** Detail page ignores global namespace selector.
+
+**Rationale:**
+- Detail page namespace is URL-driven (bookmarkable, shareable)
+- Changing namespace while on detail page would be confusing (would require redirect)
+- Consistent with GitOpsAppDetail which also ignores the selector
+
+### Sorting Algorithm
+
+**Decision:** Multi-level sort: Severity → CVSS Score → CVE ID
+
+```typescript
+const severityOrder = { CRITICAL: 0, HIGH: 1, MEDIUM: 2, LOW: 3, UNKNOWN: 4 };
+
+vulns.sort((a, b) => {
+  // Primary: severity
+  if (severityOrder[a.severity] !== severityOrder[b.severity]) {
+    return severityOrder[a.severity] - severityOrder[b.severity];
+  }
+  // Secondary: CVSS score (higher first)
+  if (a.cvssScore !== b.cvssScore) {
+    return b.cvssScore - a.cvssScore;
+  }
+  // Tertiary: CVE ID (alphabetical)
+  return a.id.localeCompare(b.id);
+});
+```
+
+---
+
+## Acceptance Criteria
+
+### Functional Requirements
+
+- [ ] Workload rows in VulnerabilityDashboard are clickable links to detail pages
+- [ ] Detail page displays all CVEs for the selected workload
+- [ ] CVEs are sorted by severity (Critical first), then by CVSS score
+- [ ] Each CVE shows: ID, package, installed version, fixed version, severity, CVSS score
+- [ ] CVE ID links to the primary vulnerability page (NVD/AVD)
+- [ ] "Fix Available" indicator appears when fixedVersion is non-empty
+- [ ] Filter by severity level works correctly
+- [ ] Filter by fix availability (fixable/unfixable) works correctly
+- [ ] Pagination displays 100 CVEs per page
+- [ ] Multi-container workloads show image name in table column
+- [ ] Back navigation returns to vulnerability dashboard
+- [ ] Cross-links from Deployment/Pod detail pages work correctly
+- [ ] Direct URL access works (bookmarkable)
+- [ ] Empty state appears for workloads without scan results
+- [ ] Kubescape workloads show summary-only message
+
+### Non-Functional Requirements
+
+- [ ] Detail page loads in < 2 seconds for workloads with < 500 CVEs
+- [ ] API response size < 2MB for typical workloads
+- [ ] No memory leaks in pagination component
+- [ ] Accessibility: color-blind friendly severity indicators (use shapes + text)
+- [ ] Mobile responsive (table scrolls horizontally on small screens)
+
+### Quality Gates
+
+- [ ] All Go tests pass (`make test-backend`)
+- [ ] All TypeScript passes type check (`npx tsc --noEmit`)
+- [ ] Deno lint passes (`deno lint`)
+- [ ] Deno format passes (`deno fmt --check`)
+- [ ] ESLint passes (`npx eslint . --quiet`)
+- [ ] E2E tests added for detail page navigation
+- [ ] Code review approved
+
+---
+
+## Dependencies & Prerequisites
+
+**Required:**
+- Phase 10 (Security Scanning) complete — ✅ DONE
+- Trivy Operator installed in cluster with VulnerabilityReports enabled
+
+**Blocked by:**
+- None
+
+---
+
+## Risk Analysis & Mitigation
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Large CVE lists cause slow page load | Medium | Medium | Client-side pagination (100/page), defer full descriptions to expand |
+| Trivy CRD schema changes break parsing | Low | High | Version check on Trivy Operator, graceful degradation |
+| RBAC complexity with CRD access | Low | Medium | Reuse existing `list` verb check, document permissions |
+| Users expect Kubescape CVE details | Medium | Low | Clear UX message explaining limitation |
+
+---
+
+## Future Considerations
+
+### Phase 2 Enhancements
+
+1. **WebSocket real-time updates** — Watch VulnerabilityReport CRDs, invalidate cache, push updates to frontend
+2. **Export to CSV/JSON** — Server-side generation with RBAC check
+3. **Rescan action** — Trigger Trivy rescan (delete VulnerabilityReport to force recreation)
+4. **Config audit tab** — Show ConfigAuditReport findings alongside vulnerabilities
+
+### Phase 3 External Integrations
+
+1. **EPSS scores** — Add Exploit Prediction Scoring System data from api.first.org
+2. **CISA KEV status** — Flag CVEs in the Known Exploited Vulnerabilities catalog
+3. **Jira/Linear integration** — Create tickets for critical vulnerabilities
+
+---
+
+## References & Research
+
+### Internal References
+
+- `backend/internal/scanning/types.go` — Existing scanner types (summary only)
+- `backend/internal/scanning/trivy.go` — Trivy adapter (lines 54-57 only read summary)
+- `backend/internal/scanning/handler.go` — Handler with singleflight + 30s cache
+- `frontend/islands/VulnerabilityDashboard.tsx` — Current dashboard implementation
+- `frontend/islands/GitOpsAppDetail.tsx` — Reference pattern for detail pages
+- `frontend/islands/ViolationBrowser.tsx` — Reference pattern for severity badges/filtering
+
+### External References
+
+- [Trivy VulnerabilityReport CRD](https://aquasecurity.github.io/trivy-operator/v0.11.0/docs/crds/vulnerability-report/)
+- [CVSS v4.0 Specification](https://www.first.org/cvss/specification-document)
+- [NVD Vulnerability Detail Pages](https://nvd.nist.gov/vuln/vulnerability-detail-pages)
+- [EPSS Model](https://www.first.org/epss/model)
+- [CISA KEV Catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog)
+
+### Related Work
+
+- Phase 10 PR: #??? (Security Scanning implementation)
+- Pattern reference: ViolationBrowser (Phase 8B)
+- Pattern reference: DiagnosticWorkspace (Phase 7C)
+
+---
+
+## Checklist Summary
+
+### Phase 1: Backend (Est. 2-3 hours)
+- [ ] Add types to `backend/internal/scanning/types.go` (`CVEDetail`, `ImageVulnDetail`, `WorkloadVulnDetail`)
+- [ ] Add `GetWorkloadVulnDetails()` to `backend/internal/scanning/trivy.go`
+- [ ] Add `HandleVulnerabilityDetail()` to `backend/internal/scanning/handler.go` (with 30s timeout)
+- [ ] Register route in `backend/internal/server/routes.go`
+- [ ] Add unit tests:
+  - CVSS score selection (NVD present, fallback, empty)
+  - Severity sorting (Critical > High > Medium > Low > Unknown)
+  - Multi-container grouping
+  - Empty reports handling
+  - RBAC filtering (403 for unauthorized)
+- [ ] Run `go vet` and `go test`
+
+### Phase 2: Frontend + Cross-links (Est. 5-6 hours)
+- [ ] Add types to `frontend/lib/scanning-types.ts` (with `computeVulnSummary` helper)
+- [ ] Add API function to `frontend/lib/api.ts`
+- [ ] Create `frontend/islands/VulnerabilityDetail.tsx` (flat table with image column)
+- [ ] Create route at `frontend/routes/security/vulnerabilities/[namespace]/[kind]/[name].tsx`
+- [ ] Modify `frontend/islands/VulnerabilityDashboard.tsx` for clickable rows (using `<a>` tags)
+- [ ] Add `FixAvailableBadge` to `frontend/components/ui/ScanBadges.tsx`
+- [ ] Add "View Vulnerabilities" link to `DeploymentOverview.tsx` and `PodOverview.tsx`
+- [ ] Add E2E tests (navigation, filtering, pagination, CVE links)
+- [ ] Run `deno lint` and `deno fmt --check`
+- [ ] Smoke test on homelab cluster

--- a/todos/292-complete-p2-scanner-availability-check-ordering.md
+++ b/todos/292-complete-p2-scanner-availability-check-ordering.md
@@ -1,0 +1,89 @@
+---
+status: pending
+priority: p2
+issue_id: "292"
+tags: [code-review, scanning, ux, pr-167]
+dependencies: []
+---
+
+# Reorder scanner-availability vs. RBAC check in HandleVulnerabilityDetail
+
+## Problem Statement
+
+In `HandleVulnerabilityDetail`, the RBAC check (`canAccessTrivy`) runs before the Trivy-availability check. A user without Trivy CRD RBAC in a cluster where Trivy isn't installed at all gets a 403 "access denied" message when the real problem is "scanner not installed."
+
+**Why it matters:** Confusing error messages mislead users — they'll open a ticket about missing permissions when the real fix is installing Trivy Operator.
+
+## Findings
+
+### Pattern Recognition Reviewer
+
+**File:** `backend/internal/scanning/handler.go:287-299`
+
+```go
+// RBAC: require Trivy access. Kubescape CVE-level detail is not supported.
+if !h.canAccessTrivy(r.Context(), user, namespace) {
+    httputil.WriteError(w, http.StatusForbidden,
+        fmt.Sprintf("access denied to vulnerability reports in namespace %q", namespace), "")
+    return
+}
+
+// Check scanner status. If only Kubescape is available, return a helpful message.
+status := h.Discoverer.Status()
+if status.Trivy == nil || !status.Trivy.Available {
+    httputil.WriteError(w, http.StatusNotImplemented,
+        "CVE-level detail requires Trivy Operator; Kubescape summaries only expose severity totals", "")
+    return
+}
+```
+
+Ordering matters: RBAC runs first and returns 403 for users who have no Trivy CRD RBAC (because Trivy isn't installed, so nobody has that RBAC). They see "access denied" instead of "scanner not installed."
+
+## Proposed Solutions
+
+### Option A: Swap the check order (Recommended)
+
+```go
+// Check scanner status first — if Trivy isn't installed, RBAC is irrelevant.
+status := h.Discoverer.Status()
+if status.Trivy == nil || !status.Trivy.Available {
+    httputil.WriteError(w, http.StatusNotImplemented,
+        "CVE-level detail requires Trivy Operator", "")
+    return
+}
+
+// RBAC: require Trivy access.
+if !h.canAccessTrivy(r.Context(), user, namespace) {
+    httputil.WriteError(w, http.StatusForbidden, ..., "")
+    return
+}
+```
+
+**Pros:** Correct error for the common case; trivial change
+**Cons:** None
+**Effort:** Trivial
+**Risk:** None
+
+## Recommended Action
+
+<!-- Filled during triage -->
+
+## Technical Details
+
+**Affected files:**
+- `backend/internal/scanning/handler.go:287-299`
+
+## Acceptance Criteria
+
+- [ ] Scanner-availability check runs before RBAC check
+- [ ] Error message is accurate when Trivy is not installed
+- [ ] Existing tests still pass
+
+## Work Log
+
+<!-- Dated record of actions taken -->
+
+## Resources
+
+- PR #167
+- Plan: `plans/security-vulnerability-detail-view.md`

--- a/todos/293-complete-p2-validate-url-params-middleware.md
+++ b/todos/293-complete-p2-validate-url-params-middleware.md
@@ -1,0 +1,96 @@
+---
+status: pending
+priority: p2
+issue_id: "293"
+tags: [code-review, scanning, validation, pr-167]
+dependencies: []
+---
+
+# Add ValidateURLParams middleware and tighten validWorkloadName
+
+## Problem Statement
+
+The new detail route `/scanning/vulnerabilities/{namespace}/{kind}/{name}` doesn't use the shared `resources.ValidateURLParams` middleware that neighboring routes (limits, velero, topology, diagnostics, policy) all apply. The handler does its own regex validation, duplicating the middleware's job.
+
+Worse: `validWorkloadName` allows up to 253 chars (DNS-1123 subdomain), but Kubernetes **label values** are capped at 63 characters. A 64-253 char name passes validation, then the label selector at `trivy.go:202` gets rejected by the API server with a validation error that gets wrapped into a generic 500.
+
+**Why it matters:** Bad UX (generic 500 instead of 400), duplication of validation logic, inconsistency with rest of codebase.
+
+## Findings
+
+### Architecture Strategist
+
+**File:** `backend/internal/server/routes.go:521`
+
+```go
+sr.Get("/vulnerabilities/{namespace}/{kind}/{name}", h.HandleVulnerabilityDetail)
+```
+
+Missing `.With(resources.ValidateURLParams)` chain that neighbors use:
+- `limits` routes.go:535: `lr.With(resources.ValidateURLParams).Get(...)`
+- `velero` routes.go:551
+- `topology` routes.go:404
+- `diagnostics` routes.go:435
+- `policy` routes.go:449
+
+### Security Sentinel
+
+**File:** `backend/internal/scanning/handler.go:259`
+
+```go
+var validWorkloadName = regexp.MustCompile(`^[a-z0-9]([a-z0-9.\-]{0,251}[a-z0-9])?$`)
+```
+
+Allows up to 253 chars — k8s label values max at 63. Name `a` × 100 passes regex, then API server rejects the label selector.
+
+## Proposed Solutions
+
+### Option A: Use shared middleware + remove handler regex (Recommended)
+
+```go
+// routes.go
+sr.With(resources.ValidateURLParams).Get("/vulnerabilities/{namespace}/{kind}/{name}", h.HandleVulnerabilityDetail)
+```
+
+Then delete `validWorkloadName` from `handler.go`. Keep `validWorkloadKind` since it isn't covered by the shared middleware (or add an allowlist map for kinds).
+
+**Pros:** Matches project convention; single source of truth for name validation; automatically handles future changes
+**Cons:** Need to verify `ValidateURLParams` actually validates `{name}` URL param (check implementation at `backend/internal/k8s/resources/handler.go`)
+**Effort:** Small
+**Risk:** Low
+
+### Option B: Keep handler regex but tighten to 63 chars
+
+```go
+var validWorkloadName = regexp.MustCompile(`^[a-z0-9]([a-z0-9.\-]{0,61}[a-z0-9])?$`)
+```
+
+**Pros:** Minimal change
+**Cons:** Still duplicates validation logic, doesn't match project convention
+**Effort:** Trivial
+**Risk:** None
+
+## Recommended Action
+
+<!-- Filled during triage -->
+
+## Technical Details
+
+**Affected files:**
+- `backend/internal/server/routes.go:521`
+- `backend/internal/scanning/handler.go:256-259`
+- Compare: `backend/internal/k8s/resources/handler.go` (ValidateURLParams implementation)
+
+## Acceptance Criteria
+
+- [ ] Route uses `resources.ValidateURLParams` middleware (if it validates `{name}`)
+- [ ] Invalid names > 63 chars return 400 with clear message (not 500)
+- [ ] No duplicate validation in handler
+
+## Work Log
+
+<!-- Dated record -->
+
+## Resources
+
+- PR #167

--- a/todos/294-complete-p2-extract-image-ref-helper.md
+++ b/todos/294-complete-p2-extract-image-ref-helper.md
@@ -1,0 +1,87 @@
+---
+status: pending
+priority: p2
+issue_id: "294"
+tags: [code-review, scanning, dry, pr-167]
+dependencies: []
+---
+
+# Extract shared image reference helper in trivy.go
+
+## Problem Statement
+
+`ListTrivyVulnSummaries` and `GetTrivyWorkloadVulnDetails` both rebuild the container image reference from `report.artifact.repository` + `report.artifact.tag`, with identical fallback logic to the container name. This is pure duplication that should be a shared helper.
+
+**Why it matters:** DRY violation; future changes (e.g., adding digest support) require editing two places.
+
+## Findings
+
+### Code Simplicity + Pattern Recognition Reviewers
+
+**File:** `backend/internal/scanning/trivy.go`
+
+**Summary path (existing, lines 62-72):**
+```go
+repo, _, _ := unstructured.NestedString(obj.Object, "report", "artifact", "repository")
+tag, _, _ := unstructured.NestedString(obj.Object, "report", "artifact", "tag")
+image := repo
+if tag != "" {
+    image = repo + ":" + tag
+}
+if image == "" {
+    image = container
+}
+```
+
+**Detail path (new, lines 228-236):** Identical 10 lines.
+
+## Proposed Solutions
+
+### Option A: Extract helper (Recommended)
+
+```go
+// imageRefFromArtifact builds a container image reference from a Trivy report's
+// artifact fields, falling back to the container name when repository is empty.
+func imageRefFromArtifact(obj map[string]interface{}, container string) string {
+    repo, _, _ := unstructured.NestedString(obj, "report", "artifact", "repository")
+    tag, _, _ := unstructured.NestedString(obj, "report", "artifact", "tag")
+    if repo == "" {
+        return container
+    }
+    if tag == "" {
+        return repo
+    }
+    return repo + ":" + tag
+}
+```
+
+Use in both `ListTrivyVulnSummaries` and `GetTrivyWorkloadVulnDetails`.
+
+**Pros:** Removes duplication; easier to extend; clearer intent
+**Cons:** None
+**Effort:** Trivial
+**Risk:** None
+
+## Recommended Action
+
+<!-- Filled during triage -->
+
+## Technical Details
+
+**Affected files:**
+- `backend/internal/scanning/trivy.go:62-72` (summary path)
+- `backend/internal/scanning/trivy.go:228-236` (detail path)
+
+## Acceptance Criteria
+
+- [ ] Helper function extracted and used in both places
+- [ ] Existing tests still pass
+- [ ] No behavior change
+
+## Work Log
+
+<!-- Dated record -->
+
+## Resources
+
+- PR #167

--- a/todos/295-complete-p2-use-labels-selector-from-set.md
+++ b/todos/295-complete-p2-use-labels-selector-from-set.md
@@ -1,0 +1,80 @@
+---
+status: pending
+priority: p2
+issue_id: "295"
+tags: [code-review, scanning, security, pr-167]
+dependencies: []
+---
+
+# Use labels.SelectorFromSet instead of fmt.Sprintf for label selector
+
+## Problem Statement
+
+`GetTrivyWorkloadVulnDetails` builds the label selector with `fmt.Sprintf`, which is safe today only because regex validators block selector-escape characters upstream. A future regression in the regexes would silently allow label-selector injection. The idiomatic client-go way is `labels.SelectorFromSet(labels.Set{...}).String()`, which cannot be mis-escaped.
+
+**Why it matters:** Defense-in-depth. Current code is safe but relies on implicit contract between validator and consumer. Using the typed API documents the contract and hardens against regex regressions.
+
+## Findings
+
+### Security Sentinel + Architecture Strategist
+
+**File:** `backend/internal/scanning/trivy.go:202-205`
+
+```go
+labelSelector := fmt.Sprintf(
+    "trivy-operator.resource.namespace=%s,trivy-operator.resource.kind=%s,trivy-operator.resource.name=%s",
+    namespace, kind, name,
+)
+```
+
+Safe today because:
+- `validNamespace`, `validWorkloadKind`, `validWorkloadName` all reject `,`, `=`, `!`, `(`, `)`, whitespace
+
+But the safety is not visible at the call site.
+
+## Proposed Solutions
+
+### Option A: Use labels.SelectorFromSet (Recommended)
+
+```go
+import "k8s.io/apimachinery/pkg/labels"
+
+selector := labels.SelectorFromSet(labels.Set{
+    "trivy-operator.resource.namespace": namespace,
+    "trivy-operator.resource.kind":      kind,
+    "trivy-operator.resource.name":      name,
+}).String()
+
+list, err := dynClient.Resource(trivyVulnReportGVR).Namespace(namespace).List(ctx, metav1.ListOptions{
+    LabelSelector: selector,
+})
+```
+
+**Pros:** Idiomatic; defense-in-depth; impossible to mis-escape
+**Cons:** One extra import
+**Effort:** Trivial
+**Risk:** None
+
+## Recommended Action
+
+<!-- Filled during triage -->
+
+## Technical Details
+
+**Affected files:**
+- `backend/internal/scanning/trivy.go:202-209`
+
+## Acceptance Criteria
+
+- [ ] Label selector built via `labels.SelectorFromSet`
+- [ ] Existing tests still pass
+- [ ] No behavior change for valid inputs
+
+## Work Log
+
+<!-- Dated record -->
+
+## Resources
+
+- PR #167
+- [k8s.io/apimachinery/pkg/labels](https://pkg.go.dev/k8s.io/apimachinery/pkg/labels)

--- a/todos/296-complete-p2-singleflight-cache-for-detail-endpoint.md
+++ b/todos/296-complete-p2-singleflight-cache-for-detail-endpoint.md
@@ -1,0 +1,113 @@
+---
+status: pending
+priority: p2
+issue_id: "296"
+tags: [code-review, scanning, performance, caching, pr-167]
+dependencies: []
+---
+
+# Add singleflight coalescing + 30s TTL cache for detail endpoint
+
+## Problem Statement
+
+The new `HandleVulnerabilityDetail` endpoint has no caching or request coalescing. Each request does an RBAC SSAR (network round-trip) + a CRD list (network round-trip, potentially large response). Rapid-click scenarios (user bouncing between workloads in a namespace) will hammer the apiserver, and concurrent identical requests (e.g., double-click) each spawn separate fetches.
+
+The project already standardizes on `singleflight + 30s cache` for read-heavy endpoints (`internal/policy`, `internal/scanning`'s existing `fetchVulns`). The new detail endpoint deviates from this pattern.
+
+**Why it matters:** Consistency with project conventions; protects apiserver from rapid-click scenarios; matches existing scanning handler state.
+
+## Findings
+
+### Performance Oracle
+
+**File:** `backend/internal/scanning/handler.go:263-321`
+
+The handler calls `GetTrivyWorkloadVulnDetails` directly with no coalescing or cache. Compare with `fetchVulns` in the same file (lines 68-86) which uses `singleflight.Group` + 30s TTL cache.
+
+Vulnerability reports update on the order of minutes to hours (tied to image pull events or Trivy rescan schedules), so 30s staleness is very safe.
+
+## Proposed Solutions
+
+### Option A: Add singleflight + detail cache (Recommended)
+
+Extend `Handler` struct with a detail cache, add a wrapper similar to `fetchVulns`:
+
+```go
+type cachedDetail struct {
+    detail    *WorkloadVulnDetail
+    fetchedAt time.Time
+}
+
+// Handler struct additions
+detailCache   map[string]*cachedDetail
+detailCacheMu sync.RWMutex
+
+func (h *Handler) fetchVulnDetail(ctx context.Context, namespace, kind, name string) (*WorkloadVulnDetail, error) {
+    cacheKey := namespace + "/" + kind + "/" + name
+    
+    h.detailCacheMu.RLock()
+    if entry := h.detailCache[cacheKey]; entry != nil && time.Since(entry.fetchedAt) < cacheTTL {
+        detail := entry.detail
+        h.detailCacheMu.RUnlock()
+        return detail, nil
+    }
+    h.detailCacheMu.RUnlock()
+    
+    key := "vuln-detail:" + cacheKey
+    result, err, _ := h.fetchGroup.Do(key, func() (any, error) {
+        dynClient := h.K8sClient.BaseDynamicClient()
+        return GetTrivyWorkloadVulnDetails(ctx, dynClient, namespace, kind, name)
+    })
+    if err != nil {
+        return nil, err
+    }
+    
+    detail := result.(*WorkloadVulnDetail)
+    h.detailCacheMu.Lock()
+    h.detailCache[cacheKey] = &cachedDetail{detail: detail, fetchedAt: time.Now()}
+    h.detailCacheMu.Unlock()
+    
+    return detail, nil
+}
+```
+
+Also extend `InvalidateCache` to clear `detailCache` so webhook-driven invalidation still works.
+
+**Pros:** Consistent with existing pattern; protects apiserver; coalesces concurrent requests
+**Cons:** ~30 lines of boilerplate; cache eviction logic needed (same pattern as existing `evictOldestLocked`)
+**Effort:** Small
+**Risk:** Low
+
+### Option B: Singleflight only (no TTL cache)
+
+Just wrap in `h.fetchGroup.Do` without TTL caching. Coalesces concurrent identical requests but doesn't reduce repeat-fetch load over time.
+
+**Pros:** 5 lines of code; zero staleness
+**Cons:** Partial fix
+**Effort:** Trivial
+**Risk:** None
+
+## Recommended Action
+
+<!-- Filled during triage -->
+
+## Technical Details
+
+**Affected files:**
+- `backend/internal/scanning/handler.go` (Handler struct + new `fetchVulnDetail` + update `HandleVulnerabilityDetail` to use it + extend `InvalidateCache`)
+
+## Acceptance Criteria
+
+- [ ] Concurrent requests for same workload coalesce via singleflight
+- [ ] Repeat requests within 30s serve from cache
+- [ ] `InvalidateCache` clears both namespace and detail caches
+- [ ] Unit test for coalescing behavior
+
+## Work Log
+
+<!-- Dated record -->
+
+## Resources
+
+- PR #167
+- Existing pattern: `backend/internal/scanning/handler.go:68-86` (`fetchVulns`)

--- a/todos/297-pending-p3-user-impersonation-for-scanning-reads.md
+++ b/todos/297-pending-p3-user-impersonation-for-scanning-reads.md
@@ -1,0 +1,101 @@
+---
+status: pending
+priority: p3
+issue_id: "297"
+tags: [code-review, scanning, security, architecture, impersonation, pre-existing]
+dependencies: []
+---
+
+# Switch scanning package to user impersonation for reads
+
+## Problem Statement
+
+CLAUDE.md states: *"All k8s API calls use user impersonation. Never use the service account's own permissions."* The scanning package (both pre-existing `HandleVulnerabilities` and the new `HandleVulnerabilityDetail`) uses `h.K8sClient.BaseDynamicClient()` — the service account — and relies on a SelfSubjectAccessReview precheck via `canAccessTrivy` for authorization.
+
+The RBAC precheck can return stale results for up to 5 minutes (AccessChecker cache TTL at `backend/internal/k8s/resources/access.go:158`), meaning a user whose RBAC was revoked can continue reading vulnerability data for up to 5 minutes.
+
+**Why it matters:** Violates documented core architecture principle. Weakens audit trails (all scanning reads show as service account, not end user). Creates stale-authorization window.
+
+**Scope:** This is a pre-existing gap across scanning/policy/gitops/velero packages. PR #167 inherits but doesn't cause it. Captured here for follow-up; **not a PR #167 blocker**.
+
+## Findings
+
+### Architecture Strategist + Security Sentinel
+
+**File:** `backend/internal/scanning/handler.go:305` (new code)
+```go
+dynClient := h.K8sClient.BaseDynamicClient()
+detail, err := GetTrivyWorkloadVulnDetails(ctx, dynClient, namespace, kind, name)
+```
+
+**Compare:** `backend/internal/gitops/handler.go:310` (`HandleGetApplication`) builds an impersonating dynamic client via `h.K8sClient.DynamicClientForUser(user.KubernetesUsername, user.KubernetesGroups)` and calls the API as the user.
+
+**Pre-existing in scanning:** `HandleVulnerabilities` at `handler.go:92` has the same pattern.
+
+## Proposed Solutions
+
+### Option A: Switch scanning reads to DynamicClientForUser
+
+```go
+dynClient, err := h.K8sClient.DynamicClientForUser(user.KubernetesUsername, user.KubernetesGroups)
+if err != nil {
+    httputil.WriteError(w, http.StatusInternalServerError, "failed to build impersonating client", "")
+    return
+}
+detail, err := GetTrivyWorkloadVulnDetails(ctx, dynClient, namespace, kind, name)
+```
+
+**Pros:** Matches gitops pattern; defense-in-depth; proper audit attribution
+**Cons:** Every scanning request now does two SSAR-style calls (precheck + impersonated read); caching model needs review (cache keys must include user identity or be per-user)
+**Effort:** Medium (also requires rework of existing namespace cache to be per-user, or removal of cache)
+**Risk:** Medium — caching model change affects `fetchVulns` path
+
+### Option B: Document as known limitation, track for wider refactor
+
+Add a comment in the code and a section in CLAUDE.md or an architecture doc explaining that scanning/policy/gitops use "SA + RBAC precheck" as an intentional caching optimization, with a note to revisit.
+
+**Pros:** No code change, transparent about trade-off
+**Cons:** Violates documented principle
+**Effort:** Trivial
+**Risk:** None
+
+## Recommended Action
+
+<!-- Filled during triage. Probably Option B for now, Option A in a dedicated refactor PR. -->
+
+## Technical Details
+
+**Affected files (cross-package):**
+- `backend/internal/scanning/handler.go` (both list and detail handlers)
+- `backend/internal/policy/handler.go`
+- `backend/internal/gitops/handler.go` (partially compliant already)
+- `backend/internal/velero/handler.go`
+- `backend/internal/k8s/resources/access.go` (AccessChecker cache)
+
+## Acceptance Criteria
+
+- [ ] Decision made: Option A or Option B
+- [ ] If Option A: all scanning reads use impersonation; caching reworked
+- [ ] If Option B: comment added to handler.go explaining the trade-off
+
+## Work Log
+
+### 2026-04-11 — PR #167 partial mitigation
+
+Option B applied: added a doc comment to `scanning.Handler` type in `backend/internal/scanning/handler.go` acknowledging the gap as a known limitation:
+
+```go
+// Known limitations carried from existing scanning endpoints (tracked for
+// follow-up; see todos/297 and todos/304):
+//   - Reads use the service account (BaseDynamicClient) plus an SSAR precheck
+//     rather than user impersonation. Stale-authorization window up to the
+//     AccessChecker cache TTL (~5 min).
+```
+
+Full fix (Option A — switching scanning/policy/gitops/velero to `DynamicClientForUser`) deferred to a dedicated refactor because it requires rework of the per-namespace/per-workload cache keying and is cross-package.
+
+## Resources
+
+- PR #167
+- CLAUDE.md — "Architecture Principles > Backend"
+- Reference pattern: `backend/internal/gitops/handler.go:310`

--- a/todos/298-complete-p3-test-coverage-gaps-vuln-detail.md
+++ b/todos/298-complete-p3-test-coverage-gaps-vuln-detail.md
@@ -1,0 +1,78 @@
+---
+status: pending
+priority: p3
+issue_id: "298"
+tags: [code-review, scanning, testing, pr-167]
+dependencies: []
+---
+
+# Improve test coverage for vulnerability detail
+
+## Problem Statement
+
+Several test gaps in the new `trivy_test.go` tests:
+
+1. `TestGetTrivyWorkloadVulnDetails_MultipleImages` only asserts `len(detail.Images) == 2`. A regression in grouping would still pass this test.
+2. `selectCVSSScore` int64/int branches (trivy.go:181-186) are not exercised — only float64 values are tested.
+3. `extractCVEDetail` top-level `"score"` fallback (trivy.go:312-316) is not exercised.
+4. No negative-path test for `GetTrivyWorkloadVulnDetails` — malformed `vulnerabilities` entry (non-map) or missing `vulnerabilityID` (both should be skipped).
+5. `selectCVSSScore` "falls back to any vendor" test has non-deterministic fallback (Go map iteration order). With two unknown vendors the test would flake.
+
+**Why it matters:** Weak tests allow regressions through.
+
+## Findings
+
+### Pattern Recognition + Simplicity Reviewers
+
+**File:** `backend/internal/scanning/trivy_test.go`
+
+- Lines 466-498: `TestGetTrivyWorkloadVulnDetails_MultipleImages` — only counts images
+- Lines 293-299: `TestSelectCVSSScore` "any vendor" case — relies on single-entry map
+
+## Proposed Solutions
+
+### Option A: Add missing assertions and edge cases (Recommended)
+
+1. Strengthen `_MultipleImages` to assert per-image `Container`, image name, and CVE IDs
+2. Add test cases for `extractCVEDetail` with top-level `"score"` (no nested CVSS)
+3. Add test case for malformed vulnerabilities array entries
+4. Either make `selectCVSSScore` fallback deterministic (sort vendor keys) or add a multi-vendor test that documents the guarantee
+
+**Pros:** Catches real regressions; pins behavior
+**Cons:** ~50 LOC of additional tests
+**Effort:** Small
+**Risk:** None
+
+### Option B: Remove weak test, keep existing coverage
+
+Drop `_MultipleImages` since it's redundant with `_SortsAndGroups` per simplicity reviewer.
+
+**Pros:** Simpler; less code to maintain
+**Cons:** Slightly reduced explicit coverage
+**Effort:** Trivial
+**Risk:** None
+
+## Recommended Action
+
+<!-- Filled during triage -->
+
+## Technical Details
+
+**Affected files:**
+- `backend/internal/scanning/trivy_test.go`
+- Possibly `backend/internal/scanning/trivy.go` (if making fallback deterministic)
+
+## Acceptance Criteria
+
+- [ ] Tests catch grouping regressions (not just count)
+- [ ] `"score"` fallback path covered
+- [ ] Malformed input skip path covered
+- [ ] No flaky tests due to map iteration order
+
+## Work Log
+
+<!-- Dated record -->
+
+## Resources
+
+- PR #167

--- a/todos/299-complete-p3-simplify-cvss-score-helpers.md
+++ b/todos/299-complete-p3-simplify-cvss-score-helpers.md
@@ -1,0 +1,103 @@
+---
+status: pending
+priority: p3
+issue_id: "299"
+tags: [code-review, scanning, simplicity, pr-167]
+dependencies: []
+---
+
+# Simplify selectCVSSScore + remove dead int branches
+
+## Problem Statement
+
+`selectCVSSScore` and `extractV3Score` in `trivy.go` are over-factored (two helpers where one suffices) and contain dead code. JSON unmarshalled through `unstructured` always produces `float64` for numeric fields, but `extractV3Score` has int64/int branches that are never reached.
+
+**Why it matters:** Less code to maintain and reason about.
+
+## Findings
+
+### Code Simplicity Reviewer
+
+**File:** `backend/internal/scanning/trivy.go:148-188`
+
+```go
+func selectCVSSScore(cvss map[string]interface{}) *float64 {
+    // ... loops over preferred vendors ...
+}
+
+func extractV3Score(cvss map[string]interface{}, vendor string) *float64 {
+    vendorMap, ok := cvss[vendor].(map[string]interface{})
+    if !ok { return nil }
+    raw, ok := vendorMap["V3Score"]
+    if !ok { return nil }
+    switch v := raw.(type) {
+    case float64:
+        return &v
+    case int64:       // DEAD - unstructured produces float64
+        f := float64(v)
+        return &f
+    case int:         // DEAD
+        f := float64(v)
+        return &f
+    }
+    return nil
+}
+```
+
+`extractV3Score` is called only from `selectCVSSScore` (single caller).
+
+## Proposed Solutions
+
+### Option A: Collapse into one function, drop dead branches (Recommended)
+
+```go
+func selectCVSSScore(cvss map[string]interface{}) *float64 {
+    get := func(vendor string) *float64 {
+        m, _ := cvss[vendor].(map[string]interface{})
+        if f, ok := m["V3Score"].(float64); ok {
+            return &f
+        }
+        return nil
+    }
+    for _, v := range []string{"nvd", "redhat", "ubuntu", "debian"} {
+        if s := get(v); s != nil {
+            return s
+        }
+    }
+    for v := range cvss {
+        if s := get(v); s != nil {
+            return s
+        }
+    }
+    return nil
+}
+```
+
+**Pros:** ~25 LOC removed; reads more directly; drops untested dead code
+**Cons:** Slight risk if some Trivy version stores int types (can be verified against actual CRD schema)
+**Effort:** Trivial
+**Risk:** Low
+
+## Recommended Action
+
+<!-- Filled during triage -->
+
+## Technical Details
+
+**Affected files:**
+- `backend/internal/scanning/trivy.go:148-188`
+
+## Acceptance Criteria
+
+- [ ] Single `selectCVSSScore` function
+- [ ] Dead int/int64 branches removed
+- [ ] Existing tests still pass
+- [ ] Consider: sort unknown-vendor iteration for determinism
+
+## Work Log
+
+<!-- Dated record -->
+
+## Resources
+
+- PR #167

--- a/todos/300-complete-p3-use-slices-sort-func.md
+++ b/todos/300-complete-p3-use-slices-sort-func.md
@@ -1,0 +1,77 @@
+---
+status: pending
+priority: p3
+issue_id: "300"
+tags: [code-review, scanning, performance, pr-167]
+dependencies: []
+---
+
+# Replace sort.SliceStable with slices.SortFunc in CVE sort
+
+## Problem Statement
+
+`GetTrivyWorkloadVulnDetails` uses `sort.SliceStable` which uses reflection-based dispatch. For 600 CVEs × 5 images, this adds measurable (though small) overhead. Generic `slices.SortFunc` is faster. Additionally, stability isn't needed because the comparator is a total order (falls through to CVE ID).
+
+**Why it matters:** Small perf win, cleaner code.
+
+## Findings
+
+### Performance Oracle
+
+**File:** `backend/internal/scanning/trivy.go:259-276`
+
+```go
+sort.SliceStable(cves, func(i, j int) bool {
+    si, sj := severityRank(cves[i].Severity), severityRank(cves[j].Severity)
+    // ...
+})
+```
+
+Also, CVSSScore being `*float64` causes dereference-on-every-compare. Consider denormalizing to `float64` with 0 sentinel during extraction.
+
+## Proposed Solutions
+
+### Option A: slices.SortFunc + value comparator (Recommended)
+
+```go
+import "slices"
+
+slices.SortFunc(cves, func(a, b CVEDetail) int {
+    if n := cmp.Compare(severityRank(a.Severity), severityRank(b.Severity)); n != 0 {
+        return n
+    }
+    ai := float64(0)
+    if a.CVSSScore != nil { ai = *a.CVSSScore }
+    bi := float64(0)
+    if b.CVSSScore != nil { bi = *b.CVSSScore }
+    if n := cmp.Compare(bi, ai); n != 0 { // descending
+        return n
+    }
+    return cmp.Compare(a.ID, b.ID)
+})
+```
+
+**Pros:** No reflection; generic/typed; slightly faster
+**Cons:** Requires Go 1.21+ (already satisfied per go.mod)
+**Effort:** Trivial
+**Risk:** None
+
+## Recommended Action
+
+<!-- Filled during triage -->
+
+## Technical Details
+
+**Affected files:**
+- `backend/internal/scanning/trivy.go:259-276`
+
+## Acceptance Criteria
+
+- [ ] Sort uses `slices.SortFunc`
+- [ ] Existing tests still pass
+
+## Work Log
+
+## Resources
+
+- PR #167

--- a/todos/301-complete-p3-drop-redundant-to-upper-on-severity.md
+++ b/todos/301-complete-p3-drop-redundant-to-upper-on-severity.md
@@ -1,0 +1,62 @@
+---
+status: pending
+priority: p3
+issue_id: "301"
+tags: [code-review, scanning, performance, pr-167]
+dependencies: []
+---
+
+# Drop redundant strings.ToUpper on severity
+
+## Problem Statement
+
+`extractCVEDetail` calls `strings.ToUpper` on every severity value. Trivy already emits severities in uppercase (`CRITICAL`, `HIGH`, `MEDIUM`, `LOW`, `UNKNOWN`), so this is a 3000-allocation-per-request no-op for typical workloads.
+
+**Why it matters:** Tiny perf win, removes redundant code.
+
+## Findings
+
+### Performance Oracle
+
+**File:** `backend/internal/scanning/trivy.go:297`
+
+```go
+Severity: strings.ToUpper(getStr("severity")),
+```
+
+Trivy Operator emits uppercase. Verified in test fixtures and in Trivy source. The `severityRank` function already handles mixed case via its own `strings.ToUpper`, so the handler path is double-covered.
+
+## Proposed Solutions
+
+### Option A: Drop ToUpper, trust Trivy (Recommended)
+
+```go
+Severity: getStr("severity"),
+```
+
+Keep `strings.ToUpper` in `severityRank` as defense.
+
+**Pros:** ~3000 fewer allocations per request for 600-CVE workloads
+**Cons:** If Trivy ever emits mixed case, we rely on severityRank to normalize at sort time (already does)
+**Effort:** Trivial
+**Risk:** None
+
+## Recommended Action
+
+<!-- Filled during triage -->
+
+## Technical Details
+
+**Affected files:**
+- `backend/internal/scanning/trivy.go:297`
+
+## Acceptance Criteria
+
+- [ ] ToUpper removed from extractCVEDetail
+- [ ] Existing tests still pass
+
+## Work Log
+
+## Resources
+
+- PR #167

--- a/todos/302-complete-p3-reduce-detail-endpoint-timeout.md
+++ b/todos/302-complete-p3-reduce-detail-endpoint-timeout.md
@@ -1,0 +1,69 @@
+---
+status: pending
+priority: p3
+issue_id: "302"
+tags: [code-review, scanning, performance, pr-167]
+dependencies: []
+---
+
+# Reduce vulnerability detail endpoint timeout from 30s to 10s
+
+## Problem Statement
+
+`HandleVulnerabilityDetail` uses a 30s context timeout. For a label-selector List against a single namespace, an apiserver taking >5s is already broken. 30s means a degraded apiserver ties up handler goroutines for 30s × concurrent requests, amplifying a partial outage into a full one.
+
+The neighboring `diagnostics` package uses 15s. No rationale for 30s.
+
+**Why it matters:** Failure-mode resilience; matches or improves on neighboring endpoints.
+
+## Findings
+
+### Performance Oracle + Pattern Recognition Reviewers
+
+**File:** `backend/internal/scanning/handler.go:302`
+
+```go
+ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+```
+
+**Compare:** `backend/internal/diagnostics/handler.go:66` uses 15s.
+
+## Proposed Solutions
+
+### Option A: Drop to 10s (Recommended)
+
+```go
+ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+```
+
+**Pros:** Faster fail-fast; matches expectations for healthy apiserver; limits goroutine hold time
+**Cons:** None expected; can be raised if CI/homelab sees timeouts
+**Effort:** Trivial
+**Risk:** Low
+
+### Option B: Match diagnostics at 15s
+
+**Pros:** Consistency with neighbor
+**Cons:** Still generous
+**Effort:** Trivial
+**Risk:** None
+
+## Recommended Action
+
+<!-- Filled during triage -->
+
+## Technical Details
+
+**Affected files:**
+- `backend/internal/scanning/handler.go:302`
+
+## Acceptance Criteria
+
+- [ ] Timeout reduced to 10s (or 15s)
+- [ ] Existing tests still pass
+
+## Work Log
+
+## Resources
+
+- PR #167

--- a/todos/303-complete-p3-split-scanning-handler-file.md
+++ b/todos/303-complete-p3-split-scanning-handler-file.md
@@ -1,0 +1,78 @@
+---
+status: pending
+priority: p3
+issue_id: "303"
+tags: [code-review, scanning, refactor, pr-167]
+dependencies: []
+---
+
+# Split scanning handler.go (now > 300 LOC)
+
+## Problem Statement
+
+`backend/internal/scanning/handler.go` is now 364 LOC after this PR. CLAUDE.md's Step 0 rule flags files > 300 LOC for structural review. The file mixes shared state/caching/RBAC/metadata helpers with three distinct endpoint handlers.
+
+**Why it matters:** Cohesion; easier navigation; limits blast radius of future edits.
+
+## Findings
+
+### Architecture Strategist
+
+**File:** `backend/internal/scanning/handler.go` (364 LOC)
+
+Contains:
+- Shared state (`Handler` struct, `cachedNSData`, constants)
+- Cache plumbing (`InitCache`, `InvalidateCache`, `fetchVulns`, `doFetchNS`, `evictOldestLocked`)
+- `HandleStatus`
+- `HandleVulnerabilities`
+- `HandleVulnerabilityDetail` (new) + regex validators
+- RBAC helpers (`canAccessTrivy`, `canAccessKubescape`)
+- Metadata helpers (`filterByScannerAccess`, `computeMetadata`)
+
+## Proposed Solutions
+
+### Option A: Split into 3 files (Recommended)
+
+```
+handler.go                         (state, cache, HandleStatus, RBAC, metadata — ~200 LOC)
+handler_vulnerabilities.go         (HandleVulnerabilities — ~60 LOC)
+handler_vulnerability_detail.go    (HandleVulnerabilityDetail + validators — ~90 LOC)
+```
+
+Matches how `gitops/handler.go` groups related actions.
+
+**Pros:** Each file < 300 LOC; clear cohesion
+**Cons:** 2 new files
+**Effort:** Small
+**Risk:** Low
+
+### Option B: Accept the LOC growth
+
+**Pros:** No refactor
+**Cons:** Violates project convention
+**Effort:** None
+**Risk:** Low
+
+## Recommended Action
+
+<!-- Filled during triage -->
+
+## Technical Details
+
+**Affected files:**
+- `backend/internal/scanning/handler.go` (split)
+- Possibly new: `backend/internal/scanning/handler_vulnerabilities.go`
+- Possibly new: `backend/internal/scanning/handler_vulnerability_detail.go`
+
+## Acceptance Criteria
+
+- [ ] handler.go < 300 LOC
+- [ ] All tests still pass
+- [ ] Package API unchanged
+
+## Work Log
+
+## Resources
+
+- PR #167
+- CLAUDE.md "Step 0 rule"

--- a/todos/304-pending-p3-scanning-multi-cluster-awareness.md
+++ b/todos/304-pending-p3-scanning-multi-cluster-awareness.md
@@ -1,0 +1,90 @@
+---
+status: pending
+priority: p3
+issue_id: "304"
+tags: [code-review, scanning, multi-cluster, architecture, pre-existing]
+dependencies: []
+---
+
+# Thread X-Cluster-ID into scanning package
+
+## Problem Statement
+
+CLAUDE.md documents that multi-cluster operations route via `X-Cluster-ID` header through `ClusterRouter`. The entire scanning package ignores this — both the pre-existing `HandleVulnerabilities` and the new `HandleVulnerabilityDetail` call `h.K8sClient.BaseDynamicClient()`, which always hits the local cluster.
+
+Users with multiple clusters registered will silently see local-cluster data only on the Security Vulnerabilities page, regardless of which cluster is selected.
+
+**Why it matters:** Violates multi-cluster architecture; confuses users in multi-cluster deployments.
+
+**Scope:** Pre-existing gap. PR #167 inherits but doesn't cause it. Not a blocker for that PR.
+
+## Findings
+
+### Architecture Strategist + Security Sentinel
+
+**Files:**
+- `backend/internal/scanning/handler.go:92` (pre-existing `HandleVulnerabilities`)
+- `backend/internal/scanning/handler.go:305` (new `HandleVulnerabilityDetail`)
+
+Both call `h.K8sClient.BaseDynamicClient()` unconditionally.
+
+**Compare:** `backend/internal/k8s/cluster_router.go` routes client requests by `X-Cluster-ID` context.
+
+## Proposed Solutions
+
+### Option A: Add ClusterRouter support to scanning Handler
+
+```go
+type Handler struct {
+    K8sClient     *k8s.ClientFactory
+    ClusterRouter *k8s.ClusterRouter  // NEW
+    // ...
+}
+
+// In each handler:
+dynClient, err := h.ClusterRouter.DynamicClientForRequest(r)
+if err != nil { ... }
+```
+
+**Pros:** Proper multi-cluster support
+**Cons:** Cache keys need clusterID; same issue in policy/gitops/velero — better solved at project-wide level
+**Effort:** Medium per-package, Large if rolled out consistently
+**Risk:** Medium — cache invalidation semantics change
+
+### Option B: Document limitation, defer to project-wide refactor
+
+Add a comment and UI warning for non-local clusters.
+
+**Pros:** Honest about current state
+**Cons:** User confusion persists
+**Effort:** Trivial
+**Risk:** None
+
+## Recommended Action
+
+<!-- Filled during triage. Likely Option B until project-wide approach is decided. -->
+
+## Technical Details
+
+**Affected files:**
+- `backend/internal/scanning/handler.go`
+- `backend/internal/scanning/discovery.go` (discovery also needs per-cluster state)
+- Possibly: `backend/internal/policy/handler.go`, `backend/internal/gitops/handler.go`, `backend/internal/velero/handler.go` (same pattern)
+
+## Acceptance Criteria
+
+- [ ] Decision made: fix in scanning only, project-wide, or document
+- [ ] Non-local clusters either work or show clear message
+
+## Work Log
+
+### 2026-04-11 — PR #167 partial mitigation
+
+Option B applied: added a doc comment to `scanning.Handler` type in `backend/internal/scanning/handler.go` acknowledging that multi-cluster routing is not threaded through the scanning package. Reads always hit the local cluster.
+
+Full fix (adding `ClusterRouter` to the scanning Handler struct and cache keys) deferred to a project-wide refactor covering scanning/policy/gitops/velero consistently.
+
+## Resources
+
+- PR #167
+- CLAUDE.md "Multi-Cluster Architecture"

--- a/todos/305-pending-p3-consolidate-duplicate-k8s-name-regexes.md
+++ b/todos/305-pending-p3-consolidate-duplicate-k8s-name-regexes.md
@@ -1,0 +1,89 @@
+---
+status: pending
+priority: p3
+issue_id: "305"
+tags: [code-review, validation, dry, architecture, pre-existing]
+dependencies: []
+---
+
+# Consolidate duplicate Kubernetes name/namespace regexes across packages
+
+## Problem Statement
+
+At least 6 packages define semantically identical regexes for DNS-1123 labels (namespaces) and DNS-1123 subdomains (resource names). PR #167 adds the 3rd copy of each.
+
+**Why it matters:** Inconsistency risk — one package tightens its regex, another doesn't, and behavior diverges. Also a maintenance burden.
+
+**Scope:** Pre-existing. PR #167 extends rather than causes.
+
+## Findings
+
+### Pattern Recognition Reviewer
+
+**Duplicated DNS-1123 label regex** (namespaces, service names):
+- `backend/internal/scanning/handler.go:46` — `validNamespace`
+- `backend/internal/server/response.go:15` — `dnsLabelRegex`
+- `backend/internal/velero/handler.go:33` — `dnsLabelRegex`
+- `backend/internal/wizard/container.go:13` — `dnsLabelRegex`
+- `backend/internal/notification/types.go:33` — `k8sNameRegex`
+- `backend/internal/alerting/rules.go:29` — variant
+
+**Duplicated DNS-1123 subdomain regex** (resource names up to 253 chars):
+- `backend/internal/k8s/resources/handler.go:233` — `k8sNameRegexp`
+- `backend/internal/storage/handler.go:29` — `k8sNameRegexp`
+- `backend/internal/scanning/handler.go:259` — `validWorkloadName` (NEW in PR #167)
+
+## Proposed Solutions
+
+### Option A: Create `internal/validate` package (Recommended)
+
+```go
+// internal/validate/k8s.go
+package validate
+
+import "regexp"
+
+var (
+    dnsLabel     = regexp.MustCompile(`^[a-z0-9]([a-z0-9\-]{0,61}[a-z0-9])?$`)
+    dnsSubdomain = regexp.MustCompile(`^[a-z0-9]([a-z0-9.\-]{0,251}[a-z0-9])?$`)
+    kindName     = regexp.MustCompile(`^[A-Z][A-Za-z0-9]{1,62}$`)
+)
+
+func IsNamespace(s string) bool    { return dnsLabel.MatchString(s) }
+func IsResourceName(s string) bool { return dnsSubdomain.MatchString(s) }
+func IsKind(s string) bool         { return kindName.MatchString(s) }
+```
+
+Migrate all 9 callsites.
+
+**Pros:** Single source of truth; easier to keep in sync with Kubernetes upstream changes
+**Cons:** Cross-cutting refactor
+**Effort:** Medium
+**Risk:** Low (regex semantics preserved)
+
+## Recommended Action
+
+<!-- Filled during triage -->
+
+## Technical Details
+
+**Affected files:** All listed above + new `internal/validate` package.
+
+## Acceptance Criteria
+
+- [ ] Single `internal/validate` package owns the regexes
+- [ ] All 9 callsites migrated
+- [ ] All tests still pass
+
+## Work Log
+
+### 2026-04-11 — PR #167 partial mitigation
+
+PR #167 originally added two new copies of DNS/subdomain regexes (`validNamespace`, `validWorkloadName`). After applying the fix for todo #293 (use shared `resources.ValidateURLParams` middleware), `validWorkloadName` was removed entirely. The only new regex remaining is `validWorkloadKind` (Kubernetes kind name — PascalCase identifier), which is genuinely unique to the scanning package and not a duplicate of any existing regex.
+
+**Net effect of PR #167:** zero new duplicate regexes. The pre-existing duplication across 7 packages remains for a future `internal/validate` package refactor.
+
+## Resources
+
+- PR #167 (adds 2 new copies)
+- [Kubernetes names and IDs](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/)

--- a/todos/306-complete-p1-cve-primary-link-xss.md
+++ b/todos/306-complete-p1-cve-primary-link-xss.md
@@ -1,0 +1,101 @@
+---
+status: pending
+priority: p1
+issue_id: "306"
+tags: [code-review, security, xss, pr-167]
+dependencies: []
+---
+
+# Unvalidated cve.primaryLink href enables javascript: URL XSS
+
+## Problem Statement
+
+`VulnerabilityDetail.tsx` renders `cve.primaryLink` directly as an `<a href>`. That value originates from Trivy VulnerabilityReport CRs, which are ultimately sourced from NVD / Aqua AVD / GHSA / vendor feeds. Preact/Fresh does not sanitize href values. If a Trivy report contains `"primaryLink": "javascript:alert(document.cookie)"` (or `data:`, `vbscript:`, `file:`), clicking the CVE ID executes attacker-controlled script in the k8sCenter origin with the user's session cookies available.
+
+**Why it matters (BLOCKS MERGE):** Anyone with write access to VulnerabilityReport CRs in any scannable namespace could plant a malicious link. That threat surface is broader than it sounds — CI pipelines, third-party scanner images, or a compromised Trivy operator all feed this field. `rel="noopener noreferrer"` does NOT mitigate this — those flags only affect new-window context for http(s) URLs; `javascript:` URLs execute in the current document regardless.
+
+## Findings
+
+### Security Sentinel — HIGH severity
+
+**File:** `frontend/islands/VulnerabilityDetail.tsx:345-359`
+
+```tsx
+const cveLink = cve.primaryLink ||
+  `https://nvd.nist.gov/vuln/detail/${cve.id}`;
+...
+<a href={cveLink} target="_blank" rel="noopener noreferrer" ...>
+```
+
+Additionally, the fallback `https://nvd.nist.gov/vuln/detail/${cve.id}` interpolates `cve.id` without `encodeURIComponent`. Trivy generally emits sane CVE IDs but since this is external data, wrapping with `encodeURIComponent` removes an entire class of future issues.
+
+## Proposed Solutions
+
+### Option A: Frontend scheme validation (Recommended — fast)
+
+Add a helper to `VulnerabilityDetail.tsx`:
+
+```tsx
+function safeHttpUrl(raw: string, fallback: string): string {
+  if (!raw) return fallback;
+  try {
+    const u = new URL(raw);
+    if (u.protocol === "https:" || u.protocol === "http:") return u.href;
+  } catch { /* fall through */ }
+  return fallback;
+}
+
+const cveLink = safeHttpUrl(
+  cve.primaryLink,
+  `https://nvd.nist.gov/vuln/detail/${encodeURIComponent(cve.id)}`,
+);
+```
+
+**Pros:** Complete fix with zero backend changes; no breaking changes
+**Cons:** Doesn't catch the issue at the source
+**Effort:** Small (~10 LOC)
+**Risk:** None
+
+### Option B: Backend scheme validation in Trivy adapter
+
+Validate `primaryLink` in `backend/internal/scanning/trivy.go` `extractCVEDetail` and drop or blank non-http(s) URLs before returning.
+
+**Pros:** Protects all current and future consumers (API, CLI, other frontends)
+**Cons:** Still need frontend guardrail as defense-in-depth; larger surface area
+**Effort:** Small
+**Risk:** Low
+
+### Option C: Both A and B (Recommended — defense-in-depth)
+
+Apply Option A now for the immediate fix, then follow up with Option B so the server never emits a non-http(s) URL.
+
+**Pros:** Full defense-in-depth; protects future API consumers
+**Cons:** Two PRs
+**Effort:** Small total
+**Risk:** None
+
+## Recommended Action
+
+Apply Option A in this PR immediately to unblock merge. File a follow-up for Option B.
+
+## Technical Details
+
+**Affected files:**
+- `frontend/islands/VulnerabilityDetail.tsx:345-359` (fix site)
+- `backend/internal/scanning/trivy.go:297-316` (optional defense-in-depth)
+
+## Acceptance Criteria
+
+- [ ] `cve.primaryLink` with `javascript:`, `data:`, `vbscript:`, `file:` schemes is rejected and falls back to NVD URL
+- [ ] Fallback NVD URL wraps `cve.id` in `encodeURIComponent`
+- [ ] A Trivy report with `"primaryLink": "javascript:alert(1)"` renders a safe NVD link instead
+- [ ] Existing http/https primaryLinks still work unchanged
+
+## Work Log
+
+<!-- Dated record of actions taken -->
+
+## Resources
+
+- PR #167
+- Security Sentinel review: javascript: URL XSS

--- a/todos/307-complete-p2-kubescape-rows-dead-ended.md
+++ b/todos/307-complete-p2-kubescape-rows-dead-ended.md
@@ -1,0 +1,69 @@
+---
+status: pending
+priority: p2
+issue_id: "307"
+tags: [code-review, ux, scanning, pr-167]
+dependencies: []
+---
+
+# Kubescape rows are silently dead-ended in the dashboard
+
+## Problem Statement
+
+The new clickable-row behavior only applies to Trivy-scanned workloads. Kubescape rows render as plain `<tr>` with no visual distinction from Trivy rows, no cursor indicator, no tooltip, and no action. Users will click them expecting the same drill-down and nothing happens. When they click the detail link on a Kubescape workload from somewhere else (e.g., direct URL), the 501 error says "This cluster does not have Trivy installed" — misleading when Trivy may in fact be installed but this specific workload was scanned by Kubescape.
+
+**Why it matters:** Blocks an entire class of users (Kubescape-only clusters) with no recovery path.
+
+## Findings
+
+### UX Reviewer — Blocker
+
+**Files:**
+- `frontend/islands/VulnerabilityDashboard.tsx:302-317` — Kubescape rows indistinguishable from Trivy rows
+- `frontend/islands/VulnerabilityDetail.tsx:70-72` — 501 error message not scanner-aware
+
+## Proposed Solutions
+
+### Option A: Visual hint + accurate error (Recommended)
+
+1. In `WorkloadRow`, when `href` is null (Kubescape), render with:
+   - `cursor-not-allowed` cursor
+   - `title` attribute: "CVE-level detail requires Trivy Operator"
+   - Greyed-out name text to show it's non-actionable
+2. In `VulnerabilityDetail.tsx` error handling, change the 501 message to: "CVE-level detail requires Trivy Operator. This workload was scanned by Kubescape, which does not expose per-CVE data under user impersonation."
+
+**Pros:** Users immediately see which rows are actionable; error message is accurate when they do navigate
+**Cons:** None
+**Effort:** Small
+**Risk:** None
+
+### Option B: Hide Kubescape rows entirely
+
+Filter Kubescape rows out of the dashboard since they're not actionable.
+
+**Pros:** No dead-ends
+**Cons:** Loses visibility of scanner coverage; users in Kubescape-only clusters see an empty dashboard
+**Effort:** Trivial
+**Risk:** Low
+
+## Recommended Action
+
+<!-- Filled during triage — Option A -->
+
+## Technical Details
+
+**Affected files:**
+- `frontend/islands/VulnerabilityDashboard.tsx:387-460` (WorkloadRow non-href branch)
+- `frontend/islands/VulnerabilityDetail.tsx:70-78` (error message)
+
+## Acceptance Criteria
+
+- [ ] Kubescape rows render with visually distinct "not clickable" state
+- [ ] Hover tooltip explains why the row is not clickable
+- [ ] 501 error message references Kubescape scanner specifically
+
+## Work Log
+
+## Resources
+
+- PR #167

--- a/todos/308-complete-p2-row-click-pattern-inconsistency.md
+++ b/todos/308-complete-p2-row-click-pattern-inconsistency.md
@@ -1,0 +1,89 @@
+---
+status: pending
+priority: p2
+issue_id: "308"
+tags: [code-review, ux, a11y, consistency, pr-167]
+dependencies: []
+---
+
+# Row-click pattern in VulnerabilityDashboard is inconsistent with project convention
+
+## Problem Statement
+
+`VulnerabilityDashboard` introduces a new row-click pattern (absolute-positioned invisible `<a>` anchor inside the first `<td>`) that diverges from every other clickable-row table in the project. The stated rationale was improved accessibility (keyboard, middle-click, right-click), but:
+
+1. Only the Name cell hosts the anchor — Tab focus lands only on Name, but clicking severity/scanner/timestamp cells still navigates (via `onClick` on the `<tr>`), creating a keyboard vs. mouse divergence.
+2. No visible focus ring on the anchor (`absolute inset-0` with no `focus:` style).
+3. The JSX for the `href` and non-href branches is duplicated verbatim (~25 LOC).
+4. `e.target.closest("a")` guard exists for inner links that don't exist ("future-proof").
+5. Clicking the name/kind text may not trigger middle-click-to-open because those divs have `relative` positioning and stack above the absolute anchor.
+
+**Why it matters:** Two conventions for row-click navigation in the same codebase creates maintenance cost and inconsistent UX.
+
+## Findings
+
+### Pattern Recognition + UX Reviewers
+
+**Existing pattern** — `frontend/islands/GitOpsApplications.tsx:314-321`:
+```tsx
+<tr
+  class="hover:bg-hover/30 cursor-pointer"
+  onClick={() => {
+    globalThis.location.href = "/gitops/applications/" + encodeURIComponent(app.id);
+  }}
+>
+```
+Plain `tr` + `onClick`. Used across all detail-listing tables.
+
+**New pattern** — `frontend/islands/VulnerabilityDashboard.tsx:427-458`: absolute-positioned invisible anchor + duplicated row JSX.
+
+## Proposed Solutions
+
+### Option A: Match GitOpsApplications convention (Recommended)
+
+Revert to plain `tr` + `onClick`. Accept the a11y limitation (no middle-click, no right-click) for consistency with the rest of the project, matching what users already expect.
+
+**Pros:** Consistent with GitOps/policy/etc; simpler code; ~40 LOC reduction
+**Cons:** Loses keyboard/middle-click/right-click (same as existing tables — no regression)
+**Effort:** Small
+**Risk:** None
+
+### Option B: Extract a shared `<ClickableRow>` component
+
+Build a proper wrapper that handles all the a11y concerns once and migrate GitOps, policy, violations, and this table to it.
+
+**Pros:** Best UX; single source of truth for a11y
+**Cons:** Cross-cutting refactor (7+ tables); larger scope than this PR
+**Effort:** Medium
+**Risk:** Low
+
+### Option C: Keep current pattern but fix the duplication
+
+Collapse the duplicated JSX branches into a single render path with conditional anchor.
+
+**Pros:** Keeps the a11y intent; removes the ~25 LOC duplication
+**Cons:** Still two conventions in the codebase
+**Effort:** Small
+**Risk:** None
+
+## Recommended Action
+
+<!-- Filled during triage — probably Option A for consistency, Option B as follow-up -->
+
+## Technical Details
+
+**Affected files:**
+- `frontend/islands/VulnerabilityDashboard.tsx:387-462` (WorkloadRow)
+- Pattern reference: `frontend/islands/GitOpsApplications.tsx:314-321`
+
+## Acceptance Criteria
+
+- [ ] Row-click pattern matches project convention OR a shared wrapper exists
+- [ ] JSX duplication removed
+- [ ] Decision documented for future reviewers
+
+## Work Log
+
+## Resources
+
+- PR #167

--- a/todos/309-complete-p2-void-severity-rank-dead-code.md
+++ b/todos/309-complete-p2-void-severity-rank-dead-code.md
@@ -1,0 +1,84 @@
+---
+status: pending
+priority: p2
+issue_id: "309"
+tags: [code-review, simplicity, dead-code, pr-167]
+dependencies: []
+---
+
+# Remove `void severityRank;` dead-code suppression and unused export
+
+## Problem Statement
+
+`VulnerabilityDetail.tsx:343` has `void severityRank;` inside `CVERow`, with a comment claiming the function is "used as defense when rendering." Nothing calls `severityRank` — there is no `.sort()` in the component. The import exists only to suppress an unused-import lint error, and the `void` statement is lying to the type system.
+
+Additionally, `severityRank` is exported from `scanning-types.ts:147` and has no other consumers in the codebase — the export is dead.
+
+**Why it matters:** Misleading comments are worse than no comments. The Step 0 rule in CLAUDE.md explicitly flags dead code that accelerates context compaction.
+
+## Findings
+
+### Pattern Recognition + Code Simplicity Reviewers
+
+**File:** `frontend/islands/VulnerabilityDetail.tsx:18, 343`
+```ts
+import {
+  ...
+  severityRank,
+  type WorkloadVulnDetail,
+} from "@/lib/scanning-types.ts";
+
+function CVERow({ cve }: { cve: FlatCVE }) {
+  // Sort order is guaranteed by the backend (severity asc → CVSS desc → ID asc),
+  // so severityRank is used here only as defense when rendering.
+  void severityRank;
+```
+
+**File:** `frontend/lib/scanning-types.ts:138-149` — `severityRank` + `SEVERITY_RANK` defined and exported but referenced only by the `void` suppressor.
+
+## Proposed Solutions
+
+### Option A: Remove both import and export (Recommended)
+
+- Delete the import line in `VulnerabilityDetail.tsx:18`
+- Delete the `void` line and misleading comment (`VulnerabilityDetail.tsx:341-343`)
+- Delete `severityRank` and `SEVERITY_RANK` from `scanning-types.ts:138-149`
+- If a future feature needs client-side CVE re-sorting, add it back then
+
+**Pros:** Removes ~15 LOC of dead code; removes misleading comment
+**Cons:** None
+**Effort:** Trivial
+**Risk:** None — function confirmed unused by grep
+
+### Option B: Actually use severityRank defensively
+
+Wire a real client-side sort in `allCVEs` using severityRank so the import earns its keep.
+
+**Pros:** Honest — the comment becomes true
+**Cons:** Duplicates backend work; more code to maintain
+**Effort:** Small
+**Risk:** Low
+
+## Recommended Action
+
+Option A — delete all dead references.
+
+## Technical Details
+
+**Affected files:**
+- `frontend/islands/VulnerabilityDetail.tsx:18, 341-343`
+- `frontend/lib/scanning-types.ts:138-149`
+
+## Acceptance Criteria
+
+- [ ] `severityRank` import removed from VulnerabilityDetail.tsx
+- [ ] `void` statement and misleading comment removed
+- [ ] `severityRank` and `SEVERITY_RANK` removed from scanning-types.ts
+- [ ] `deno check` + `deno lint` clean
+
+## Work Log
+
+## Resources
+
+- PR #167
+- CLAUDE.md Step 0 rule

--- a/todos/310-complete-p2-page-value-mutation-during-render.md
+++ b/todos/310-complete-p2-page-value-mutation-during-render.md
@@ -1,0 +1,87 @@
+---
+status: pending
+priority: p2
+issue_id: "310"
+tags: [code-review, bug, signals, pr-167]
+dependencies: []
+---
+
+# Mutating page.value during render is a latent bug
+
+## Problem Statement
+
+`VulnerabilityDetail.tsx:115` contains `if (page.value > totalPages) page.value = totalPages;` inside the component's render body. Preact Signals tolerates this (no React-style render loop) but it's an unusual pattern — mutating a signal inside render can trigger a re-render in the same tick and will confuse any future reader.
+
+**Why it matters:** Latent bug. Works today because of Signals' specific semantics; fragile under future refactors.
+
+## Findings
+
+### Code Simplicity + Pattern Recognition Reviewers
+
+**File:** `frontend/islands/VulnerabilityDetail.tsx:115`
+
+```tsx
+const totalPages = Math.max(
+  1,
+  Math.ceil(filtered.value.length / PAGE_SIZE),
+);
+if (page.value > totalPages) page.value = totalPages;
+const displayed = filtered.value.slice(
+  (page.value - 1) * PAGE_SIZE,
+  page.value * PAGE_SIZE,
+);
+```
+
+## Proposed Solutions
+
+### Option A: Compute clamped page locally (Recommended)
+
+```tsx
+const totalPages = Math.max(1, Math.ceil(filtered.value.length / PAGE_SIZE));
+const currentPage = Math.min(page.value, totalPages);
+const displayed = filtered.value.slice(
+  (currentPage - 1) * PAGE_SIZE,
+  currentPage * PAGE_SIZE,
+);
+```
+
+Then reset `page.value = 1` in the filter-change handlers (already done for severity + fixable).
+
+**Pros:** No signal mutation during render; obvious behavior
+**Cons:** None
+**Effort:** Trivial
+**Risk:** None
+
+### Option B: useEffect to clamp
+
+```tsx
+useEffect(() => {
+  if (page.value > totalPages) page.value = totalPages;
+}, [totalPages]);
+```
+
+**Pros:** Keeps page.value truthy
+**Cons:** Extra render cycle; still has coupling
+**Effort:** Trivial
+**Risk:** None
+
+## Recommended Action
+
+Option A — use a local clamped variable.
+
+## Technical Details
+
+**Affected files:**
+- `frontend/islands/VulnerabilityDetail.tsx:111-121`
+
+## Acceptance Criteria
+
+- [ ] No signal mutation inside render body
+- [ ] Pagination still clamps correctly when filters reduce result count
+- [ ] Existing tests still pass
+
+## Work Log
+
+## Resources
+
+- PR #167

--- a/todos/311-complete-p2-simplification-bundle.md
+++ b/todos/311-complete-p2-simplification-bundle.md
@@ -1,0 +1,86 @@
+---
+status: pending
+priority: p2
+issue_id: "311"
+tags: [code-review, simplicity, yagni, pr-167]
+dependencies: []
+---
+
+# Bundle: simplification cleanups in VulnerabilityDetail + scanning-types
+
+## Problem Statement
+
+Several small YAGNI/simplicity issues in the Phase 2A frontend that are cheap to fix together:
+
+1. **`unfixable` counter is computed but never displayed.** The summary panel only renders `fixable`. Remove the field.
+2. **`flattenCVEs` helper is a one-caller wrapper.** Inline it with `flatMap`.
+3. **`useComputed` for trivial one-liner derivations.** `summary`, `allCVEs`, and `filtered` use `useComputed` where plain `const` would work — signals' `.value` reads already re-run the render.
+4. **Redundant `IS_BROWSER` guards.** Both the effect (line 85) and the main return (line 109) guard the same condition. One is enough.
+5. **WorkloadRow JSX duplicated across the two branches** — see todo 308 for the row-click pattern fix; the JSX dedup can be addressed there.
+
+**Why it matters:** ~35 LOC of ceremony in a 360-LOC island. Makes future reviewers second-guess the intent.
+
+## Findings
+
+### Code Simplicity Reviewer
+
+**File:** `frontend/islands/VulnerabilityDetail.tsx`
+- Lines 30-47: FlatCVE interface + flattenCVEs helper (one caller)
+- Lines 85, 109: duplicate IS_BROWSER guards
+- Lines 89-104: useComputed for trivial derivations
+
+**File:** `frontend/lib/scanning-types.ts`
+- Line 91: `unfixable` field
+- Lines 130-132: unfixable increment (else branch)
+
+## Proposed Solutions
+
+### Option A: Apply all cleanups (Recommended)
+
+1. Drop `unfixable` from `VulnDetailSummary` type and the else branch in `computeVulnSummary`
+2. Inline `flattenCVEs`:
+   ```ts
+   const allCVEs = detail.value
+     ? detail.value.images.flatMap((img) =>
+         img.vulnerabilities.map((v) => ({ ...v, image: img.name, container: img.container })))
+     : [];
+   ```
+3. Replace `useComputed` with plain consts where derivations are trivial
+4. Remove one of the two `IS_BROWSER` guards
+
+**Pros:** ~35 LOC removed; clearer intent; no behavior change
+**Cons:** None
+**Effort:** Small
+**Risk:** None
+
+### Option B: Cherry-pick only the YAGNI items
+
+Fix only `unfixable` removal and `flattenCVEs` inlining; leave `useComputed` as-is (harmless).
+
+**Pros:** Minimal change
+**Cons:** Partial fix
+**Effort:** Trivial
+**Risk:** None
+
+## Recommended Action
+
+Option A.
+
+## Technical Details
+
+**Affected files:**
+- `frontend/islands/VulnerabilityDetail.tsx`
+- `frontend/lib/scanning-types.ts`
+
+## Acceptance Criteria
+
+- [ ] `unfixable` removed from types and compute function
+- [ ] `flattenCVEs` inlined (or kept only if it earns its keep)
+- [ ] At most one `IS_BROWSER` guard
+- [ ] Tests/lint/fmt/build clean
+
+## Work Log
+
+## Resources
+
+- PR #167

--- a/todos/312-complete-p2-use-apierror-instead-of-cast.md
+++ b/todos/312-complete-p2-use-apierror-instead-of-cast.md
@@ -1,0 +1,87 @@
+---
+status: pending
+priority: p2
+issue_id: "312"
+tags: [code-review, error-handling, pattern, pr-167]
+dependencies: []
+---
+
+# Use ApiError instead of ad-hoc type cast in VulnerabilityDetail
+
+## Problem Statement
+
+`VulnerabilityDetail.tsx:69` casts the caught error to `{ status?: number; message?: string }` instead of using the exported `ApiError` class from `lib/api.ts:46`. A thrown non-ApiError (e.g., a plain `TypeError` from `fetch` failing) would have `undefined` status and fall into the generic "Failed to load" branch — but if some other code throws an object that happens to have a `status` field, it would be silently misinterpreted as an HTTP response.
+
+**Why it matters:** Type safety hole; masks the difference between HTTP errors and network errors.
+
+## Findings
+
+### Pattern Recognition Reviewer
+
+**File:** `frontend/islands/VulnerabilityDetail.tsx:69-79`
+```ts
+} catch (e) {
+  const err = e as { status?: number; message?: string };
+  if (err.status === 501) { ... }
+  else if (err.status === 403) { ... }
+  else { error.value = err.message ?? "Failed to load vulnerability details"; }
+}
+```
+
+**Project convention** — `frontend/lib/api.ts:46`:
+```ts
+export class ApiError extends Error {
+  constructor(public status: number, public code: number | string, message: string) {
+    super(message);
+  }
+}
+```
+
+## Proposed Solutions
+
+### Option A: Import and instanceof-check ApiError (Recommended)
+
+```ts
+import { ApiError } from "@/lib/api.ts";
+
+} catch (e) {
+  if (e instanceof ApiError) {
+    if (e.status === 501) {
+      error.value = "CVE-level detail requires Trivy Operator...";
+    } else if (e.status === 403) {
+      error.value = "Access denied...";
+    } else {
+      error.value = e.message || "Failed to load vulnerability details";
+    }
+  } else {
+    error.value = "Failed to load vulnerability details";
+  }
+}
+```
+
+**Pros:** Type-safe; distinguishes HTTP errors from network errors
+**Cons:** None
+**Effort:** Trivial
+**Risk:** None
+
+## Recommended Action
+
+<!-- Filled during triage -->
+
+## Technical Details
+
+**Affected files:**
+- `frontend/islands/VulnerabilityDetail.tsx:69-79`
+
+## Acceptance Criteria
+
+- [ ] `ApiError` imported and used via `instanceof`
+- [ ] Non-ApiError exceptions produce the generic message
+- [ ] Existing 501 and 403 messages still displayed correctly
+
+## Work Log
+
+## Resources
+
+- PR #167
+- `frontend/lib/api.ts:46` (ApiError class)

--- a/todos/313-complete-p2-stale-data-and-refresh-indicator.md
+++ b/todos/313-complete-p2-stale-data-and-refresh-indicator.md
@@ -1,0 +1,72 @@
+---
+status: pending
+priority: p2
+issue_id: "313"
+tags: [code-review, ux, pr-167]
+dependencies: []
+---
+
+# No stale-data indicator or loading overlay on refresh
+
+## Problem Statement
+
+Two related UX issues:
+
+1. **`lastScanned` is shown but without relative time or staleness warning.** Trivy results lag image changes by minutes to hours. A scan that's 3 days old looks identical to one that's 30 seconds old. The detail page empty-state acknowledges lag, but nothing warns when *displayed* data is stale.
+
+2. **Refresh button has no visible effect on the data area.** The button label changes to "Refreshing..." but the table keeps showing stale rows. On slow networks users can't tell if the refresh did anything.
+
+**Why it matters:** Security engineers need to know if they're looking at live or stale data when deciding whether to roll out a fix.
+
+## Findings
+
+### UX Reviewer — friction
+
+**Files:**
+- `frontend/islands/VulnerabilityDashboard.tsx:79-85, 333` — refresh handler, lastScanned display
+- `frontend/islands/VulnerabilityDetail.tsx:147-150` — detail page lastScanned display
+
+## Proposed Solutions
+
+### Option A: Relative time + stale warning
+
+1. Replace `new Date(lastScanned).toLocaleString()` with a `TimeAgo`-style "2h ago" + a tooltip showing the full timestamp
+2. Add a stale-data warning badge when `lastScanned` is older than a threshold (e.g., 7 days)
+3. On refresh, dim the table (opacity: 0.5) until fresh data arrives
+
+**Pros:** Clear staleness signaling; familiar pattern from other parts of the app
+**Cons:** Requires a shared TimeAgo component (check if one exists; `lib/format.ts` has `age()`)
+**Effort:** Small
+**Risk:** None
+
+### Option B: Minimal — add "Last updated" header
+
+Just show relative time in the header. Skip the dim-on-refresh.
+
+**Pros:** Trivial
+**Cons:** Partial fix
+**Effort:** Trivial
+**Risk:** None
+
+## Recommended Action
+
+<!-- Filled during triage -->
+
+## Technical Details
+
+**Affected files:**
+- `frontend/islands/VulnerabilityDashboard.tsx`
+- `frontend/islands/VulnerabilityDetail.tsx`
+- Reference: `frontend/lib/format.ts` (check for existing age/relative-time helper)
+
+## Acceptance Criteria
+
+- [ ] Users can see relative time of last scan
+- [ ] Stale data (> threshold) is visually flagged
+- [ ] Refresh has a visible effect on the data area
+
+## Work Log
+
+## Resources
+
+- PR #167

--- a/todos/314-complete-p2-dashboard-color-only-severity.md
+++ b/todos/314-complete-p2-dashboard-color-only-severity.md
@@ -1,0 +1,74 @@
+---
+status: pending
+priority: p2
+issue_id: "314"
+tags: [code-review, a11y, pr-167]
+dependencies: []
+---
+
+# Dashboard severity cells use color alone — colorblind users can't distinguish
+
+## Problem Statement
+
+`SeverityCell` in `VulnerabilityDashboard` renders severity counts as plain digits where color is the only differentiator. Colorblind users (especially red/green deficient) see identical-looking numbers across all severity columns. The column headers help somewhat, but the cell content itself has no icon, weight, or shape difference.
+
+The detail page does this better — it uses `CVESeverityBadge` with text labels. The dashboard should match.
+
+**Why it matters:** WCAG 2.x requires color not to be the sole means of conveying information.
+
+## Findings
+
+### UX Reviewer — friction (a11y)
+
+**File:** `frontend/islands/VulnerabilityDashboard.tsx:370-379`
+```tsx
+function SeverityCell({ count, severity }: { count: number; severity: string }) {
+  const color = count > 0 ? SEVERITY_COLORS[severity] : "var(--text-muted)";
+  return (
+    <td class="px-3 py-2 text-center text-xs font-medium" style={{ color }}>
+      {count}
+    </td>
+  );
+}
+```
+
+## Proposed Solutions
+
+### Option A: Add weight/opacity difference beyond color
+
+When count > 0, also apply `font-bold`. When count === 0, reduce opacity. This makes "has issues" scannable without relying on color.
+
+**Pros:** Minimal change; preserves compact layout
+**Cons:** Still subtle
+**Effort:** Trivial
+**Risk:** None
+
+### Option B: Colored backgrounds with sufficient contrast
+
+Wrap the count in a colored pill with text-on-color contrast, similar to `SeverityCount` used in the summary area.
+
+**Pros:** Matches detail page style
+**Cons:** Takes more horizontal space; changes visual density
+**Effort:** Small
+**Risk:** None
+
+## Recommended Action
+
+<!-- Filled during triage -->
+
+## Technical Details
+
+**Affected files:**
+- `frontend/islands/VulnerabilityDashboard.tsx:370-379`
+
+## Acceptance Criteria
+
+- [ ] Severity cells distinguishable without color (weight, shape, or background)
+- [ ] Visual density preserved or improved
+
+## Work Log
+
+## Resources
+
+- PR #167
+- [WCAG 2.1 SC 1.4.1 Use of Color](https://www.w3.org/WAI/WCAG21/Understanding/use-of-color)

--- a/todos/315-complete-p3-detail-page-refresh-and-wsrefetch.md
+++ b/todos/315-complete-p3-detail-page-refresh-and-wsrefetch.md
@@ -1,0 +1,66 @@
+---
+status: pending
+priority: p3
+issue_id: "315"
+tags: [code-review, ux, real-time, pr-167]
+dependencies: []
+---
+
+# VulnerabilityDetail has no Refresh button and no useWsRefetch
+
+## Problem Statement
+
+`VulnerabilityDetail` only loads CVE data on mount. There's no Refresh button and no `useWsRefetch` integration. The dashboard (list view) has a Refresh button but detail pages don't.
+
+**Why it matters:** After remediating a CVE, users want to verify the next scan shows the fix. Currently they have to reload the page.
+
+## Findings
+
+### Pattern Recognition Reviewer
+
+**File:** `frontend/islands/VulnerabilityDetail.tsx`
+
+**Compare:**
+- `frontend/islands/GitOpsAppDetail.tsx:107-109` — uses `useWsRefetch`
+- `frontend/islands/GitOpsAppDetail.tsx:304-311` — Refresh button
+- `frontend/islands/ViolationBrowser.tsx:56-59` — uses `useWsRefetch`
+
+## Proposed Solutions
+
+### Option A: Add Refresh button
+
+Mirror the dashboard's refresh button pattern in the detail header.
+
+**Pros:** Simple; matches dashboard
+**Cons:** No live updates
+**Effort:** Trivial
+**Risk:** None
+
+### Option B: Add useWsRefetch with VulnerabilityReport topic
+
+Check if the backend has a websocket watch for VulnerabilityReport CRDs. If yes, subscribe.
+
+**Pros:** Live updates
+**Cons:** Backend may not support it yet
+**Effort:** Small (frontend) or Medium (with backend support)
+**Risk:** Low
+
+## Recommended Action
+
+<!-- Filled during triage — Option A as first step -->
+
+## Technical Details
+
+**Affected files:**
+- `frontend/islands/VulnerabilityDetail.tsx`
+
+## Acceptance Criteria
+
+- [ ] Refresh button on detail page header
+- [ ] Optional: live updates via websocket
+
+## Work Log
+
+## Resources
+
+- PR #167

--- a/todos/316-pending-p3-package-grouping-view.md
+++ b/todos/316-pending-p3-package-grouping-view.md
@@ -1,0 +1,67 @@
+---
+status: pending
+priority: p3
+issue_id: "316"
+tags: [code-review, ux, feature, pr-167]
+dependencies: []
+---
+
+# Add package-grouped view for remediation prioritization
+
+## Problem Statement
+
+A single vulnerable package (e.g., `openssl`) often produces dozens of CVEs per image. The current flat CVE table renders each as a separate row. An SRE's first question — "what packages should I upgrade to close the most CVEs?" — requires manual counting.
+
+**Why it matters:** Primary remediation workflow isn't supported.
+
+## Findings
+
+### UX Reviewer — blocker (prioritization)
+
+**File:** `frontend/islands/VulnerabilityDetail.tsx:252-291` — flat CVE table
+
+## Proposed Solutions
+
+### Option A: Toggle between CVE view and Package view
+
+Add a view toggle; package view groups by `package` field with counts per severity + a unified "Fix Available" column showing the highest-version fix.
+
+**Pros:** Best remediation UX
+**Cons:** Extra UI; more state
+**Effort:** Medium
+**Risk:** Low
+
+### Option B: Add a secondary sort option
+
+Let users sort by package name as secondary, which puts same-package CVEs adjacent.
+
+**Pros:** Minimal change
+**Cons:** Still 40 rows for one package
+**Effort:** Small
+**Risk:** None
+
+## Recommended Action
+
+<!-- Filled during triage -->
+
+## Technical Details
+
+**Affected files:**
+- `frontend/islands/VulnerabilityDetail.tsx`
+- Possibly `frontend/lib/scanning-types.ts` (helper for package grouping)
+
+## Acceptance Criteria
+
+- [ ] Users can answer "what packages should I upgrade?" without manual counting
+
+## Work Log
+
+### 2026-04-11 — Deferred
+
+Not addressed in the review-fix batch because this is a feature addition (new view toggle + grouping logic) rather than a bug fix. The surrounding P1/P2/P3 fixes in review batch #2 landed in commit 1d9fccf; this remains open for a dedicated follow-up.
+
+Mitigation in the interim: users can now filter by severity and "fixable only" and sort by CVE ID, which partially addresses prioritization. Package grouping would go further but needs its own design pass.
+
+## Resources
+
+- PR #167

--- a/todos/317-complete-p3-vulnerabilitylink-inline-styles.md
+++ b/todos/317-complete-p3-vulnerabilitylink-inline-styles.md
@@ -1,0 +1,70 @@
+---
+status: pending
+priority: p3
+issue_id: "317"
+tags: [code-review, design-system, pr-167]
+dependencies: []
+---
+
+# VulnerabilityLink uses inline styles instead of utility classes
+
+## Problem Statement
+
+`VulnerabilityLink.tsx` mixes inline `style={{}}` with Tailwind `class` on adjacent elements. Phase 6C normalization established utility-class-only for all frontend components.
+
+**Why it matters:** Inconsistency with Phase 6C design normalization.
+
+## Findings
+
+### UX Reviewer — polish
+
+**File:** `frontend/components/k8s/detail/VulnerabilityLink.tsx:21-31`
+
+```tsx
+<div
+  style={{
+    fontSize: "14px",
+    fontWeight: 600,
+    color: "var(--text-primary)",
+    marginBottom: "8px",
+  }}
+>
+  Security
+</div>
+```
+
+## Proposed Solutions
+
+### Option A: Convert to utility classes
+
+```tsx
+<div class="text-sm font-semibold text-text-primary mb-2">Security</div>
+```
+
+Or reuse the existing `SectionHeader`/`SectionTitle` components (grep for the exact name under `components/k8s/detail/`).
+
+**Pros:** Matches design system
+**Cons:** None
+**Effort:** Trivial
+**Risk:** None
+
+## Recommended Action
+
+<!-- Filled during triage -->
+
+## Technical Details
+
+**Affected files:**
+- `frontend/components/k8s/detail/VulnerabilityLink.tsx`
+
+## Acceptance Criteria
+
+- [ ] No inline `style` attributes
+- [ ] Renders identically
+
+## Work Log
+
+## Resources
+
+- PR #167
+- CLAUDE.md Phase 6C

--- a/todos/318-complete-p3-ux-polish-bundle.md
+++ b/todos/318-complete-p3-ux-polish-bundle.md
@@ -1,0 +1,75 @@
+---
+status: pending
+priority: p3
+issue_id: "318"
+tags: [code-review, ux, polish, pr-167]
+dependencies: []
+---
+
+# Bundle: UX polish items for vulnerability detail view
+
+## Problem Statement
+
+Cheap UX wins grouped together for batch fix:
+
+1. **Pagination has only Prev/Next** — no page-number input or jump-to-last. With 500+ CVEs this is annoying.
+2. **CVE title is only in tooltip** — users scanning for "openssl buffer overflow" have no visible hook. Add truncated title as a second line under the CVE ID.
+3. **Summary severity cards look clickable but aren't filters.** Users will click them expecting to filter.
+4. **Back link on detail page** loses the dashboard's search/scanner filter state. Consider query-string round-tripping.
+
+**Why it matters:** Each item is small friction; together they degrade the feel.
+
+## Findings
+
+### UX Reviewer — friction/polish
+
+**File:** `frontend/islands/VulnerabilityDetail.tsx`
+- Pagination at lines 302-323 (Prev/Next only)
+- CVE column at line 351-361 (title in tooltip only)
+- Summary cards at lines 170-202 (not clickable)
+- Back link at lines 125-131 (hardcoded)
+
+## Proposed Solutions
+
+### Option A: Fix all four items
+
+1. Add a page input or "go to last page" button
+2. Render truncated `cve.title` below the CVE ID (keep tooltip too)
+3. Make severity cards clickable toggles that drive the severity filter
+4. Preserve dashboard filter state via query-string
+
+**Pros:** Fast small wins
+**Cons:** Touches 4 code regions
+**Effort:** Small total
+**Risk:** None
+
+### Option B: Cherry-pick #2 and #3 only
+
+The most user-visible.
+
+**Pros:** Minimal; biggest wins
+**Cons:** Leaves pagination and back-link annoyances
+**Effort:** Trivial
+**Risk:** None
+
+## Recommended Action
+
+<!-- Filled during triage -->
+
+## Technical Details
+
+**Affected files:**
+- `frontend/islands/VulnerabilityDetail.tsx`
+
+## Acceptance Criteria
+
+- [ ] CVE titles visible in rows
+- [ ] Severity cards drive filter OR are visually clearly non-interactive
+- [ ] Pagination improvements shipped
+- [ ] Optional: filter state preserved on back-nav
+
+## Work Log
+
+## Resources
+
+- PR #167

--- a/todos/319-complete-p3-image-column-truncation-direction.md
+++ b/todos/319-complete-p3-image-column-truncation-direction.md
@@ -1,0 +1,69 @@
+---
+status: pending
+priority: p3
+issue_id: "319"
+tags: [code-review, ux, pr-167]
+dependencies: []
+---
+
+# Image column truncates from right, losing the tag
+
+## Problem Statement
+
+`VulnerabilityDetail.tsx:368` truncates image references to 180px from the right, which loses the tag. A long reference like `registry.example.com/very/long/path:v1.2.3` becomes `registry.examp...` — cutting off the tag, which is the most important part for remediation.
+
+**Why it matters:** The tag is the actionable signal (which version to upgrade to). Users need to hover to see it.
+
+## Findings
+
+### UX Reviewer — polish
+
+**File:** `frontend/islands/VulnerabilityDetail.tsx:366-373`
+
+## Proposed Solutions
+
+### Option A: Truncate from the left (RTL trick)
+
+Use `direction: rtl; text-align: left;` or the `truncate` CSS with a leading ellipsis pattern so the tag stays visible.
+
+**Pros:** Tag always visible
+**Cons:** RTL trick is a bit obscure
+**Effort:** Trivial
+**Risk:** None
+
+### Option B: Strip the registry prefix
+
+If image contains `/`, show everything after the first `/`. Registry prefix (e.g., `registry.example.com/`) is usually repeated noise.
+
+**Pros:** Cleaner
+**Cons:** Ambiguous for multi-registry setups
+**Effort:** Trivial
+**Risk:** None
+
+### Option C: Two-line cell
+
+Row 1: image path (truncated), Row 2: tag.
+
+**Pros:** Tag always visible, no clever CSS
+**Cons:** Doubles row height
+**Effort:** Trivial
+**Risk:** None
+
+## Recommended Action
+
+<!-- Filled during triage -->
+
+## Technical Details
+
+**Affected files:**
+- `frontend/islands/VulnerabilityDetail.tsx:366-373`
+
+## Acceptance Criteria
+
+- [ ] Image tag visible without hover
+
+## Work Log
+
+## Resources
+
+- PR #167

--- a/todos/320-complete-p3-loading-error-early-return.md
+++ b/todos/320-complete-p3-loading-error-early-return.md
@@ -1,0 +1,55 @@
+---
+status: pending
+priority: p3
+issue_id: "320"
+tags: [code-review, pattern, consistency, pr-167]
+dependencies: []
+---
+
+# VulnerabilityDetail renders loading/error inline instead of early return
+
+## Problem Statement
+
+`VulnerabilityDetail.tsx:154-165` renders loading and error states inline, inside the main shell, alongside conditional content blocks. `GitOpsAppDetail.tsx:204-232` uses an early-return pattern instead. Not wrong, but inconsistent.
+
+**Why it matters:** Pattern drift makes the codebase harder to scan.
+
+## Findings
+
+### Pattern Recognition Reviewer
+
+**File:** `frontend/islands/VulnerabilityDetail.tsx:154-165` vs `frontend/islands/GitOpsAppDetail.tsx:204-232`
+
+## Proposed Solutions
+
+### Option A: Match GitOpsAppDetail's early-return pattern
+
+Extract loading and error into their own returns at the top of the function, before the main render tree.
+
+**Pros:** Consistency with project convention
+**Cons:** Slightly more verbose
+**Effort:** Trivial
+**Risk:** None
+
+### Option B: Leave as-is
+
+Accept minor inconsistency.
+
+## Recommended Action
+
+<!-- Filled during triage -->
+
+## Technical Details
+
+**Affected files:**
+- `frontend/islands/VulnerabilityDetail.tsx:154-165`
+
+## Acceptance Criteria
+
+- [ ] Pattern matches GitOpsAppDetail OR decision documented
+
+## Work Log
+
+## Resources
+
+- PR #167


### PR DESCRIPTION
## Summary

Phase 1 of the security vulnerability detail view feature. Adds a new backend endpoint that returns individual CVE findings for a specific workload by reading the `report.vulnerabilities[]` array from Trivy VulnerabilityReport CRDs — data the existing summary endpoint silently ignored.

- **New endpoint:** `GET /v1/scanning/vulnerabilities/{namespace}/{kind}/{name}`
- **Types:** `CVEDetail`, `ImageVulnDetail`, `WorkloadVulnDetail` — `CVSSScore` is `*float64` so "no score" is distinguishable from `0.0`
- **Sorting:** severity (Critical → Unknown) → CVSS score desc → CVE ID asc
- **CVSS vendor preference:** NVD → RedHat → Ubuntu → Debian → first available
- **Security:** same Trivy RBAC check as the list endpoint; namespace/kind/name input validation; 30s context timeout
- **Kubescape:** returns 501 — per-CVE data lives in the `kubescape` namespace and isn't reachable under the user-impersonation security model

## Plan

Full feature plan with UX mockups, phased checklist, and technical decisions: [`plans/security-vulnerability-detail-view.md`](plans/security-vulnerability-detail-view.md)

This PR is **Phase 1 (backend only)**. Phase 2A (detail page + clickable dashboard rows) and Phase 2B (cross-links from workload overviews) will follow as additional commits to this branch.

## Testing

- [x] Unit tests: CVSS selection (5 cases), severity ranking (8 cases), multi-image grouping, sort ordering with mixed/missing CVSS, empty-report handling
- [x] `go vet ./...` clean
- [x] `go test ./...` all packages pass
- [ ] Smoke test against homelab cluster (deferred until Phase 2 lands so it can be tested end-to-end via the UI)

## Files Changed

| File | Change |
|---|---|
| `backend/internal/scanning/types.go` | +30 lines — new detail types |
| `backend/internal/scanning/trivy.go` | +194 lines — `GetTrivyWorkloadVulnDetails`, `selectCVSSScore`, `severityRank`, `extractCVEDetail` |
| `backend/internal/scanning/handler.go` | +71 lines — `HandleVulnerabilityDetail` with input validation, RBAC, timeout |
| `backend/internal/scanning/trivy_test.go` | +272 lines — 4 new test functions |
| `backend/internal/server/routes.go` | +1 line — route registration |
| `plans/security-vulnerability-detail-view.md` | +644 lines — full feature plan |

🤖 Generated with [Claude Code](https://claude.com/claude-code)