### PR TITLE
chore(argocd): wire argocd-image-updater for auto image rollout

### DIFF
--- a/argocd/k8scenter-application.yaml
+++ b/argocd/k8scenter-application.yaml
@@ -6,13 +6,11 @@
 # After that, ArgoCD tracks `main` and keeps the cluster in sync with
 # the Helm chart at helm/kubecenter/ using values-homelab.yaml.
 #
-# Note on image updates: both backend and frontend pin `tag: latest` with
-# `pullPolicy: Always` in values-homelab.yaml. Because the rendered manifest
-# doesn't change when a new image is pushed to GHCR, ArgoCD won't detect
-# drift and won't restart pods on its own. To pick up a new image either:
-#   1. Run `kubectl rollout restart deploy/kubecenter-backend deploy/kubecenter-frontend -n kubecenter`
-#   2. Or install argocd-image-updater to automate registry polling:
-#      https://argocd-image-updater.readthedocs.io/
+# Image updates are automated via argocd-image-updater:
+#   - Polls ghcr.io for new digests on the `latest` tag
+#   - Writes parameter overrides back to this Application
+#   - ArgoCD detects drift and rolls out new pods
+# See the argocd-image-updater.argoproj.io/* annotations below.
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -20,6 +18,32 @@ metadata:
   namespace: argocd
   finalizers:
     - resources-finalizer.argocd.argoproj.io
+  annotations:
+    # --- argocd-image-updater configuration ---
+    # Watches both container images on GHCR. Uses the `digest` strategy
+    # so a new push to the mutable `latest` tag triggers an update as
+    # soon as the image digest changes, even though the tag string
+    # itself stays the same.
+    argocd-image-updater.argoproj.io/image-list: >-
+      backend=ghcr.io/maulepilot117/k8scenter-backend,
+      frontend=ghcr.io/maulepilot117/k8scenter-frontend
+
+    # Write parameter overrides directly back to this Application CR.
+    # No git write credentials required; values-homelab.yaml stays
+    # the source of truth for everything else.
+    argocd-image-updater.argoproj.io/write-back-method: argocd
+
+    # Backend image tracking
+    argocd-image-updater.argoproj.io/backend.update-strategy: digest
+    argocd-image-updater.argoproj.io/backend.allow-tags: regexp:^latest$
+    argocd-image-updater.argoproj.io/backend.helm.image-name: backend.image.repository
+    argocd-image-updater.argoproj.io/backend.helm.image-tag: backend.image.tag
+
+    # Frontend image tracking
+    argocd-image-updater.argoproj.io/frontend.update-strategy: digest
+    argocd-image-updater.argoproj.io/frontend.allow-tags: regexp:^latest$
+    argocd-image-updater.argoproj.io/frontend.helm.image-name: frontend.image.repository
+    argocd-image-updater.argoproj.io/frontend.helm.image-tag: frontend.image.tag
 spec:
   project: default
 


### PR DESCRIPTION
## Summary

Adds \`argocd-image-updater.argoproj.io/*\` annotations to the k8sCenter Application so new image pushes to GHCR trigger automatic pod rollouts — no more manual \`kubectl rollout restart\` after merges to \`main\`.

## Strategy

- **update-strategy: digest** — watches the mutable \`latest\` tag's digest and updates when it changes, even though the tag string itself stays constant
- **allow-tags: regexp:^latest$** — constrains the watcher to only the \`latest\` tag (won't chase semver release tags)
- **write-back-method: argocd** — image-updater writes parameter overrides back to this Application CR, not git. No git write credentials required; \`values-homelab.yaml\` stays the source of truth for everything else
- **helm.image-name / image-tag** — maps each watched image onto the \`backend.image.{repository,tag}\` and \`frontend.image.{repository,tag}\` paths exposed by the chart

## Flow after merge

1. image-updater polls GHCR on its sync interval (default 2m)
2. Detects a new digest on the \`latest\` tag
3. Patches \`spec.source.helm.parameters\` on this Application with the new pinned digest
4. ArgoCD detects drift, re-renders the chart, applies the new image reference, pods roll out

## Testing

- [ ] After merge, sync this Application on the homelab and verify the annotations land on the live CR
- [ ] Push a new image to \`ghcr.io/maulepilot117/k8scenter-backend:latest\` and confirm image-updater rolls the backend deployment within a sync interval

🤖 Generated with [Claude Code](https://claude.com/claude-code)