### PR TITLE
fix(helm): sanitize image tag used as k8s label value

### DIFF
--- a/argocd/k8scenter-application.yaml
+++ b/argocd/k8scenter-application.yaml
@@ -6,11 +6,11 @@
 # After that, ArgoCD tracks `main` and keeps the cluster in sync with
 # the Helm chart at helm/kubecenter/ using values-homelab.yaml.
 #
-# Image updates are automated via argocd-image-updater:
-#   - Polls ghcr.io for new digests on the `latest` tag
-#   - Writes parameter overrides back to this Application
-#   - ArgoCD detects drift and rolls out new pods
-# See the argocd-image-updater.argoproj.io/* annotations below.
+# Image updates are automated by argocd-image-updater — see the
+# k8scenter-image-updater.yaml in this directory for the ImageUpdater
+# CR that drives backend/frontend digest tracking on the `latest` tag.
+# Note: argocd-image-updater v1.x is CRD-based; the legacy
+# argocd-image-updater.argoproj.io/* annotations are no longer read.
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -18,32 +18,6 @@ metadata:
   namespace: argocd
   finalizers:
     - resources-finalizer.argocd.argoproj.io
-  annotations:
-    # --- argocd-image-updater configuration ---
-    # Watches both container images on GHCR. Uses the `digest` strategy
-    # so a new push to the mutable `latest` tag triggers an update as
-    # soon as the image digest changes, even though the tag string
-    # itself stays the same.
-    argocd-image-updater.argoproj.io/image-list: >-
-      backend=ghcr.io/maulepilot117/k8scenter-backend,
-      frontend=ghcr.io/maulepilot117/k8scenter-frontend
-
-    # Write parameter overrides directly back to this Application CR.
-    # No git write credentials required; values-homelab.yaml stays
-    # the source of truth for everything else.
-    argocd-image-updater.argoproj.io/write-back-method: argocd
-
-    # Backend image tracking
-    argocd-image-updater.argoproj.io/backend.update-strategy: digest
-    argocd-image-updater.argoproj.io/backend.allow-tags: regexp:^latest$
-    argocd-image-updater.argoproj.io/backend.helm.image-name: backend.image.repository
-    argocd-image-updater.argoproj.io/backend.helm.image-tag: backend.image.tag
-
-    # Frontend image tracking
-    argocd-image-updater.argoproj.io/frontend.update-strategy: digest
-    argocd-image-updater.argoproj.io/frontend.allow-tags: regexp:^latest$
-    argocd-image-updater.argoproj.io/frontend.helm.image-name: frontend.image.repository
-    argocd-image-updater.argoproj.io/frontend.helm.image-tag: frontend.image.tag
 spec:
   project: default
 

--- a/argocd/k8scenter-image-updater.yaml
+++ b/argocd/k8scenter-image-updater.yaml
@@ -1,0 +1,46 @@
+# argocd-image-updater v1.1.1 CRD-based configuration.
+#
+# The v1 operator redesigned image tracking from Application annotations
+# to a dedicated CRD. This ImageUpdater CR tells the controller to watch
+# the k8scenter Application in the argocd namespace and update its
+# backend/frontend images when new digests appear on the `latest` tag in
+# GHCR.
+#
+# Apply with:
+#   kubectl apply -n argocd -f argocd/k8scenter-image-updater.yaml
+#
+# Flow on each reconcile (default every 2 minutes):
+#   1. Controller polls ghcr.io for ghcr.io/maulepilot117/k8scenter-{backend,frontend}
+#   2. Detects a new digest on the `latest` tag
+#   3. Writes new helm parameter overrides to the k8scenter Application CR
+#   4. ArgoCD detects drift, re-renders, applies, pods roll out
+apiVersion: argocd-image-updater.argoproj.io/v1alpha1
+kind: ImageUpdater
+metadata:
+  name: k8scenter-images
+  namespace: argocd
+spec:
+  # Defaults inherited by every image below.
+  commonUpdateSettings:
+    updateStrategy: digest
+    allowTags: "regexp:^latest$"
+
+  # Write parameter overrides back to the Application CR (no git credentials).
+  writeBackConfig:
+    method: argocd
+
+  applicationRefs:
+    - namePattern: k8scenter
+      images:
+        - alias: backend
+          imageName: ghcr.io/maulepilot117/k8scenter-backend:latest
+          manifestTargets:
+            helm:
+              name: backend.image.repository
+              tag: backend.image.tag
+        - alias: frontend
+          imageName: ghcr.io/maulepilot117/k8scenter-frontend:latest
+          manifestTargets:
+            helm:
+              name: frontend.image.repository
+              tag: frontend.image.tag

--- a/helm/kubecenter/templates/_helpers.tpl
+++ b/helm/kubecenter/templates/_helpers.tpl
@@ -23,11 +23,20 @@ Create a default fully qualified app name.
 
 {{/*
 Common labels
+
+The app.kubernetes.io/version label must be a valid Kubernetes label value
+(RFC 1123 subdomain, ≤63 chars, alphanumeric + [-_.]). argocd-image-updater's
+`digest` strategy rewrites image tags to `latest@sha256:<digest>`, which is
+88 chars and contains `@` and `:` — both illegal. Strip anything after `@`
+and truncate to 63 chars so the label stays valid regardless of which
+update strategy is in use.
 */}}
 {{- define "kubecenter.labels" -}}
+{{- $rawVersion := .Values.backend.image.tag | default .Chart.AppVersion -}}
+{{- $version := $rawVersion | toString | splitList "@" | first | trunc 63 | trimSuffix "-" | trimSuffix "." | trimSuffix "_" -}}
 helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{ include "kubecenter.selectorLabels" . }}
-app.kubernetes.io/version: {{ .Values.backend.image.tag | default .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ $version | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 


### PR DESCRIPTION
## Summary

Fixes a sync failure discovered right after installing argocd-image-updater v1.1.1 on the homelab and wiring up the new ImageUpdater CR.

The chart's common-labels helper (\`helm/kubecenter/templates/_helpers.tpl:30\`) passes \`.Values.backend.image.tag\` straight into \`app.kubernetes.io/version\`. When argocd-image-updater rewrites the tag to \`latest@sha256:330a3a5c...\` (88 chars, contains \`@\` and \`:\`), every resource in the kubecenter namespace fails to sync:

\`\`\`
ServiceAccount "kubecenter" is invalid: metadata.labels:
  Invalid value: "latest@sha256:330a...": must be no more than 63 characters
\`\`\`

## Fix

Split the tag on \`@\` and take the first segment, trunc to 63, strip trailing punctuation:

\`\`\`tpl
{{- \$version := \$rawVersion | toString | splitList "@" | first | trunc 63 | trimSuffix "-" | trimSuffix "." | trimSuffix "_" -}}
\`\`\`

Result:
- \`latest\` → \`latest\`
- \`v1.2.3\` → \`v1.2.3\`
- \`latest@sha256:330a...f8\` → \`latest\`

## Also in this commit

- **\`argocd/k8scenter-image-updater.yaml\` (new)**: ImageUpdater CR driving the digest tracking. argocd-image-updater v1.1.1 was a complete redesign from annotation-scraping to a dedicated CRD operator — without this CR the controller logs \"No ImageUpdater CRs to process\" and no images are ever updated. The CR selects the k8scenter Application by \`namePattern\` and declares backend/frontend images with digest strategy + \`regexp:^latest\$\` allow-tags.

- **\`argocd/k8scenter-application.yaml\`**: removed the now-obsolete \`argocd-image-updater.argoproj.io/*\` annotations added in PR #170. v1.x silently ignores them; leaving them would be misleading documentation. The ImageUpdater CR is the single source of truth.

## Testing

- [x] \`helm template\` with injected digest tag produces valid \`app.kubernetes.io/version: \"latest\"\` label
- [x] \`helm lint\` clean
- [ ] After merge: apply to homelab, confirm sync succeeds and pods roll to the digest-pinned images

🤖 Generated with [Claude Code](https://claude.com/claude-code)