### PR TITLE
feat: Gateway API dashboard with CRD discovery (#176)

### DIFF
--- a/backend/cmd/kubecenter/main.go
+++ b/backend/cmd/kubecenter/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kubecenter/kubecenter/internal/alerting"
 	"github.com/kubecenter/kubecenter/internal/audit"
 	"github.com/kubecenter/kubecenter/internal/certmanager"
+	"github.com/kubecenter/kubecenter/internal/gateway"
 	"github.com/kubecenter/kubecenter/internal/auth"
 	"github.com/kubecenter/kubecenter/internal/config"
 	"github.com/kubecenter/kubecenter/internal/diagnostics"
@@ -667,6 +668,10 @@ func main() {
 	cmPoller := certmanager.NewPoller(k8sClient, cmDisc, cmHandler, notifService, logger)
 	go cmPoller.Start(ctx)
 
+	// Gateway API integration
+	gwDisc := gateway.NewDiscoverer(k8sClient, logger)
+	gwHandler := gateway.NewHandler(k8sClient, gwDisc, accessChecker, logger)
+
 	// Ready state: true after informer sync, false during shutdown
 	var ready atomic.Bool
 	ready.Store(true)
@@ -707,6 +712,7 @@ func main() {
 		LimitsHandler:      limitsHandler,
 		VeleroHandler:      veleroHandler,
 		CertManagerHandler: cmHandler,
+		GatewayHandler:     gwHandler,
 		CRDHandler:         crdHandler,
 		LogQueryLimiter:    logQueryLimiter,
 		WebhookRateLimiter: webhookRateLimiter,

--- a/backend/internal/gateway/discovery.go
+++ b/backend/internal/gateway/discovery.go
@@ -89,16 +89,27 @@ func (d *Discoverer) Probe(ctx context.Context) GatewayAPIStatus {
 	status.Available = true
 	status.Version = "v1"
 
-	// Collect installed kinds from v1.
+	// Collect installed kinds as lowercase plural resource names (matching frontend GatewayResourceKind).
+	kindToResource := map[string]string{
+		"GatewayClass": "gatewayclasses",
+		"Gateway":      "gateways",
+		"HTTPRoute":    "httproutes",
+		"GRPCRoute":    "grpcroutes",
+		"TCPRoute":     "tcproutes",
+		"TLSRoute":     "tlsroutes",
+		"UDPRoute":     "udproutes",
+	}
 	for _, kind := range []string{"GatewayClass", "Gateway", "HTTPRoute", "GRPCRoute"} {
 		if v1Kinds[kind] {
-			status.InstalledKinds = append(status.InstalledKinds, kind)
+			status.InstalledKinds = append(status.InstalledKinds, kindToResource[kind])
 		}
 	}
 
 	// Check if TLSRoute is already at v1 (some clusters promote it early).
+	hasTLSRoute := false
 	if v1Kinds["TLSRoute"] {
-		status.InstalledKinds = append(status.InstalledKinds, "TLSRoute")
+		status.InstalledKinds = append(status.InstalledKinds, kindToResource["TLSRoute"])
+		hasTLSRoute = true
 	}
 
 	// Probe v1alpha2 for experimental route kinds.
@@ -110,11 +121,11 @@ func (d *Discoverer) Probe(ctx context.Context) GatewayAPIStatus {
 			}
 			switch r.Kind {
 			case "TCPRoute", "UDPRoute":
-				status.InstalledKinds = append(status.InstalledKinds, r.Kind)
+				status.InstalledKinds = append(status.InstalledKinds, kindToResource[r.Kind])
 			case "TLSRoute":
 				// Only add if not already found in v1.
-				if !v1Kinds["TLSRoute"] {
-					status.InstalledKinds = append(status.InstalledKinds, r.Kind)
+				if !hasTLSRoute {
+					status.InstalledKinds = append(status.InstalledKinds, kindToResource[r.Kind])
 				}
 			}
 		}

--- a/backend/internal/gateway/discovery.go
+++ b/backend/internal/gateway/discovery.go
@@ -1,0 +1,131 @@
+package gateway
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/kubecenter/kubecenter/internal/k8s"
+)
+
+const staleDuration = 5 * time.Minute
+
+// Discoverer probes the cluster for Gateway API CRDs and maintains cached discovery state.
+type Discoverer struct {
+	k8sClient *k8s.ClientFactory
+	logger    *slog.Logger
+
+	mu     sync.RWMutex
+	status GatewayAPIStatus
+}
+
+// NewDiscoverer creates a new Gateway API discoverer.
+func NewDiscoverer(k8sClient *k8s.ClientFactory, logger *slog.Logger) *Discoverer {
+	return &Discoverer{
+		k8sClient: k8sClient,
+		logger:    logger,
+		status: GatewayAPIStatus{
+			LastChecked: time.Now().UTC(),
+		},
+	}
+}
+
+// Status returns a copy of the cached Gateway API status.
+// If the cache is stale (older than staleDuration), it triggers a re-probe.
+func (d *Discoverer) Status(ctx context.Context) GatewayAPIStatus {
+	d.mu.RLock()
+	if time.Since(d.status.LastChecked) < staleDuration {
+		status := d.status
+		d.mu.RUnlock()
+		return status
+	}
+	d.mu.RUnlock()
+
+	return d.Probe(ctx)
+}
+
+// IsAvailable returns true if Gateway API CRDs were detected.
+func (d *Discoverer) IsAvailable(ctx context.Context) bool {
+	return d.Status(ctx).Available
+}
+
+// Probe checks if gateway.networking.k8s.io CRDs exist and updates cached state.
+func (d *Discoverer) Probe(ctx context.Context) GatewayAPIStatus {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	status := GatewayAPIStatus{
+		LastChecked: time.Now().UTC(),
+	}
+
+	disco := d.k8sClient.DiscoveryClient()
+
+	// Check for Gateway API v1 CRDs.
+	v1Resources, err := disco.ServerResourcesForGroupVersion("gateway.networking.k8s.io/v1")
+	if err != nil || v1Resources == nil {
+		d.logger.Debug("gateway API CRDs not found", "error", err)
+		d.status = status
+		return status
+	}
+
+	// Build a set of available Kind names, skipping sub-resources (contain "/").
+	v1Kinds := make(map[string]bool)
+	for _, r := range v1Resources.APIResources {
+		if strings.Contains(r.Name, "/") {
+			continue
+		}
+		v1Kinds[r.Kind] = true
+	}
+
+	// Require both Gateway and GatewayClass as minimum for availability.
+	if !v1Kinds["Gateway"] || !v1Kinds["GatewayClass"] {
+		d.logger.Debug("gateway API missing required kinds (Gateway, GatewayClass)")
+		d.status = status
+		return status
+	}
+
+	status.Available = true
+	status.Version = "v1"
+
+	// Collect installed kinds from v1.
+	for _, kind := range []string{"GatewayClass", "Gateway", "HTTPRoute", "GRPCRoute"} {
+		if v1Kinds[kind] {
+			status.InstalledKinds = append(status.InstalledKinds, kind)
+		}
+	}
+
+	// Check if TLSRoute is already at v1 (some clusters promote it early).
+	if v1Kinds["TLSRoute"] {
+		status.InstalledKinds = append(status.InstalledKinds, "TLSRoute")
+	}
+
+	// Probe v1alpha2 for experimental route kinds.
+	v1a2Resources, err := disco.ServerResourcesForGroupVersion("gateway.networking.k8s.io/v1alpha2")
+	if err == nil && v1a2Resources != nil {
+		for _, r := range v1a2Resources.APIResources {
+			if strings.Contains(r.Name, "/") {
+				continue
+			}
+			switch r.Kind {
+			case "TCPRoute", "UDPRoute":
+				status.InstalledKinds = append(status.InstalledKinds, r.Kind)
+			case "TLSRoute":
+				// Only add if not already found in v1.
+				if !v1Kinds["TLSRoute"] {
+					status.InstalledKinds = append(status.InstalledKinds, r.Kind)
+				}
+			}
+		}
+	}
+
+	d.status = status
+	d.logger.Info("gateway API discovery completed",
+		"available", status.Available,
+		"version", status.Version,
+		"kinds", status.InstalledKinds,
+	)
+
+	return status
+}

--- a/backend/internal/gateway/handler.go
+++ b/backend/internal/gateway/handler.go
@@ -50,7 +50,8 @@ type cachedData struct {
 	gatewayClasses []GatewayClassSummary
 	gateways       []GatewaySummary
 	httpRoutes     []HTTPRouteSummary
-	routes         []RouteSummary // ALL non-HTTP routes (GRPC, TCP, TLS, UDP), differentiated by Kind
+	routes         []RouteSummary        // ALL non-HTTP routes (GRPC, TCP, TLS, UDP), differentiated by Kind
+	summary        GatewayAPISummary     // pre-computed unfiltered summary
 	fetchedAt      time.Time
 }
 
@@ -166,7 +167,7 @@ func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error)
 	g, gctx := errgroup.WithContext(ctx)
 
 	g.Go(func() error {
-		list, err := dynClient.Resource(GatewayClassGVR).List(gctx, metav1.ListOptions{})
+		list, err := dynClient.Resource(GatewayClassGVR).List(gctx, metav1.ListOptions{ResourceVersion: "0"})
 		if err != nil {
 			return fmt.Errorf("list gatewayclasses: %w", err)
 		}
@@ -178,7 +179,7 @@ func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error)
 	})
 
 	g.Go(func() error {
-		list, err := dynClient.Resource(GatewayGVR).Namespace("").List(gctx, metav1.ListOptions{})
+		list, err := dynClient.Resource(GatewayGVR).Namespace("").List(gctx, metav1.ListOptions{ResourceVersion: "0"})
 		if err != nil {
 			return fmt.Errorf("list gateways: %w", err)
 		}
@@ -190,7 +191,7 @@ func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error)
 	})
 
 	g.Go(func() error {
-		list, err := dynClient.Resource(HTTPRouteGVR).Namespace("").List(gctx, metav1.ListOptions{})
+		list, err := dynClient.Resource(HTTPRouteGVR).Namespace("").List(gctx, metav1.ListOptions{ResourceVersion: "0"})
 		if err != nil {
 			return fmt.Errorf("list httproutes: %w", err)
 		}
@@ -243,11 +244,15 @@ func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error)
 
 	_ = g2.Wait()
 
+	// Pre-compute unfiltered summary to avoid O(n) iteration on every summary request.
+	sum := computeSummary(gatewayClasses, gateways, httpRoutes, routes)
+
 	data := &cachedData{
 		gatewayClasses: gatewayClasses,
 		gateways:       gateways,
 		httpRoutes:     httpRoutes,
 		routes:         routes,
+		summary:        sum,
 		fetchedAt:      time.Now(),
 	}
 
@@ -294,54 +299,62 @@ func (h *Handler) HandleSummary(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx := r.Context()
-	summary := GatewayAPISummary{}
-
 	// RBAC-filter before counting so users only see counts for resources they can access.
+	ctx := r.Context()
 
-	// GatewayClasses: cluster-scoped RBAC check
+	var filteredClasses []GatewayClassSummary
 	if h.canAccess(ctx, user, "list", "gatewayclasses", "") {
-		summary.GatewayClasses.Total = len(data.gatewayClasses)
-		for _, gc := range data.gatewayClasses {
-			if hasCondition(gc.Conditions, "Accepted", "True") {
-				summary.GatewayClasses.Healthy++
-			} else {
-				summary.GatewayClasses.Degraded++
-			}
+		filteredClasses = data.gatewayClasses
+	}
+
+	summary := computeSummary(
+		filteredClasses,
+		filterByRBAC(ctx, h, user, "gateways", data.gateways),
+		filterByRBAC(ctx, h, user, "httproutes", data.httpRoutes),
+		filterByRBAC(ctx, h, user, "httproutes", data.routes),
+	)
+
+	httputil.WriteData(w, summary)
+}
+
+// computeSummary builds a GatewayAPISummary from the given resource slices.
+func computeSummary(gatewayClasses []GatewayClassSummary, gateways []GatewaySummary, httpRoutes []HTTPRouteSummary, routes []RouteSummary) GatewayAPISummary {
+	s := GatewayAPISummary{}
+
+	s.GatewayClasses.Total = len(gatewayClasses)
+	for _, gc := range gatewayClasses {
+		if hasCondition(gc.Conditions, "Accepted", "True") {
+			s.GatewayClasses.Healthy++
+		} else {
+			s.GatewayClasses.Degraded++
 		}
 	}
 
-	// Gateways: healthy = has Programmed=True condition
-	filteredGateways := filterByRBAC(ctx, h, user, "gateways", data.gateways)
-	summary.Gateways.Total = len(filteredGateways)
-	for _, gw := range filteredGateways {
+	s.Gateways.Total = len(gateways)
+	for _, gw := range gateways {
 		if hasCondition(gw.Conditions, "Programmed", "True") {
-			summary.Gateways.Healthy++
+			s.Gateways.Healthy++
 		} else {
-			summary.Gateways.Degraded++
+			s.Gateways.Degraded++
 		}
 	}
 
-	// HTTPRoutes: healthy = has Accepted=True condition
-	filteredHTTPRoutes := filterByRBAC(ctx, h, user, "httproutes", data.httpRoutes)
-	summary.HTTPRoutes.Total = len(filteredHTTPRoutes)
-	for _, hr := range filteredHTTPRoutes {
+	s.HTTPRoutes.Total = len(httpRoutes)
+	for _, hr := range httpRoutes {
 		if hasCondition(hr.Conditions, "Accepted", "True") {
-			summary.HTTPRoutes.Healthy++
+			s.HTTPRoutes.Healthy++
 		} else {
-			summary.HTTPRoutes.Degraded++
+			s.HTTPRoutes.Degraded++
 		}
 	}
 
-	// Non-HTTP routes: RBAC-filter then group by Kind
-	filteredRoutes := filterByRBAC(ctx, h, user, "httproutes", data.routes)
 	routesByKind := map[string]*KindSummary{
-		"GRPCRoute": &summary.GRPCRoutes,
-		"TCPRoute":  &summary.TCPRoutes,
-		"TLSRoute":  &summary.TLSRoutes,
-		"UDPRoute":  &summary.UDPRoutes,
+		"GRPCRoute": &s.GRPCRoutes,
+		"TCPRoute":  &s.TCPRoutes,
+		"TLSRoute":  &s.TLSRoutes,
+		"UDPRoute":  &s.UDPRoutes,
 	}
-	for _, rt := range filteredRoutes {
+	for _, rt := range routes {
 		ks, ok := routesByKind[rt.Kind]
 		if !ok {
 			continue
@@ -354,7 +367,7 @@ func (h *Handler) HandleSummary(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	httputil.WriteData(w, summary)
+	return s
 }
 
 // hasCondition checks if the conditions slice contains a condition with the given type and status.

--- a/backend/internal/gateway/handler.go
+++ b/backend/internal/gateway/handler.go
@@ -1,0 +1,782 @@
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/singleflight"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/kubecenter/kubecenter/internal/auth"
+	"github.com/kubecenter/kubecenter/internal/httputil"
+	"github.com/kubecenter/kubecenter/internal/k8s"
+	"github.com/kubecenter/kubecenter/internal/k8s/resources"
+)
+
+// routeKindToKind maps query-param route kind values to Gateway API Kind names.
+var routeKindToKind = map[string]string{
+	"grpcroutes": "GRPCRoute",
+	"tcproutes":  "TCPRoute",
+	"tlsroutes":  "TLSRoute",
+	"udproutes":  "UDPRoute",
+}
+
+// ============================================================================
+// Handler
+// ============================================================================
+
+// Handler serves Gateway API HTTP endpoints.
+type Handler struct {
+	K8sClient     *k8s.ClientFactory
+	Discoverer    *Discoverer
+	AccessChecker *resources.AccessChecker
+	Logger        *slog.Logger
+
+	fetchGroup singleflight.Group
+	cacheMu    sync.RWMutex
+	cache      *cachedData
+	cacheGen   uint64
+}
+
+type cachedData struct {
+	gatewayClasses []GatewayClassSummary
+	gateways       []GatewaySummary
+	httpRoutes     []HTTPRouteSummary
+	routes         []RouteSummary // ALL non-HTTP routes (GRPC, TCP, TLS, UDP), differentiated by Kind
+	fetchedAt      time.Time
+}
+
+// NewHandler creates a new Gateway API handler.
+func NewHandler(
+	k8sClient *k8s.ClientFactory,
+	discoverer *Discoverer,
+	accessChecker *resources.AccessChecker,
+	logger *slog.Logger,
+) *Handler {
+	return &Handler{
+		K8sClient:     k8sClient,
+		Discoverer:    discoverer,
+		AccessChecker: accessChecker,
+		Logger:        logger,
+	}
+}
+
+// InvalidateCache clears the cached data.
+func (h *Handler) InvalidateCache() {
+	h.cacheMu.Lock()
+	h.cacheGen++
+	h.cache = nil
+	h.cacheMu.Unlock()
+}
+
+// ============================================================================
+// Helper methods
+// ============================================================================
+
+// getImpersonatingClient creates a dynamic client impersonating the user and handles errors.
+func (h *Handler) getImpersonatingClient(w http.ResponseWriter, user *auth.User) (dynamic.Interface, bool) {
+	client, err := h.K8sClient.DynamicClientForUser(user.KubernetesUsername, user.KubernetesGroups)
+	if err != nil {
+		h.Logger.Error("failed to create impersonating client", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "internal error", "")
+		return nil, false
+	}
+	return client, true
+}
+
+// canAccess checks if the user can access a Gateway API resource.
+func (h *Handler) canAccess(ctx context.Context, user *auth.User, verb, resource, namespace string) bool {
+	can, err := h.AccessChecker.CanAccessGroupResource(
+		ctx,
+		user.KubernetesUsername,
+		user.KubernetesGroups,
+		verb,
+		APIGroup,
+		resource,
+		namespace,
+	)
+	return err == nil && can
+}
+
+// ============================================================================
+// RBAC filter helpers
+// ============================================================================
+
+// filterByRBAC returns only items the user can access in their respective namespaces.
+func filterByRBAC[T namespacedResource](ctx context.Context, h *Handler, user *auth.User, resource string, items []T) []T {
+	nsAllow := map[string]bool{}
+	out := make([]T, 0, len(items))
+	for _, item := range items {
+		ns := item.getNamespace()
+		allowed, ok := nsAllow[ns]
+		if !ok {
+			allowed = h.canAccess(ctx, user, "get", resource, ns)
+			nsAllow[ns] = allowed
+		}
+		if allowed {
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
+// ============================================================================
+// Cache (singleflight + 30s TTL)
+// ============================================================================
+
+func (h *Handler) getCached(ctx context.Context) (*cachedData, error) {
+	h.cacheMu.RLock()
+	if h.cache != nil && time.Since(h.cache.fetchedAt) < cacheTTL {
+		data := h.cache
+		h.cacheMu.RUnlock()
+		return data, nil
+	}
+	gen := h.cacheGen
+	h.cacheMu.RUnlock()
+
+	result, err, _ := h.fetchGroup.Do("all", func() (any, error) {
+		return h.fetchAll(ctx, gen)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*cachedData), nil
+}
+
+func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	dynClient := h.K8sClient.BaseDynamicClient()
+
+	var (
+		gatewayClasses []GatewayClassSummary
+		gateways       []GatewaySummary
+		httpRoutes     []HTTPRouteSummary
+	)
+
+	g, gctx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		list, err := dynClient.Resource(GatewayClassGVR).List(gctx, metav1.ListOptions{})
+		if err != nil {
+			return fmt.Errorf("list gatewayclasses: %w", err)
+		}
+		gatewayClasses = make([]GatewayClassSummary, 0, len(list.Items))
+		for i := range list.Items {
+			gatewayClasses = append(gatewayClasses, normalizeGatewayClass(&list.Items[i]))
+		}
+		return nil
+	})
+
+	g.Go(func() error {
+		list, err := dynClient.Resource(GatewayGVR).Namespace("").List(gctx, metav1.ListOptions{})
+		if err != nil {
+			return fmt.Errorf("list gateways: %w", err)
+		}
+		gateways = make([]GatewaySummary, 0, len(list.Items))
+		for i := range list.Items {
+			gateways = append(gateways, normalizeGateway(&list.Items[i]))
+		}
+		return nil
+	})
+
+	g.Go(func() error {
+		list, err := dynClient.Resource(HTTPRouteGVR).Namespace("").List(gctx, metav1.ListOptions{})
+		if err != nil {
+			return fmt.Errorf("list httproutes: %w", err)
+		}
+		httpRoutes = make([]HTTPRouteSummary, 0, len(list.Items))
+		for i := range list.Items {
+			httpRoutes = append(httpRoutes, normalizeHTTPRoute(&list.Items[i]))
+		}
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	// Fetch non-HTTP routes based on which kinds are installed.
+	status := h.Discoverer.Status(ctx)
+	installedSet := make(map[string]bool, len(status.InstalledKinds))
+	for _, k := range status.InstalledKinds {
+		installedSet[k] = true
+	}
+
+	type routeFetchSpec struct {
+		kind     string
+		gvr      func() interface{ /* dummy */ }
+		kindName string
+	}
+
+	var routes []RouteSummary
+	var routesMu sync.Mutex
+
+	g2, gctx2 := errgroup.WithContext(ctx)
+
+	for rk, gvr := range routeKindGVR {
+		kindName := routeKindToKind[string(rk)]
+		if !installedSet[kindName] {
+			continue
+		}
+		capturedGVR := gvr
+		capturedKind := kindName
+		g2.Go(func() error {
+			list, err := dynClient.Resource(capturedGVR).Namespace("").List(gctx2, metav1.ListOptions{})
+			if err != nil {
+				h.Logger.Debug("failed to list routes", "kind", capturedKind, "error", err)
+				return nil // skip unavailable kinds gracefully
+			}
+			items := make([]RouteSummary, 0, len(list.Items))
+			for i := range list.Items {
+				items = append(items, normalizeRoute(&list.Items[i], capturedKind))
+			}
+			routesMu.Lock()
+			routes = append(routes, items...)
+			routesMu.Unlock()
+			return nil
+		})
+	}
+
+	_ = g2.Wait()
+
+	data := &cachedData{
+		gatewayClasses: gatewayClasses,
+		gateways:       gateways,
+		httpRoutes:     httpRoutes,
+		routes:         routes,
+		fetchedAt:      time.Now(),
+	}
+
+	h.cacheMu.Lock()
+	if h.cacheGen == gen {
+		h.cache = data
+	}
+	h.cacheMu.Unlock()
+
+	return data, nil
+}
+
+// ============================================================================
+// Read handlers
+// ============================================================================
+
+// HandleStatus returns the Gateway API detection status.
+func (h *Handler) HandleStatus(w http.ResponseWriter, r *http.Request) {
+	_, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	status := h.Discoverer.Status(r.Context())
+	httputil.WriteData(w, status)
+}
+
+// HandleSummary returns aggregated counts and health per Gateway API kind.
+func (h *Handler) HandleSummary(w http.ResponseWriter, r *http.Request) {
+	_, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	if !h.Discoverer.IsAvailable(r.Context()) {
+		httputil.WriteData(w, GatewayAPISummary{})
+		return
+	}
+
+	data, err := h.getCached(r.Context())
+	if err != nil {
+		h.Logger.Error("failed to fetch gateway data", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to fetch gateway data", "")
+		return
+	}
+
+	summary := GatewayAPISummary{}
+
+	// GatewayClasses: healthy = has Accepted=True condition
+	summary.GatewayClasses.Total = len(data.gatewayClasses)
+	for _, gc := range data.gatewayClasses {
+		if hasCondition(gc.Conditions, "Accepted", "True") {
+			summary.GatewayClasses.Healthy++
+		} else {
+			summary.GatewayClasses.Degraded++
+		}
+	}
+
+	// Gateways: healthy = has Programmed=True condition
+	summary.Gateways.Total = len(data.gateways)
+	for _, gw := range data.gateways {
+		if hasCondition(gw.Conditions, "Programmed", "True") {
+			summary.Gateways.Healthy++
+		} else {
+			summary.Gateways.Degraded++
+		}
+	}
+
+	// HTTPRoutes: healthy = has Accepted=True condition
+	summary.HTTPRoutes.Total = len(data.httpRoutes)
+	for _, hr := range data.httpRoutes {
+		if hasCondition(hr.Conditions, "Accepted", "True") {
+			summary.HTTPRoutes.Healthy++
+		} else {
+			summary.HTTPRoutes.Degraded++
+		}
+	}
+
+	// Non-HTTP routes: group by Kind
+	routesByKind := map[string]*KindSummary{
+		"GRPCRoute": &summary.GRPCRoutes,
+		"TCPRoute":  &summary.TCPRoutes,
+		"TLSRoute":  &summary.TLSRoutes,
+		"UDPRoute":  &summary.UDPRoutes,
+	}
+	for _, rt := range data.routes {
+		ks, ok := routesByKind[rt.Kind]
+		if !ok {
+			continue
+		}
+		ks.Total++
+		if hasCondition(rt.Conditions, "Accepted", "True") {
+			ks.Healthy++
+		} else {
+			ks.Degraded++
+		}
+	}
+
+	httputil.WriteData(w, summary)
+}
+
+// hasCondition checks if the conditions slice contains a condition with the given type and status.
+func hasCondition(conds []Condition, condType, condStatus string) bool {
+	for _, c := range conds {
+		if c.Type == condType && c.Status == condStatus {
+			return true
+		}
+	}
+	return false
+}
+
+// HandleListGatewayClasses returns all GatewayClass resources.
+func (h *Handler) HandleListGatewayClasses(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	if !h.Discoverer.IsAvailable(r.Context()) {
+		httputil.WriteData(w, []GatewayClassSummary{})
+		return
+	}
+
+	// Cluster-scoped RBAC check
+	if !h.canAccess(r.Context(), user, "list", "gatewayclasses", "") {
+		httputil.WriteData(w, []GatewayClassSummary{})
+		return
+	}
+
+	data, err := h.getCached(r.Context())
+	if err != nil {
+		h.Logger.Error("failed to fetch gateway classes", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to fetch gateway classes", "")
+		return
+	}
+
+	httputil.WriteData(w, data.gatewayClasses)
+}
+
+// HandleGetGatewayClass returns a single GatewayClass by name.
+func (h *Handler) HandleGetGatewayClass(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	name := chi.URLParam(r, "name")
+
+	if !h.canAccess(r.Context(), user, "get", "gatewayclasses", "") {
+		httputil.WriteError(w, http.StatusForbidden, "access denied", "")
+		return
+	}
+
+	dynClient, ok := h.getImpersonatingClient(w, user)
+	if !ok {
+		return
+	}
+
+	obj, err := dynClient.Resource(GatewayClassGVR).Get(r.Context(), name, metav1.GetOptions{})
+	if err != nil {
+		h.Logger.Error("failed to get gatewayclass", "name", name, "error", err)
+		httputil.WriteError(w, http.StatusNotFound, "gateway class not found", "")
+		return
+	}
+
+	httputil.WriteData(w, normalizeGatewayClass(obj))
+}
+
+// HandleListGateways returns all Gateway resources filtered by RBAC.
+func (h *Handler) HandleListGateways(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	if !h.Discoverer.IsAvailable(r.Context()) {
+		httputil.WriteData(w, []GatewaySummary{})
+		return
+	}
+
+	data, err := h.getCached(r.Context())
+	if err != nil {
+		h.Logger.Error("failed to fetch gateways", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to fetch gateways", "")
+		return
+	}
+
+	filtered := filterByRBAC(r.Context(), h, user, "gateways", data.gateways)
+	httputil.WriteData(w, filtered)
+}
+
+// HandleGetGateway returns a single Gateway with its attached routes.
+func (h *Handler) HandleGetGateway(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	ns := chi.URLParam(r, "namespace")
+	name := chi.URLParam(r, "name")
+
+	if !h.canAccess(r.Context(), user, "get", "gateways", ns) {
+		httputil.WriteError(w, http.StatusForbidden, "access denied", "")
+		return
+	}
+
+	dynClient, ok := h.getImpersonatingClient(w, user)
+	if !ok {
+		return
+	}
+
+	obj, err := dynClient.Resource(GatewayGVR).Namespace(ns).Get(r.Context(), name, metav1.GetOptions{})
+	if err != nil {
+		h.Logger.Error("failed to get gateway", "namespace", ns, "name", name, "error", err)
+		httputil.WriteError(w, http.StatusNotFound, "gateway not found", "")
+		return
+	}
+
+	detail := normalizeGatewayDetail(obj)
+
+	// Resolve attached routes from cache.
+	cached, err := h.getCached(r.Context())
+	if err == nil {
+		var attached []RouteSummary
+
+		// Check HTTPRoutes
+		for _, hr := range cached.httpRoutes {
+			if matchesParentRef(hr.ParentRefs, name, ns) {
+				attached = append(attached, RouteSummary{
+					Kind:       "HTTPRoute",
+					Name:       hr.Name,
+					Namespace:  hr.Namespace,
+					Hostnames:  hr.Hostnames,
+					ParentRefs: hr.ParentRefs,
+					Conditions: hr.Conditions,
+					Age:        hr.Age,
+				})
+			}
+		}
+
+		// Check non-HTTP routes
+		for _, rt := range cached.routes {
+			if matchesParentRef(rt.ParentRefs, name, ns) {
+				attached = append(attached, rt)
+			}
+		}
+
+		detail.AttachedRoutes = attached
+	}
+
+	if detail.AttachedRoutes == nil {
+		detail.AttachedRoutes = []RouteSummary{}
+	}
+
+	httputil.WriteData(w, detail)
+}
+
+// matchesParentRef checks if any parentRef in the list references the given gateway name and namespace.
+func matchesParentRef(refs []ParentRef, gwName, gwNamespace string) bool {
+	for _, ref := range refs {
+		if ref.Name == gwName && ref.Namespace == gwNamespace {
+			return true
+		}
+	}
+	return false
+}
+
+// HandleListHTTPRoutes returns all HTTPRoute resources filtered by RBAC.
+func (h *Handler) HandleListHTTPRoutes(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	if !h.Discoverer.IsAvailable(r.Context()) {
+		httputil.WriteData(w, []HTTPRouteSummary{})
+		return
+	}
+
+	data, err := h.getCached(r.Context())
+	if err != nil {
+		h.Logger.Error("failed to fetch http routes", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to fetch http routes", "")
+		return
+	}
+
+	filtered := filterByRBAC(r.Context(), h, user, "httproutes", data.httpRoutes)
+	httputil.WriteData(w, filtered)
+}
+
+// HandleGetHTTPRoute returns a single HTTPRoute with resolved parent gateways and backend services.
+func (h *Handler) HandleGetHTTPRoute(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	ns := chi.URLParam(r, "namespace")
+	name := chi.URLParam(r, "name")
+
+	if !h.canAccess(r.Context(), user, "get", "httproutes", ns) {
+		httputil.WriteError(w, http.StatusForbidden, "access denied", "")
+		return
+	}
+
+	dynClient, ok := h.getImpersonatingClient(w, user)
+	if !ok {
+		return
+	}
+
+	obj, err := dynClient.Resource(HTTPRouteGVR).Namespace(ns).Get(r.Context(), name, metav1.GetOptions{})
+	if err != nil {
+		h.Logger.Error("failed to get httproute", "namespace", ns, "name", name, "error", err)
+		httputil.WriteError(w, http.StatusNotFound, "http route not found", "")
+		return
+	}
+
+	detail := normalizeHTTPRouteDetail(obj)
+
+	h.resolveRouteRelationships(r.Context(), user, dynClient, detail.ParentRefs, detail.Rules)
+
+	httputil.WriteData(w, detail)
+}
+
+// HandleListRoutes returns non-HTTP routes filtered by kind and RBAC.
+func (h *Handler) HandleListRoutes(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	kind := r.URL.Query().Get("kind")
+	kindName, valid := routeKindToKind[strings.ToLower(kind)]
+	if !valid {
+		httputil.WriteError(w, http.StatusBadRequest, "missing or invalid kind parameter", "must be one of: grpcroutes, tcproutes, tlsroutes, udproutes")
+		return
+	}
+
+	if !h.Discoverer.IsAvailable(r.Context()) {
+		httputil.WriteData(w, []RouteSummary{})
+		return
+	}
+
+	data, err := h.getCached(r.Context())
+	if err != nil {
+		h.Logger.Error("failed to fetch routes", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to fetch routes", "")
+		return
+	}
+
+	// Filter by kind
+	kindFiltered := make([]RouteSummary, 0, len(data.routes))
+	for _, rt := range data.routes {
+		if rt.Kind == kindName {
+			kindFiltered = append(kindFiltered, rt)
+		}
+	}
+
+	filtered := filterByRBAC(r.Context(), h, user, strings.ToLower(kind), kindFiltered)
+	httputil.WriteData(w, filtered)
+}
+
+// HandleGetRoute returns a single non-HTTP route with resolved parent gateways and backend services.
+func (h *Handler) HandleGetRoute(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	kindParam := chi.URLParam(r, "kind")
+	ns := chi.URLParam(r, "namespace")
+	name := chi.URLParam(r, "name")
+
+	rk := routeKind(strings.ToLower(kindParam))
+	gvr, valid := routeKindGVR[rk]
+	if !valid {
+		httputil.WriteError(w, http.StatusBadRequest, "invalid route kind", "must be one of: grpcroutes, tcproutes, tlsroutes, udproutes")
+		return
+	}
+
+	if !h.canAccess(r.Context(), user, "get", string(rk), ns) {
+		httputil.WriteError(w, http.StatusForbidden, "access denied", "")
+		return
+	}
+
+	dynClient, ok := h.getImpersonatingClient(w, user)
+	if !ok {
+		return
+	}
+
+	obj, err := dynClient.Resource(gvr).Namespace(ns).Get(r.Context(), name, metav1.GetOptions{})
+	if err != nil {
+		h.Logger.Error("failed to get route", "kind", kindParam, "namespace", ns, "name", name, "error", err)
+		httputil.WriteError(w, http.StatusNotFound, "route not found", "")
+		return
+	}
+
+	if rk == RouteKindGRPC {
+		detail := normalizeGRPCRouteDetail(obj)
+		// Resolve parent gateways
+		h.resolveParentGateways(r.Context(), dynClient, detail.ParentRefs)
+		// Resolve backend services from rules
+		for ri := range detail.Rules {
+			h.resolveBackendServices(r.Context(), user, ns, detail.Rules[ri].BackendRefs)
+		}
+		httputil.WriteData(w, detail)
+		return
+	}
+
+	kindName := routeKindToKind[string(rk)]
+	detail := normalizeSimpleRouteDetail(obj, kindName)
+	// Resolve parent gateways and backend services
+	h.resolveParentGateways(r.Context(), dynClient, detail.ParentRefs)
+	h.resolveBackendServices(r.Context(), user, ns, detail.BackendRefs)
+	httputil.WriteData(w, detail)
+}
+
+// ============================================================================
+// Relationship resolution helpers
+// ============================================================================
+
+// resolveRouteRelationships resolves parent gateway conditions and backend service existence
+// for HTTPRoute detail views. Uses a WaitGroup with a 2s timeout.
+func (h *Handler) resolveRouteRelationships(ctx context.Context, user *auth.User, dynClient dynamic.Interface, parentRefs []ParentRef, rules []HTTPRouteRule) {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+
+	// Resolve parent gateways
+	for i := range parentRefs {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			ref := &parentRefs[idx]
+			gwObj, err := dynClient.Resource(GatewayGVR).Namespace(ref.Namespace).Get(ctx, ref.Name, metav1.GetOptions{})
+			if err != nil {
+				return
+			}
+			ref.GatewayConditions = extractConditions(gwObj.Object, "status", "conditions")
+		}(i)
+	}
+
+	// Resolve backend services
+	for ri := range rules {
+		for bi := range rules[ri].BackendRefs {
+			wg.Add(1)
+			go func(ruleIdx, backendIdx int) {
+				defer wg.Done()
+				ref := &rules[ruleIdx].BackendRefs[backendIdx]
+				if ref.Kind != "Service" && ref.Kind != "" {
+					return
+				}
+				svcNs := ref.Namespace
+				if svcNs == "" {
+					// Default to the route's namespace — use first parentRef namespace as fallback.
+					if len(parentRefs) > 0 {
+						svcNs = parentRefs[0].Namespace
+					}
+				}
+				cs, err := h.K8sClient.ClientForUser(user.KubernetesUsername, user.KubernetesGroups)
+				if err != nil {
+					return
+				}
+				_, err = cs.CoreV1().Services(svcNs).Get(ctx, ref.Name, metav1.GetOptions{})
+				if err == nil {
+					ref.Resolved = true
+				}
+			}(ri, bi)
+		}
+	}
+
+	wg.Wait()
+}
+
+// resolveParentGateways resolves gateway conditions for parent refs.
+func (h *Handler) resolveParentGateways(ctx context.Context, dynClient dynamic.Interface, parentRefs []ParentRef) {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	for i := range parentRefs {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			ref := &parentRefs[idx]
+			gwObj, err := dynClient.Resource(GatewayGVR).Namespace(ref.Namespace).Get(ctx, ref.Name, metav1.GetOptions{})
+			if err != nil {
+				return
+			}
+			ref.GatewayConditions = extractConditions(gwObj.Object, "status", "conditions")
+		}(i)
+	}
+	wg.Wait()
+}
+
+// resolveBackendServices checks existence of backend service refs.
+func (h *Handler) resolveBackendServices(ctx context.Context, user *auth.User, routeNs string, refs []BackendRef) {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	for i := range refs {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			ref := &refs[idx]
+			if ref.Kind != "Service" && ref.Kind != "" {
+				return
+			}
+			svcNs := ref.Namespace
+			if svcNs == "" {
+				svcNs = routeNs
+			}
+			cs, err := h.K8sClient.ClientForUser(user.KubernetesUsername, user.KubernetesGroups)
+			if err != nil {
+				return
+			}
+			_, err = cs.CoreV1().Services(svcNs).Get(ctx, ref.Name, metav1.GetOptions{})
+			if err == nil {
+				ref.Resolved = true
+			}
+		}(i)
+	}
+	wg.Wait()
+}

--- a/backend/internal/gateway/handler.go
+++ b/backend/internal/gateway/handler.go
@@ -212,22 +212,16 @@ func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error)
 		installedSet[k] = true
 	}
 
-	type routeFetchSpec struct {
-		kind     string
-		gvr      func() interface{ /* dummy */ }
-		kindName string
-	}
-
 	var routes []RouteSummary
 	var routesMu sync.Mutex
 
 	g2, gctx2 := errgroup.WithContext(ctx)
 
 	for rk, gvr := range routeKindGVR {
-		kindName := routeKindToKind[string(rk)]
-		if !installedSet[kindName] {
+		if !installedSet[string(rk)] {
 			continue
 		}
+		kindName := routeKindToKind[string(rk)]
 		capturedGVR := gvr
 		capturedKind := kindName
 		g2.Go(func() error {
@@ -283,7 +277,7 @@ func (h *Handler) HandleStatus(w http.ResponseWriter, r *http.Request) {
 
 // HandleSummary returns aggregated counts and health per Gateway API kind.
 func (h *Handler) HandleSummary(w http.ResponseWriter, r *http.Request) {
-	_, ok := httputil.RequireUser(w, r)
+	user, ok := httputil.RequireUser(w, r)
 	if !ok {
 		return
 	}
@@ -300,21 +294,27 @@ func (h *Handler) HandleSummary(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	ctx := r.Context()
 	summary := GatewayAPISummary{}
 
-	// GatewayClasses: healthy = has Accepted=True condition
-	summary.GatewayClasses.Total = len(data.gatewayClasses)
-	for _, gc := range data.gatewayClasses {
-		if hasCondition(gc.Conditions, "Accepted", "True") {
-			summary.GatewayClasses.Healthy++
-		} else {
-			summary.GatewayClasses.Degraded++
+	// RBAC-filter before counting so users only see counts for resources they can access.
+
+	// GatewayClasses: cluster-scoped RBAC check
+	if h.canAccess(ctx, user, "list", "gatewayclasses", "") {
+		summary.GatewayClasses.Total = len(data.gatewayClasses)
+		for _, gc := range data.gatewayClasses {
+			if hasCondition(gc.Conditions, "Accepted", "True") {
+				summary.GatewayClasses.Healthy++
+			} else {
+				summary.GatewayClasses.Degraded++
+			}
 		}
 	}
 
 	// Gateways: healthy = has Programmed=True condition
-	summary.Gateways.Total = len(data.gateways)
-	for _, gw := range data.gateways {
+	filteredGateways := filterByRBAC(ctx, h, user, "gateways", data.gateways)
+	summary.Gateways.Total = len(filteredGateways)
+	for _, gw := range filteredGateways {
 		if hasCondition(gw.Conditions, "Programmed", "True") {
 			summary.Gateways.Healthy++
 		} else {
@@ -323,8 +323,9 @@ func (h *Handler) HandleSummary(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// HTTPRoutes: healthy = has Accepted=True condition
-	summary.HTTPRoutes.Total = len(data.httpRoutes)
-	for _, hr := range data.httpRoutes {
+	filteredHTTPRoutes := filterByRBAC(ctx, h, user, "httproutes", data.httpRoutes)
+	summary.HTTPRoutes.Total = len(filteredHTTPRoutes)
+	for _, hr := range filteredHTTPRoutes {
 		if hasCondition(hr.Conditions, "Accepted", "True") {
 			summary.HTTPRoutes.Healthy++
 		} else {
@@ -332,14 +333,15 @@ func (h *Handler) HandleSummary(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Non-HTTP routes: group by Kind
+	// Non-HTTP routes: RBAC-filter then group by Kind
+	filteredRoutes := filterByRBAC(ctx, h, user, "httproutes", data.routes)
 	routesByKind := map[string]*KindSummary{
 		"GRPCRoute": &summary.GRPCRoutes,
 		"TCPRoute":  &summary.TCPRoutes,
 		"TLSRoute":  &summary.TLSRoutes,
 		"UDPRoute":  &summary.UDPRoutes,
 	}
-	for _, rt := range data.routes {
+	for _, rt := range filteredRoutes {
 		ks, ok := routesByKind[rt.Kind]
 		if !ok {
 			continue
@@ -501,7 +503,8 @@ func (h *Handler) HandleGetGateway(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		detail.AttachedRoutes = attached
+		// RBAC-filter attached routes so users only see routes in namespaces they can access.
+		detail.AttachedRoutes = filterByRBAC(r.Context(), h, user, "httproutes", attached)
 	}
 
 	if detail.AttachedRoutes == nil {
@@ -675,12 +678,19 @@ func (h *Handler) HandleGetRoute(w http.ResponseWriter, r *http.Request) {
 // Relationship resolution helpers
 // ============================================================================
 
+// maxResolveConcurrency caps goroutine fan-out for relationship resolution.
+const maxResolveConcurrency = 10
+
 // resolveRouteRelationships resolves parent gateway conditions and backend service existence
-// for HTTPRoute detail views. Uses a WaitGroup with a 2s timeout.
+// for HTTPRoute detail views. Uses a WaitGroup with a 2s timeout and bounded concurrency.
 func (h *Handler) resolveRouteRelationships(ctx context.Context, user *auth.User, dynClient dynamic.Interface, parentRefs []ParentRef, rules []HTTPRouteRule) {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 
+	// Hoist typed client creation outside goroutine loop.
+	cs, csErr := h.K8sClient.ClientForUser(user.KubernetesUsername, user.KubernetesGroups)
+
+	sem := make(chan struct{}, maxResolveConcurrency)
 	var wg sync.WaitGroup
 
 	// Resolve parent gateways
@@ -688,6 +698,8 @@ func (h *Handler) resolveRouteRelationships(ctx context.Context, user *auth.User
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
 			ref := &parentRefs[idx]
 			gwObj, err := dynClient.Resource(GatewayGVR).Namespace(ref.Namespace).Get(ctx, ref.Name, metav1.GetOptions{})
 			if err != nil {
@@ -698,31 +710,30 @@ func (h *Handler) resolveRouteRelationships(ctx context.Context, user *auth.User
 	}
 
 	// Resolve backend services
-	for ri := range rules {
-		for bi := range rules[ri].BackendRefs {
-			wg.Add(1)
-			go func(ruleIdx, backendIdx int) {
-				defer wg.Done()
-				ref := &rules[ruleIdx].BackendRefs[backendIdx]
-				if ref.Kind != "Service" && ref.Kind != "" {
-					return
-				}
-				svcNs := ref.Namespace
-				if svcNs == "" {
-					// Default to the route's namespace — use first parentRef namespace as fallback.
-					if len(parentRefs) > 0 {
-						svcNs = parentRefs[0].Namespace
+	if csErr == nil {
+		for ri := range rules {
+			for bi := range rules[ri].BackendRefs {
+				wg.Add(1)
+				go func(ruleIdx, backendIdx int) {
+					defer wg.Done()
+					sem <- struct{}{}
+					defer func() { <-sem }()
+					ref := &rules[ruleIdx].BackendRefs[backendIdx]
+					if ref.Kind != "Service" && ref.Kind != "" {
+						return
 					}
-				}
-				cs, err := h.K8sClient.ClientForUser(user.KubernetesUsername, user.KubernetesGroups)
-				if err != nil {
-					return
-				}
-				_, err = cs.CoreV1().Services(svcNs).Get(ctx, ref.Name, metav1.GetOptions{})
-				if err == nil {
-					ref.Resolved = true
-				}
-			}(ri, bi)
+					svcNs := ref.Namespace
+					if svcNs == "" {
+						if len(parentRefs) > 0 {
+							svcNs = parentRefs[0].Namespace
+						}
+					}
+					_, err := cs.CoreV1().Services(svcNs).Get(ctx, ref.Name, metav1.GetOptions{})
+					if err == nil {
+						ref.Resolved = true
+					}
+				}(ri, bi)
+			}
 		}
 	}
 
@@ -734,11 +745,14 @@ func (h *Handler) resolveParentGateways(ctx context.Context, dynClient dynamic.I
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 
+	sem := make(chan struct{}, maxResolveConcurrency)
 	var wg sync.WaitGroup
 	for i := range parentRefs {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
 			ref := &parentRefs[idx]
 			gwObj, err := dynClient.Resource(GatewayGVR).Namespace(ref.Namespace).Get(ctx, ref.Name, metav1.GetOptions{})
 			if err != nil {
@@ -755,11 +769,20 @@ func (h *Handler) resolveBackendServices(ctx context.Context, user *auth.User, r
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 
+	// Hoist typed client creation outside goroutine loop.
+	cs, err := h.K8sClient.ClientForUser(user.KubernetesUsername, user.KubernetesGroups)
+	if err != nil {
+		return
+	}
+
+	sem := make(chan struct{}, maxResolveConcurrency)
 	var wg sync.WaitGroup
 	for i := range refs {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
 			ref := &refs[idx]
 			if ref.Kind != "Service" && ref.Kind != "" {
 				return
@@ -768,12 +791,8 @@ func (h *Handler) resolveBackendServices(ctx context.Context, user *auth.User, r
 			if svcNs == "" {
 				svcNs = routeNs
 			}
-			cs, err := h.K8sClient.ClientForUser(user.KubernetesUsername, user.KubernetesGroups)
-			if err != nil {
-				return
-			}
-			_, err = cs.CoreV1().Services(svcNs).Get(ctx, ref.Name, metav1.GetOptions{})
-			if err == nil {
+			_, svcErr := cs.CoreV1().Services(svcNs).Get(ctx, ref.Name, metav1.GetOptions{})
+			if svcErr == nil {
 				ref.Resolved = true
 			}
 		}(i)

--- a/backend/internal/gateway/normalize.go
+++ b/backend/internal/gateway/normalize.go
@@ -184,80 +184,10 @@ func normalizeGatewayClass(u *unstructured.Unstructured) GatewayClassSummary {
 }
 
 // normalizeGateway converts an unstructured Gateway into a GatewaySummary.
-func normalizeGateway(u *unstructured.Unstructured) GatewaySummary {
-	obj := u.Object
-
-	className, _, _ := unstructured.NestedString(obj, "spec", "gatewayClassName")
-
-	// Parse spec.listeners[]
-	specListeners, _, _ := unstructured.NestedSlice(obj, "spec", "listeners")
-	listeners := make([]Listener, 0, len(specListeners))
-	for _, item := range specListeners {
-		lm, ok := item.(map[string]any)
-		if !ok {
-			continue
-		}
-		listeners = append(listeners, Listener{
-			Name:     stringFrom(lm, "name"),
-			Port:     intFrom(lm, "port"),
-			Protocol: stringFrom(lm, "protocol"),
-			Hostname: stringFrom(lm, "hostname"),
-		})
-	}
-
-	// Merge attachedRoutes count from status.listeners[]
-	statusListeners, _, _ := unstructured.NestedSlice(obj, "status", "listeners")
-	attachedTotal := 0
-	for _, item := range statusListeners {
-		slm, ok := item.(map[string]any)
-		if !ok {
-			continue
-		}
-		name := stringFrom(slm, "name")
-		count := intFrom(slm, "attachedRoutes")
-		attachedTotal += count
-		// Match to spec listener by name and set count.
-		for i := range listeners {
-			if listeners[i].Name == name {
-				listeners[i].AttachedRouteCount = count
-				break
-			}
-		}
-	}
-
-	// Addresses from status.addresses[]
-	var addresses []string
-	addrSlice, _, _ := unstructured.NestedSlice(obj, "status", "addresses")
-	for _, item := range addrSlice {
-		am, ok := item.(map[string]any)
-		if !ok {
-			continue
-		}
-		if v := stringFrom(am, "value"); v != "" {
-			addresses = append(addresses, v)
-		}
-	}
-
-	return GatewaySummary{
-		Name:               u.GetName(),
-		Namespace:          u.GetNamespace(),
-		GatewayClassName:   className,
-		Listeners:          listeners,
-		Addresses:          addresses,
-		AttachedRouteCount: attachedTotal,
-		Conditions:         extractConditions(obj, "status", "conditions"),
-		Age:                u.GetCreationTimestamp().Time,
-	}
-}
-
-// normalizeGatewayDetail converts an unstructured Gateway into a GatewayDetail
-// with richer listener data. AttachedRoutes starts empty (filled by handler from cache).
-func normalizeGatewayDetail(u *unstructured.Unstructured) GatewayDetail {
-	obj := u.Object
-
-	className, _, _ := unstructured.NestedString(obj, "spec", "gatewayClassName")
-
-	// Parse spec.listeners[] with full detail (TLS, allowedRoutes).
+// parseListeners extracts listeners from spec.listeners[], optionally including detail fields (TLS, allowedRoutes).
+// It also merges per-listener attachedRoutes counts (and conditions if detail=true) from status.listeners[].
+// Returns the listeners slice and total attached route count.
+func parseListeners(obj map[string]any, detail bool) ([]Listener, int) {
 	specListeners, _, _ := unstructured.NestedSlice(obj, "spec", "listeners")
 	listeners := make([]Listener, 0, len(specListeners))
 	for _, item := range specListeners {
@@ -271,32 +201,28 @@ func normalizeGatewayDetail(u *unstructured.Unstructured) GatewayDetail {
 			Protocol: stringFrom(lm, "protocol"),
 			Hostname: stringFrom(lm, "hostname"),
 		}
-
-		// TLS mode and certificate ref.
-		if tls, ok := lm["tls"].(map[string]any); ok {
-			l.TLSMode = stringFrom(tls, "mode")
-			if certRefs, ok := tls["certificateRefs"].([]any); ok && len(certRefs) > 0 {
-				if cr, ok := certRefs[0].(map[string]any); ok {
-					ns := stringFrom(cr, "namespace")
-					name := stringFrom(cr, "name")
-					if ns != "" {
-						l.CertificateRef = ns + "/" + name
-					} else {
-						l.CertificateRef = name
+		if detail {
+			if tls, ok := lm["tls"].(map[string]any); ok {
+				l.TLSMode = stringFrom(tls, "mode")
+				if certRefs, ok := tls["certificateRefs"].([]any); ok && len(certRefs) > 0 {
+					if cr, ok := certRefs[0].(map[string]any); ok {
+						ns := stringFrom(cr, "namespace")
+						name := stringFrom(cr, "name")
+						if ns != "" {
+							l.CertificateRef = ns + "/" + name
+						} else {
+							l.CertificateRef = name
+						}
 					}
 				}
 			}
+			if ar, ok := lm["allowedRoutes"].(map[string]any); ok {
+				l.AllowedRoutes = stringifyAllowedRoutes(ar)
+			}
 		}
-
-		// AllowedRoutes: stringify kind constraints.
-		if ar, ok := lm["allowedRoutes"].(map[string]any); ok {
-			l.AllowedRoutes = stringifyAllowedRoutes(ar)
-		}
-
 		listeners = append(listeners, l)
 	}
 
-	// Merge per-listener conditions and attachedRoutes from status.listeners[].
 	statusListeners, _, _ := unstructured.NestedSlice(obj, "status", "listeners")
 	attachedTotal := 0
 	for _, item := range statusListeners {
@@ -307,19 +233,24 @@ func normalizeGatewayDetail(u *unstructured.Unstructured) GatewayDetail {
 		name := stringFrom(slm, "name")
 		count := intFrom(slm, "attachedRoutes")
 		attachedTotal += count
-		conds := extractConditions(slm, "conditions")
 		for i := range listeners {
 			if listeners[i].Name == name {
 				listeners[i].AttachedRouteCount = count
-				listeners[i].Conditions = conds
+				if detail {
+					listeners[i].Conditions = extractConditions(slm, "conditions")
+				}
 				break
 			}
 		}
 	}
 
-	// Addresses from status.addresses[].
-	var addresses []string
+	return listeners, attachedTotal
+}
+
+// parseAddresses extracts address values from status.addresses[].
+func parseAddresses(obj map[string]any) []string {
 	addrSlice, _, _ := unstructured.NestedSlice(obj, "status", "addresses")
+	var addresses []string
 	for _, item := range addrSlice {
 		am, ok := item.(map[string]any)
 		if !ok {
@@ -329,6 +260,32 @@ func normalizeGatewayDetail(u *unstructured.Unstructured) GatewayDetail {
 			addresses = append(addresses, v)
 		}
 	}
+	return addresses
+}
+
+func normalizeGateway(u *unstructured.Unstructured) GatewaySummary {
+	obj := u.Object
+	className, _, _ := unstructured.NestedString(obj, "spec", "gatewayClassName")
+	listeners, attachedTotal := parseListeners(obj, false)
+
+	return GatewaySummary{
+		Name:               u.GetName(),
+		Namespace:          u.GetNamespace(),
+		GatewayClassName:   className,
+		Listeners:          listeners,
+		Addresses:          parseAddresses(obj),
+		AttachedRouteCount: attachedTotal,
+		Conditions:         extractConditions(obj, "status", "conditions"),
+		Age:                u.GetCreationTimestamp().Time,
+	}
+}
+
+// normalizeGatewayDetail converts an unstructured Gateway into a GatewayDetail
+// with richer listener data. AttachedRoutes starts empty (filled by handler from cache).
+func normalizeGatewayDetail(u *unstructured.Unstructured) GatewayDetail {
+	obj := u.Object
+	className, _, _ := unstructured.NestedString(obj, "spec", "gatewayClassName")
+	listeners, attachedTotal := parseListeners(obj, true)
 
 	return GatewayDetail{
 		GatewaySummary: GatewaySummary{
@@ -336,7 +293,7 @@ func normalizeGatewayDetail(u *unstructured.Unstructured) GatewayDetail {
 			Namespace:          u.GetNamespace(),
 			GatewayClassName:   className,
 			Listeners:          listeners,
-			Addresses:          addresses,
+			Addresses:          parseAddresses(obj),
 			AttachedRouteCount: attachedTotal,
 			Conditions:         extractConditions(obj, "status", "conditions"),
 			Age:                u.GetCreationTimestamp().Time,

--- a/backend/internal/gateway/normalize.go
+++ b/backend/internal/gateway/normalize.go
@@ -1,0 +1,695 @@
+package gateway
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// stringFrom safely extracts a string value from a map by key.
+// Returns "" if the map is nil or the key is absent / not a string.
+func stringFrom(m map[string]any, key string) string {
+	if m == nil {
+		return ""
+	}
+	s, _ := m[key].(string)
+	return s
+}
+
+// intFrom safely extracts an int from a map by key.
+// Handles both int and float64 (JSON unmarshalling produces float64).
+// Returns 0 if the map is nil or the key is absent / not numeric.
+func intFrom(m map[string]any, key string) int {
+	if m == nil {
+		return 0
+	}
+	switch v := m[key].(type) {
+	case int:
+		return v
+	case int64:
+		return int(v)
+	case float64:
+		return int(v)
+	}
+	return 0
+}
+
+// parseTimeField parses an RFC3339 timestamp from a nested map path.
+// Returns nil on any error or missing value.
+func parseTimeField(obj map[string]any, fields ...string) *time.Time {
+	s, found, err := unstructured.NestedString(obj, fields...)
+	if err != nil || !found || s == "" {
+		return nil
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return nil
+	}
+	return &t
+}
+
+// extractConditions reads status conditions from a nested path.
+// Used for both top-level status.conditions and per-listener/per-parent conditions.
+func extractConditions(obj map[string]any, path ...string) []Condition {
+	val, found, err := unstructured.NestedSlice(obj, path...)
+	if err != nil || !found {
+		return nil
+	}
+	var out []Condition
+	for _, item := range val {
+		cm, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		c := Condition{
+			Type:    stringFrom(cm, "type"),
+			Status:  stringFrom(cm, "status"),
+			Reason:  stringFrom(cm, "reason"),
+			Message: stringFrom(cm, "message"),
+		}
+		c.LastTransitionTime = parseTimeField(cm, "lastTransitionTime")
+		out = append(out, c)
+	}
+	return out
+}
+
+// extractParentRefs reads spec.parentRefs from an unstructured object.
+// Handles defaults: Group defaults to "gateway.networking.k8s.io", Kind defaults to "Gateway".
+func extractParentRefs(u *unstructured.Unstructured) []ParentRef {
+	refs, found, err := unstructured.NestedSlice(u.Object, "spec", "parentRefs")
+	if err != nil || !found {
+		return nil
+	}
+	var out []ParentRef
+	for _, item := range refs {
+		rm, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		group := stringFrom(rm, "group")
+		if group == "" {
+			group = APIGroup
+		}
+		kind := stringFrom(rm, "kind")
+		if kind == "" {
+			kind = "Gateway"
+		}
+		out = append(out, ParentRef{
+			Group:       group,
+			Kind:        kind,
+			Name:        stringFrom(rm, "name"),
+			Namespace:   stringFrom(rm, "namespace"),
+			SectionName: stringFrom(rm, "sectionName"),
+		})
+	}
+	return out
+}
+
+// extractBackendRefs reads backendRefs from a slice of unstructured items.
+// Handles defaults: Group defaults to "" (core), Kind defaults to "Service".
+func extractBackendRefs(items []any) []BackendRef {
+	var out []BackendRef
+	for _, item := range items {
+		rm, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		kind := stringFrom(rm, "kind")
+		if kind == "" {
+			kind = "Service"
+		}
+		ref := BackendRef{
+			Group:     stringFrom(rm, "group"),
+			Kind:      kind,
+			Name:      stringFrom(rm, "name"),
+			Namespace: stringFrom(rm, "namespace"),
+		}
+		if p := intFrom(rm, "port"); p != 0 {
+			port := p
+			ref.Port = &port
+		}
+		if _, ok := rm["weight"]; ok {
+			wt := intFrom(rm, "weight")
+			ref.Weight = &wt
+		}
+		out = append(out, ref)
+	}
+	return out
+}
+
+// aggregateRouteConditions collects conditions from status.parents[] and deduplicates
+// by type, keeping the first occurrence with a non-empty status.
+func aggregateRouteConditions(obj map[string]any) []Condition {
+	parents, found, err := unstructured.NestedSlice(obj, "status", "parents")
+	if err != nil || !found {
+		return nil
+	}
+	seen := map[string]bool{}
+	var out []Condition
+	for _, p := range parents {
+		pm, ok := p.(map[string]any)
+		if !ok {
+			continue
+		}
+		conds := extractConditions(pm, "conditions")
+		for _, c := range conds {
+			if seen[c.Type] {
+				continue
+			}
+			if c.Status != "" {
+				seen[c.Type] = true
+			}
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// normalizeGatewayClass converts an unstructured GatewayClass into a GatewayClassSummary.
+func normalizeGatewayClass(u *unstructured.Unstructured) GatewayClassSummary {
+	obj := u.Object
+
+	controllerName, _, _ := unstructured.NestedString(obj, "spec", "controllerName")
+	description, _, _ := unstructured.NestedString(obj, "spec", "description")
+
+	return GatewayClassSummary{
+		Name:           u.GetName(),
+		ControllerName: controllerName,
+		Description:    description,
+		Conditions:     extractConditions(obj, "status", "conditions"),
+		Age:            u.GetCreationTimestamp().Time,
+	}
+}
+
+// normalizeGateway converts an unstructured Gateway into a GatewaySummary.
+func normalizeGateway(u *unstructured.Unstructured) GatewaySummary {
+	obj := u.Object
+
+	className, _, _ := unstructured.NestedString(obj, "spec", "gatewayClassName")
+
+	// Parse spec.listeners[]
+	specListeners, _, _ := unstructured.NestedSlice(obj, "spec", "listeners")
+	listeners := make([]Listener, 0, len(specListeners))
+	for _, item := range specListeners {
+		lm, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		listeners = append(listeners, Listener{
+			Name:     stringFrom(lm, "name"),
+			Port:     intFrom(lm, "port"),
+			Protocol: stringFrom(lm, "protocol"),
+			Hostname: stringFrom(lm, "hostname"),
+		})
+	}
+
+	// Merge attachedRoutes count from status.listeners[]
+	statusListeners, _, _ := unstructured.NestedSlice(obj, "status", "listeners")
+	attachedTotal := 0
+	for _, item := range statusListeners {
+		slm, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		name := stringFrom(slm, "name")
+		count := intFrom(slm, "attachedRoutes")
+		attachedTotal += count
+		// Match to spec listener by name and set count.
+		for i := range listeners {
+			if listeners[i].Name == name {
+				listeners[i].AttachedRouteCount = count
+				break
+			}
+		}
+	}
+
+	// Addresses from status.addresses[]
+	var addresses []string
+	addrSlice, _, _ := unstructured.NestedSlice(obj, "status", "addresses")
+	for _, item := range addrSlice {
+		am, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if v := stringFrom(am, "value"); v != "" {
+			addresses = append(addresses, v)
+		}
+	}
+
+	return GatewaySummary{
+		Name:               u.GetName(),
+		Namespace:          u.GetNamespace(),
+		GatewayClassName:   className,
+		Listeners:          listeners,
+		Addresses:          addresses,
+		AttachedRouteCount: attachedTotal,
+		Conditions:         extractConditions(obj, "status", "conditions"),
+		Age:                u.GetCreationTimestamp().Time,
+	}
+}
+
+// normalizeGatewayDetail converts an unstructured Gateway into a GatewayDetail
+// with richer listener data. AttachedRoutes starts empty (filled by handler from cache).
+func normalizeGatewayDetail(u *unstructured.Unstructured) GatewayDetail {
+	obj := u.Object
+
+	className, _, _ := unstructured.NestedString(obj, "spec", "gatewayClassName")
+
+	// Parse spec.listeners[] with full detail (TLS, allowedRoutes).
+	specListeners, _, _ := unstructured.NestedSlice(obj, "spec", "listeners")
+	listeners := make([]Listener, 0, len(specListeners))
+	for _, item := range specListeners {
+		lm, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		l := Listener{
+			Name:     stringFrom(lm, "name"),
+			Port:     intFrom(lm, "port"),
+			Protocol: stringFrom(lm, "protocol"),
+			Hostname: stringFrom(lm, "hostname"),
+		}
+
+		// TLS mode and certificate ref.
+		if tls, ok := lm["tls"].(map[string]any); ok {
+			l.TLSMode = stringFrom(tls, "mode")
+			if certRefs, ok := tls["certificateRefs"].([]any); ok && len(certRefs) > 0 {
+				if cr, ok := certRefs[0].(map[string]any); ok {
+					ns := stringFrom(cr, "namespace")
+					name := stringFrom(cr, "name")
+					if ns != "" {
+						l.CertificateRef = ns + "/" + name
+					} else {
+						l.CertificateRef = name
+					}
+				}
+			}
+		}
+
+		// AllowedRoutes: stringify kind constraints.
+		if ar, ok := lm["allowedRoutes"].(map[string]any); ok {
+			l.AllowedRoutes = stringifyAllowedRoutes(ar)
+		}
+
+		listeners = append(listeners, l)
+	}
+
+	// Merge per-listener conditions and attachedRoutes from status.listeners[].
+	statusListeners, _, _ := unstructured.NestedSlice(obj, "status", "listeners")
+	attachedTotal := 0
+	for _, item := range statusListeners {
+		slm, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		name := stringFrom(slm, "name")
+		count := intFrom(slm, "attachedRoutes")
+		attachedTotal += count
+		conds := extractConditions(slm, "conditions")
+		for i := range listeners {
+			if listeners[i].Name == name {
+				listeners[i].AttachedRouteCount = count
+				listeners[i].Conditions = conds
+				break
+			}
+		}
+	}
+
+	// Addresses from status.addresses[].
+	var addresses []string
+	addrSlice, _, _ := unstructured.NestedSlice(obj, "status", "addresses")
+	for _, item := range addrSlice {
+		am, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if v := stringFrom(am, "value"); v != "" {
+			addresses = append(addresses, v)
+		}
+	}
+
+	return GatewayDetail{
+		GatewaySummary: GatewaySummary{
+			Name:               u.GetName(),
+			Namespace:          u.GetNamespace(),
+			GatewayClassName:   className,
+			Listeners:          listeners,
+			Addresses:          addresses,
+			AttachedRouteCount: attachedTotal,
+			Conditions:         extractConditions(obj, "status", "conditions"),
+			Age:                u.GetCreationTimestamp().Time,
+		},
+		// AttachedRoutes left empty — filled by handler from cache.
+	}
+}
+
+// stringifyAllowedRoutes converts an allowedRoutes map into a human-readable string.
+func stringifyAllowedRoutes(ar map[string]any) string {
+	var parts []string
+
+	if kinds, ok := ar["kinds"].([]any); ok {
+		for _, k := range kinds {
+			km, ok := k.(map[string]any)
+			if !ok {
+				continue
+			}
+			kind := stringFrom(km, "kind")
+			group := stringFrom(km, "group")
+			if group != "" && group != APIGroup {
+				kind = group + "/" + kind
+			}
+			if kind != "" {
+				parts = append(parts, kind)
+			}
+		}
+	}
+
+	if ns, ok := ar["namespaces"].(map[string]any); ok {
+		from := stringFrom(ns, "from")
+		if from != "" {
+			parts = append(parts, "from:"+from)
+		}
+	}
+
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, ", ")
+}
+
+// normalizeHTTPRoute converts an unstructured HTTPRoute into an HTTPRouteSummary.
+func normalizeHTTPRoute(u *unstructured.Unstructured) HTTPRouteSummary {
+	obj := u.Object
+
+	hostnames, _, _ := unstructured.NestedStringSlice(obj, "spec", "hostnames")
+
+	// Count total backend refs across all rules.
+	backendCount := 0
+	rules, _, _ := unstructured.NestedSlice(obj, "spec", "rules")
+	for _, r := range rules {
+		rm, ok := r.(map[string]any)
+		if !ok {
+			continue
+		}
+		if refs, ok := rm["backendRefs"].([]any); ok {
+			backendCount += len(refs)
+		}
+	}
+
+	return HTTPRouteSummary{
+		Name:         u.GetName(),
+		Namespace:    u.GetNamespace(),
+		Hostnames:    hostnames,
+		ParentRefs:   extractParentRefs(u),
+		BackendCount: backendCount,
+		Conditions:   aggregateRouteConditions(obj),
+		Age:          u.GetCreationTimestamp().Time,
+	}
+}
+
+// normalizeHTTPRouteDetail converts an unstructured HTTPRoute into an HTTPRouteDetail.
+func normalizeHTTPRouteDetail(u *unstructured.Unstructured) HTTPRouteDetail {
+	obj := u.Object
+
+	hostnames, _, _ := unstructured.NestedStringSlice(obj, "spec", "hostnames")
+
+	rawRules, _, _ := unstructured.NestedSlice(obj, "spec", "rules")
+	var httpRules []HTTPRouteRule
+	backendCount := 0
+
+	for _, r := range rawRules {
+		rm, ok := r.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		rule := HTTPRouteRule{}
+
+		// Matches.
+		if matches, ok := rm["matches"].([]any); ok {
+			for _, m := range matches {
+				mm, ok := m.(map[string]any)
+				if !ok {
+					continue
+				}
+				match := HTTPRouteMatch{}
+
+				if path, ok := mm["path"].(map[string]any); ok {
+					match.PathType = stringFrom(path, "type")
+					match.PathValue = stringFrom(path, "value")
+				}
+
+				if headers, ok := mm["headers"].([]any); ok {
+					for _, h := range headers {
+						hm, ok := h.(map[string]any)
+						if !ok {
+							continue
+						}
+						match.Headers = append(match.Headers, stringFrom(hm, "name")+"="+stringFrom(hm, "value"))
+					}
+				}
+
+				match.Method = stringFrom(mm, "method")
+
+				if qps, ok := mm["queryParams"].([]any); ok {
+					for _, qp := range qps {
+						qpm, ok := qp.(map[string]any)
+						if !ok {
+							continue
+						}
+						match.QueryParams = append(match.QueryParams, stringFrom(qpm, "name")+"="+stringFrom(qpm, "value"))
+					}
+				}
+
+				rule.Matches = append(rule.Matches, match)
+			}
+		}
+
+		// Filters.
+		if filters, ok := rm["filters"].([]any); ok {
+			for _, f := range filters {
+				fm, ok := f.(map[string]any)
+				if !ok {
+					continue
+				}
+				filter := HTTPRouteFilter{
+					Type:    stringFrom(fm, "type"),
+					Details: buildFilterDetails(fm),
+				}
+				rule.Filters = append(rule.Filters, filter)
+			}
+		}
+
+		// BackendRefs.
+		if refs, ok := rm["backendRefs"].([]any); ok {
+			rule.BackendRefs = extractBackendRefs(refs)
+			backendCount += len(refs)
+		}
+
+		httpRules = append(httpRules, rule)
+	}
+
+	return HTTPRouteDetail{
+		Name:         u.GetName(),
+		Namespace:    u.GetNamespace(),
+		Hostnames:    hostnames,
+		ParentRefs:   extractParentRefs(u),
+		BackendCount: backendCount,
+		Conditions:   aggregateRouteConditions(obj),
+		Age:          u.GetCreationTimestamp().Time,
+		Rules:        httpRules,
+	}
+}
+
+// buildFilterDetails builds a human-readable details string from an HTTPRoute filter config.
+func buildFilterDetails(fm map[string]any) string {
+	filterType := stringFrom(fm, "type")
+	switch filterType {
+	case "RequestHeaderModifier":
+		return describeHeaderModifier(fm, "requestHeaderModifier")
+	case "ResponseHeaderModifier":
+		return describeHeaderModifier(fm, "responseHeaderModifier")
+	case "RequestRedirect":
+		if rr, ok := fm["requestRedirect"].(map[string]any); ok {
+			var parts []string
+			if scheme := stringFrom(rr, "scheme"); scheme != "" {
+				parts = append(parts, "scheme:"+scheme)
+			}
+			if host := stringFrom(rr, "hostname"); host != "" {
+				parts = append(parts, "host:"+host)
+			}
+			if code := intFrom(rr, "statusCode"); code != 0 {
+				parts = append(parts, fmt.Sprintf("code:%d", code))
+			}
+			return strings.Join(parts, " ")
+		}
+	case "URLRewrite":
+		if uw, ok := fm["urlRewrite"].(map[string]any); ok {
+			var parts []string
+			if host := stringFrom(uw, "hostname"); host != "" {
+				parts = append(parts, "host:"+host)
+			}
+			if pp, ok := uw["path"].(map[string]any); ok {
+				parts = append(parts, stringFrom(pp, "type")+":"+stringFrom(pp, "value"))
+			}
+			return strings.Join(parts, " ")
+		}
+	case "RequestMirror":
+		if rm, ok := fm["requestMirror"].(map[string]any); ok {
+			if br, ok := rm["backendRef"].(map[string]any); ok {
+				return stringFrom(br, "name")
+			}
+		}
+	case "ExtensionRef":
+		if er, ok := fm["extensionRef"].(map[string]any); ok {
+			return stringFrom(er, "group") + "/" + stringFrom(er, "kind") + "/" + stringFrom(er, "name")
+		}
+	}
+	return ""
+}
+
+// describeHeaderModifier summarizes a header modifier filter.
+func describeHeaderModifier(fm map[string]any, key string) string {
+	hm, ok := fm[key].(map[string]any)
+	if !ok {
+		return ""
+	}
+	var parts []string
+	if sets, ok := hm["set"].([]any); ok {
+		for _, s := range sets {
+			sm, ok := s.(map[string]any)
+			if !ok {
+				continue
+			}
+			parts = append(parts, "set:"+stringFrom(sm, "name"))
+		}
+	}
+	if adds, ok := hm["add"].([]any); ok {
+		for _, a := range adds {
+			am, ok := a.(map[string]any)
+			if !ok {
+				continue
+			}
+			parts = append(parts, "add:"+stringFrom(am, "name"))
+		}
+	}
+	if removes, ok := hm["remove"].([]any); ok {
+		for _, r := range removes {
+			if s, ok := r.(string); ok {
+				parts = append(parts, "remove:"+s)
+			}
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+// normalizeGRPCRouteDetail converts an unstructured GRPCRoute into a GRPCRouteDetail.
+func normalizeGRPCRouteDetail(u *unstructured.Unstructured) GRPCRouteDetail {
+	obj := u.Object
+
+	rawRules, _, _ := unstructured.NestedSlice(obj, "spec", "rules")
+	var grpcRules []GRPCRouteRule
+
+	for _, r := range rawRules {
+		rm, ok := r.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		rule := GRPCRouteRule{}
+
+		// Matches.
+		if matches, ok := rm["matches"].([]any); ok {
+			for _, m := range matches {
+				mm, ok := m.(map[string]any)
+				if !ok {
+					continue
+				}
+				match := GRPCRouteMatch{}
+
+				if method, ok := mm["method"].(map[string]any); ok {
+					match.Service = stringFrom(method, "service")
+					match.Method = stringFrom(method, "method")
+				}
+
+				if headers, ok := mm["headers"].([]any); ok {
+					for _, h := range headers {
+						hm, ok := h.(map[string]any)
+						if !ok {
+							continue
+						}
+						match.Headers = append(match.Headers, stringFrom(hm, "name")+"="+stringFrom(hm, "value"))
+					}
+				}
+
+				rule.Matches = append(rule.Matches, match)
+			}
+		}
+
+		// BackendRefs.
+		if refs, ok := rm["backendRefs"].([]any); ok {
+			rule.BackendRefs = extractBackendRefs(refs)
+		}
+
+		grpcRules = append(grpcRules, rule)
+	}
+
+	return GRPCRouteDetail{
+		Name:       u.GetName(),
+		Namespace:  u.GetNamespace(),
+		ParentRefs: extractParentRefs(u),
+		Rules:      grpcRules,
+		Conditions: aggregateRouteConditions(obj),
+		Age:        u.GetCreationTimestamp().Time,
+	}
+}
+
+// normalizeRoute converts an unstructured route resource into a generic RouteSummary.
+// Used for list views of any route type.
+func normalizeRoute(u *unstructured.Unstructured, kind string) RouteSummary {
+	obj := u.Object
+
+	hostnames, _, _ := unstructured.NestedStringSlice(obj, "spec", "hostnames")
+
+	return RouteSummary{
+		Kind:       kind,
+		Name:       u.GetName(),
+		Namespace:  u.GetNamespace(),
+		Hostnames:  hostnames,
+		ParentRefs: extractParentRefs(u),
+		Conditions: aggregateRouteConditions(obj),
+		Age:        u.GetCreationTimestamp().Time,
+	}
+}
+
+// normalizeSimpleRouteDetail converts an unstructured TCP, TLS, or UDP route into
+// a SimpleRouteDetail. Hostnames are only populated for TLSRoute.
+func normalizeSimpleRouteDetail(u *unstructured.Unstructured, kind string) SimpleRouteDetail {
+	obj := u.Object
+
+	hostnames, _, _ := unstructured.NestedStringSlice(obj, "spec", "hostnames")
+
+	// TCP/UDP/TLS routes have rules with backendRefs.
+	var backendRefs []BackendRef
+	rules, _, _ := unstructured.NestedSlice(obj, "spec", "rules")
+	if len(rules) > 0 {
+		if rm, ok := rules[0].(map[string]any); ok {
+			if refs, ok := rm["backendRefs"].([]any); ok {
+				backendRefs = extractBackendRefs(refs)
+			}
+		}
+	}
+
+	return SimpleRouteDetail{
+		Kind:        kind,
+		Name:        u.GetName(),
+		Namespace:   u.GetNamespace(),
+		Hostnames:   hostnames,
+		ParentRefs:  extractParentRefs(u),
+		BackendRefs: backendRefs,
+		Conditions:  aggregateRouteConditions(obj),
+		Age:         u.GetCreationTimestamp().Time,
+	}
+}

--- a/backend/internal/gateway/normalize.go
+++ b/backend/internal/gateway/normalize.go
@@ -671,14 +671,16 @@ func normalizeSimpleRouteDetail(u *unstructured.Unstructured, kind string) Simpl
 
 	hostnames, _, _ := unstructured.NestedStringSlice(obj, "spec", "hostnames")
 
-	// TCP/UDP/TLS routes have rules with backendRefs.
+	// TCP/UDP/TLS routes have rules with backendRefs — aggregate from all rules.
 	var backendRefs []BackendRef
 	rules, _, _ := unstructured.NestedSlice(obj, "spec", "rules")
-	if len(rules) > 0 {
-		if rm, ok := rules[0].(map[string]any); ok {
-			if refs, ok := rm["backendRefs"].([]any); ok {
-				backendRefs = extractBackendRefs(refs)
-			}
+	for _, rule := range rules {
+		rm, ok := rule.(map[string]any)
+		if !ok {
+			continue
+		}
+		if refs, ok := rm["backendRefs"].([]any); ok {
+			backendRefs = append(backendRefs, extractBackendRefs(refs)...)
 		}
 	}
 

--- a/backend/internal/gateway/normalize_test.go
+++ b/backend/internal/gateway/normalize_test.go
@@ -1,0 +1,793 @@
+package gateway
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func makeUnstructured(obj map[string]any) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: obj}
+}
+
+func TestNormalizeGatewayClass(t *testing.T) {
+	tests := []struct {
+		name           string
+		obj            map[string]any
+		wantName       string
+		wantController string
+		wantDesc       string
+		wantConditions int
+	}{
+		{
+			name: "full gateway class",
+			obj: map[string]any{
+				"metadata": map[string]any{
+					"name":              "cilium",
+					"creationTimestamp": "2024-01-01T00:00:00Z",
+				},
+				"spec": map[string]any{
+					"controllerName": "io.cilium/gateway-controller",
+					"description":    "Cilium GatewayClass",
+				},
+				"status": map[string]any{
+					"conditions": []any{
+						map[string]any{
+							"type":   "Accepted",
+							"status": "True",
+							"reason": "Accepted",
+						},
+					},
+				},
+			},
+			wantName:       "cilium",
+			wantController: "io.cilium/gateway-controller",
+			wantDesc:       "Cilium GatewayClass",
+			wantConditions: 1,
+		},
+		{
+			name: "minimal gateway class",
+			obj: map[string]any{
+				"metadata": map[string]any{
+					"name":              "minimal",
+					"creationTimestamp": "2025-06-15T12:00:00Z",
+				},
+				"spec": map[string]any{},
+			},
+			wantName:       "minimal",
+			wantController: "",
+			wantDesc:       "",
+			wantConditions: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u := makeUnstructured(tt.obj)
+			got := normalizeGatewayClass(u)
+
+			if got.Name != tt.wantName {
+				t.Errorf("Name = %q; want %q", got.Name, tt.wantName)
+			}
+			if got.ControllerName != tt.wantController {
+				t.Errorf("ControllerName = %q; want %q", got.ControllerName, tt.wantController)
+			}
+			if got.Description != tt.wantDesc {
+				t.Errorf("Description = %q; want %q", got.Description, tt.wantDesc)
+			}
+			if len(got.Conditions) != tt.wantConditions {
+				t.Fatalf("Conditions len = %d; want %d", len(got.Conditions), tt.wantConditions)
+			}
+			if tt.wantConditions > 0 {
+				if got.Conditions[0].Type != "Accepted" {
+					t.Errorf("Conditions[0].Type = %q; want %q", got.Conditions[0].Type, "Accepted")
+				}
+				if got.Conditions[0].Status != "True" {
+					t.Errorf("Conditions[0].Status = %q; want %q", got.Conditions[0].Status, "True")
+				}
+			}
+			if got.Age.IsZero() {
+				t.Error("Age is zero; want non-zero")
+			}
+		})
+	}
+}
+
+func TestNormalizeGateway(t *testing.T) {
+	tests := []struct {
+		name               string
+		obj                map[string]any
+		wantName           string
+		wantNamespace      string
+		wantClassName      string
+		wantListeners      int
+		wantAddresses      int
+		wantAttachedRoutes int
+		wantConditions     int
+	}{
+		{
+			name: "gateway with listeners and addresses",
+			obj: map[string]any{
+				"metadata": map[string]any{
+					"name":              "my-gateway",
+					"namespace":         "default",
+					"creationTimestamp": "2024-06-01T10:00:00Z",
+				},
+				"spec": map[string]any{
+					"gatewayClassName": "cilium",
+					"listeners": []any{
+						map[string]any{
+							"name":     "http",
+							"port":     int64(80),
+							"protocol": "HTTP",
+							"hostname": "example.com",
+						},
+						map[string]any{
+							"name":     "https",
+							"port":     int64(443),
+							"protocol": "HTTPS",
+							"hostname": "example.com",
+						},
+					},
+				},
+				"status": map[string]any{
+					"addresses": []any{
+						map[string]any{"value": "10.0.0.1"},
+						map[string]any{"value": "10.0.0.2"},
+					},
+					"conditions": []any{
+						map[string]any{
+							"type":   "Accepted",
+							"status": "True",
+							"reason": "Accepted",
+						},
+					},
+					"listeners": []any{
+						map[string]any{
+							"name":           "http",
+							"attachedRoutes": int64(3),
+						},
+						map[string]any{
+							"name":           "https",
+							"attachedRoutes": int64(2),
+						},
+					},
+				},
+			},
+			wantName:           "my-gateway",
+			wantNamespace:      "default",
+			wantClassName:      "cilium",
+			wantListeners:      2,
+			wantAddresses:      2,
+			wantAttachedRoutes: 5,
+			wantConditions:     1,
+		},
+		{
+			name: "gateway with zero listeners",
+			obj: map[string]any{
+				"metadata": map[string]any{
+					"name":              "empty-gw",
+					"namespace":         "infra",
+					"creationTimestamp": "2025-01-01T00:00:00Z",
+				},
+				"spec": map[string]any{
+					"gatewayClassName": "istio",
+				},
+			},
+			wantName:           "empty-gw",
+			wantNamespace:      "infra",
+			wantClassName:      "istio",
+			wantListeners:      0,
+			wantAddresses:      0,
+			wantAttachedRoutes: 0,
+			wantConditions:     0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u := makeUnstructured(tt.obj)
+			got := normalizeGateway(u)
+
+			if got.Name != tt.wantName {
+				t.Errorf("Name = %q; want %q", got.Name, tt.wantName)
+			}
+			if got.Namespace != tt.wantNamespace {
+				t.Errorf("Namespace = %q; want %q", got.Namespace, tt.wantNamespace)
+			}
+			if got.GatewayClassName != tt.wantClassName {
+				t.Errorf("GatewayClassName = %q; want %q", got.GatewayClassName, tt.wantClassName)
+			}
+			if len(got.Listeners) != tt.wantListeners {
+				t.Fatalf("Listeners len = %d; want %d", len(got.Listeners), tt.wantListeners)
+			}
+			if len(got.Addresses) != tt.wantAddresses {
+				t.Errorf("Addresses len = %d; want %d", len(got.Addresses), tt.wantAddresses)
+			}
+			if got.AttachedRouteCount != tt.wantAttachedRoutes {
+				t.Errorf("AttachedRouteCount = %d; want %d", got.AttachedRouteCount, tt.wantAttachedRoutes)
+			}
+			if len(got.Conditions) != tt.wantConditions {
+				t.Errorf("Conditions len = %d; want %d", len(got.Conditions), tt.wantConditions)
+			}
+			// Verify per-listener attached route counts are merged from status.
+			if tt.wantListeners == 2 {
+				if got.Listeners[0].AttachedRouteCount != 3 {
+					t.Errorf("Listeners[0].AttachedRouteCount = %d; want 3", got.Listeners[0].AttachedRouteCount)
+				}
+				if got.Listeners[1].AttachedRouteCount != 2 {
+					t.Errorf("Listeners[1].AttachedRouteCount = %d; want 2", got.Listeners[1].AttachedRouteCount)
+				}
+			}
+		})
+	}
+}
+
+func TestNormalizeHTTPRoute(t *testing.T) {
+	tests := []struct {
+		name             string
+		obj              map[string]any
+		wantName         string
+		wantNamespace    string
+		wantHostnames    int
+		wantParentRefs   int
+		wantBackendCount int
+	}{
+		{
+			name: "httproute with hostnames and backends",
+			obj: map[string]any{
+				"metadata": map[string]any{
+					"name":              "web-route",
+					"namespace":         "apps",
+					"creationTimestamp": "2024-03-01T08:00:00Z",
+				},
+				"spec": map[string]any{
+					"hostnames": []any{"app.example.com", "www.example.com"},
+					"parentRefs": []any{
+						map[string]any{
+							"name":      "my-gateway",
+							"namespace": "default",
+						},
+					},
+					"rules": []any{
+						map[string]any{
+							"backendRefs": []any{
+								map[string]any{"name": "svc-a", "port": int64(8080)},
+								map[string]any{"name": "svc-b", "port": int64(8080)},
+							},
+						},
+						map[string]any{
+							"backendRefs": []any{
+								map[string]any{"name": "svc-c", "port": int64(9090)},
+							},
+						},
+					},
+				},
+			},
+			wantName:         "web-route",
+			wantNamespace:    "apps",
+			wantHostnames:    2,
+			wantParentRefs:   1,
+			wantBackendCount: 3,
+		},
+		{
+			name: "httproute with empty rules",
+			obj: map[string]any{
+				"metadata": map[string]any{
+					"name":              "empty-route",
+					"namespace":         "test",
+					"creationTimestamp": "2025-01-01T00:00:00Z",
+				},
+				"spec": map[string]any{},
+			},
+			wantName:         "empty-route",
+			wantNamespace:    "test",
+			wantHostnames:    0,
+			wantParentRefs:   0,
+			wantBackendCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u := makeUnstructured(tt.obj)
+			got := normalizeHTTPRoute(u)
+
+			if got.Name != tt.wantName {
+				t.Errorf("Name = %q; want %q", got.Name, tt.wantName)
+			}
+			if got.Namespace != tt.wantNamespace {
+				t.Errorf("Namespace = %q; want %q", got.Namespace, tt.wantNamespace)
+			}
+			if len(got.Hostnames) != tt.wantHostnames {
+				t.Errorf("Hostnames len = %d; want %d", len(got.Hostnames), tt.wantHostnames)
+			}
+			if len(got.ParentRefs) != tt.wantParentRefs {
+				t.Errorf("ParentRefs len = %d; want %d", len(got.ParentRefs), tt.wantParentRefs)
+			}
+			if got.BackendCount != tt.wantBackendCount {
+				t.Errorf("BackendCount = %d; want %d", got.BackendCount, tt.wantBackendCount)
+			}
+		})
+	}
+}
+
+func TestNormalizeRoute(t *testing.T) {
+	tests := []struct {
+		name          string
+		kind          string
+		obj           map[string]any
+		wantKind      string
+		wantName      string
+		wantHostnames int
+	}{
+		{
+			name: "TCPRoute",
+			kind: "TCPRoute",
+			obj: map[string]any{
+				"metadata": map[string]any{
+					"name":              "tcp-route",
+					"namespace":         "infra",
+					"creationTimestamp": "2024-05-01T00:00:00Z",
+				},
+				"spec": map[string]any{},
+			},
+			wantKind:      "TCPRoute",
+			wantName:      "tcp-route",
+			wantHostnames: 0,
+		},
+		{
+			name: "TLSRoute with hostnames",
+			kind: "TLSRoute",
+			obj: map[string]any{
+				"metadata": map[string]any{
+					"name":              "tls-route",
+					"namespace":         "secure",
+					"creationTimestamp": "2024-05-01T00:00:00Z",
+				},
+				"spec": map[string]any{
+					"hostnames": []any{"secure.example.com"},
+				},
+			},
+			wantKind:      "TLSRoute",
+			wantName:      "tls-route",
+			wantHostnames: 1,
+		},
+		{
+			name: "UDPRoute",
+			kind: "UDPRoute",
+			obj: map[string]any{
+				"metadata": map[string]any{
+					"name":              "udp-route",
+					"namespace":         "gaming",
+					"creationTimestamp": "2024-05-01T00:00:00Z",
+				},
+				"spec": map[string]any{},
+			},
+			wantKind:      "UDPRoute",
+			wantName:      "udp-route",
+			wantHostnames: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u := makeUnstructured(tt.obj)
+			got := normalizeRoute(u, tt.kind)
+
+			if got.Kind != tt.wantKind {
+				t.Errorf("Kind = %q; want %q", got.Kind, tt.wantKind)
+			}
+			if got.Name != tt.wantName {
+				t.Errorf("Name = %q; want %q", got.Name, tt.wantName)
+			}
+			if len(got.Hostnames) != tt.wantHostnames {
+				t.Errorf("Hostnames len = %d; want %d", len(got.Hostnames), tt.wantHostnames)
+			}
+		})
+	}
+}
+
+func TestNormalizeSimpleRouteDetail(t *testing.T) {
+	tests := []struct {
+		name            string
+		kind            string
+		obj             map[string]any
+		wantKind        string
+		wantHostnames   int
+		wantBackendRefs int
+	}{
+		{
+			name: "TLSRoute with hostnames and backends",
+			kind: "TLSRoute",
+			obj: map[string]any{
+				"metadata": map[string]any{
+					"name":              "tls-detail",
+					"namespace":         "secure",
+					"creationTimestamp": "2024-07-01T00:00:00Z",
+				},
+				"spec": map[string]any{
+					"hostnames": []any{"secure.example.com", "api.example.com"},
+					"parentRefs": []any{
+						map[string]any{"name": "my-gw", "namespace": "default"},
+					},
+					"rules": []any{
+						map[string]any{
+							"backendRefs": []any{
+								map[string]any{"name": "backend-svc", "port": int64(443)},
+								map[string]any{"name": "fallback-svc", "port": int64(443)},
+							},
+						},
+					},
+				},
+			},
+			wantKind:        "TLSRoute",
+			wantHostnames:   2,
+			wantBackendRefs: 2,
+		},
+		{
+			name: "TCPRoute with no hostnames",
+			kind: "TCPRoute",
+			obj: map[string]any{
+				"metadata": map[string]any{
+					"name":              "tcp-detail",
+					"namespace":         "infra",
+					"creationTimestamp": "2024-07-01T00:00:00Z",
+				},
+				"spec": map[string]any{},
+			},
+			wantKind:        "TCPRoute",
+			wantHostnames:   0,
+			wantBackendRefs: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u := makeUnstructured(tt.obj)
+			got := normalizeSimpleRouteDetail(u, tt.kind)
+
+			if got.Kind != tt.wantKind {
+				t.Errorf("Kind = %q; want %q", got.Kind, tt.wantKind)
+			}
+			if len(got.Hostnames) != tt.wantHostnames {
+				t.Errorf("Hostnames len = %d; want %d", len(got.Hostnames), tt.wantHostnames)
+			}
+			if len(got.BackendRefs) != tt.wantBackendRefs {
+				t.Fatalf("BackendRefs len = %d; want %d", len(got.BackendRefs), tt.wantBackendRefs)
+			}
+			if tt.wantBackendRefs > 0 {
+				if got.BackendRefs[0].Name != "backend-svc" {
+					t.Errorf("BackendRefs[0].Name = %q; want %q", got.BackendRefs[0].Name, "backend-svc")
+				}
+			}
+		})
+	}
+}
+
+func TestExtractParentRefs(t *testing.T) {
+	tests := []struct {
+		name      string
+		obj       map[string]any
+		wantLen   int
+		wantGroup string
+		wantKind  string
+	}{
+		{
+			name: "explicit group and kind",
+			obj: map[string]any{
+				"spec": map[string]any{
+					"parentRefs": []any{
+						map[string]any{
+							"group":       "custom.io",
+							"kind":        "CustomGateway",
+							"name":        "my-gw",
+							"namespace":   "infra",
+							"sectionName": "https",
+						},
+					},
+				},
+			},
+			wantLen:   1,
+			wantGroup: "custom.io",
+			wantKind:  "CustomGateway",
+		},
+		{
+			name: "default group and kind",
+			obj: map[string]any{
+				"spec": map[string]any{
+					"parentRefs": []any{
+						map[string]any{
+							"name":      "default-gw",
+							"namespace": "default",
+						},
+					},
+				},
+			},
+			wantLen:   1,
+			wantGroup: "gateway.networking.k8s.io",
+			wantKind:  "Gateway",
+		},
+		{
+			name: "empty parentRefs",
+			obj: map[string]any{
+				"spec": map[string]any{},
+			},
+			wantLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u := makeUnstructured(tt.obj)
+			got := extractParentRefs(u)
+
+			if len(got) != tt.wantLen {
+				t.Fatalf("len = %d; want %d", len(got), tt.wantLen)
+			}
+			if tt.wantLen > 0 {
+				if got[0].Group != tt.wantGroup {
+					t.Errorf("Group = %q; want %q", got[0].Group, tt.wantGroup)
+				}
+				if got[0].Kind != tt.wantKind {
+					t.Errorf("Kind = %q; want %q", got[0].Kind, tt.wantKind)
+				}
+			}
+		})
+	}
+}
+
+func TestExtractBackendRefs(t *testing.T) {
+	tests := []struct {
+		name       string
+		items      []any
+		wantLen    int
+		wantKind   string
+		wantPort   *int
+		wantWeight *int
+	}{
+		{
+			name: "service with port and weight",
+			items: []any{
+				map[string]any{
+					"kind":   "Service",
+					"name":   "backend",
+					"port":   int64(8080),
+					"weight": int64(75),
+				},
+			},
+			wantLen:    1,
+			wantKind:   "Service",
+			wantPort:   intPtr(8080),
+			wantWeight: intPtr(75),
+		},
+		{
+			name: "default kind when omitted",
+			items: []any{
+				map[string]any{
+					"name": "implicit-svc",
+					"port": int64(3000),
+				},
+			},
+			wantLen:  1,
+			wantKind: "Service",
+			wantPort: intPtr(3000),
+		},
+		{
+			name: "missing port",
+			items: []any{
+				map[string]any{
+					"name": "no-port-svc",
+				},
+			},
+			wantLen:  1,
+			wantKind: "Service",
+			wantPort: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractBackendRefs(tt.items)
+
+			if len(got) != tt.wantLen {
+				t.Fatalf("len = %d; want %d", len(got), tt.wantLen)
+			}
+			if tt.wantLen > 0 {
+				if got[0].Kind != tt.wantKind {
+					t.Errorf("Kind = %q; want %q", got[0].Kind, tt.wantKind)
+				}
+				if tt.wantPort == nil {
+					if got[0].Port != nil {
+						t.Errorf("Port = %v; want nil", *got[0].Port)
+					}
+				} else {
+					if got[0].Port == nil {
+						t.Fatalf("Port is nil; want %d", *tt.wantPort)
+					}
+					if *got[0].Port != *tt.wantPort {
+						t.Errorf("Port = %d; want %d", *got[0].Port, *tt.wantPort)
+					}
+				}
+				if tt.wantWeight == nil {
+					if got[0].Weight != nil {
+						t.Errorf("Weight = %v; want nil", *got[0].Weight)
+					}
+				} else {
+					if got[0].Weight == nil {
+						t.Fatalf("Weight is nil; want %d", *tt.wantWeight)
+					}
+					if *got[0].Weight != *tt.wantWeight {
+						t.Errorf("Weight = %d; want %d", *got[0].Weight, *tt.wantWeight)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestExtractConditions(t *testing.T) {
+	transitionTime := "2024-06-01T12:00:00Z"
+	parsedTime, _ := time.Parse(time.RFC3339, transitionTime)
+
+	tests := []struct {
+		name    string
+		obj     map[string]any
+		path    []string
+		wantLen int
+	}{
+		{
+			name: "multiple conditions with all fields",
+			obj: map[string]any{
+				"status": map[string]any{
+					"conditions": []any{
+						map[string]any{
+							"type":               "Accepted",
+							"status":             "True",
+							"reason":             "Accepted",
+							"message":            "Gateway accepted",
+							"lastTransitionTime": transitionTime,
+						},
+						map[string]any{
+							"type":    "Programmed",
+							"status":  "True",
+							"reason":  "Programmed",
+							"message": "Gateway programmed",
+						},
+					},
+				},
+			},
+			path:    []string{"status", "conditions"},
+			wantLen: 2,
+		},
+		{
+			name: "empty conditions list",
+			obj: map[string]any{
+				"status": map[string]any{
+					"conditions": []any{},
+				},
+			},
+			path:    []string{"status", "conditions"},
+			wantLen: 0,
+		},
+		{
+			name:    "missing conditions path",
+			obj:     map[string]any{},
+			path:    []string{"status", "conditions"},
+			wantLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractConditions(tt.obj, tt.path...)
+
+			if len(got) != tt.wantLen {
+				t.Fatalf("len = %d; want %d", len(got), tt.wantLen)
+			}
+			if tt.name == "multiple conditions with all fields" {
+				if got[0].Type != "Accepted" {
+					t.Errorf("Conditions[0].Type = %q; want %q", got[0].Type, "Accepted")
+				}
+				if got[0].Status != "True" {
+					t.Errorf("Conditions[0].Status = %q; want %q", got[0].Status, "True")
+				}
+				if got[0].Message != "Gateway accepted" {
+					t.Errorf("Conditions[0].Message = %q; want %q", got[0].Message, "Gateway accepted")
+				}
+				if got[0].LastTransitionTime == nil {
+					t.Fatal("Conditions[0].LastTransitionTime is nil; want non-nil")
+				}
+				if !got[0].LastTransitionTime.Equal(parsedTime) {
+					t.Errorf("Conditions[0].LastTransitionTime = %v; want %v", got[0].LastTransitionTime, parsedTime)
+				}
+				if got[1].Type != "Programmed" {
+					t.Errorf("Conditions[1].Type = %q; want %q", got[1].Type, "Programmed")
+				}
+				if got[1].LastTransitionTime != nil {
+					t.Errorf("Conditions[1].LastTransitionTime = %v; want nil", got[1].LastTransitionTime)
+				}
+			}
+		})
+	}
+}
+
+func TestAggregateRouteConditions(t *testing.T) {
+	tests := []struct {
+		name    string
+		obj     map[string]any
+		wantLen int
+	}{
+		{
+			name: "two parents with overlapping conditions",
+			obj: map[string]any{
+				"status": map[string]any{
+					"parents": []any{
+						map[string]any{
+							"conditions": []any{
+								map[string]any{
+									"type":   "Accepted",
+									"status": "True",
+									"reason": "Accepted",
+								},
+								map[string]any{
+									"type":   "ResolvedRefs",
+									"status": "True",
+									"reason": "ResolvedRefs",
+								},
+							},
+						},
+						map[string]any{
+							"conditions": []any{
+								map[string]any{
+									"type":   "Accepted",
+									"status": "True",
+									"reason": "Accepted",
+								},
+								map[string]any{
+									"type":   "Programmed",
+									"status": "True",
+									"reason": "Programmed",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantLen: 3, // Accepted (deduped), ResolvedRefs, Programmed
+		},
+		{
+			name: "no parents",
+			obj: map[string]any{
+				"status": map[string]any{},
+			},
+			wantLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := aggregateRouteConditions(tt.obj)
+
+			if len(got) != tt.wantLen {
+				t.Fatalf("len = %d; want %d", len(got), tt.wantLen)
+			}
+			if tt.wantLen == 3 {
+				// Verify deduplication: should have Accepted, ResolvedRefs, Programmed.
+				types := map[string]bool{}
+				for _, c := range got {
+					types[c.Type] = true
+				}
+				for _, expected := range []string{"Accepted", "ResolvedRefs", "Programmed"} {
+					if !types[expected] {
+						t.Errorf("missing expected condition type %q", expected)
+					}
+				}
+			}
+		})
+	}
+}
+
+// intPtr is a helper that returns a pointer to an int value.
+func intPtr(v int) *int { return &v }

--- a/backend/internal/gateway/types.go
+++ b/backend/internal/gateway/types.go
@@ -249,8 +249,6 @@ type namespacedResource interface {
 	getNamespace() string
 }
 
-func (g GatewaySummary) getNamespace() string    { return g.Namespace }
-func (h HTTPRouteSummary) getNamespace() string   { return h.Namespace }
-func (r RouteSummary) getNamespace() string       { return r.Namespace }
-func (g GRPCRouteDetail) getNamespace() string    { return g.Namespace }
-func (s SimpleRouteDetail) getNamespace() string  { return s.Namespace }
+func (g GatewaySummary) getNamespace() string  { return g.Namespace }
+func (h HTTPRouteSummary) getNamespace() string { return h.Namespace }
+func (r RouteSummary) getNamespace() string     { return r.Namespace }

--- a/backend/internal/gateway/types.go
+++ b/backend/internal/gateway/types.go
@@ -1,0 +1,256 @@
+// Package gateway provides Gateway API integration for k8sCenter.
+package gateway
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// GVR constants for gateway.networking.k8s.io resources.
+var (
+	GatewayClassGVR = schema.GroupVersionResource{
+		Group: "gateway.networking.k8s.io", Version: "v1", Resource: "gatewayclasses",
+	}
+	GatewayGVR = schema.GroupVersionResource{
+		Group: "gateway.networking.k8s.io", Version: "v1", Resource: "gateways",
+	}
+	HTTPRouteGVR = schema.GroupVersionResource{
+		Group: "gateway.networking.k8s.io", Version: "v1", Resource: "httproutes",
+	}
+	GRPCRouteGVR = schema.GroupVersionResource{
+		Group: "gateway.networking.k8s.io", Version: "v1", Resource: "grpcroutes",
+	}
+	TCPRouteGVR = schema.GroupVersionResource{
+		Group: "gateway.networking.k8s.io", Version: "v1alpha2", Resource: "tcproutes",
+	}
+	TLSRouteGVR = schema.GroupVersionResource{
+		Group: "gateway.networking.k8s.io", Version: "v1alpha2", Resource: "tlsroutes",
+	}
+	UDPRouteGVR = schema.GroupVersionResource{
+		Group: "gateway.networking.k8s.io", Version: "v1alpha2", Resource: "udproutes",
+	}
+)
+
+// APIGroup is the Gateway API group name.
+const APIGroup = "gateway.networking.k8s.io"
+
+// cacheTTL is the duration for which cached Gateway API data is considered fresh.
+const cacheTTL = 30 * time.Second
+
+// routeKind identifies a non-HTTP route resource type for dispatch.
+type routeKind string
+
+const (
+	RouteKindGRPC routeKind = "grpcroutes"
+	RouteKindTCP  routeKind = "tcproutes"
+	RouteKindTLS  routeKind = "tlsroutes"
+	RouteKindUDP  routeKind = "udproutes"
+)
+
+// routeKindGVR maps each routeKind to its GroupVersionResource.
+var routeKindGVR = map[routeKind]schema.GroupVersionResource{
+	RouteKindGRPC: GRPCRouteGVR,
+	RouteKindTCP:  TCPRouteGVR,
+	RouteKindTLS:  TLSRouteGVR,
+	RouteKindUDP:  UDPRouteGVR,
+}
+
+// GatewayAPIStatus is returned by GET /gateway/status.
+type GatewayAPIStatus struct {
+	Available      bool      `json:"available"`
+	Version        string    `json:"version,omitempty"`
+	InstalledKinds []string  `json:"installedKinds,omitempty"`
+	LastChecked    time.Time `json:"lastChecked"`
+}
+
+// GatewayAPISummary aggregates counts across all Gateway API resource kinds.
+type GatewayAPISummary struct {
+	GatewayClasses KindSummary `json:"gatewayClasses"`
+	Gateways       KindSummary `json:"gateways"`
+	HTTPRoutes     KindSummary `json:"httpRoutes"`
+	GRPCRoutes     KindSummary `json:"grpcRoutes"`
+	TCPRoutes      KindSummary `json:"tcpRoutes"`
+	TLSRoutes      KindSummary `json:"tlsRoutes"`
+	UDPRoutes      KindSummary `json:"udpRoutes"`
+}
+
+// KindSummary provides health-categorized counts for a single resource kind.
+type KindSummary struct {
+	Total    int `json:"total"`
+	Healthy  int `json:"healthy"`
+	Degraded int `json:"degraded"`
+}
+
+// Condition represents a Kubernetes-style status condition.
+type Condition struct {
+	Type               string     `json:"type"`
+	Status             string     `json:"status"`
+	Reason             string     `json:"reason"`
+	Message            string     `json:"message"`
+	LastTransitionTime *time.Time `json:"lastTransitionTime,omitempty"`
+}
+
+// ParentRef identifies a parent resource (typically a Gateway) that a route is attached to.
+type ParentRef struct {
+	Group             string      `json:"group"`
+	Kind              string      `json:"kind"`
+	Name              string      `json:"name"`
+	Namespace         string      `json:"namespace"`
+	SectionName       string      `json:"sectionName"`
+	Status            string      `json:"status"`
+	GatewayConditions []Condition `json:"gatewayConditions,omitempty"`
+}
+
+// BackendRef identifies a backend target for route traffic.
+type BackendRef struct {
+	Group     string `json:"group"`
+	Kind      string `json:"kind"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	Port      *int   `json:"port,omitempty"`
+	Weight    *int   `json:"weight,omitempty"`
+	Resolved  bool   `json:"resolved"`
+}
+
+// RouteSummary is a generic route representation used for non-HTTP route listings.
+type RouteSummary struct {
+	Kind       string      `json:"kind"`
+	Name       string      `json:"name"`
+	Namespace  string      `json:"namespace"`
+	Hostnames  []string    `json:"hostnames,omitempty"`
+	ParentRefs []ParentRef `json:"parentRefs,omitempty"`
+	Conditions []Condition `json:"conditions,omitempty"`
+	Age        time.Time   `json:"age"`
+}
+
+// GatewayClassSummary is the API representation of a GatewayClass resource.
+type GatewayClassSummary struct {
+	Name           string      `json:"name"`
+	ControllerName string     `json:"controllerName"`
+	Description    string      `json:"description,omitempty"`
+	Conditions     []Condition `json:"conditions,omitempty"`
+	Age            time.Time   `json:"age"`
+}
+
+// Listener represents a single listener on a Gateway.
+type Listener struct {
+	Name               string      `json:"name"`
+	Port               int         `json:"port"`
+	Protocol           string      `json:"protocol"`
+	Hostname           string      `json:"hostname,omitempty"`
+	AttachedRouteCount int         `json:"attachedRouteCount"`
+	TLSMode            string      `json:"tlsMode,omitempty"`
+	CertificateRef     string      `json:"certificateRef,omitempty"`
+	AllowedRoutes      string      `json:"allowedRoutes,omitempty"`
+	Conditions         []Condition `json:"conditions,omitempty"`
+}
+
+// GatewaySummary is the API representation of a Gateway resource.
+type GatewaySummary struct {
+	Name               string      `json:"name"`
+	Namespace          string      `json:"namespace"`
+	GatewayClassName   string      `json:"gatewayClassName"`
+	Listeners          []Listener  `json:"listeners"`
+	Addresses          []string    `json:"addresses,omitempty"`
+	AttachedRouteCount int         `json:"attachedRouteCount"`
+	Conditions         []Condition `json:"conditions,omitempty"`
+	Age                time.Time   `json:"age"`
+}
+
+// GatewayDetail extends GatewaySummary with attached route information.
+type GatewayDetail struct {
+	GatewaySummary
+	AttachedRoutes []RouteSummary `json:"attachedRoutes"`
+}
+
+// HTTPRouteSummary is the API representation of an HTTPRoute resource.
+type HTTPRouteSummary struct {
+	Name         string      `json:"name"`
+	Namespace    string      `json:"namespace"`
+	Hostnames    []string    `json:"hostnames,omitempty"`
+	ParentRefs   []ParentRef `json:"parentRefs,omitempty"`
+	BackendCount int         `json:"backendCount"`
+	Conditions   []Condition `json:"conditions,omitempty"`
+	Age          time.Time   `json:"age"`
+}
+
+// HTTPRouteMatch describes a single match clause in an HTTPRoute rule.
+type HTTPRouteMatch struct {
+	PathType    string   `json:"pathType"`
+	PathValue   string   `json:"pathValue"`
+	Headers     []string `json:"headers,omitempty"`
+	Method      string   `json:"method,omitempty"`
+	QueryParams []string `json:"queryParams,omitempty"`
+}
+
+// HTTPRouteFilter describes a filter applied to matched HTTP traffic.
+type HTTPRouteFilter struct {
+	Type    string `json:"type"`
+	Details string `json:"details"`
+}
+
+// HTTPRouteRule represents a single rule in an HTTPRoute spec.
+type HTTPRouteRule struct {
+	Matches     []HTTPRouteMatch  `json:"matches,omitempty"`
+	Filters     []HTTPRouteFilter `json:"filters,omitempty"`
+	BackendRefs []BackendRef      `json:"backendRefs,omitempty"`
+}
+
+// HTTPRouteDetail is the full detail view of an HTTPRoute resource.
+type HTTPRouteDetail struct {
+	Name         string          `json:"name"`
+	Namespace    string          `json:"namespace"`
+	Hostnames    []string        `json:"hostnames,omitempty"`
+	ParentRefs   []ParentRef     `json:"parentRefs,omitempty"`
+	BackendCount int             `json:"backendCount"`
+	Conditions   []Condition     `json:"conditions,omitempty"`
+	Age          time.Time       `json:"age"`
+	Rules        []HTTPRouteRule `json:"rules,omitempty"`
+}
+
+// GRPCRouteMatch describes a single match clause in a GRPCRoute rule.
+type GRPCRouteMatch struct {
+	Service string   `json:"service"`
+	Method  string   `json:"method"`
+	Headers []string `json:"headers,omitempty"`
+}
+
+// GRPCRouteRule represents a single rule in a GRPCRoute spec.
+type GRPCRouteRule struct {
+	Matches     []GRPCRouteMatch `json:"matches,omitempty"`
+	BackendRefs []BackendRef     `json:"backendRefs,omitempty"`
+}
+
+// GRPCRouteDetail is the full detail view of a GRPCRoute resource.
+type GRPCRouteDetail struct {
+	Name       string          `json:"name"`
+	Namespace  string          `json:"namespace"`
+	ParentRefs []ParentRef     `json:"parentRefs,omitempty"`
+	Rules      []GRPCRouteRule `json:"rules,omitempty"`
+	Conditions []Condition     `json:"conditions,omitempty"`
+	Age        time.Time       `json:"age"`
+}
+
+// SimpleRouteDetail is the detail view for TCP, TLS, and UDP routes.
+type SimpleRouteDetail struct {
+	Kind        string       `json:"kind"`
+	Name        string       `json:"name"`
+	Namespace   string       `json:"namespace"`
+	Hostnames   []string     `json:"hostnames,omitempty"`
+	ParentRefs  []ParentRef  `json:"parentRefs,omitempty"`
+	BackendRefs []BackendRef `json:"backendRefs,omitempty"`
+	Conditions  []Condition  `json:"conditions,omitempty"`
+	Age         time.Time    `json:"age"`
+}
+
+// namespacedResource is implemented by types that belong to a Kubernetes namespace.
+type namespacedResource interface {
+	getNamespace() string
+}
+
+func (g GatewaySummary) getNamespace() string    { return g.Namespace }
+func (h HTTPRouteSummary) getNamespace() string   { return h.Namespace }
+func (r RouteSummary) getNamespace() string       { return r.Namespace }
+func (g GRPCRouteDetail) getNamespace() string    { return g.Namespace }
+func (s SimpleRouteDetail) getNamespace() string  { return s.Namespace }

--- a/backend/internal/server/routes.go
+++ b/backend/internal/server/routes.go
@@ -606,17 +606,24 @@ func (s *Server) registerCertManagerRoutes(ar chi.Router) {
 
 func (s *Server) registerGatewayRoutes(ar chi.Router) {
 	h := s.GatewayHandler
+	rl := s.YAMLRateLimiter
+	if rl == nil {
+		rl = s.RateLimiter
+	}
 	ar.Route("/gateway", func(gr chi.Router) {
+		// Cached list endpoints (no direct API calls)
 		gr.Get("/status", h.HandleStatus)
 		gr.Get("/summary", h.HandleSummary)
 		gr.Get("/gatewayclasses", h.HandleListGatewayClasses)
-		gr.With(resources.ValidateURLParams).Get("/gatewayclasses/{name}", h.HandleGetGatewayClass)
 		gr.Get("/gateways", h.HandleListGateways)
-		gr.With(resources.ValidateURLParams).Get("/gateways/{namespace}/{name}", h.HandleGetGateway)
 		gr.Get("/httproutes", h.HandleListHTTPRoutes)
-		gr.With(resources.ValidateURLParams).Get("/httproutes/{namespace}/{name}", h.HandleGetHTTPRoute)
 		gr.Get("/routes", h.HandleListRoutes)
-		gr.With(resources.ValidateURLParams).Get("/routes/{kind}/{namespace}/{name}", h.HandleGetRoute)
+
+		// Detail endpoints hit the API server directly — rate-limited
+		gr.With(middleware.RateLimit(rl), resources.ValidateURLParams).Get("/gatewayclasses/{name}", h.HandleGetGatewayClass)
+		gr.With(middleware.RateLimit(rl), resources.ValidateURLParams).Get("/gateways/{namespace}/{name}", h.HandleGetGateway)
+		gr.With(middleware.RateLimit(rl), resources.ValidateURLParams).Get("/httproutes/{namespace}/{name}", h.HandleGetHTTPRoute)
+		gr.With(middleware.RateLimit(rl), resources.ValidateURLParams).Get("/routes/{kind}/{namespace}/{name}", h.HandleGetRoute)
 	})
 }
 

--- a/backend/internal/server/routes.go
+++ b/backend/internal/server/routes.go
@@ -171,6 +171,11 @@ func (s *Server) registerRoutes() {
 				s.registerCertManagerRoutes(ar)
 			}
 
+			// Gateway API routes — only registered if gateway handler is available
+			if s.GatewayHandler != nil {
+				s.registerGatewayRoutes(ar)
+			}
+
 			// Notification center routes
 			if s.NotifCenterHandler != nil {
 				s.registerNotifCenterRoutes(ar)
@@ -596,6 +601,22 @@ func (s *Server) registerCertManagerRoutes(ar chi.Router) {
 			Post("/certificates/{namespace}/{name}/renew", h.HandleRenew)
 		cr.With(middleware.RateLimit(yamlRL), resources.ValidateURLParams).
 			Post("/certificates/{namespace}/{name}/reissue", h.HandleReissue)
+	})
+}
+
+func (s *Server) registerGatewayRoutes(ar chi.Router) {
+	h := s.GatewayHandler
+	ar.Route("/gateway", func(gr chi.Router) {
+		gr.Get("/status", h.HandleStatus)
+		gr.Get("/summary", h.HandleSummary)
+		gr.Get("/gatewayclasses", h.HandleListGatewayClasses)
+		gr.With(resources.ValidateURLParams).Get("/gatewayclasses/{name}", h.HandleGetGatewayClass)
+		gr.Get("/gateways", h.HandleListGateways)
+		gr.With(resources.ValidateURLParams).Get("/gateways/{namespace}/{name}", h.HandleGetGateway)
+		gr.Get("/httproutes", h.HandleListHTTPRoutes)
+		gr.With(resources.ValidateURLParams).Get("/httproutes/{namespace}/{name}", h.HandleGetHTTPRoute)
+		gr.Get("/routes", h.HandleListRoutes)
+		gr.With(resources.ValidateURLParams).Get("/routes/{kind}/{namespace}/{name}", h.HandleGetRoute)
 	})
 }
 

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kubecenter/kubecenter/internal/auth"
 	"github.com/kubecenter/kubecenter/internal/config"
 	"github.com/kubecenter/kubecenter/internal/diagnostics"
+	"github.com/kubecenter/kubecenter/internal/gateway"
 	"github.com/kubecenter/kubecenter/internal/gitops"
 	"github.com/kubecenter/kubecenter/internal/k8s"
 	"github.com/kubecenter/kubecenter/internal/k8s/resources"
@@ -73,6 +74,7 @@ type Server struct {
 	LimitsHandler      *limits.Handler
 	VeleroHandler      *velero.Handler
 	CertManagerHandler *certmanager.Handler
+	GatewayHandler     *gateway.Handler
 	CRDHandler         *resources.GenericCRDHandler
 	NotifCenterHandler *notifications.Handler
 	NotifCenterService *notifications.NotificationService
@@ -117,6 +119,7 @@ type Deps struct {
 	LimitsHandler      *limits.Handler
 	VeleroHandler      *velero.Handler
 	CertManagerHandler *certmanager.Handler
+	GatewayHandler     *gateway.Handler
 	CRDHandler         *resources.GenericCRDHandler
 	NotifCenterHandler *notifications.Handler
 	NotifCenterService *notifications.NotificationService
@@ -267,6 +270,11 @@ func New(deps Deps) *Server {
 	// Cert-Manager handler
 	if deps.CertManagerHandler != nil {
 		s.CertManagerHandler = deps.CertManagerHandler
+	}
+
+	// Gateway API handler
+	if deps.GatewayHandler != nil {
+		s.GatewayHandler = deps.GatewayHandler
 	}
 
 	// Notification center

--- a/docs/superpowers/specs/2026-04-12-gateway-api-design.md
+++ b/docs/superpowers/specs/2026-04-12-gateway-api-design.md
@@ -1,0 +1,191 @@
+# Gateway API Dashboard — Design Spec
+
+**Date:** 2026-04-12
+**Status:** Approved
+
+## Overview
+
+Add a "Gateway API" tab to the networking section that displays all Kubernetes Gateway API resources (GatewayClass, Gateway, HTTPRoute, GRPCRoute, TCPRoute, TLSRoute, UDPRoute) with CRD availability detection, a dashboard overview, and custom detail pages showing cross-resource relationships.
+
+## Architecture
+
+### Backend: `internal/gateway/` package
+
+Dedicated package following the certmanager/policy pattern:
+
+- **CRD Discovery** — checks for `gateway.networking.k8s.io` group CRDs at startup and on-demand (5 min TTL). Reports which resource kinds are installed.
+- **Handler** — singleflight + 30s TTL cache for list endpoints. RBAC filtering via `CanAccessGroupResource`. User impersonation for all reads.
+- **Normalized types** — Go structs for each Gateway API kind with relationship fields (Gateway carries attached route summaries, routes carry resolved parent Gateway and backend Service refs).
+- **Relationship resolution** — detail endpoints fetch the primary resource plus related resources in parallel via `sync.WaitGroup` with 2s timeout per lookup.
+
+### API Endpoints
+
+All under `/api/v1/gateway/`:
+
+| Endpoint | Description |
+|---|---|
+| `GET /gateway/status` | CRD discovery — which kinds are installed, API version |
+| `GET /gateway/gatewayclasses` | List GatewayClasses (cluster-scoped) |
+| `GET /gateway/gateways` | List Gateways with attached route counts |
+| `GET /gateway/gateways/:ns/:name` | Gateway detail + attached routes list |
+| `GET /gateway/httproutes` | List HTTPRoutes with parent/backend summaries |
+| `GET /gateway/httproutes/:ns/:name` | HTTPRoute detail + resolved parents & backends |
+| `GET /gateway/grpcroutes` | List GRPCRoutes |
+| `GET /gateway/grpcroutes/:ns/:name` | GRPCRoute detail |
+| `GET /gateway/tcproutes` | List TCPRoutes |
+| `GET /gateway/tcproutes/:ns/:name` | TCPRoute detail |
+| `GET /gateway/tlsroutes` | List TLSRoutes |
+| `GET /gateway/tlsroutes/:ns/:name` | TLSRoute detail |
+| `GET /gateway/udproutes` | List UDPRoutes |
+| `GET /gateway/udproutes/:ns/:name` | UDPRoute detail |
+
+### Frontend
+
+**Route:** `/networking/gateway-api` — single tab in the networking SubNav.
+
+**Dashboard island:** `GatewayAPIDashboard.tsx`
+- Calls `GET /gateway/status` for CRD availability check
+- Shows "Gateway API not installed" state with guidance if no CRDs found
+- When available: overview cards per installed kind showing count + health summary (e.g., "4 Gateways — 3 Programmed, 1 Not Ready")
+- Cards are clickable — navigate to a filtered list view within the same island (client-side tab switching)
+- List views use kind-specific table columns
+
+**Detail islands** (one per resource kind):
+
+| Island | Key Panels |
+|---|---|
+| `GatewayClassDetail.tsx` | Description, controller name, supported features, conditions |
+| `GatewayDetail.tsx` | Listeners table (port, protocol, hostname, TLS), attached routes list (linked), addresses, conditions |
+| `HTTPRouteDetail.tsx` | Parent gateways (linked), hostnames, rules table (matches + filters + backends with weights), resolved backend service links, conditions |
+| `GRPCRouteDetail.tsx` | Parent gateways, rules (method/header matches + backends), conditions |
+| `TCPRouteDetail.tsx` | Parent gateways, backend refs, conditions |
+| `TLSRouteDetail.tsx` | Parent gateways, hostnames, backend refs, conditions |
+| `UDPRouteDetail.tsx` | Parent gateways, backend refs, conditions |
+
+**Detail routes:**
+- Namespaced kinds: `/networking/gateway-api/:kind/:ns/:name` — parameterized route rendering the appropriate detail island based on `:kind`.
+- GatewayClass (cluster-scoped): `/networking/gateway-api/gatewayclasses/:name` — no namespace param.
+
+**Types:** `frontend/lib/gateway-types.ts` — TypeScript interfaces matching backend normalized types.
+
+**Nav integration:**
+- New tab in `constants.ts` under network section: `{ label: "Gateway API", href: "/networking/gateway-api" }`
+- Command palette quick action: "Gateway API" navigates to the dashboard
+
+## Data Model
+
+### Backend Normalized Types (`internal/gateway/types.go`)
+
+```
+GatewayAPIStatus (CRD discovery response)
+├── available: bool
+├── version: string (e.g., "v1", "v1beta1")
+└── installedKinds: []string
+
+Condition (shared across all types)
+├── type, status, reason, message, lastTransitionTime
+
+GatewayClassSummary
+├── name, controllerName, description
+└── conditions: []Condition (Accepted)
+
+GatewaySummary
+├── name, namespace, className, age
+├── listeners: []ListenerSummary (name, port, protocol, hostname, attachedRouteCount)
+├── addresses: []string
+├── attachedRoutes: []RouteSummary (kind, name, namespace)
+└── conditions: []Condition (Accepted, Programmed)
+
+GatewayDetail (extends GatewaySummary)
+├── listeners: []ListenerDetail (adds TLS config, allowedRoutes, conditions per listener)
+└── attachedRoutes: []RouteSummary (full list with hostnames)
+
+HTTPRouteSummary
+├── name, namespace, age
+├── hostnames: []string
+├── parentRefs: []ParentRefSummary (gateway name/ns, status)
+├── backendCount: int
+└── conditions: []Condition (Accepted, ResolvedRefs)
+
+HTTPRouteDetail (extends HTTPRouteSummary)
+├── rules: []HTTPRouteRule
+│   ├── matches: []HTTPRouteMatch (path, headers, method, queryParams)
+│   ├── filters: []HTTPRouteFilter (requestRedirect, requestHeaderModifier, etc.)
+│   └── backendRefs: []BackendRefDetail (service name/ns/port, weight, resolved: bool)
+└── parentRefs: []ParentRefDetail (gateway name/ns + gateway conditions)
+
+RouteSummary (shared for GRPC/TCP/TLS/UDP list views)
+├── kind, name, namespace, age
+├── parentRefs: []ParentRefSummary
+└── conditions: []Condition
+
+GRPCRouteDetail
+├── (extends RouteSummary)
+├── rules: []GRPCRouteRule
+│   ├── matches: []GRPCRouteMatch (service, method, headers)
+│   └── backendRefs: []BackendRefDetail
+└── parentRefs: []ParentRefDetail
+
+TCPRouteDetail / TLSRouteDetail / UDPRouteDetail
+├── (extends RouteSummary)
+├── backendRefs: []BackendRefDetail
+└── parentRefs: []ParentRefDetail
+(TLSRouteDetail also has hostnames: []string)
+```
+
+### TypeScript Interfaces (`frontend/lib/gateway-types.ts`)
+
+Mirror the Go types with camelCase fields. Use existing `K8sMetadata` for common metadata.
+
+## Relationship Resolution
+
+### Gateway → Routes
+When fetching Gateway detail, query all installed route kinds across all namespaces. Filter routes whose `spec.parentRefs` reference this Gateway (match by name, namespace, optionally sectionName/port). Return as `attachedRoutes` array.
+
+### Route → Gateway
+When fetching any route detail, resolve each `spec.parentRefs` entry to the actual Gateway object. Include the Gateway's conditions so the detail page can show attachment status.
+
+### Route → Backend Services
+For HTTPRoute/GRPCRoute, resolve `spec.rules[].backendRefs` to Service objects. For TCP/TLS/UDP routes, resolve `spec.backendRefs` directly. Include `resolved: bool` — false if the Service doesn't exist or RBAC blocks access.
+
+All resolution uses `sync.WaitGroup` for parallel fetching with 2s timeout. Unresolvable references return `resolved: false` rather than erroring the request.
+
+## Caching
+
+| Scope | Strategy |
+|---|---|
+| List endpoints | singleflight + 30s TTL cache (keyed by user for RBAC) |
+| Detail endpoints | No cache — always fresh for current relationship data |
+| CRD discovery | Cached at startup, 5 min TTL, refreshable via status endpoint |
+
+## RBAC
+
+- All reads use user impersonation — users only see resources they have access to
+- Relationship resolution respects RBAC — unresolvable refs show name only with `resolved: false`
+- GatewayClass is cluster-scoped — uses `CanAccessGroupResource` for `gateway.networking.k8s.io/gatewayclasses`
+
+## Files to Create
+
+### Backend
+- `backend/internal/gateway/types.go` — normalized Go types
+- `backend/internal/gateway/discovery.go` — CRD discovery with caching
+- `backend/internal/gateway/handler.go` — HTTP handlers with singleflight/cache
+- `backend/internal/gateway/relationships.go` — cross-resource resolution logic
+
+### Frontend
+- `frontend/routes/networking/gateway-api.tsx` — dashboard route
+- `frontend/routes/networking/gateway-api/[kind]/[ns]/[name].tsx` — detail route
+- `frontend/islands/GatewayAPIDashboard.tsx` — overview cards + list views
+- `frontend/islands/GatewayClassDetail.tsx` — GatewayClass detail page
+- `frontend/islands/GatewayDetail.tsx` — Gateway detail page
+- `frontend/islands/GatewayHTTPRouteDetail.tsx` — HTTPRoute detail page
+- `frontend/islands/GatewayGRPCRouteDetail.tsx` — GRPCRoute detail page
+- `frontend/islands/GatewayTCPRouteDetail.tsx` — TCPRoute detail page
+- `frontend/islands/GatewayTLSRouteDetail.tsx` — TLSRoute detail page
+- `frontend/islands/GatewayUDPRouteDetail.tsx` — UDPRoute detail page
+- `frontend/lib/gateway-types.ts` — TypeScript interfaces
+
+### Files to Modify
+- `frontend/lib/constants.ts` — add Gateway API tab to network section
+- `backend/internal/server/routes.go` — register gateway routes
+- `backend/internal/server/server.go` — initialize gateway handler

--- a/frontend/components/gateway/BackendRefsTable.tsx
+++ b/frontend/components/gateway/BackendRefsTable.tsx
@@ -1,0 +1,76 @@
+import type { BackendRef } from "@/lib/gateway-types.ts";
+
+export default function BackendRefsTable(
+  { backendRefs }: { backendRefs?: BackendRef[] },
+) {
+  if (!backendRefs || backendRefs.length === 0) {
+    return null;
+  }
+
+  return (
+    <div class="mt-4">
+      <h3 class="text-sm font-medium text-text-secondary mb-2">
+        Backend References
+      </h3>
+      <div class="rounded-lg border border-border-primary overflow-hidden">
+        <table class="min-w-full divide-y divide-border-subtle">
+          <thead class="bg-surface">
+            <tr>
+              <th class="px-4 py-2 text-left text-xs font-medium text-text-muted">
+                Kind
+              </th>
+              <th class="px-4 py-2 text-left text-xs font-medium text-text-muted">
+                Name
+              </th>
+              <th class="px-4 py-2 text-left text-xs font-medium text-text-muted">
+                Namespace
+              </th>
+              <th class="px-4 py-2 text-left text-xs font-medium text-text-muted">
+                Port
+              </th>
+              <th class="px-4 py-2 text-left text-xs font-medium text-text-muted">
+                Weight
+              </th>
+              <th class="px-4 py-2 text-left text-xs font-medium text-text-muted">
+                Resolved
+              </th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-border-subtle">
+            {backendRefs.map((ref, i) => (
+              <tr key={i}>
+                <td class="px-4 py-2 text-sm text-text-muted">{ref.kind}</td>
+                <td class="px-4 py-2 text-sm">
+                  {ref.resolved && ref.kind === "Service"
+                    ? (
+                      <a
+                        href={`/networking/services/${ref.namespace}/${ref.name}`}
+                        class="text-brand hover:underline"
+                      >
+                        {ref.name}
+                      </a>
+                    )
+                    : <span class="text-text-primary">{ref.name}</span>}
+                </td>
+                <td class="px-4 py-2 text-sm text-text-secondary">
+                  {ref.namespace || "-"}
+                </td>
+                <td class="px-4 py-2 text-sm text-text-muted">
+                  {ref.port != null ? ref.port : "-"}
+                </td>
+                <td class="px-4 py-2 text-sm text-text-muted">
+                  {ref.weight != null ? ref.weight : "-"}
+                </td>
+                <td class="px-4 py-2 text-sm">
+                  <span class={ref.resolved ? "text-success" : "text-danger"}>
+                    {ref.resolved ? "Yes" : "No"}
+                  </span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/gateway/ConditionsTable.tsx
+++ b/frontend/components/gateway/ConditionsTable.tsx
@@ -1,0 +1,73 @@
+import type { Condition } from "@/lib/gateway-types.ts";
+
+function formatTime(ts?: string): string {
+  if (!ts) return "-";
+  const d = new Date(ts);
+  return d.toLocaleDateString() + " " + d.toLocaleTimeString();
+}
+
+export default function ConditionsTable(
+  { conditions }: { conditions?: Condition[] },
+) {
+  if (!conditions || conditions.length === 0) {
+    return null;
+  }
+
+  return (
+    <div class="mt-4">
+      <h3 class="text-sm font-medium text-text-secondary mb-2">Conditions</h3>
+      <div class="rounded-lg border border-border-primary overflow-hidden">
+        <table class="min-w-full divide-y divide-border-subtle">
+          <thead class="bg-surface">
+            <tr>
+              <th class="px-4 py-2 text-left text-xs font-medium text-text-muted">
+                Type
+              </th>
+              <th class="px-4 py-2 text-left text-xs font-medium text-text-muted">
+                Status
+              </th>
+              <th class="px-4 py-2 text-left text-xs font-medium text-text-muted">
+                Reason
+              </th>
+              <th class="px-4 py-2 text-left text-xs font-medium text-text-muted">
+                Message
+              </th>
+              <th class="px-4 py-2 text-left text-xs font-medium text-text-muted">
+                Last Transition
+              </th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-border-subtle">
+            {conditions.map((c, i) => (
+              <tr key={i}>
+                <td class="px-4 py-2 text-sm text-text-primary font-medium">
+                  {c.type}
+                </td>
+                <td class="px-4 py-2 text-sm">
+                  <span
+                    class={c.status === "True"
+                      ? "text-success"
+                      : c.status === "False"
+                      ? "text-danger"
+                      : "text-warning"}
+                  >
+                    {c.status}
+                  </span>
+                </td>
+                <td class="px-4 py-2 text-sm text-text-secondary">
+                  {c.reason || "-"}
+                </td>
+                <td class="px-4 py-2 text-sm text-text-muted max-w-xs truncate">
+                  {c.message || "-"}
+                </td>
+                <td class="px-4 py-2 text-sm text-text-muted">
+                  {formatTime(c.lastTransitionTime)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/gateway/ParentGatewaysTable.tsx
+++ b/frontend/components/gateway/ParentGatewaysTable.tsx
@@ -1,0 +1,68 @@
+import type { ParentRef } from "@/lib/gateway-types.ts";
+
+export default function ParentGatewaysTable(
+  { parentRefs }: { parentRefs?: ParentRef[] },
+) {
+  if (!parentRefs || parentRefs.length === 0) {
+    return null;
+  }
+
+  return (
+    <div class="mt-4">
+      <h3 class="text-sm font-medium text-text-secondary mb-2">
+        Parent Gateways
+      </h3>
+      <div class="rounded-lg border border-border-primary overflow-hidden">
+        <table class="min-w-full divide-y divide-border-subtle">
+          <thead class="bg-surface">
+            <tr>
+              <th class="px-4 py-2 text-left text-xs font-medium text-text-muted">
+                Name
+              </th>
+              <th class="px-4 py-2 text-left text-xs font-medium text-text-muted">
+                Namespace
+              </th>
+              <th class="px-4 py-2 text-left text-xs font-medium text-text-muted">
+                Section
+              </th>
+              <th class="px-4 py-2 text-left text-xs font-medium text-text-muted">
+                Status
+              </th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-border-subtle">
+            {parentRefs.map((ref, i) => (
+              <tr key={i}>
+                <td class="px-4 py-2 text-sm">
+                  <a
+                    href={`/networking/gateway-api/gateways/${ref.namespace}/${ref.name}`}
+                    class="text-brand hover:underline"
+                  >
+                    {ref.name}
+                  </a>
+                </td>
+                <td class="px-4 py-2 text-sm text-text-secondary">
+                  {ref.namespace || "-"}
+                </td>
+                <td class="px-4 py-2 text-sm text-text-muted">
+                  {ref.sectionName || "-"}
+                </td>
+                <td class="px-4 py-2 text-sm">
+                  <span
+                    class={ref.status === "Accepted"
+                      ? "text-success"
+                      : ref.status
+                      ? "text-danger"
+                      : "text-text-muted"}
+                  >
+                    {ref.status || "-"}
+                  </span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/ui/GatewayBadges.tsx
+++ b/frontend/components/ui/GatewayBadges.tsx
@@ -1,0 +1,57 @@
+import type { Condition } from "@/lib/gateway-types.ts";
+
+export function ConditionBadge({ condition }: { condition: Condition }) {
+  const colorClass = condition.status === "True"
+    ? "text-success bg-success/10"
+    : condition.status === "False"
+    ? "text-danger bg-danger/10"
+    : "text-warning bg-warning/10";
+
+  return (
+    <span
+      class={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${colorClass}`}
+    >
+      {condition.type}: {condition.status}
+    </span>
+  );
+}
+
+export function ProtocolBadge({ protocol }: { protocol: string }) {
+  const colorClass = protocol === "HTTPS" || protocol === "TLS"
+    ? "text-success bg-success/10"
+    : protocol === "HTTP"
+    ? "text-brand bg-brand/10"
+    : "text-text-secondary bg-surface";
+
+  return (
+    <span
+      class={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${colorClass}`}
+    >
+      {protocol}
+    </span>
+  );
+}
+
+export function StatusBadge(
+  { conditions }: { conditions?: Condition[] },
+) {
+  if (!conditions || conditions.length === 0) {
+    return <span class="text-text-muted text-sm">-</span>;
+  }
+
+  // Find the most relevant condition (Accepted or Programmed)
+  const primary = conditions.find(
+    (c) => c.type === "Accepted" || c.type === "Programmed",
+  );
+
+  if (!primary) {
+    return <span class="text-text-muted text-sm">Unknown</span>;
+  }
+
+  const isHealthy = primary.status === "True";
+  return (
+    <span class={`text-sm ${isHealthy ? "text-success" : "text-danger"}`}>
+      {isHealthy ? primary.type : primary.reason || "Not Ready"}
+    </span>
+  );
+}

--- a/frontend/components/ui/GatewayBadges.tsx
+++ b/frontend/components/ui/GatewayBadges.tsx
@@ -1,21 +1,3 @@
-import type { Condition } from "@/lib/gateway-types.ts";
-
-export function ConditionBadge({ condition }: { condition: Condition }) {
-  const colorClass = condition.status === "True"
-    ? "text-success bg-success/10"
-    : condition.status === "False"
-    ? "text-danger bg-danger/10"
-    : "text-warning bg-warning/10";
-
-  return (
-    <span
-      class={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${colorClass}`}
-    >
-      {condition.type}: {condition.status}
-    </span>
-  );
-}
-
 export function ProtocolBadge({ protocol }: { protocol: string }) {
   const colorClass = protocol === "HTTPS" || protocol === "TLS"
     ? "text-success bg-success/10"
@@ -28,30 +10,6 @@ export function ProtocolBadge({ protocol }: { protocol: string }) {
       class={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${colorClass}`}
     >
       {protocol}
-    </span>
-  );
-}
-
-export function StatusBadge(
-  { conditions }: { conditions?: Condition[] },
-) {
-  if (!conditions || conditions.length === 0) {
-    return <span class="text-text-muted text-sm">-</span>;
-  }
-
-  // Find the most relevant condition (Accepted or Programmed)
-  const primary = conditions.find(
-    (c) => c.type === "Accepted" || c.type === "Programmed",
-  );
-
-  if (!primary) {
-    return <span class="text-text-muted text-sm">Unknown</span>;
-  }
-
-  const isHealthy = primary.status === "True";
-  return (
-    <span class={`text-sm ${isHealthy ? "text-success" : "text-danger"}`}>
-      {isHealthy ? primary.type : primary.reason || "Not Ready"}
     </span>
   );
 }

--- a/frontend/islands/CommandPalette.tsx
+++ b/frontend/islands/CommandPalette.tsx
@@ -88,6 +88,7 @@ function buildSearchIndex(): SearchItem[] {
       label: "View Expiring Certificates",
       href: "/security/certificates?status=expiring",
     },
+    { label: "View Gateway API", href: "/networking/gateway-api" },
     { label: "View Notifications", href: "/notifications" },
     { label: "Notification Channels", href: "/admin/notifications/channels" },
     { label: "Notification Rules", href: "/admin/notifications/rules" },

--- a/frontend/islands/GatewayAPIDashboard.tsx
+++ b/frontend/islands/GatewayAPIDashboard.tsx
@@ -1,0 +1,613 @@
+import { IS_BROWSER } from "fresh/runtime";
+import { useEffect } from "preact/hooks";
+import { useSignal } from "@preact/signals";
+import { apiGet } from "@/lib/api.ts";
+import { SearchBar } from "@/components/ui/SearchBar.tsx";
+import { Spinner } from "@/components/ui/Spinner.tsx";
+import type {
+  GatewayAPIStatus,
+  GatewayAPISummary,
+  GatewayClassSummary,
+  GatewayListData,
+  GatewayResourceKind,
+  GatewaySummary,
+  HTTPRouteSummary,
+  KindSummary,
+  RouteSummary,
+} from "@/lib/gateway-types.ts";
+
+const KIND_LABELS: Record<GatewayResourceKind, string> = {
+  gatewayclasses: "Gateway Classes",
+  gateways: "Gateways",
+  httproutes: "HTTP Routes",
+  grpcroutes: "gRPC Routes",
+  tcproutes: "TCP Routes",
+  tlsroutes: "TLS Routes",
+  udproutes: "UDP Routes",
+};
+
+const SUMMARY_KEYS: Record<GatewayResourceKind, keyof GatewayAPISummary> = {
+  gatewayclasses: "gatewayClasses",
+  gateways: "gateways",
+  httproutes: "httpRoutes",
+  grpcroutes: "grpcRoutes",
+  tcproutes: "tcpRoutes",
+  tlsroutes: "tlsRoutes",
+  udproutes: "udpRoutes",
+};
+
+function formatAge(ageStr: string): string {
+  if (!ageStr) return "\u2014";
+  const date = new Date(ageStr);
+  if (isNaN(date.getTime())) {
+    // Already a relative string like "2d" from the backend
+    return ageStr;
+  }
+  const now = Date.now();
+  const diffMs = now - date.getTime();
+  if (diffMs < 0) return "0s";
+  const seconds = Math.floor(diffMs / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `${days}d`;
+}
+
+function getAcceptedStatus(
+  conditions?: { type: string; status: string }[],
+): boolean {
+  if (!conditions || conditions.length === 0) return false;
+  const accepted = conditions.find(
+    (c) => c.type === "Accepted" || c.type === "Programmed",
+  );
+  return accepted?.status === "True";
+}
+
+function StatusBadge(
+  { conditions }: { conditions?: { type: string; status: string }[] },
+) {
+  const ok = getAcceptedStatus(conditions);
+  return (
+    <span
+      class={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+        ok ? "bg-success/15 text-success" : "bg-danger/15 text-danger"
+      }`}
+    >
+      {ok ? "Accepted" : "Not Ready"}
+    </span>
+  );
+}
+
+export default function GatewayAPIDashboard() {
+  const status = useSignal<GatewayAPIStatus | null>(null);
+  const summary = useSignal<GatewayAPISummary | null>(null);
+  const loading = useSignal(true);
+  const error = useSignal("");
+  const activeKind = useSignal<GatewayResourceKind | null>(null);
+  const listData = useSignal<GatewayListData | null>(null);
+  const listLoading = useSignal(false);
+  const search = useSignal("");
+
+  async function fetchList(kind: GatewayResourceKind) {
+    listLoading.value = true;
+    try {
+      let endpoint: string;
+      switch (kind) {
+        case "gatewayclasses":
+          endpoint = "/v1/gateway/gatewayclasses";
+          break;
+        case "gateways":
+          endpoint = "/v1/gateway/gateways";
+          break;
+        case "httproutes":
+          endpoint = "/v1/gateway/httproutes";
+          break;
+        default:
+          endpoint = `/v1/gateway/routes?kind=${kind}`;
+          break;
+      }
+      const res = await apiGet<unknown[]>(endpoint);
+      const items = Array.isArray(res.data) ? res.data : [];
+      // deno-lint-ignore no-explicit-any
+      listData.value = { kind, items } as any;
+    } catch {
+      listData.value = { kind, items: [] } as GatewayListData;
+    }
+    listLoading.value = false;
+  }
+
+  function handleCardClick(kind: GatewayResourceKind) {
+    activeKind.value = kind;
+    search.value = "";
+    fetchList(kind);
+  }
+
+  // URL state sync
+  useEffect(() => {
+    if (!IS_BROWSER) return;
+    if (activeKind.value) {
+      const url = new URL(globalThis.location.href);
+      url.searchParams.set("kind", activeKind.value);
+      globalThis.history.replaceState(null, "", url.toString());
+    } else {
+      const url = new URL(globalThis.location.href);
+      url.searchParams.delete("kind");
+      globalThis.history.replaceState(null, "", url.toString());
+    }
+  }, [activeKind.value]);
+
+  // Initial load
+  useEffect(() => {
+    if (!IS_BROWSER) return;
+    const params = new URLSearchParams(globalThis.location.search);
+    const kindParam = params.get("kind") as GatewayResourceKind | null;
+
+    Promise.all([
+      apiGet<GatewayAPIStatus>("/v1/gateway/status"),
+      apiGet<GatewayAPISummary>("/v1/gateway/summary"),
+    ]).then(([statusRes, summaryRes]) => {
+      status.value = statusRes.data ?? null;
+      summary.value = summaryRes.data ?? null;
+
+      if (
+        kindParam && status.value?.available &&
+        Object.keys(KIND_LABELS).includes(kindParam)
+      ) {
+        activeKind.value = kindParam;
+        fetchList(kindParam);
+      }
+      loading.value = false;
+    }).catch(() => {
+      error.value = "Failed to load Gateway API status";
+      loading.value = false;
+    });
+  }, []);
+
+  if (!IS_BROWSER) return null;
+
+  if (loading.value) {
+    return (
+      <div class="flex justify-center py-12">
+        <Spinner class="text-brand" />
+      </div>
+    );
+  }
+
+  if (error.value) {
+    return <p class="text-sm text-danger py-4">{error.value}</p>;
+  }
+
+  if (!status.value?.available) {
+    return (
+      <div class="rounded-lg border border-border-primary bg-bg-elevated p-8 text-center">
+        <h3 class="text-lg font-medium text-text-primary">
+          Gateway API Not Detected
+        </h3>
+        <p class="mt-2 text-sm text-text-muted">
+          No Gateway API CRDs found in this cluster. Install Gateway API to
+          manage Gateways, HTTPRoutes, and other resources.
+        </p>
+      </div>
+    );
+  }
+
+  // List mode
+  if (activeKind.value) {
+    return (
+      <div>
+        <button
+          type="button"
+          onClick={() => {
+            activeKind.value = null;
+            listData.value = null;
+            search.value = "";
+          }}
+          class="mb-4 inline-flex items-center gap-1 text-sm text-text-muted hover:text-text-primary transition-colors"
+        >
+          <svg
+            class="h-4 w-4"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+          >
+            <path
+              fill-rule="evenodd"
+              d="M17 10a.75.75 0 01-.75.75H5.612l4.158 3.96a.75.75 0 11-1.04 1.08l-5.5-5.25a.75.75 0 010-1.08l5.5-5.25a.75.75 0 111.04 1.08L5.612 9.25H16.25A.75.75 0 0117 10z"
+              clip-rule="evenodd"
+            />
+          </svg>
+          Back to overview
+        </button>
+
+        <h2 class="text-xl font-semibold text-text-primary mb-4">
+          {KIND_LABELS[activeKind.value]}
+        </h2>
+
+        <div class="mb-4 flex flex-wrap items-center gap-4">
+          <div class="flex-1 max-w-xs">
+            <SearchBar
+              value={search.value}
+              onInput={(v) => {
+                search.value = v;
+              }}
+              placeholder="Filter by name or namespace..."
+            />
+          </div>
+          {listData.value && (
+            <span class="text-xs text-text-muted">
+              {listData.value.items.length} total
+            </span>
+          )}
+        </div>
+
+        {listLoading.value && (
+          <div class="flex justify-center py-12">
+            <Spinner class="text-brand" />
+          </div>
+        )}
+
+        {!listLoading.value && listData.value &&
+          renderTable(activeKind.value, listData.value, search.value)}
+      </div>
+    );
+  }
+
+  // Overview mode
+  const installedKinds = (status.value.installedKinds ?? []) as string[];
+  const allKinds = Object.keys(KIND_LABELS) as GatewayResourceKind[];
+  const visibleKinds = allKinds.filter((k) => installedKinds.includes(k));
+
+  if (visibleKinds.length === 0) {
+    return (
+      <div class="rounded-lg border border-border-primary bg-bg-elevated p-8 text-center">
+        <h3 class="text-lg font-medium text-text-primary">
+          No Gateway API Resources
+        </h3>
+        <p class="mt-2 text-sm text-text-muted">
+          Gateway API CRDs are installed but no resource kinds were detected.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+      {visibleKinds.map((kind) => {
+        const kindSummary: KindSummary = summary.value
+          ? summary.value[SUMMARY_KEYS[kind]]
+          : { total: 0, healthy: 0, degraded: 0 };
+        return (
+          <button
+            type="button"
+            key={kind}
+            onClick={() => handleCardClick(kind)}
+            class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-left transition-colors hover:border-border-hover hover:bg-hover/30"
+          >
+            <div class="text-sm font-medium text-text-muted">
+              {KIND_LABELS[kind]}
+            </div>
+            <div class="mt-1 text-2xl font-semibold text-text-primary">
+              {kindSummary.total}
+            </div>
+            <div class="mt-1 text-xs">
+              {kindSummary.healthy > 0 && (
+                <span class="text-success">
+                  {kindSummary.healthy} healthy
+                </span>
+              )}
+              {kindSummary.degraded > 0 && (
+                <span class="text-danger ml-2">
+                  {kindSummary.degraded} degraded
+                </span>
+              )}
+              {kindSummary.healthy === 0 && kindSummary.degraded === 0 &&
+                kindSummary.total > 0 && (
+                <span class="text-text-muted">
+                  {kindSummary.total} total
+                </span>
+              )}
+            </div>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function filterBySearch<
+  T extends { name: string; namespace?: string },
+>(items: T[], query: string): T[] {
+  if (!query) return items;
+  const q = query.toLowerCase();
+  return items.filter(
+    (item) =>
+      item.name.toLowerCase().includes(q) ||
+      (item.namespace && item.namespace.toLowerCase().includes(q)),
+  );
+}
+
+function getDetailHref(
+  kind: GatewayResourceKind,
+  item: { name: string; namespace?: string },
+): string {
+  switch (kind) {
+    case "gatewayclasses":
+      return `/networking/gateway-api/gatewayclasses/${item.name}`;
+    case "gateways":
+      return `/networking/gateway-api/gateways/${item.namespace}/${item.name}`;
+    case "httproutes":
+      return `/networking/gateway-api/httproutes/${item.namespace}/${item.name}`;
+    default:
+      return `/networking/gateway-api/${kind}/${item.namespace}/${item.name}`;
+  }
+}
+
+const TH = "px-3 py-2 text-left text-xs font-medium text-text-muted";
+const TD = "px-3 py-2";
+const TD_SEC = "px-3 py-2 text-text-secondary";
+
+function renderTable(
+  kind: GatewayResourceKind,
+  data: GatewayListData,
+  query: string,
+) {
+  switch (kind) {
+    case "gatewayclasses":
+      return renderGatewayClassesTable(
+        filterBySearch(
+          data.items as GatewayClassSummary[],
+          query,
+        ),
+      );
+    case "gateways":
+      return renderGatewaysTable(
+        filterBySearch(data.items as GatewaySummary[], query),
+      );
+    case "httproutes":
+      return renderHTTPRoutesTable(
+        filterBySearch(
+          data.items as HTTPRouteSummary[],
+          query,
+        ),
+      );
+    default:
+      return renderRoutesTable(
+        kind,
+        filterBySearch(data.items as RouteSummary[], query),
+      );
+  }
+}
+
+function EmptyTable({ message }: { message: string }) {
+  return (
+    <div class="text-center py-12 rounded-lg border border-border-primary bg-bg-elevated">
+      <p class="text-text-muted">{message}</p>
+    </div>
+  );
+}
+
+function renderGatewayClassesTable(items: GatewayClassSummary[]) {
+  if (items.length === 0) {
+    return <EmptyTable message="No gateway classes found." />;
+  }
+  return (
+    <div class="overflow-x-auto rounded-lg border border-border-primary">
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="border-b border-border-primary bg-surface">
+            <th class={TH}>Name</th>
+            <th class={TH}>Controller</th>
+            <th class={TH}>Description</th>
+            <th class={TH}>Status</th>
+            <th class={TH}>Age</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-border-subtle">
+          {items.map((item) => (
+            <tr
+              key={item.name}
+              class="hover:bg-hover/30 cursor-pointer"
+              onClick={() => {
+                globalThis.location.href = getDetailHref(
+                  "gatewayclasses",
+                  item,
+                );
+              }}
+            >
+              <td class={TD}>
+                <a
+                  href={getDetailHref("gatewayclasses", item)}
+                  class="font-medium text-brand hover:underline"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {item.name}
+                </a>
+              </td>
+              <td class={TD_SEC}>{item.controllerName}</td>
+              <td class={`${TD_SEC} max-w-[200px] truncate`}>
+                {item.description || "\u2014"}
+              </td>
+              <td class={TD}>
+                <StatusBadge conditions={item.conditions} />
+              </td>
+              <td class={TD_SEC}>{formatAge(item.age)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function renderGatewaysTable(items: GatewaySummary[]) {
+  if (items.length === 0) {
+    return <EmptyTable message="No gateways found." />;
+  }
+  return (
+    <div class="overflow-x-auto rounded-lg border border-border-primary">
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="border-b border-border-primary bg-surface">
+            <th class={TH}>Name</th>
+            <th class={TH}>Namespace</th>
+            <th class={TH}>Class</th>
+            <th class={TH}>Listeners</th>
+            <th class={TH}>Addresses</th>
+            <th class={TH}>Status</th>
+            <th class={TH}>Age</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-border-subtle">
+          {items.map((item) => (
+            <tr
+              key={`${item.namespace}/${item.name}`}
+              class="hover:bg-hover/30 cursor-pointer"
+              onClick={() => {
+                globalThis.location.href = getDetailHref("gateways", item);
+              }}
+            >
+              <td class={TD}>
+                <a
+                  href={getDetailHref("gateways", item)}
+                  class="font-medium text-brand hover:underline"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {item.name}
+                </a>
+              </td>
+              <td class={TD_SEC}>{item.namespace}</td>
+              <td class={TD_SEC}>{item.gatewayClassName}</td>
+              <td class={TD_SEC}>
+                {item.listeners?.length ?? 0}
+              </td>
+              <td class={`${TD_SEC} max-w-[200px] truncate text-xs`}>
+                {(item.addresses ?? []).join(", ") || "\u2014"}
+              </td>
+              <td class={TD}>
+                <StatusBadge conditions={item.conditions} />
+              </td>
+              <td class={TD_SEC}>{formatAge(item.age)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function renderHTTPRoutesTable(items: HTTPRouteSummary[]) {
+  if (items.length === 0) {
+    return <EmptyTable message="No HTTP routes found." />;
+  }
+  return (
+    <div class="overflow-x-auto rounded-lg border border-border-primary">
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="border-b border-border-primary bg-surface">
+            <th class={TH}>Name</th>
+            <th class={TH}>Namespace</th>
+            <th class={TH}>Hostnames</th>
+            <th class={TH}>Parents</th>
+            <th class={TH}>Backends</th>
+            <th class={TH}>Status</th>
+            <th class={TH}>Age</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-border-subtle">
+          {items.map((item) => (
+            <tr
+              key={`${item.namespace}/${item.name}`}
+              class="hover:bg-hover/30 cursor-pointer"
+              onClick={() => {
+                globalThis.location.href = getDetailHref("httproutes", item);
+              }}
+            >
+              <td class={TD}>
+                <a
+                  href={getDetailHref("httproutes", item)}
+                  class="font-medium text-brand hover:underline"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {item.name}
+                </a>
+              </td>
+              <td class={TD_SEC}>{item.namespace}</td>
+              <td class={`${TD_SEC} max-w-[200px] truncate text-xs`}>
+                {(item.hostnames ?? []).join(", ") || "\u2014"}
+              </td>
+              <td class={TD_SEC}>
+                {item.parentRefs?.length ?? 0}
+              </td>
+              <td class={TD_SEC}>
+                {item.backendCount ?? 0}
+              </td>
+              <td class={TD}>
+                <StatusBadge conditions={item.conditions} />
+              </td>
+              <td class={TD_SEC}>{formatAge(item.age)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function renderRoutesTable(
+  kind: GatewayResourceKind,
+  items: RouteSummary[],
+) {
+  if (items.length === 0) {
+    return (
+      <EmptyTable
+        message={`No ${KIND_LABELS[kind]?.toLowerCase() ?? "routes"} found.`}
+      />
+    );
+  }
+  return (
+    <div class="overflow-x-auto rounded-lg border border-border-primary">
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="border-b border-border-primary bg-surface">
+            <th class={TH}>Name</th>
+            <th class={TH}>Namespace</th>
+            <th class={TH}>Parents</th>
+            <th class={TH}>Status</th>
+            <th class={TH}>Age</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-border-subtle">
+          {items.map((item) => (
+            <tr
+              key={`${item.namespace}/${item.name}`}
+              class="hover:bg-hover/30 cursor-pointer"
+              onClick={() => {
+                globalThis.location.href = getDetailHref(kind, item);
+              }}
+            >
+              <td class={TD}>
+                <a
+                  href={getDetailHref(kind, item)}
+                  class="font-medium text-brand hover:underline"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {item.name}
+                </a>
+              </td>
+              <td class={TD_SEC}>{item.namespace}</td>
+              <td class={TD_SEC}>
+                {item.parentRefs?.length ?? 0}
+              </td>
+              <td class={TD}>
+                <StatusBadge conditions={item.conditions} />
+              </td>
+              <td class={TD_SEC}>{formatAge(item.age)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/islands/GatewayClassDetail.tsx
+++ b/frontend/islands/GatewayClassDetail.tsx
@@ -1,0 +1,87 @@
+import { useSignal } from "@preact/signals";
+import { IS_BROWSER } from "fresh/runtime";
+import { useEffect } from "preact/hooks";
+import { apiGet } from "@/lib/api.ts";
+import { Spinner } from "@/components/ui/Spinner.tsx";
+import type { GatewayClassSummary } from "@/lib/gateway-types.ts";
+import ConditionsTable from "@/components/gateway/ConditionsTable.tsx";
+
+interface Props {
+  name: string;
+}
+
+export default function GatewayClassDetailIsland({ name }: Props) {
+  const loading = useSignal(true);
+  const error = useSignal<string | null>(null);
+  const data = useSignal<GatewayClassSummary | null>(null);
+
+  useEffect(() => {
+    if (!IS_BROWSER) return;
+    async function fetch() {
+      loading.value = true;
+      error.value = null;
+      try {
+        const res = await apiGet<GatewayClassSummary>(
+          `/v1/gateway/gatewayclasses/${name}`,
+        );
+        data.value = res.data ?? null;
+      } catch {
+        error.value = "Failed to load GatewayClass details";
+      } finally {
+        loading.value = false;
+      }
+    }
+    fetch();
+  }, [name]);
+
+  if (!IS_BROWSER) return null;
+
+  if (loading.value) {
+    return (
+      <div class="flex justify-center py-12">
+        <Spinner class="text-brand" />
+      </div>
+    );
+  }
+
+  if (error.value) {
+    return <p class="text-sm text-danger p-6">{error.value}</p>;
+  }
+
+  if (!data.value) return null;
+
+  const gc = data.value;
+
+  return (
+    <div class="p-6 space-y-6">
+      <a
+        href="/networking/gateway-api?kind=gatewayclasses"
+        class="text-sm text-brand hover:underline"
+      >
+        &larr; Back to Gateway Classes
+      </a>
+
+      <h2 class="text-2xl font-bold text-text-primary">{gc.name}</h2>
+
+      <div class="rounded-lg border border-border-primary bg-bg-elevated p-5">
+        <h3 class="text-sm font-semibold text-text-primary mb-4">Details</h3>
+        <dl class="grid grid-cols-2 gap-4 text-sm">
+          <div>
+            <dt class="text-text-muted">Controller</dt>
+            <dd class="text-text-primary">{gc.controllerName}</dd>
+          </div>
+          <div>
+            <dt class="text-text-muted">Description</dt>
+            <dd class="text-text-primary">{gc.description || "-"}</dd>
+          </div>
+          <div>
+            <dt class="text-text-muted">Age</dt>
+            <dd class="text-text-primary">{gc.age}</dd>
+          </div>
+        </dl>
+      </div>
+
+      <ConditionsTable conditions={gc.conditions} />
+    </div>
+  );
+}

--- a/frontend/islands/GatewayDetail.tsx
+++ b/frontend/islands/GatewayDetail.tsx
@@ -1,0 +1,236 @@
+import { useSignal } from "@preact/signals";
+import { IS_BROWSER } from "fresh/runtime";
+import { useEffect } from "preact/hooks";
+import { apiGet } from "@/lib/api.ts";
+import { Spinner } from "@/components/ui/Spinner.tsx";
+import { ProtocolBadge } from "@/components/ui/GatewayBadges.tsx";
+import type { GatewayDetail } from "@/lib/gateway-types.ts";
+import ConditionsTable from "@/components/gateway/ConditionsTable.tsx";
+
+interface Props {
+  namespace: string;
+  name: string;
+}
+
+export default function GatewayDetailIsland({ namespace, name }: Props) {
+  const loading = useSignal(true);
+  const error = useSignal<string | null>(null);
+  const data = useSignal<GatewayDetail | null>(null);
+
+  useEffect(() => {
+    if (!IS_BROWSER) return;
+    async function fetch() {
+      loading.value = true;
+      error.value = null;
+      try {
+        const res = await apiGet<GatewayDetail>(
+          `/v1/gateway/gateways/${namespace}/${name}`,
+        );
+        data.value = res.data ?? null;
+      } catch {
+        error.value = "Failed to load Gateway details";
+      } finally {
+        loading.value = false;
+      }
+    }
+    fetch();
+  }, [namespace, name]);
+
+  if (!IS_BROWSER) return null;
+
+  if (loading.value) {
+    return (
+      <div class="flex justify-center py-12">
+        <Spinner class="text-brand" />
+      </div>
+    );
+  }
+
+  if (error.value) {
+    return <p class="text-sm text-danger p-6">{error.value}</p>;
+  }
+
+  if (!data.value) return null;
+
+  const gw = data.value;
+
+  return (
+    <div class="p-6 space-y-6">
+      <a
+        href="/networking/gateway-api?kind=gateways"
+        class="text-sm text-brand hover:underline"
+      >
+        &larr; Back to Gateways
+      </a>
+
+      <div class="flex flex-wrap items-center gap-3">
+        <h2 class="text-2xl font-bold text-text-primary">{gw.name}</h2>
+        <span class="rounded-full bg-surface px-2.5 py-0.5 text-xs font-medium text-text-secondary">
+          {gw.namespace}
+        </span>
+      </div>
+
+      {/* Details */}
+      <div class="rounded-lg border border-border-primary bg-bg-elevated p-5">
+        <h3 class="text-sm font-semibold text-text-primary mb-4">Details</h3>
+        <dl class="grid grid-cols-2 gap-4 text-sm">
+          <div>
+            <dt class="text-text-muted">Gateway Class</dt>
+            <dd>
+              <a
+                href={`/networking/gateway-api/gatewayclasses/${gw.gatewayClassName}`}
+                class="text-brand hover:underline"
+              >
+                {gw.gatewayClassName}
+              </a>
+            </dd>
+          </div>
+          <div>
+            <dt class="text-text-muted">Addresses</dt>
+            <dd class="text-text-primary">
+              {(gw.addresses ?? []).join(", ") || "-"}
+            </dd>
+          </div>
+          <div>
+            <dt class="text-text-muted">Age</dt>
+            <dd class="text-text-primary">{gw.age}</dd>
+          </div>
+        </dl>
+      </div>
+
+      {/* Listeners */}
+      {gw.listeners && gw.listeners.length > 0 && (
+        <div class="rounded-lg border border-border-primary">
+          <h3 class="text-sm font-semibold text-text-primary px-4 py-3 border-b border-border-primary">
+            Listeners ({gw.listeners.length})
+          </h3>
+          <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+              <thead>
+                <tr class="border-b border-border-primary bg-surface">
+                  <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
+                    Name
+                  </th>
+                  <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
+                    Port
+                  </th>
+                  <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
+                    Protocol
+                  </th>
+                  <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
+                    Hostname
+                  </th>
+                  <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
+                    TLS Mode
+                  </th>
+                  <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
+                    Cert Ref
+                  </th>
+                  <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
+                    Attached Routes
+                  </th>
+                  <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
+                    Status
+                  </th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-border-subtle">
+                {gw.listeners.map((l) => {
+                  const accepted = l.conditions?.find(
+                    (c) => c.type === "Accepted",
+                  );
+                  const isHealthy = accepted?.status === "True";
+                  return (
+                    <tr key={l.name} class="hover:bg-hover/30">
+                      <td class="px-3 py-2 font-medium text-text-primary">
+                        {l.name}
+                      </td>
+                      <td class="px-3 py-2 text-text-secondary">{l.port}</td>
+                      <td class="px-3 py-2">
+                        <ProtocolBadge protocol={l.protocol} />
+                      </td>
+                      <td class="px-3 py-2 text-text-secondary">
+                        {l.hostname || "*"}
+                      </td>
+                      <td class="px-3 py-2 text-text-secondary">
+                        {l.tlsMode || "-"}
+                      </td>
+                      <td class="px-3 py-2 text-text-secondary">
+                        {l.certificateRef || "-"}
+                      </td>
+                      <td class="px-3 py-2 text-text-secondary">
+                        {l.attachedRouteCount}
+                      </td>
+                      <td class="px-3 py-2">
+                        {accepted
+                          ? (
+                            <span
+                              class={isHealthy ? "text-success" : "text-danger"}
+                            >
+                              {isHealthy
+                                ? "Accepted"
+                                : accepted.reason || "Not Accepted"}
+                            </span>
+                          )
+                          : <span class="text-text-muted">-</span>}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {/* Attached Routes */}
+      {gw.attachedRoutes && gw.attachedRoutes.length > 0 && (
+        <div class="rounded-lg border border-border-primary">
+          <h3 class="text-sm font-semibold text-text-primary px-4 py-3 border-b border-border-primary">
+            Attached Routes ({gw.attachedRoutes.length})
+          </h3>
+          <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+              <thead>
+                <tr class="border-b border-border-primary bg-surface">
+                  <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
+                    Kind
+                  </th>
+                  <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
+                    Name
+                  </th>
+                  <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
+                    Namespace
+                  </th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-border-subtle">
+                {gw.attachedRoutes.map((r) => (
+                  <tr
+                    key={`${r.kind}-${r.namespace}-${r.name}`}
+                    class="hover:bg-hover/30"
+                  >
+                    <td class="px-3 py-2 text-text-secondary">{r.kind}</td>
+                    <td class="px-3 py-2">
+                      <a
+                        href={`/networking/gateway-api/${r.kind.toLowerCase()}s/${r.namespace}/${r.name}`}
+                        class="text-brand hover:underline font-medium"
+                      >
+                        {r.name}
+                      </a>
+                    </td>
+                    <td class="px-3 py-2 text-text-secondary">
+                      {r.namespace}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      <ConditionsTable conditions={gw.conditions} />
+    </div>
+  );
+}

--- a/frontend/islands/GatewayGRPCRouteDetail.tsx
+++ b/frontend/islands/GatewayGRPCRouteDetail.tsx
@@ -1,0 +1,151 @@
+import { useSignal } from "@preact/signals";
+import { IS_BROWSER } from "fresh/runtime";
+import { useEffect } from "preact/hooks";
+import { apiGet } from "@/lib/api.ts";
+import { Spinner } from "@/components/ui/Spinner.tsx";
+import type { GRPCRouteDetail } from "@/lib/gateway-types.ts";
+import ConditionsTable from "@/components/gateway/ConditionsTable.tsx";
+import ParentGatewaysTable from "@/components/gateway/ParentGatewaysTable.tsx";
+import BackendRefsTable from "@/components/gateway/BackendRefsTable.tsx";
+
+interface Props {
+  namespace: string;
+  name: string;
+}
+
+export default function GatewayGRPCRouteDetailIsland(
+  { namespace, name }: Props,
+) {
+  const loading = useSignal(true);
+  const error = useSignal<string | null>(null);
+  const data = useSignal<GRPCRouteDetail | null>(null);
+
+  async function fetchDetail() {
+    loading.value = true;
+    error.value = null;
+    try {
+      const res = await apiGet<GRPCRouteDetail>(
+        `/v1/gateway/routes/grpcroutes/${namespace}/${name}`,
+      );
+      data.value = res.data ?? null;
+    } catch {
+      error.value = "Failed to load GRPCRoute details";
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  useEffect(() => {
+    if (!IS_BROWSER) return;
+    fetchDetail();
+  }, [namespace, name]);
+
+  if (!IS_BROWSER) return null;
+
+  if (loading.value) {
+    return (
+      <div class="flex justify-center py-12">
+        <Spinner class="text-brand" />
+      </div>
+    );
+  }
+
+  if (error.value) {
+    return <p class="text-sm text-danger p-6">{error.value}</p>;
+  }
+
+  if (!data.value) return null;
+
+  const detail = data.value;
+
+  return (
+    <div class="p-6 space-y-6">
+      {/* Back link */}
+      <a
+        href="/networking/gateway-api?kind=grpcroutes"
+        class="text-sm text-brand hover:underline"
+      >
+        &larr; Back to gRPC Routes
+      </a>
+
+      {/* Header */}
+      <div>
+        <h1 class="text-2xl font-bold text-text-primary">{detail.name}</h1>
+        <p class="text-sm text-text-muted mt-1">
+          Namespace: {detail.namespace}
+        </p>
+      </div>
+
+      {/* Parent Gateways */}
+      <ParentGatewaysTable parentRefs={detail.parentRefs} />
+
+      {/* Rules */}
+      {detail.rules && detail.rules.length > 0 && (
+        <div class="space-y-4">
+          <h2 class="text-sm font-semibold text-text-primary">
+            Rules ({detail.rules.length})
+          </h2>
+          {detail.rules.map((rule, ri) => (
+            <div
+              key={ri}
+              class="rounded-lg border border-border-primary bg-bg-elevated p-5 space-y-4"
+            >
+              <h3 class="text-sm font-medium text-text-primary">
+                Rule {ri + 1}
+              </h3>
+
+              {/* Matches */}
+              {rule.matches && rule.matches.length > 0 && (
+                <div>
+                  <h4 class="text-xs font-medium text-text-muted mb-2">
+                    Matches
+                  </h4>
+                  <div class="rounded border border-border-primary overflow-hidden">
+                    <table class="min-w-full divide-y divide-border-subtle">
+                      <thead class="bg-surface">
+                        <tr>
+                          <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
+                            Service
+                          </th>
+                          <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
+                            Method
+                          </th>
+                          <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
+                            Headers
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody class="divide-y divide-border-subtle">
+                        {rule.matches.map((m, mi) => (
+                          <tr key={mi}>
+                            <td class="px-3 py-2 text-sm text-text-primary font-mono">
+                              {m.service || "\u2014"}
+                            </td>
+                            <td class="px-3 py-2 text-sm text-text-primary font-mono">
+                              {m.method || "\u2014"}
+                            </td>
+                            <td class="px-3 py-2 text-sm text-text-muted">
+                              {m.headers && m.headers.length > 0
+                                ? m.headers.join(", ")
+                                : "\u2014"}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              )}
+
+              {/* Backends */}
+              <BackendRefsTable backendRefs={rule.backendRefs} />
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Conditions */}
+      <ConditionsTable conditions={detail.conditions} />
+    </div>
+  );
+}

--- a/frontend/islands/GatewayHTTPRouteDetail.tsx
+++ b/frontend/islands/GatewayHTTPRouteDetail.tsx
@@ -1,0 +1,206 @@
+import { useSignal } from "@preact/signals";
+import { IS_BROWSER } from "fresh/runtime";
+import { useEffect } from "preact/hooks";
+import { apiGet } from "@/lib/api.ts";
+import { Spinner } from "@/components/ui/Spinner.tsx";
+import type { HTTPRouteDetail } from "@/lib/gateway-types.ts";
+import ConditionsTable from "@/components/gateway/ConditionsTable.tsx";
+import ParentGatewaysTable from "@/components/gateway/ParentGatewaysTable.tsx";
+import BackendRefsTable from "@/components/gateway/BackendRefsTable.tsx";
+
+interface Props {
+  namespace: string;
+  name: string;
+}
+
+export default function GatewayHTTPRouteDetailIsland(
+  { namespace, name }: Props,
+) {
+  const loading = useSignal(true);
+  const error = useSignal<string | null>(null);
+  const data = useSignal<HTTPRouteDetail | null>(null);
+
+  async function fetchDetail() {
+    loading.value = true;
+    error.value = null;
+    try {
+      const res = await apiGet<HTTPRouteDetail>(
+        `/v1/gateway/httproutes/${namespace}/${name}`,
+      );
+      data.value = res.data ?? null;
+    } catch {
+      error.value = "Failed to load HTTPRoute details";
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  useEffect(() => {
+    if (!IS_BROWSER) return;
+    fetchDetail();
+  }, [namespace, name]);
+
+  if (!IS_BROWSER) return null;
+
+  if (loading.value) {
+    return (
+      <div class="flex justify-center py-12">
+        <Spinner class="text-brand" />
+      </div>
+    );
+  }
+
+  if (error.value) {
+    return <p class="text-sm text-danger p-6">{error.value}</p>;
+  }
+
+  if (!data.value) return null;
+
+  const detail = data.value;
+
+  return (
+    <div class="p-6 space-y-6">
+      {/* Back link */}
+      <a
+        href="/networking/gateway-api?kind=httproutes"
+        class="text-sm text-brand hover:underline"
+      >
+        &larr; Back to HTTP Routes
+      </a>
+
+      {/* Header */}
+      <div>
+        <h1 class="text-2xl font-bold text-text-primary">{detail.name}</h1>
+        <p class="text-sm text-text-muted mt-1">
+          Namespace: {detail.namespace}
+        </p>
+      </div>
+
+      {/* Hostnames */}
+      {detail.hostnames && detail.hostnames.length > 0 && (
+        <div>
+          <h2 class="text-sm font-semibold text-text-primary mb-2">
+            Hostnames
+          </h2>
+          <div class="flex flex-wrap gap-2">
+            {detail.hostnames.map((h) => (
+              <span
+                key={h}
+                class="inline-block rounded-full px-3 py-1 text-xs font-medium bg-bg-elevated border border-border-primary text-text-secondary"
+              >
+                {h}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Parent Gateways */}
+      <ParentGatewaysTable parentRefs={detail.parentRefs} />
+
+      {/* Rules */}
+      {detail.rules && detail.rules.length > 0 && (
+        <div class="space-y-4">
+          <h2 class="text-sm font-semibold text-text-primary">
+            Rules ({detail.rules.length})
+          </h2>
+          {detail.rules.map((rule, ri) => (
+            <div
+              key={ri}
+              class="rounded-lg border border-border-primary bg-bg-elevated p-5 space-y-4"
+            >
+              <h3 class="text-sm font-medium text-text-primary">
+                Rule {ri + 1}
+              </h3>
+
+              {/* Matches */}
+              {rule.matches && rule.matches.length > 0 && (
+                <div>
+                  <h4 class="text-xs font-medium text-text-muted mb-2">
+                    Matches
+                  </h4>
+                  <div class="rounded border border-border-primary overflow-hidden">
+                    <table class="min-w-full divide-y divide-border-subtle">
+                      <thead class="bg-surface">
+                        <tr>
+                          <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
+                            Path Type
+                          </th>
+                          <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
+                            Path Value
+                          </th>
+                          <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
+                            Method
+                          </th>
+                          <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
+                            Headers
+                          </th>
+                          <th class="px-3 py-2 text-left text-xs font-medium text-text-muted">
+                            Query Params
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody class="divide-y divide-border-subtle">
+                        {rule.matches.map((m, mi) => (
+                          <tr key={mi}>
+                            <td class="px-3 py-2 text-sm text-text-primary">
+                              {m.pathType || "\u2014"}
+                            </td>
+                            <td class="px-3 py-2 text-sm text-text-primary font-mono">
+                              {m.pathValue || "\u2014"}
+                            </td>
+                            <td class="px-3 py-2 text-sm text-text-secondary">
+                              {m.method || "\u2014"}
+                            </td>
+                            <td class="px-3 py-2 text-sm text-text-muted">
+                              {m.headers && m.headers.length > 0
+                                ? m.headers.join(", ")
+                                : "\u2014"}
+                            </td>
+                            <td class="px-3 py-2 text-sm text-text-muted">
+                              {m.queryParams && m.queryParams.length > 0
+                                ? m.queryParams.join(", ")
+                                : "\u2014"}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              )}
+
+              {/* Filters */}
+              {rule.filters && rule.filters.length > 0 && (
+                <div>
+                  <h4 class="text-xs font-medium text-text-muted mb-2">
+                    Filters
+                  </h4>
+                  <ul class="space-y-1">
+                    {rule.filters.map((f, fi) => (
+                      <li
+                        key={fi}
+                        class="text-sm text-text-secondary"
+                      >
+                        <span class="font-medium text-text-primary">
+                          {f.type}
+                        </span>{" "}
+                        — {f.details}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {/* Backends */}
+              <BackendRefsTable backendRefs={rule.backendRefs} />
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Conditions */}
+      <ConditionsTable conditions={detail.conditions} />
+    </div>
+  );
+}

--- a/frontend/islands/GatewaySimpleRouteDetail.tsx
+++ b/frontend/islands/GatewaySimpleRouteDetail.tsx
@@ -1,0 +1,120 @@
+import { useSignal } from "@preact/signals";
+import { IS_BROWSER } from "fresh/runtime";
+import { useEffect } from "preact/hooks";
+import { apiGet } from "@/lib/api.ts";
+import { Spinner } from "@/components/ui/Spinner.tsx";
+import type { SimpleRouteDetail } from "@/lib/gateway-types.ts";
+import ConditionsTable from "@/components/gateway/ConditionsTable.tsx";
+import ParentGatewaysTable from "@/components/gateway/ParentGatewaysTable.tsx";
+import BackendRefsTable from "@/components/gateway/BackendRefsTable.tsx";
+
+interface Props {
+  kind: string;
+  namespace: string;
+  name: string;
+}
+
+const KIND_LABELS: Record<string, string> = {
+  tcproutes: "TCP Route",
+  tlsroutes: "TLS Route",
+  udproutes: "UDP Route",
+};
+
+export default function GatewaySimpleRouteDetailIsland(
+  { kind, namespace, name }: Props,
+) {
+  const loading = useSignal(true);
+  const error = useSignal<string | null>(null);
+  const data = useSignal<SimpleRouteDetail | null>(null);
+
+  const kindLabel = KIND_LABELS[kind] ?? kind;
+
+  async function fetchDetail() {
+    loading.value = true;
+    error.value = null;
+    try {
+      const res = await apiGet<SimpleRouteDetail>(
+        `/v1/gateway/routes/${kind}/${namespace}/${name}`,
+      );
+      data.value = res.data ?? null;
+    } catch {
+      error.value = `Failed to load ${kindLabel} details`;
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  useEffect(() => {
+    if (!IS_BROWSER) return;
+    fetchDetail();
+  }, [kind, namespace, name]);
+
+  if (!IS_BROWSER) return null;
+
+  if (loading.value) {
+    return (
+      <div class="flex justify-center py-12">
+        <Spinner class="text-brand" />
+      </div>
+    );
+  }
+
+  if (error.value) {
+    return <p class="text-sm text-danger p-6">{error.value}</p>;
+  }
+
+  if (!data.value) return null;
+
+  const detail = data.value;
+
+  return (
+    <div class="p-6 space-y-6">
+      {/* Back link */}
+      <a
+        href={`/networking/gateway-api?kind=${kind}`}
+        class="text-sm text-brand hover:underline"
+      >
+        &larr; Back to {kindLabel}s
+      </a>
+
+      {/* Header */}
+      <div class="flex flex-wrap items-center gap-3">
+        <h1 class="text-2xl font-bold text-text-primary">{detail.name}</h1>
+        <span class="inline-block rounded-full px-3 py-1 text-xs font-medium bg-bg-elevated border border-border-primary text-text-secondary">
+          {kindLabel}
+        </span>
+      </div>
+      <p class="text-sm text-text-muted">
+        Namespace: {detail.namespace}
+      </p>
+
+      {/* Hostnames (TLS only) */}
+      {detail.hostnames && detail.hostnames.length > 0 && (
+        <div>
+          <h2 class="text-sm font-semibold text-text-primary mb-2">
+            Hostnames
+          </h2>
+          <div class="flex flex-wrap gap-2">
+            {detail.hostnames.map((h) => (
+              <span
+                key={h}
+                class="inline-block rounded-full px-3 py-1 text-xs font-medium bg-bg-elevated border border-border-primary text-text-secondary"
+              >
+                {h}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Parent Gateways */}
+      <ParentGatewaysTable parentRefs={detail.parentRefs} />
+
+      {/* Backend References */}
+      <BackendRefsTable backendRefs={detail.backendRefs} />
+
+      {/* Conditions */}
+      <ConditionsTable conditions={detail.conditions} />
+    </div>
+  );
+}

--- a/frontend/lib/constants.ts
+++ b/frontend/lib/constants.ts
@@ -441,6 +441,7 @@ export const DOMAIN_SECTIONS: DomainSection[] = [
         kind: "endpointslices",
         count: true,
       },
+      { label: "Gateway API", href: "/networking/gateway-api" },
     ],
   },
   {

--- a/frontend/lib/gateway-types.ts
+++ b/frontend/lib/gateway-types.ts
@@ -1,0 +1,186 @@
+/** Gateway API types matching backend/internal/gateway/types.go */
+
+export type GatewayResourceKind =
+  | "gatewayclasses"
+  | "gateways"
+  | "httproutes"
+  | "grpcroutes"
+  | "tcproutes"
+  | "tlsroutes"
+  | "udproutes";
+
+export interface GatewayAPIStatus {
+  available: boolean;
+  version?: string;
+  installedKinds?: string[];
+  lastChecked: string;
+}
+
+export interface GatewayAPISummary {
+  gatewayClasses: KindSummary;
+  gateways: KindSummary;
+  httpRoutes: KindSummary;
+  grpcRoutes: KindSummary;
+  tcpRoutes: KindSummary;
+  tlsRoutes: KindSummary;
+  udpRoutes: KindSummary;
+}
+
+export interface KindSummary {
+  total: number;
+  healthy: number;
+  degraded: number;
+}
+
+export interface Condition {
+  type: string;
+  status: string;
+  reason: string;
+  message: string;
+  lastTransitionTime?: string;
+}
+
+export interface ParentRef {
+  group: string;
+  kind: string;
+  name: string;
+  namespace: string;
+  sectionName: string;
+  status: string;
+  gatewayConditions?: Condition[];
+}
+
+export interface BackendRef {
+  group: string;
+  kind: string;
+  name: string;
+  namespace: string;
+  port?: number;
+  weight?: number;
+  resolved: boolean;
+}
+
+export interface RouteSummary {
+  kind: string;
+  name: string;
+  namespace: string;
+  hostnames?: string[];
+  parentRefs?: ParentRef[];
+  conditions?: Condition[];
+  age: string;
+}
+
+export interface GatewayClassSummary {
+  name: string;
+  controllerName: string;
+  description?: string;
+  conditions?: Condition[];
+  age: string;
+}
+
+export interface Listener {
+  name: string;
+  port: number;
+  protocol: string;
+  hostname?: string;
+  attachedRouteCount: number;
+  tlsMode?: string;
+  certificateRef?: string;
+  allowedRoutes?: string;
+  conditions?: Condition[];
+}
+
+export interface GatewaySummary {
+  name: string;
+  namespace: string;
+  gatewayClassName: string;
+  listeners: Listener[];
+  addresses?: string[];
+  attachedRouteCount: number;
+  conditions?: Condition[];
+  age: string;
+}
+
+export interface GatewayDetail extends GatewaySummary {
+  attachedRoutes: RouteSummary[];
+}
+
+export interface HTTPRouteSummary {
+  name: string;
+  namespace: string;
+  hostnames?: string[];
+  parentRefs?: ParentRef[];
+  backendCount: number;
+  conditions?: Condition[];
+  age: string;
+}
+
+export interface HTTPRouteMatch {
+  pathType: string;
+  pathValue: string;
+  headers?: string[];
+  method?: string;
+  queryParams?: string[];
+}
+
+export interface HTTPRouteFilter {
+  type: string;
+  details: string;
+}
+
+export interface HTTPRouteRule {
+  matches?: HTTPRouteMatch[];
+  filters?: HTTPRouteFilter[];
+  backendRefs?: BackendRef[];
+}
+
+export interface HTTPRouteDetail {
+  name: string;
+  namespace: string;
+  hostnames?: string[];
+  parentRefs?: ParentRef[];
+  backendCount: number;
+  conditions?: Condition[];
+  age: string;
+  rules?: HTTPRouteRule[];
+}
+
+export interface GRPCRouteMatch {
+  service: string;
+  method: string;
+  headers?: string[];
+}
+
+export interface GRPCRouteRule {
+  matches?: GRPCRouteMatch[];
+  backendRefs?: BackendRef[];
+}
+
+export interface GRPCRouteDetail {
+  name: string;
+  namespace: string;
+  parentRefs?: ParentRef[];
+  rules?: GRPCRouteRule[];
+  conditions?: Condition[];
+  age: string;
+}
+
+export interface SimpleRouteDetail {
+  kind: string;
+  name: string;
+  namespace: string;
+  hostnames?: string[];
+  parentRefs?: ParentRef[];
+  backendRefs?: BackendRef[];
+  conditions?: Condition[];
+  age: string;
+}
+
+export type GatewayListData =
+  | { kind: "gatewayclasses"; items: GatewayClassSummary[] }
+  | { kind: "gateways"; items: GatewaySummary[] }
+  | { kind: "httproutes"; items: HTTPRouteSummary[] }
+  | {
+    kind: "grpcroutes" | "tcproutes" | "tlsroutes" | "udproutes";
+    items: RouteSummary[];
+  };

--- a/frontend/routes/networking/gateway-api.tsx
+++ b/frontend/routes/networking/gateway-api.tsx
@@ -1,0 +1,15 @@
+import { define } from "@/utils.ts";
+import SubNav from "@/islands/SubNav.tsx";
+import { DOMAIN_SECTIONS } from "@/lib/constants.ts";
+import GatewayAPIDashboard from "@/islands/GatewayAPIDashboard.tsx";
+
+const section = DOMAIN_SECTIONS.find((s) => s.id === "network")!;
+
+export default define.page(function GatewayAPIPage(ctx) {
+  return (
+    <>
+      <SubNav tabs={section.tabs ?? []} currentPath={ctx.url.pathname} />
+      <GatewayAPIDashboard />
+    </>
+  );
+});

--- a/frontend/routes/networking/gateway-api/gatewayclasses/[name].tsx
+++ b/frontend/routes/networking/gateway-api/gatewayclasses/[name].tsx
@@ -1,0 +1,19 @@
+import { define } from "@/utils.ts";
+import SubNav from "@/islands/SubNav.tsx";
+import { DOMAIN_SECTIONS } from "@/lib/constants.ts";
+import GatewayClassDetail from "@/islands/GatewayClassDetail.tsx";
+
+const section = DOMAIN_SECTIONS.find((s) => s.id === "network")!;
+
+export default define.page(function GatewayClassDetailPage(ctx) {
+  const { name } = ctx.params;
+  return (
+    <>
+      <SubNav
+        tabs={section.tabs ?? []}
+        currentPath="/networking/gateway-api"
+      />
+      <GatewayClassDetail name={name} />
+    </>
+  );
+});

--- a/frontend/routes/networking/gateway-api/gateways/[ns]/[name].tsx
+++ b/frontend/routes/networking/gateway-api/gateways/[ns]/[name].tsx
@@ -1,0 +1,19 @@
+import { define } from "@/utils.ts";
+import SubNav from "@/islands/SubNav.tsx";
+import { DOMAIN_SECTIONS } from "@/lib/constants.ts";
+import GatewayDetail from "@/islands/GatewayDetail.tsx";
+
+const section = DOMAIN_SECTIONS.find((s) => s.id === "network")!;
+
+export default define.page(function GatewayDetailPage(ctx) {
+  const { ns, name } = ctx.params;
+  return (
+    <>
+      <SubNav
+        tabs={section.tabs ?? []}
+        currentPath="/networking/gateway-api"
+      />
+      <GatewayDetail namespace={ns} name={name} />
+    </>
+  );
+});

--- a/frontend/routes/networking/gateway-api/grpcroutes/[ns]/[name].tsx
+++ b/frontend/routes/networking/gateway-api/grpcroutes/[ns]/[name].tsx
@@ -1,0 +1,19 @@
+import { define } from "@/utils.ts";
+import SubNav from "@/islands/SubNav.tsx";
+import { DOMAIN_SECTIONS } from "@/lib/constants.ts";
+import GatewayGRPCRouteDetail from "@/islands/GatewayGRPCRouteDetail.tsx";
+
+const section = DOMAIN_SECTIONS.find((s) => s.id === "network")!;
+
+export default define.page(function GRPCRouteDetailPage(ctx) {
+  const { ns, name } = ctx.params;
+  return (
+    <>
+      <SubNav
+        tabs={section.tabs ?? []}
+        currentPath="/networking/gateway-api"
+      />
+      <GatewayGRPCRouteDetail namespace={ns} name={name} />
+    </>
+  );
+});

--- a/frontend/routes/networking/gateway-api/httproutes/[ns]/[name].tsx
+++ b/frontend/routes/networking/gateway-api/httproutes/[ns]/[name].tsx
@@ -1,0 +1,19 @@
+import { define } from "@/utils.ts";
+import SubNav from "@/islands/SubNav.tsx";
+import { DOMAIN_SECTIONS } from "@/lib/constants.ts";
+import GatewayHTTPRouteDetail from "@/islands/GatewayHTTPRouteDetail.tsx";
+
+const section = DOMAIN_SECTIONS.find((s) => s.id === "network")!;
+
+export default define.page(function HTTPRouteDetailPage(ctx) {
+  const { ns, name } = ctx.params;
+  return (
+    <>
+      <SubNav
+        tabs={section.tabs ?? []}
+        currentPath="/networking/gateway-api"
+      />
+      <GatewayHTTPRouteDetail namespace={ns} name={name} />
+    </>
+  );
+});

--- a/frontend/routes/networking/gateway-api/tcproutes/[ns]/[name].tsx
+++ b/frontend/routes/networking/gateway-api/tcproutes/[ns]/[name].tsx
@@ -1,0 +1,19 @@
+import { define } from "@/utils.ts";
+import SubNav from "@/islands/SubNav.tsx";
+import { DOMAIN_SECTIONS } from "@/lib/constants.ts";
+import GatewaySimpleRouteDetail from "@/islands/GatewaySimpleRouteDetail.tsx";
+
+const section = DOMAIN_SECTIONS.find((s) => s.id === "network")!;
+
+export default define.page(function TCPRouteDetailPage(ctx) {
+  const { ns, name } = ctx.params;
+  return (
+    <>
+      <SubNav
+        tabs={section.tabs ?? []}
+        currentPath="/networking/gateway-api"
+      />
+      <GatewaySimpleRouteDetail kind="tcproutes" namespace={ns} name={name} />
+    </>
+  );
+});

--- a/frontend/routes/networking/gateway-api/tlsroutes/[ns]/[name].tsx
+++ b/frontend/routes/networking/gateway-api/tlsroutes/[ns]/[name].tsx
@@ -1,0 +1,19 @@
+import { define } from "@/utils.ts";
+import SubNav from "@/islands/SubNav.tsx";
+import { DOMAIN_SECTIONS } from "@/lib/constants.ts";
+import GatewaySimpleRouteDetail from "@/islands/GatewaySimpleRouteDetail.tsx";
+
+const section = DOMAIN_SECTIONS.find((s) => s.id === "network")!;
+
+export default define.page(function TLSRouteDetailPage(ctx) {
+  const { ns, name } = ctx.params;
+  return (
+    <>
+      <SubNav
+        tabs={section.tabs ?? []}
+        currentPath="/networking/gateway-api"
+      />
+      <GatewaySimpleRouteDetail kind="tlsroutes" namespace={ns} name={name} />
+    </>
+  );
+});

--- a/frontend/routes/networking/gateway-api/udproutes/[ns]/[name].tsx
+++ b/frontend/routes/networking/gateway-api/udproutes/[ns]/[name].tsx
@@ -1,0 +1,19 @@
+import { define } from "@/utils.ts";
+import SubNav from "@/islands/SubNav.tsx";
+import { DOMAIN_SECTIONS } from "@/lib/constants.ts";
+import GatewaySimpleRouteDetail from "@/islands/GatewaySimpleRouteDetail.tsx";
+
+const section = DOMAIN_SECTIONS.find((s) => s.id === "network")!;
+
+export default define.page(function UDPRouteDetailPage(ctx) {
+  const { ns, name } = ctx.params;
+  return (
+    <>
+      <SubNav
+        tabs={section.tabs ?? []}
+        currentPath="/networking/gateway-api"
+      />
+      <GatewaySimpleRouteDetail kind="udproutes" namespace={ns} name={name} />
+    </>
+  );
+});

--- a/plans/gateway-api-dashboard.md
+++ b/plans/gateway-api-dashboard.md
@@ -1,0 +1,767 @@
+# Gateway API Dashboard — Implementation Plan
+
+**Spec:** `docs/superpowers/specs/2026-04-12-gateway-api-design.md`
+**Branch:** `feat/gateway-api-dashboard`
+
+---
+
+## Phase 1: Backend Package Foundation (types, discovery, normalize)
+
+**Files to create:** 3 | **Files to modify:** 0
+
+### Step 1.1: `backend/internal/gateway/types.go`
+
+Define all GVR constants and normalized Go structs.
+
+**GVR constants** (package-level `var` block, match certmanager pattern):
+
+| Constant | Group | Version | Resource |
+|---|---|---|---|
+| `GatewayClassGVR` | `gateway.networking.k8s.io` | `v1` | `gatewayclasses` |
+| `GatewayGVR` | `gateway.networking.k8s.io` | `v1` | `gateways` |
+| `HTTPRouteGVR` | `gateway.networking.k8s.io` | `v1` | `httproutes` |
+| `GRPCRouteGVR` | `gateway.networking.k8s.io` | `v1` | `grpcroutes` |
+| `TCPRouteGVR` | `gateway.networking.k8s.io` | `v1alpha2` | `tcproutes` |
+| `TLSRouteGVR` | `gateway.networking.k8s.io` | `v1alpha2` | `tlsroutes` |
+| `UDPRouteGVR` | `gateway.networking.k8s.io` | `v1alpha2` | `udproutes` |
+
+Note: TLSRoute may also be at `v1` (Gateway API >= v1.5). Discovery should check `v1` first, fall back to `v1alpha2`.
+
+**API group constant:**
+```go
+const APIGroup = "gateway.networking.k8s.io"
+```
+
+**Cache TTL constant:**
+```go
+const cacheTTL = 30 * time.Second
+```
+
+**Structs to define** (all with `json:"camelCase"` tags, `omitempty` for optional fields):
+
+```
+GatewayAPIStatus
+  Available     bool
+  Version       string       // "v1", "v1beta1"
+  InstalledKinds []string    // which CRDs are present
+  LastChecked   time.Time
+
+Condition
+  Type               string
+  Status             string
+  Reason             string
+  Message            string
+  LastTransitionTime *time.Time
+
+ParentRefSummary
+  Group     string
+  Kind      string
+  Name      string
+  Namespace string
+  SectionName string
+  Status    string  // "Accepted", "Not Accepted", ""
+
+BackendRefDetail
+  Group     string
+  Kind      string
+  Name      string
+  Namespace string
+  Port      *int
+  Weight    *int
+  Resolved  bool
+
+RouteSummary  (shared across all route kinds in list views + Gateway's attachedRoutes)
+  Kind       string
+  Name       string
+  Namespace  string
+  Hostnames  []string
+  ParentRefs []ParentRefSummary
+  Conditions []Condition
+  Age        time.Time
+
+GatewayClassSummary
+  Name           string
+  ControllerName string
+  Description    string
+  Conditions     []Condition
+  Age            time.Time
+
+ListenerSummary
+  Name              string
+  Port              int
+  Protocol          string
+  Hostname          string
+  AttachedRouteCount int
+
+ListenerDetail (extends ListenerSummary)
+  TLSMode           string
+  CertificateRef    string
+  AllowedRoutes     string
+  Conditions        []Condition
+
+GatewaySummary
+  Name           string
+  Namespace      string
+  GatewayClassName string
+  Listeners      []ListenerSummary
+  Addresses      []string
+  AttachedRouteCount int
+  Conditions     []Condition
+  Age            time.Time
+
+GatewayDetail (extends GatewaySummary)
+  Listeners      []ListenerDetail  // overrides with richer data
+  AttachedRoutes []RouteSummary
+
+HTTPRouteSummary
+  Name         string
+  Namespace    string
+  Hostnames    []string
+  ParentRefs   []ParentRefSummary
+  BackendCount int
+  Conditions   []Condition
+  Age          time.Time
+
+HTTPRouteMatch
+  PathType  string
+  PathValue string
+  Headers   []string  // "name=value" pairs
+  Method    string
+  QueryParams []string
+
+HTTPRouteFilter
+  Type    string
+  Details string  // human-readable summary
+
+HTTPRouteRule
+  Matches     []HTTPRouteMatch
+  Filters     []HTTPRouteFilter
+  BackendRefs []BackendRefDetail
+
+HTTPRouteDetail (extends HTTPRouteSummary)
+  Rules      []HTTPRouteRule
+  ParentRefs []ParentRefDetail  // overrides with richer data
+
+ParentRefDetail (extends ParentRefSummary)
+  GatewayConditions []Condition
+
+GRPCRouteMatch
+  Service string
+  Method  string
+  Headers []string
+
+GRPCRouteRule
+  Matches     []GRPCRouteMatch
+  BackendRefs []BackendRefDetail
+
+GRPCRouteDetail
+  Name       string
+  Namespace  string
+  ParentRefs []ParentRefDetail
+  Rules      []GRPCRouteRule
+  Conditions []Condition
+  Age        time.Time
+
+TCPRouteDetail / UDPRouteDetail
+  Name       string
+  Namespace  string
+  ParentRefs []ParentRefDetail
+  BackendRefs []BackendRefDetail
+  Conditions []Condition
+  Age        time.Time
+
+TLSRouteDetail
+  Name       string
+  Namespace  string
+  Hostnames  []string
+  ParentRefs []ParentRefDetail
+  BackendRefs []BackendRefDetail
+  Conditions []Condition
+  Age        time.Time
+```
+
+**namespacedResource interface** (for RBAC filtering, same as certmanager):
+```go
+type namespacedResource interface {
+    getNamespace() string
+}
+```
+
+Implement `getNamespace()` on: GatewaySummary, HTTPRouteSummary, RouteSummary (all namespaced types).
+
+### Step 1.2: `backend/internal/gateway/discovery.go`
+
+Follow `certmanager/discovery.go` pattern exactly.
+
+**Struct:**
+```go
+type Discoverer struct {
+    k8sClient *k8s.ClientFactory
+    logger    *slog.Logger
+    mu        sync.RWMutex
+    status    GatewayAPIStatus
+}
+```
+
+**Constructor:** `NewDiscoverer(k8sClient *k8s.ClientFactory, logger *slog.Logger) *Discoverer`
+
+**Methods:**
+- `Status() GatewayAPIStatus` — returns cached status, re-probes if stale (5 min)
+- `IsAvailable() bool` — convenience wrapper
+- `Probe() GatewayAPIStatus` — queries discovery API
+
+**Probe logic:**
+1. Call `disco.ServerResourcesForGroupVersion("gateway.networking.k8s.io/v1")`
+2. If error or nil → not available, return
+3. Scan `APIResources` for each Kind (skip sub-resources containing `/`)
+4. Require Gateway + GatewayClass as minimum for `Detected = true`
+5. Record which standard kinds are present (HTTPRoute, GRPCRoute)
+6. Separately probe `gateway.networking.k8s.io/v1alpha2` for experimental kinds (TCPRoute, TLSRoute, UDPRoute)
+7. Check if TLSRoute is at `v1` as well (Gateway API >= v1.5)
+8. Build `InstalledKinds` string slice from all detected kinds
+
+### Step 1.3: `backend/internal/gateway/normalize.go`
+
+Follow `certmanager/normalize.go` pattern — pure functions converting `*unstructured.Unstructured` to typed structs.
+
+**Functions to implement:**
+
+```
+normalizeGatewayClass(u) → GatewayClassSummary
+normalizeGateway(u) → GatewaySummary
+normalizeGatewayDetail(u) → GatewayDetail
+normalizeHTTPRoute(u) → HTTPRouteSummary
+normalizeHTTPRouteDetail(u) → HTTPRouteDetail
+normalizeGRPCRouteDetail(u) → GRPCRouteDetail
+normalizeRoute(u, kind) → RouteSummary  (generic for any route type in list views)
+normalizeTCPRouteDetail(u) → TCPRouteDetail
+normalizeTLSRouteDetail(u) → TLSRouteDetail
+normalizeUDPRouteDetail(u) → UDPRouteDetail
+```
+
+**Shared helpers** (same as certmanager):
+- `stringFrom(m map[string]any, key string) string`
+- `intFrom(m map[string]any, key string) int`
+- `extractConditions(obj map[string]any, path ...string) []Condition`
+- `extractParentRefs(obj *unstructured.Unstructured) []ParentRefSummary` — handle defaults (Group defaults to `gateway.networking.k8s.io`, Kind defaults to `Gateway`)
+- `extractBackendRefs(slice []any) []BackendRefDetail` — handle defaults (Group defaults to `""`, Kind defaults to `Service`)
+
+**Key extraction paths:**
+- Gateway listeners: `spec.listeners[]` → name, port, protocol, hostname, tls.mode, tls.certificateRefs, allowedRoutes
+- Gateway status listeners: `status.listeners[]` → attachedRoutes count, conditions
+- Gateway addresses: `status.addresses[].value`
+- HTTPRoute rules: `spec.rules[]` → matches (path, headers, method, queryParams), filters (type + config), backendRefs
+- Route status: `status.parents[]` → parentRef + conditions (NOT top-level `status.conditions`)
+
+### Verification checkpoint:
+```bash
+cd backend && go vet ./internal/gateway/...
+```
+
+---
+
+## Phase 2: Backend Handler + Route Registration
+
+**Files to create:** 1 | **Files to modify:** 3
+
+### Step 2.1: `backend/internal/gateway/handler.go`
+
+Follow `certmanager/handler.go` pattern exactly.
+
+**Handler struct:**
+```go
+type Handler struct {
+    K8sClient     *k8s.ClientFactory
+    Discoverer    *Discoverer
+    AccessChecker *resources.AccessChecker
+    Logger        *slog.Logger
+
+    fetchGroup singleflight.Group
+    cacheMu    sync.RWMutex
+    cache      *cachedData
+    cacheGen   uint64
+}
+```
+
+No `AuditLogger` or `NotifService` needed — this is read-only (no mutations).
+
+**Constructor:** `NewHandler(k8sClient, discoverer, accessChecker, logger) *Handler`
+
+**cachedData struct:**
+```go
+type cachedData struct {
+    gatewayClasses []GatewayClassSummary
+    gateways       []GatewaySummary
+    httpRoutes     []HTTPRouteSummary
+    grpcRoutes     []RouteSummary
+    tcpRoutes      []RouteSummary
+    tlsRoutes      []RouteSummary
+    udpRoutes      []RouteSummary
+    fetchedAt      time.Time
+}
+```
+
+**Cache methods** (copy from certmanager):
+- `getCached(ctx) (*cachedData, error)` — singleflight + 30s TTL + generation counter
+- `fetchAll(ctx, gen) (*cachedData, error)` — `errgroup.WithContext`, parallel fetch of all kinds via `BaseDynamicClient()`, skip unavailable experimental kinds gracefully (check `Discoverer.Status().InstalledKinds`), only write cache if `cacheGen` unchanged
+- `InvalidateCache()` — increment `cacheGen`, nil cache
+
+**RBAC helper:**
+```go
+func (h *Handler) canAccess(ctx, user, verb, resource, namespace) bool
+```
+Uses `AccessChecker.CanAccessGroupResource` with group `"gateway.networking.k8s.io"`.
+
+**RBAC filtering** — reuse the generic `filterByRBAC[T namespacedResource]()` pattern from certmanager. GatewayClass is cluster-scoped — check with `canAccess(ctx, user, "list", "gatewayclasses", "")`.
+
+**List handlers** (14 endpoints):
+
+| Handler method | Route | Logic |
+|---|---|---|
+| `HandleStatus` | `GET /status` | Return `Discoverer.Status()` |
+| `HandleListGatewayClasses` | `GET /gatewayclasses` | getCached → filter RBAC → return |
+| `HandleListGateways` | `GET /gateways` | getCached → filter RBAC → return |
+| `HandleListHTTPRoutes` | `GET /httproutes` | getCached → filter RBAC → return |
+| `HandleListGRPCRoutes` | `GET /grpcroutes` | getCached → filter RBAC → return |
+| `HandleListTCPRoutes` | `GET /tcproutes` | getCached → filter RBAC → return |
+| `HandleListTLSRoutes` | `GET /tlsroutes` | getCached → filter RBAC → return |
+| `HandleListUDPRoutes` | `GET /udproutes` | getCached → filter RBAC → return |
+
+**Detail handlers** (7 endpoints) — these bypass cache, use impersonating client:
+
+| Handler method | Route | Logic |
+|---|---|---|
+| `HandleGetGatewayClass` | `GET /gatewayclasses/{name}` | Impersonating Get + normalize + no relationships needed |
+| `HandleGetGateway` | `GET /gateways/{namespace}/{name}` | Impersonating Get + resolve attached routes |
+| `HandleGetHTTPRoute` | `GET /httproutes/{namespace}/{name}` | Impersonating Get + resolve parents & backends |
+| `HandleGetGRPCRoute` | `GET /grpcroutes/{namespace}/{name}` | Impersonating Get + resolve parents & backends |
+| `HandleGetTCPRoute` | `GET /tcproutes/{namespace}/{name}` | Impersonating Get + resolve parents & backends |
+| `HandleGetTLSRoute` | `GET /tlsroutes/{namespace}/{name}` | Impersonating Get + resolve parents & backends |
+| `HandleGetUDPRoute` | `GET /udproutes/{namespace}/{name}` | Impersonating Get + resolve parents & backends |
+
+**Relationship resolution in detail handlers:**
+
+Gateway detail → attached routes:
+1. After fetching the Gateway, list all installed route kinds (parallel via WaitGroup, 2s timeout)
+2. Filter routes whose `spec.parentRefs` match this Gateway (name + namespace)
+3. Return as `AttachedRoutes []RouteSummary`
+
+Route detail → parent gateways + backend services:
+1. After fetching the route, extract `spec.parentRefs`
+2. For each parentRef, fetch the Gateway object (parallel, 2s timeout)
+3. If resolved, include Gateway conditions; if not, set `resolved: false`
+4. For HTTP/GRPC routes, extract `spec.rules[].backendRefs`; for TCP/TLS/UDP, extract `spec.backendRefs`
+5. For each backendRef pointing to a Service, fetch the Service (parallel, 2s timeout)
+6. Set `resolved: true/false` based on whether the Service was found
+
+Use `sync.WaitGroup` (not errgroup) for relationship resolution — failure of one lookup should not cancel others.
+
+### Step 2.2: Modify `backend/internal/server/server.go`
+
+Add to `Server` struct:
+```go
+GatewayHandler *gateway.Handler
+```
+
+Add to `Deps` struct:
+```go
+GatewayHandler *gateway.Handler
+```
+
+Add to `New()` function:
+```go
+if deps.GatewayHandler != nil {
+    s.GatewayHandler = deps.GatewayHandler
+}
+```
+
+### Step 2.3: Modify `backend/internal/server/routes.go`
+
+Add nil-guarded registration in the authenticated router section (near certmanager registration):
+```go
+if s.GatewayHandler != nil {
+    s.registerGatewayRoutes(ar)
+}
+```
+
+Add `registerGatewayRoutes` method:
+```go
+func (s *Server) registerGatewayRoutes(ar chi.Router) {
+    h := s.GatewayHandler
+    ar.Route("/gateway", func(gr chi.Router) {
+        gr.Get("/status", h.HandleStatus)
+        gr.Get("/gatewayclasses", h.HandleListGatewayClasses)
+        gr.With(resources.ValidateURLParams).Get("/gatewayclasses/{name}", h.HandleGetGatewayClass)
+        gr.Get("/gateways", h.HandleListGateways)
+        gr.With(resources.ValidateURLParams).Get("/gateways/{namespace}/{name}", h.HandleGetGateway)
+        gr.Get("/httproutes", h.HandleListHTTPRoutes)
+        gr.With(resources.ValidateURLParams).Get("/httproutes/{namespace}/{name}", h.HandleGetHTTPRoute)
+        gr.Get("/grpcroutes", h.HandleListGRPCRoutes)
+        gr.With(resources.ValidateURLParams).Get("/grpcroutes/{namespace}/{name}", h.HandleGetGRPCRoute)
+        gr.Get("/tcproutes", h.HandleListTCPRoutes)
+        gr.With(resources.ValidateURLParams).Get("/tcproutes/{namespace}/{name}", h.HandleGetTCPRoute)
+        gr.Get("/tlsroutes", h.HandleListTLSRoutes)
+        gr.With(resources.ValidateURLParams).Get("/tlsroutes/{namespace}/{name}", h.HandleGetTLSRoute)
+        gr.Get("/udproutes", h.HandleListUDPRoutes)
+        gr.With(resources.ValidateURLParams).Get("/udproutes/{namespace}/{name}", h.HandleGetUDPRoute)
+    })
+}
+```
+
+### Step 2.4: Modify `backend/cmd/kubecenter/main.go`
+
+Add initialization near certmanager init:
+```go
+gwDisc := gateway.NewDiscoverer(k8sClient, logger)
+gwHandler := gateway.NewHandler(k8sClient, gwDisc, accessChecker, logger)
+```
+
+Add to Deps struct literal:
+```go
+GatewayHandler: gwHandler,
+```
+
+### Verification checkpoint:
+```bash
+cd backend && go vet ./internal/gateway/... && go vet ./internal/server/... && go vet ./cmd/kubecenter/...
+```
+
+---
+
+## Phase 3: Frontend Types + Dashboard Island
+
+**Files to create:** 3 | **Files to modify:** 2
+
+### Step 3.1: `frontend/lib/gateway-types.ts`
+
+TypeScript interfaces mirroring Go types. Follow `frontend/lib/certmanager-types.ts` pattern.
+
+```typescript
+/** Gateway API types matching backend/internal/gateway/types.go */
+
+export interface GatewayAPIStatus { available: boolean; version: string; installedKinds: string[]; }
+
+export interface Condition { type: string; status: string; reason: string; message: string; lastTransitionTime?: string; }
+
+export interface ParentRefSummary { group: string; kind: string; name: string; namespace: string; sectionName: string; status: string; }
+export interface ParentRefDetail extends ParentRefSummary { gatewayConditions: Condition[]; }
+
+export interface BackendRefDetail { group: string; kind: string; name: string; namespace: string; port?: number; weight?: number; resolved: boolean; }
+
+export interface RouteSummary { kind: string; name: string; namespace: string; hostnames: string[]; parentRefs: ParentRefSummary[]; conditions: Condition[]; age: string; }
+
+export interface GatewayClassSummary { name: string; controllerName: string; description: string; conditions: Condition[]; age: string; }
+
+export interface ListenerSummary { name: string; port: number; protocol: string; hostname: string; attachedRouteCount: number; }
+export interface ListenerDetail extends ListenerSummary { tlsMode: string; certificateRef: string; allowedRoutes: string; conditions: Condition[]; }
+
+export interface GatewaySummary { name: string; namespace: string; gatewayClassName: string; listeners: ListenerSummary[]; addresses: string[]; attachedRouteCount: number; conditions: Condition[]; age: string; }
+export interface GatewayDetail extends GatewaySummary { listeners: ListenerDetail[]; attachedRoutes: RouteSummary[]; }
+
+export interface HTTPRouteSummary { name: string; namespace: string; hostnames: string[]; parentRefs: ParentRefSummary[]; backendCount: number; conditions: Condition[]; age: string; }
+export interface HTTPRouteMatch { pathType: string; pathValue: string; headers: string[]; method: string; queryParams: string[]; }
+export interface HTTPRouteFilter { type: string; details: string; }
+export interface HTTPRouteRule { matches: HTTPRouteMatch[]; filters: HTTPRouteFilter[]; backendRefs: BackendRefDetail[]; }
+export interface HTTPRouteDetail extends HTTPRouteSummary { rules: HTTPRouteRule[]; parentRefs: ParentRefDetail[]; }
+
+export interface GRPCRouteMatch { service: string; method: string; headers: string[]; }
+export interface GRPCRouteRule { matches: GRPCRouteMatch[]; backendRefs: BackendRefDetail[]; }
+export interface GRPCRouteDetail { name: string; namespace: string; parentRefs: ParentRefDetail[]; rules: GRPCRouteRule[]; conditions: Condition[]; age: string; }
+
+export interface TCPRouteDetail { name: string; namespace: string; parentRefs: ParentRefDetail[]; backendRefs: BackendRefDetail[]; conditions: Condition[]; age: string; }
+export interface TLSRouteDetail { name: string; namespace: string; hostnames: string[]; parentRefs: ParentRefDetail[]; backendRefs: BackendRefDetail[]; conditions: Condition[]; age: string; }
+export interface UDPRouteDetail { name: string; namespace: string; parentRefs: ParentRefDetail[]; backendRefs: BackendRefDetail[]; conditions: Condition[]; age: string; }
+```
+
+### Step 3.2: `frontend/routes/networking/gateway-api.tsx`
+
+Dashboard route. Follow `routes/security/certificates.tsx` pattern:
+
+```tsx
+import { define } from "@/utils.ts";
+import SubNav from "@/islands/SubNav.tsx";
+import { DOMAIN_SECTIONS } from "@/lib/constants.ts";
+import GatewayAPIDashboard from "@/islands/GatewayAPIDashboard.tsx";
+
+const section = DOMAIN_SECTIONS.find((s) => s.id === "network")!;
+
+export default define.page(function GatewayAPIPage(ctx) {
+  return (
+    <>
+      <SubNav tabs={section.tabs ?? []} currentPath={ctx.url.pathname} />
+      <GatewayAPIDashboard />
+    </>
+  );
+});
+```
+
+### Step 3.3: `frontend/islands/GatewayAPIDashboard.tsx`
+
+Main dashboard island with overview cards + list views.
+
+**State:**
+- `status: Signal<GatewayAPIStatus | null>` — CRD availability
+- `loading: Signal<boolean>`
+- `error: Signal<string>`
+- `activeKind: Signal<string | null>` — which list view is active (null = overview)
+- `listData: Signal<any[]>` — current list data
+- `search: Signal<string>` — filter text
+
+**Flow:**
+1. On mount, fetch `GET /api/v1/gateway/status`
+2. If `!status.available`, render "Gateway API not installed" state with guidance
+3. If available, render overview cards for each installed kind
+4. Each card shows: icon, kind name, count, health summary (e.g., "3 Programmed, 1 Not Ready")
+5. Clicking a card sets `activeKind` and fetches the list endpoint
+6. List view renders a kind-specific table (columns vary by kind)
+7. "Back" button returns to overview
+
+**Overview cards** (only show for installed kinds):
+- GatewayClasses — count + accepted/pending
+- Gateways — count + programmed/not programmed
+- HTTPRoutes — count + accepted/not accepted
+- GRPCRoutes — count
+- TCPRoutes — count
+- TLSRoutes — count
+- UDPRoutes — count
+
+**List table columns per kind:**
+
+| Kind | Columns |
+|---|---|
+| GatewayClass | Name, Controller, Description, Accepted, Age |
+| Gateway | Name, Namespace, Class, Listeners, Addresses, Programmed, Age |
+| HTTPRoute | Name, Namespace, Hostnames, Parents, Backends, Accepted, Age |
+| GRPCRoute | Name, Namespace, Parents, Accepted, Age |
+| TCPRoute | Name, Namespace, Parents, Backends, Accepted, Age |
+| TLSRoute | Name, Namespace, Hostnames, Parents, Backends, Age |
+| UDPRoute | Name, Namespace, Parents, Backends, Age |
+
+Each row is clickable — navigates to detail page.
+
+**Styling:** Use CSS custom property tokens exclusively. Follow CertificatesList.tsx patterns:
+- Card: `rounded-lg border border-border-primary bg-bg-elevated p-5`
+- Table: `rounded-lg border border-border-primary`, `bg-surface` header, `divide-y divide-border-subtle`
+- Status badges: `text-success` for healthy, `text-warning` for degraded, `text-danger` for failed
+
+### Step 3.4: Modify `frontend/lib/constants.ts`
+
+Add Gateway API tab to the network section's `tabs` array (after EndpointSlices):
+```ts
+{ label: "Gateway API", href: "/networking/gateway-api" },
+```
+
+No `kind`/`count` — the dashboard fetches its own counts from the dedicated status endpoint.
+
+### Step 3.5: Modify `frontend/islands/CommandPalette.tsx`
+
+Add quick action to the actions array:
+```ts
+{ label: "View Gateway API", href: "/networking/gateway-api" },
+```
+
+### Verification checkpoint:
+```bash
+cd frontend && deno fmt --check && deno lint
+```
+
+---
+
+## Phase 4: Frontend Detail Routes + Detail Islands (Part 1: Gateway + GatewayClass)
+
+**Files to create:** 4
+
+### Step 4.1: `frontend/routes/networking/gateway-api/gatewayclasses/[name].tsx`
+
+Cluster-scoped detail route (no namespace param):
+```tsx
+export default define.page(function GatewayClassDetailPage(ctx) {
+  const { name } = ctx.params;
+  return (
+    <>
+      <SubNav tabs={section.tabs ?? []} currentPath="/networking/gateway-api" />
+      <GatewayClassDetail name={name} />
+    </>
+  );
+});
+```
+
+### Step 4.2: `frontend/routes/networking/gateway-api/[kind]/[ns]/[name].tsx`
+
+Parameterized detail route for all namespaced kinds:
+```tsx
+export default define.page(function GatewayResourceDetailPage(ctx) {
+  const { kind, ns, name } = ctx.params;
+  return (
+    <>
+      <SubNav tabs={section.tabs ?? []} currentPath="/networking/gateway-api" />
+      <GatewayResourceDetail kind={kind} namespace={ns} name={name} />
+    </>
+  );
+});
+```
+
+Where `GatewayResourceDetail` is a dispatcher island that renders the appropriate detail component based on `kind`.
+
+### Step 4.3: `frontend/islands/GatewayClassDetail.tsx`
+
+**Props:** `{ name: string }`
+**API:** `GET /api/v1/gateway/gatewayclasses/${name}`
+
+**Panels:**
+- Header: name + controller name
+- Description text
+- Conditions table: Type, Status, Reason, Message, Last Transition
+- Supported features (if available in the object)
+
+### Step 4.4: `frontend/islands/GatewayDetail.tsx`
+
+**Props:** `{ namespace: string; name: string }`
+**API:** `GET /api/v1/gateway/gateways/${namespace}/${name}`
+
+**Panels:**
+- Header: name + namespace + gateway class (linked to GatewayClass detail)
+- Addresses list
+- Listeners table: Name, Port, Protocol, Hostname, TLS Mode, Certificate Ref, Attached Routes, Status
+- Attached Routes table: Kind, Name, Namespace, Hostnames (each row links to route detail)
+- Conditions table
+
+### Verification checkpoint:
+```bash
+cd frontend && deno fmt --check && deno lint
+```
+
+---
+
+## Phase 5: Frontend Detail Islands (Part 2: Routes)
+
+**Files to create:** 5
+
+### Step 5.1: `frontend/islands/GatewayResourceDetail.tsx`
+
+Dispatcher island that renders the correct detail component based on `kind` prop:
+```tsx
+switch (kind) {
+  case "httproutes": return <HTTPRouteDetail namespace={namespace} name={name} />;
+  case "grpcroutes": return <GRPCRouteDetail namespace={namespace} name={name} />;
+  case "tcproutes":  return <TCPRouteDetail namespace={namespace} name={name} />;
+  case "tlsroutes":  return <TLSRouteDetail namespace={namespace} name={name} />;
+  case "udproutes":  return <UDPRouteDetail namespace={namespace} name={name} />;
+  default: return <div>Unknown resource kind</div>;
+}
+```
+
+### Step 5.2: `frontend/islands/GatewayHTTPRouteDetail.tsx`
+
+**Props:** `{ namespace: string; name: string }`
+**API:** `GET /api/v1/gateway/httproutes/${namespace}/${name}`
+
+**Panels:**
+- Header: name + namespace
+- Hostnames list
+- Parent Gateways table: Name, Namespace, Status (each links to Gateway detail). Show Gateway conditions inline.
+- Rules section (one card per rule):
+  - Matches: path type/value, method, headers, query params
+  - Filters: type + details
+  - Backend Refs table: Service Name, Namespace, Port, Weight, Resolved status (linked to service detail if resolved)
+- Conditions table
+
+### Step 5.3: `frontend/islands/GatewayGRPCRouteDetail.tsx`
+
+**Props:** `{ namespace: string; name: string }`
+**API:** `GET /api/v1/gateway/grpcroutes/${namespace}/${name}`
+
+**Panels:**
+- Header: name + namespace
+- Parent Gateways table (linked)
+- Rules section:
+  - Matches: Service, Method, Headers
+  - Backend Refs table (linked)
+- Conditions table
+
+### Step 5.4: `frontend/islands/GatewayTCPRouteDetail.tsx`
+
+Simpler layout (no rules, just backendRefs):
+- Header + Parent Gateways table + Backend Refs table + Conditions
+
+### Step 5.5: `frontend/islands/GatewayTLSRouteDetail.tsx`
+
+Same as TCP but with Hostnames panel.
+
+### Step 5.6: `frontend/islands/GatewayUDPRouteDetail.tsx`
+
+Same structure as TCPRouteDetail.
+
+**Note:** TCP/TLS/UDP detail islands share very similar structure. Consider extracting a shared `SimpleRouteDetail` component that all three use, parameterized by whether to show hostnames.
+
+### Verification checkpoint:
+```bash
+cd frontend && deno fmt --check && deno lint
+```
+
+---
+
+## Phase 6: Integration Testing + Full Verification
+
+### Step 6.1: Backend type checking
+```bash
+cd backend && go vet ./... && go build ./...
+```
+
+### Step 6.2: Frontend linting + formatting
+```bash
+cd frontend && deno fmt --check && deno lint && deno task build
+```
+
+### Step 6.3: Smoke test (requires homelab with Cilium Gateway API)
+
+1. Start dev environment: `make dev-db && make dev-backend && make dev-frontend`
+2. Navigate to `/networking/gateway-api`
+3. Verify:
+   - Status check shows Gateway API availability
+   - Overview cards display correct counts
+   - Click each card → list view loads with correct columns
+   - Click a row → detail page renders with relationship data
+   - GatewayClass detail accessible at `/networking/gateway-api/gatewayclasses/:name`
+   - Back navigation works
+   - Command palette "Gateway API" action works
+   - "Not installed" state renders correctly (if no Gateway API CRDs)
+
+### Step 6.4: Run full CI checks
+```bash
+make lint && make test && make build
+```
+
+---
+
+## File Summary
+
+### New files (18):
+| File | Phase |
+|---|---|
+| `backend/internal/gateway/types.go` | 1 |
+| `backend/internal/gateway/discovery.go` | 1 |
+| `backend/internal/gateway/normalize.go` | 1 |
+| `backend/internal/gateway/handler.go` | 2 |
+| `frontend/lib/gateway-types.ts` | 3 |
+| `frontend/routes/networking/gateway-api.tsx` | 3 |
+| `frontend/islands/GatewayAPIDashboard.tsx` | 3 |
+| `frontend/routes/networking/gateway-api/gatewayclasses/[name].tsx` | 4 |
+| `frontend/routes/networking/gateway-api/[kind]/[ns]/[name].tsx` | 4 |
+| `frontend/islands/GatewayClassDetail.tsx` | 4 |
+| `frontend/islands/GatewayDetail.tsx` | 4 |
+| `frontend/islands/GatewayResourceDetail.tsx` | 5 |
+| `frontend/islands/GatewayHTTPRouteDetail.tsx` | 5 |
+| `frontend/islands/GatewayGRPCRouteDetail.tsx` | 5 |
+| `frontend/islands/GatewayTCPRouteDetail.tsx` | 5 |
+| `frontend/islands/GatewayTLSRouteDetail.tsx` | 5 |
+| `frontend/islands/GatewayUDPRouteDetail.tsx` | 5 |
+
+### Modified files (4):
+| File | Phase | Change |
+|---|---|---|
+| `backend/internal/server/server.go` | 2 | Add GatewayHandler to Server + Deps structs |
+| `backend/internal/server/routes.go` | 2 | Add registerGatewayRoutes + nil-guard call |
+| `backend/cmd/kubecenter/main.go` | 2 | Initialize discoverer + handler, add to Deps |
+| `frontend/lib/constants.ts` | 3 | Add Gateway API tab to network section |
+| `frontend/islands/CommandPalette.tsx` | 3 | Add quick action |

--- a/plans/gateway-api-dashboard.md
+++ b/plans/gateway-api-dashboard.md
@@ -2,12 +2,13 @@
 
 **Spec:** `docs/superpowers/specs/2026-04-12-gateway-api-design.md`
 **Branch:** `feat/gateway-api-dashboard`
+**Review:** Revised per DHH, Kieran, and Simplicity feedback
 
 ---
 
-## Phase 1: Backend Package Foundation (types, discovery, normalize)
+## Phase 1: Backend Package Foundation (types, discovery, normalize, tests)
 
-**Files to create:** 3 | **Files to modify:** 0
+**Files to create:** 4 | **Files to modify:** 0
 
 ### Step 1.1: `backend/internal/gateway/types.go`
 
@@ -25,8 +26,6 @@ Define all GVR constants and normalized Go structs.
 | `TLSRouteGVR` | `gateway.networking.k8s.io` | `v1alpha2` | `tlsroutes` |
 | `UDPRouteGVR` | `gateway.networking.k8s.io` | `v1alpha2` | `udproutes` |
 
-Note: TLSRoute may also be at `v1` (Gateway API >= v1.5). Discovery should check `v1` first, fall back to `v1alpha2`.
-
 **API group constant:**
 ```go
 const APIGroup = "gateway.networking.k8s.io"
@@ -41,10 +40,24 @@ const cacheTTL = 30 * time.Second
 
 ```
 GatewayAPIStatus
-  Available     bool
-  Version       string       // "v1", "v1beta1"
-  InstalledKinds []string    // which CRDs are present
-  LastChecked   time.Time
+  Available      bool
+  Version        string       // "v1", "v1beta1"
+  InstalledKinds []string     // which CRDs are present
+  LastChecked    time.Time
+
+GatewayAPISummary                 // returned by GET /gateway/summary
+  GatewayClasses GatewayKindSummary
+  Gateways       GatewayKindSummary
+  HTTPRoutes     GatewayKindSummary
+  GRPCRoutes     GatewayKindSummary
+  TCPRoutes      GatewayKindSummary
+  TLSRoutes      GatewayKindSummary
+  UDPRoutes      GatewayKindSummary
+
+GatewayKindSummary
+  Total    int
+  Healthy  int               // Accepted/Programmed count
+  Degraded int               // not healthy count
 
 Condition
   Type               string
@@ -53,15 +66,16 @@ Condition
   Message            string
   LastTransitionTime *time.Time
 
-ParentRefSummary
-  Group     string
-  Kind      string
-  Name      string
-  Namespace string
-  SectionName string
-  Status    string  // "Accepted", "Not Accepted", ""
+ParentRef                         // single type, no Summary/Detail split
+  Group             string
+  Kind              string
+  Name              string
+  Namespace         string
+  SectionName       string
+  Status            string        // "Accepted", "Not Accepted", ""
+  GatewayConditions []Condition   `json:"gatewayConditions,omitempty"`  // populated in detail endpoints only
 
-BackendRefDetail
+BackendRef
   Group     string
   Kind      string
   Name      string
@@ -70,12 +84,12 @@ BackendRefDetail
   Weight    *int
   Resolved  bool
 
-RouteSummary  (shared across all route kinds in list views + Gateway's attachedRoutes)
+RouteSummary  (shared across ALL route kinds in list views + Gateway's attachedRoutes)
   Kind       string
   Name       string
   Namespace  string
   Hostnames  []string
-  ParentRefs []ParentRefSummary
+  ParentRefs []ParentRef
   Conditions []Condition
   Age        time.Time
 
@@ -86,47 +100,45 @@ GatewayClassSummary
   Conditions     []Condition
   Age            time.Time
 
-ListenerSummary
+Listener                          // single type, no Summary/Detail split
   Name              string
   Port              int
   Protocol          string
   Hostname          string
   AttachedRouteCount int
-
-ListenerDetail (extends ListenerSummary)
-  TLSMode           string
-  CertificateRef    string
-  AllowedRoutes     string
-  Conditions        []Condition
+  TLSMode           string        `json:"tlsMode,omitempty"`        // populated in detail only
+  CertificateRef    string        `json:"certificateRef,omitempty"` // populated in detail only
+  AllowedRoutes     string        `json:"allowedRoutes,omitempty"`  // populated in detail only
+  Conditions        []Condition   `json:"conditions,omitempty"`     // populated in detail only
 
 GatewaySummary
-  Name           string
-  Namespace      string
+  Name             string
+  Namespace        string
   GatewayClassName string
-  Listeners      []ListenerSummary
-  Addresses      []string
+  Listeners        []Listener
+  Addresses        []string
   AttachedRouteCount int
-  Conditions     []Condition
-  Age            time.Time
+  Conditions       []Condition
+  Age              time.Time
 
-GatewayDetail (extends GatewaySummary)
-  Listeners      []ListenerDetail  // overrides with richer data
-  AttachedRoutes []RouteSummary
+GatewayDetail
+  GatewaySummary                  // embedded
+  AttachedRoutes []RouteSummary   // resolved from cache
 
 HTTPRouteSummary
   Name         string
   Namespace    string
   Hostnames    []string
-  ParentRefs   []ParentRefSummary
+  ParentRefs   []ParentRef
   BackendCount int
   Conditions   []Condition
   Age          time.Time
 
 HTTPRouteMatch
-  PathType  string
-  PathValue string
-  Headers   []string  // "name=value" pairs
-  Method    string
+  PathType    string
+  PathValue   string
+  Headers     []string  // "name=value" pairs
+  Method      string
   QueryParams []string
 
 HTTPRouteFilter
@@ -136,14 +148,12 @@ HTTPRouteFilter
 HTTPRouteRule
   Matches     []HTTPRouteMatch
   Filters     []HTTPRouteFilter
-  BackendRefs []BackendRefDetail
+  BackendRefs []BackendRef
 
-HTTPRouteDetail (extends HTTPRouteSummary)
+HTTPRouteDetail
+  HTTPRouteSummary                // embedded
   Rules      []HTTPRouteRule
-  ParentRefs []ParentRefDetail  // overrides with richer data
-
-ParentRefDetail (extends ParentRefSummary)
-  GatewayConditions []Condition
+  ParentRefs []ParentRef          // same type, but with GatewayConditions populated
 
 GRPCRouteMatch
   Service string
@@ -152,30 +162,23 @@ GRPCRouteMatch
 
 GRPCRouteRule
   Matches     []GRPCRouteMatch
-  BackendRefs []BackendRefDetail
+  BackendRefs []BackendRef
 
 GRPCRouteDetail
   Name       string
   Namespace  string
-  ParentRefs []ParentRefDetail
+  ParentRefs []ParentRef
   Rules      []GRPCRouteRule
   Conditions []Condition
   Age        time.Time
 
-TCPRouteDetail / UDPRouteDetail
+SimpleRouteDetail                 // covers TCP, TLS, and UDP routes
+  Kind       string               // "TCPRoute", "TLSRoute", "UDPRoute"
   Name       string
   Namespace  string
-  ParentRefs []ParentRefDetail
-  BackendRefs []BackendRefDetail
-  Conditions []Condition
-  Age        time.Time
-
-TLSRouteDetail
-  Name       string
-  Namespace  string
-  Hostnames  []string
-  ParentRefs []ParentRefDetail
-  BackendRefs []BackendRefDetail
+  Hostnames  []string             // only populated for TLSRoute
+  ParentRefs []ParentRef
+  BackendRefs []BackendRef
   Conditions []Condition
   Age        time.Time
 ```
@@ -187,7 +190,26 @@ type namespacedResource interface {
 }
 ```
 
-Implement `getNamespace()` on: GatewaySummary, HTTPRouteSummary, RouteSummary (all namespaced types).
+Implement `getNamespace()` on: GatewaySummary, HTTPRouteSummary, RouteSummary, SimpleRouteDetail, GRPCRouteDetail.
+
+**Route kind type** (for parameterized handler dispatch):
+```go
+type routeKind string
+
+const (
+    RouteKindGRPC routeKind = "grpcroutes"
+    RouteKindTCP  routeKind = "tcproutes"
+    RouteKindTLS  routeKind = "tlsroutes"
+    RouteKindUDP  routeKind = "udproutes"
+)
+
+var routeKindGVR = map[routeKind]schema.GroupVersionResource{
+    RouteKindGRPC: GRPCRouteGVR,
+    RouteKindTCP:  TCPRouteGVR,
+    RouteKindTLS:  TLSRouteGVR,
+    RouteKindUDP:  UDPRouteGVR,
+}
+```
 
 ### Step 1.2: `backend/internal/gateway/discovery.go`
 
@@ -215,36 +237,33 @@ type Discoverer struct {
 2. If error or nil → not available, return
 3. Scan `APIResources` for each Kind (skip sub-resources containing `/`)
 4. Require Gateway + GatewayClass as minimum for `Detected = true`
-5. Record which standard kinds are present (HTTPRoute, GRPCRoute)
+5. Record which standard kinds are present (HTTPRoute, GRPCRoute, TLSRoute at v1)
 6. Separately probe `gateway.networking.k8s.io/v1alpha2` for experimental kinds (TCPRoute, TLSRoute, UDPRoute)
-7. Check if TLSRoute is at `v1` as well (Gateway API >= v1.5)
-8. Build `InstalledKinds` string slice from all detected kinds
+7. Build `InstalledKinds` string slice from all detected kinds
 
 ### Step 1.3: `backend/internal/gateway/normalize.go`
 
 Follow `certmanager/normalize.go` pattern — pure functions converting `*unstructured.Unstructured` to typed structs.
 
-**Functions to implement:**
+**Functions to implement (7 total, down from 10):**
 
 ```
-normalizeGatewayClass(u) → GatewayClassSummary
-normalizeGateway(u) → GatewaySummary
-normalizeGatewayDetail(u) → GatewayDetail
-normalizeHTTPRoute(u) → HTTPRouteSummary
-normalizeHTTPRouteDetail(u) → HTTPRouteDetail
-normalizeGRPCRouteDetail(u) → GRPCRouteDetail
-normalizeRoute(u, kind) → RouteSummary  (generic for any route type in list views)
-normalizeTCPRouteDetail(u) → TCPRouteDetail
-normalizeTLSRouteDetail(u) → TLSRouteDetail
-normalizeUDPRouteDetail(u) → UDPRouteDetail
+normalizeGatewayClass(u)       → GatewayClassSummary
+normalizeGateway(u)            → GatewaySummary
+normalizeGatewayDetail(u)      → GatewayDetail
+normalizeHTTPRoute(u)          → HTTPRouteSummary
+normalizeHTTPRouteDetail(u)    → HTTPRouteDetail
+normalizeGRPCRouteDetail(u)    → GRPCRouteDetail
+normalizeRoute(u, kind)        → RouteSummary         // generic for any route kind in list views
+normalizeSimpleRouteDetail(u, kind) → SimpleRouteDetail  // TCP, TLS, UDP all use this
 ```
 
 **Shared helpers** (same as certmanager):
 - `stringFrom(m map[string]any, key string) string`
 - `intFrom(m map[string]any, key string) int`
 - `extractConditions(obj map[string]any, path ...string) []Condition`
-- `extractParentRefs(obj *unstructured.Unstructured) []ParentRefSummary` — handle defaults (Group defaults to `gateway.networking.k8s.io`, Kind defaults to `Gateway`)
-- `extractBackendRefs(slice []any) []BackendRefDetail` — handle defaults (Group defaults to `""`, Kind defaults to `Service`)
+- `extractParentRefs(obj *unstructured.Unstructured) []ParentRef` — handle defaults (Group defaults to `gateway.networking.k8s.io`, Kind defaults to `Gateway`)
+- `extractBackendRefs(slice []any) []BackendRef` — handle defaults (Group defaults to `""`, Kind defaults to `Service`)
 
 **Key extraction paths:**
 - Gateway listeners: `spec.listeners[]` → name, port, protocol, hostname, tls.mode, tls.certificateRefs, allowedRoutes
@@ -253,9 +272,25 @@ normalizeUDPRouteDetail(u) → UDPRouteDetail
 - HTTPRoute rules: `spec.rules[]` → matches (path, headers, method, queryParams), filters (type + config), backendRefs
 - Route status: `status.parents[]` → parentRef + conditions (NOT top-level `status.conditions`)
 
+### Step 1.4: `backend/internal/gateway/normalize_test.go`
+
+Table-driven tests for each normalize function. Follow `certmanager/normalize_test.go` pattern.
+
+**Test cases per function:**
+- `normalizeGatewayClass`: valid GatewayClass, missing optional fields, empty conditions
+- `normalizeGateway`: multiple listeners, multiple addresses, zero attached routes
+- `normalizeGatewayDetail`: listeners with TLS config, listeners without TLS
+- `normalizeHTTPRoute`: multiple rules, empty matches, empty backendRefs, multiple hostnames
+- `normalizeHTTPRouteDetail`: filters extraction, weight handling, parentRef defaults
+- `normalizeGRPCRouteDetail`: service/method matches, header matches
+- `normalizeRoute`: each route kind produces correct RouteSummary with Kind set
+- `normalizeSimpleRouteDetail`: TCP (no hostnames), TLS (with hostnames), UDP (no hostnames)
+- `extractParentRefs`: default group/kind handling, explicit group/kind, missing namespace
+- `extractBackendRefs`: default group/kind, explicit values, missing port
+
 ### Verification checkpoint:
 ```bash
-cd backend && go vet ./internal/gateway/...
+cd backend && go vet ./internal/gateway/... && go test ./internal/gateway/...
 ```
 
 ---
@@ -293,17 +328,14 @@ type cachedData struct {
     gatewayClasses []GatewayClassSummary
     gateways       []GatewaySummary
     httpRoutes     []HTTPRouteSummary
-    grpcRoutes     []RouteSummary
-    tcpRoutes      []RouteSummary
-    tlsRoutes      []RouteSummary
-    udpRoutes      []RouteSummary
+    routes         []RouteSummary  // ALL non-HTTP routes (GRPC, TCP, TLS, UDP), differentiated by Kind field
     fetchedAt      time.Time
 }
 ```
 
 **Cache methods** (copy from certmanager):
 - `getCached(ctx) (*cachedData, error)` — singleflight + 30s TTL + generation counter
-- `fetchAll(ctx, gen) (*cachedData, error)` — `errgroup.WithContext`, parallel fetch of all kinds via `BaseDynamicClient()`, skip unavailable experimental kinds gracefully (check `Discoverer.Status().InstalledKinds`), only write cache if `cacheGen` unchanged
+- `fetchAll(ctx, gen) (*cachedData, error)` — `errgroup.WithContext`, parallel fetch of all kinds via `BaseDynamicClient()`, skip unavailable experimental kinds gracefully (check `Discoverer.Status().InstalledKinds`), only write cache if `cacheGen` unchanged. Call `InvalidateCache()` when discovery detects a change in installed kinds.
 - `InvalidateCache()` — increment `cacheGen`, nil cache
 
 **RBAC helper:**
@@ -314,43 +346,35 @@ Uses `AccessChecker.CanAccessGroupResource` with group `"gateway.networking.k8s.
 
 **RBAC filtering** — reuse the generic `filterByRBAC[T namespacedResource]()` pattern from certmanager. GatewayClass is cluster-scoped — check with `canAccess(ctx, user, "list", "gatewayclasses", "")`.
 
-**List handlers** (14 endpoints):
+**Endpoints (10 total, down from 15):**
 
 | Handler method | Route | Logic |
 |---|---|---|
 | `HandleStatus` | `GET /status` | Return `Discoverer.Status()` |
+| `HandleSummary` | `GET /summary` | getCached → compute counts/health per kind → return `GatewayAPISummary` |
 | `HandleListGatewayClasses` | `GET /gatewayclasses` | getCached → filter RBAC → return |
+| `HandleGetGatewayClass` | `GET /gatewayclasses/{name}` | Impersonating Get + normalize |
 | `HandleListGateways` | `GET /gateways` | getCached → filter RBAC → return |
+| `HandleGetGateway` | `GET /gateways/{ns}/{name}` | Impersonating Get + resolve attached routes **from cache** |
 | `HandleListHTTPRoutes` | `GET /httproutes` | getCached → filter RBAC → return |
-| `HandleListGRPCRoutes` | `GET /grpcroutes` | getCached → filter RBAC → return |
-| `HandleListTCPRoutes` | `GET /tcproutes` | getCached → filter RBAC → return |
-| `HandleListTLSRoutes` | `GET /tlsroutes` | getCached → filter RBAC → return |
-| `HandleListUDPRoutes` | `GET /udproutes` | getCached → filter RBAC → return |
+| `HandleGetHTTPRoute` | `GET /httproutes/{ns}/{name}` | Impersonating Get + resolve parents & backends |
+| `HandleListRoutes` | `GET /routes?kind=X` | getCached → filter by Kind → filter RBAC → return |
+| `HandleGetRoute` | `GET /routes/{kind}/{ns}/{name}` | Impersonating Get + resolve parents & backends |
 
-**Detail handlers** (7 endpoints) — these bypass cache, use impersonating client:
+**`HandleListRoutes`** accepts `?kind=grpcroutes|tcproutes|tlsroutes|udproutes` query param. Filters `cachedData.routes` by the `Kind` field. Returns 400 if kind is missing or invalid.
 
-| Handler method | Route | Logic |
-|---|---|---|
-| `HandleGetGatewayClass` | `GET /gatewayclasses/{name}` | Impersonating Get + normalize + no relationships needed |
-| `HandleGetGateway` | `GET /gateways/{namespace}/{name}` | Impersonating Get + resolve attached routes |
-| `HandleGetHTTPRoute` | `GET /httproutes/{namespace}/{name}` | Impersonating Get + resolve parents & backends |
-| `HandleGetGRPCRoute` | `GET /grpcroutes/{namespace}/{name}` | Impersonating Get + resolve parents & backends |
-| `HandleGetTCPRoute` | `GET /tcproutes/{namespace}/{name}` | Impersonating Get + resolve parents & backends |
-| `HandleGetTLSRoute` | `GET /tlsroutes/{namespace}/{name}` | Impersonating Get + resolve parents & backends |
-| `HandleGetUDPRoute` | `GET /udproutes/{namespace}/{name}` | Impersonating Get + resolve parents & backends |
+**`HandleGetRoute`** uses `routeKindGVR` map to resolve the GVR from the `{kind}` URL param. For GRPC routes, normalizes to `GRPCRouteDetail`. For TCP/TLS/UDP, normalizes to `SimpleRouteDetail` via `normalizeSimpleRouteDetail`.
 
-**Relationship resolution in detail handlers:**
+**Relationship resolution:**
 
 Gateway detail → attached routes:
-1. After fetching the Gateway, list all installed route kinds (parallel via WaitGroup, 2s timeout)
-2. Filter routes whose `spec.parentRefs` match this Gateway (name + namespace)
-3. Return as `AttachedRoutes []RouteSummary`
+- Filter the **cached** route data (30s TTL) by matching `parentRef.name`/`parentRef.namespace` to this Gateway. No fresh cluster-wide listing needed — the cache already has all routes.
 
 Route detail → parent gateways + backend services:
 1. After fetching the route, extract `spec.parentRefs`
-2. For each parentRef, fetch the Gateway object (parallel, 2s timeout)
-3. If resolved, include Gateway conditions; if not, set `resolved: false`
-4. For HTTP/GRPC routes, extract `spec.rules[].backendRefs`; for TCP/TLS/UDP, extract `spec.backendRefs`
+2. For each parentRef, fetch the Gateway object (parallel via WaitGroup, 2s timeout)
+3. If resolved, populate `GatewayConditions` on the ParentRef; if not, leave it empty
+4. For HTTP/GRPC routes, extract `spec.rules[].backendRefs`; for simple routes, extract `spec.backendRefs`
 5. For each backendRef pointing to a Service, fetch the Service (parallel, 2s timeout)
 6. Set `resolved: true/false` based on whether the Service was found
 
@@ -390,20 +414,15 @@ func (s *Server) registerGatewayRoutes(ar chi.Router) {
     h := s.GatewayHandler
     ar.Route("/gateway", func(gr chi.Router) {
         gr.Get("/status", h.HandleStatus)
+        gr.Get("/summary", h.HandleSummary)
         gr.Get("/gatewayclasses", h.HandleListGatewayClasses)
         gr.With(resources.ValidateURLParams).Get("/gatewayclasses/{name}", h.HandleGetGatewayClass)
         gr.Get("/gateways", h.HandleListGateways)
         gr.With(resources.ValidateURLParams).Get("/gateways/{namespace}/{name}", h.HandleGetGateway)
         gr.Get("/httproutes", h.HandleListHTTPRoutes)
         gr.With(resources.ValidateURLParams).Get("/httproutes/{namespace}/{name}", h.HandleGetHTTPRoute)
-        gr.Get("/grpcroutes", h.HandleListGRPCRoutes)
-        gr.With(resources.ValidateURLParams).Get("/grpcroutes/{namespace}/{name}", h.HandleGetGRPCRoute)
-        gr.Get("/tcproutes", h.HandleListTCPRoutes)
-        gr.With(resources.ValidateURLParams).Get("/tcproutes/{namespace}/{name}", h.HandleGetTCPRoute)
-        gr.Get("/tlsroutes", h.HandleListTLSRoutes)
-        gr.With(resources.ValidateURLParams).Get("/tlsroutes/{namespace}/{name}", h.HandleGetTLSRoute)
-        gr.Get("/udproutes", h.HandleListUDPRoutes)
-        gr.With(resources.ValidateURLParams).Get("/udproutes/{namespace}/{name}", h.HandleGetUDPRoute)
+        gr.Get("/routes", h.HandleListRoutes)
+        gr.With(resources.ValidateURLParams).Get("/routes/{kind}/{namespace}/{name}", h.HandleGetRoute)
     })
 }
 ```
@@ -439,38 +458,177 @@ TypeScript interfaces mirroring Go types. Follow `frontend/lib/certmanager-types
 ```typescript
 /** Gateway API types matching backend/internal/gateway/types.go */
 
-export interface GatewayAPIStatus { available: boolean; version: string; installedKinds: string[]; }
+export type GatewayResourceKind =
+  | "gatewayclasses" | "gateways" | "httproutes"
+  | "grpcroutes" | "tcproutes" | "tlsroutes" | "udproutes";
 
-export interface Condition { type: string; status: string; reason: string; message: string; lastTransitionTime?: string; }
+export interface GatewayAPIStatus {
+  available: boolean;
+  version: string;
+  installedKinds: string[];
+  lastChecked: string;
+}
 
-export interface ParentRefSummary { group: string; kind: string; name: string; namespace: string; sectionName: string; status: string; }
-export interface ParentRefDetail extends ParentRefSummary { gatewayConditions: Condition[]; }
+export interface GatewayAPISummary {
+  gatewayClasses: GatewayKindSummary;
+  gateways: GatewayKindSummary;
+  httpRoutes: GatewayKindSummary;
+  grpcRoutes: GatewayKindSummary;
+  tcpRoutes: GatewayKindSummary;
+  tlsRoutes: GatewayKindSummary;
+  udpRoutes: GatewayKindSummary;
+}
 
-export interface BackendRefDetail { group: string; kind: string; name: string; namespace: string; port?: number; weight?: number; resolved: boolean; }
+export interface GatewayKindSummary {
+  total: number;
+  healthy: number;
+  degraded: number;
+}
 
-export interface RouteSummary { kind: string; name: string; namespace: string; hostnames: string[]; parentRefs: ParentRefSummary[]; conditions: Condition[]; age: string; }
+export interface Condition {
+  type: string;
+  status: string;
+  reason: string;
+  message: string;
+  lastTransitionTime?: string;
+}
 
-export interface GatewayClassSummary { name: string; controllerName: string; description: string; conditions: Condition[]; age: string; }
+export interface ParentRef {
+  group: string;
+  kind: string;
+  name: string;
+  namespace: string;
+  sectionName: string;
+  status: string;
+  gatewayConditions?: Condition[];
+}
 
-export interface ListenerSummary { name: string; port: number; protocol: string; hostname: string; attachedRouteCount: number; }
-export interface ListenerDetail extends ListenerSummary { tlsMode: string; certificateRef: string; allowedRoutes: string; conditions: Condition[]; }
+export interface BackendRef {
+  group: string;
+  kind: string;
+  name: string;
+  namespace: string;
+  port?: number;
+  weight?: number;
+  resolved: boolean;
+}
 
-export interface GatewaySummary { name: string; namespace: string; gatewayClassName: string; listeners: ListenerSummary[]; addresses: string[]; attachedRouteCount: number; conditions: Condition[]; age: string; }
-export interface GatewayDetail extends GatewaySummary { listeners: ListenerDetail[]; attachedRoutes: RouteSummary[]; }
+export interface RouteSummary {
+  kind: string;
+  name: string;
+  namespace: string;
+  hostnames: string[];
+  parentRefs: ParentRef[];
+  conditions: Condition[];
+  age: string;
+}
 
-export interface HTTPRouteSummary { name: string; namespace: string; hostnames: string[]; parentRefs: ParentRefSummary[]; backendCount: number; conditions: Condition[]; age: string; }
-export interface HTTPRouteMatch { pathType: string; pathValue: string; headers: string[]; method: string; queryParams: string[]; }
-export interface HTTPRouteFilter { type: string; details: string; }
-export interface HTTPRouteRule { matches: HTTPRouteMatch[]; filters: HTTPRouteFilter[]; backendRefs: BackendRefDetail[]; }
-export interface HTTPRouteDetail extends HTTPRouteSummary { rules: HTTPRouteRule[]; parentRefs: ParentRefDetail[]; }
+export interface GatewayClassSummary {
+  name: string;
+  controllerName: string;
+  description: string;
+  conditions: Condition[];
+  age: string;
+}
 
-export interface GRPCRouteMatch { service: string; method: string; headers: string[]; }
-export interface GRPCRouteRule { matches: GRPCRouteMatch[]; backendRefs: BackendRefDetail[]; }
-export interface GRPCRouteDetail { name: string; namespace: string; parentRefs: ParentRefDetail[]; rules: GRPCRouteRule[]; conditions: Condition[]; age: string; }
+export interface Listener {
+  name: string;
+  port: number;
+  protocol: string;
+  hostname: string;
+  attachedRouteCount: number;
+  tlsMode?: string;
+  certificateRef?: string;
+  allowedRoutes?: string;
+  conditions?: Condition[];
+}
 
-export interface TCPRouteDetail { name: string; namespace: string; parentRefs: ParentRefDetail[]; backendRefs: BackendRefDetail[]; conditions: Condition[]; age: string; }
-export interface TLSRouteDetail { name: string; namespace: string; hostnames: string[]; parentRefs: ParentRefDetail[]; backendRefs: BackendRefDetail[]; conditions: Condition[]; age: string; }
-export interface UDPRouteDetail { name: string; namespace: string; parentRefs: ParentRefDetail[]; backendRefs: BackendRefDetail[]; conditions: Condition[]; age: string; }
+export interface GatewaySummary {
+  name: string;
+  namespace: string;
+  gatewayClassName: string;
+  listeners: Listener[];
+  addresses: string[];
+  attachedRouteCount: number;
+  conditions: Condition[];
+  age: string;
+}
+
+export interface GatewayDetail extends GatewaySummary {
+  attachedRoutes: RouteSummary[];
+}
+
+export interface HTTPRouteSummary {
+  name: string;
+  namespace: string;
+  hostnames: string[];
+  parentRefs: ParentRef[];
+  backendCount: number;
+  conditions: Condition[];
+  age: string;
+}
+
+export interface HTTPRouteMatch {
+  pathType: string;
+  pathValue: string;
+  headers: string[];
+  method: string;
+  queryParams: string[];
+}
+
+export interface HTTPRouteFilter {
+  type: string;
+  details: string;
+}
+
+export interface HTTPRouteRule {
+  matches: HTTPRouteMatch[];
+  filters: HTTPRouteFilter[];
+  backendRefs: BackendRef[];
+}
+
+export interface HTTPRouteDetail extends HTTPRouteSummary {
+  rules: HTTPRouteRule[];
+  parentRefs: ParentRef[];
+}
+
+export interface GRPCRouteMatch {
+  service: string;
+  method: string;
+  headers: string[];
+}
+
+export interface GRPCRouteRule {
+  matches: GRPCRouteMatch[];
+  backendRefs: BackendRef[];
+}
+
+export interface GRPCRouteDetail {
+  name: string;
+  namespace: string;
+  parentRefs: ParentRef[];
+  rules: GRPCRouteRule[];
+  conditions: Condition[];
+  age: string;
+}
+
+export interface SimpleRouteDetail {
+  kind: string;
+  name: string;
+  namespace: string;
+  hostnames: string[];
+  parentRefs: ParentRef[];
+  backendRefs: BackendRef[];
+  conditions: Condition[];
+  age: string;
+}
+
+/** Discriminated union for typed list data in the dashboard */
+export type GatewayListData =
+  | { kind: "gatewayclasses"; items: GatewayClassSummary[] }
+  | { kind: "gateways"; items: GatewaySummary[] }
+  | { kind: "httproutes"; items: HTTPRouteSummary[] }
+  | { kind: "grpcroutes" | "tcproutes" | "tlsroutes" | "udproutes"; items: RouteSummary[] };
 ```
 
 ### Step 3.2: `frontend/routes/networking/gateway-api.tsx`
@@ -499,31 +657,36 @@ export default define.page(function GatewayAPIPage(ctx) {
 
 Main dashboard island with overview cards + list views.
 
-**State:**
+**State (properly typed):**
 - `status: Signal<GatewayAPIStatus | null>` — CRD availability
+- `summary: Signal<GatewayAPISummary | null>` — counts per kind from `GET /gateway/summary`
 - `loading: Signal<boolean>`
 - `error: Signal<string>`
-- `activeKind: Signal<string | null>` — which list view is active (null = overview)
-- `listData: Signal<any[]>` — current list data
-- `search: Signal<string>` — filter text
+- `activeKind: Signal<GatewayResourceKind | null>` — which list is active (null = overview)
+- `listData: Signal<GatewayListData | null>` — typed discriminated union
+- `search: Signal<string>` — filter by name/namespace
+
+**URL state sync:** Read/write `?kind=` query param via `URLSearchParams`. When `activeKind` changes, update `window.history.replaceState`. On mount, read `?kind=` to restore state. This ensures browser back navigation works.
+
+**IS_BROWSER guard:** `if (!IS_BROWSER) return <div />` at the top of the component, same as all other islands.
 
 **Flow:**
-1. On mount, fetch `GET /api/v1/gateway/status`
+1. On mount, fetch `GET /api/v1/gateway/status` and `GET /api/v1/gateway/summary` in parallel
 2. If `!status.available`, render "Gateway API not installed" state with guidance
-3. If available, render overview cards for each installed kind
-4. Each card shows: icon, kind name, count, health summary (e.g., "3 Programmed, 1 Not Ready")
-5. Clicking a card sets `activeKind` and fetches the list endpoint
+3. If available, render overview cards for each installed kind using summary data
+4. Each card shows: kind name, total count, healthy/degraded breakdown
+5. Clicking a card sets `activeKind`, updates URL `?kind=`, and fetches the list endpoint
 6. List view renders a kind-specific table (columns vary by kind)
-7. "Back" button returns to overview
+7. "Back to overview" button clears `activeKind` and URL param
 
-**Overview cards** (only show for installed kinds):
-- GatewayClasses — count + accepted/pending
-- Gateways — count + programmed/not programmed
-- HTTPRoutes — count + accepted/not accepted
-- GRPCRoutes — count
-- TCPRoutes — count
-- TLSRoutes — count
-- UDPRoutes — count
+**Overview cards** (only show for installed kinds, data from `GatewayAPISummary`):
+- GatewayClasses — total + accepted/pending
+- Gateways — total + programmed/not programmed
+- HTTPRoutes — total + accepted/not accepted
+- GRPCRoutes — total
+- TCPRoutes — total
+- TLSRoutes — total
+- UDPRoutes — total
 
 **List table columns per kind:**
 
@@ -532,12 +695,17 @@ Main dashboard island with overview cards + list views.
 | GatewayClass | Name, Controller, Description, Accepted, Age |
 | Gateway | Name, Namespace, Class, Listeners, Addresses, Programmed, Age |
 | HTTPRoute | Name, Namespace, Hostnames, Parents, Backends, Accepted, Age |
-| GRPCRoute | Name, Namespace, Parents, Accepted, Age |
-| TCPRoute | Name, Namespace, Parents, Backends, Accepted, Age |
-| TLSRoute | Name, Namespace, Hostnames, Parents, Backends, Age |
-| UDPRoute | Name, Namespace, Parents, Backends, Age |
+| GRPCRoute/TCP/TLS/UDP | Name, Namespace, Parents, Accepted, Age |
 
-Each row is clickable — navigates to detail page.
+Each row is clickable — navigates to detail page using per-kind URLs.
+
+**API calls by kind:**
+- `gatewayclasses` → `GET /api/v1/gateway/gatewayclasses`
+- `gateways` → `GET /api/v1/gateway/gateways`
+- `httproutes` → `GET /api/v1/gateway/httproutes`
+- `grpcroutes|tcproutes|tlsroutes|udproutes` → `GET /api/v1/gateway/routes?kind=X`
+
+**Response handling:** Use defensive unwrapping `Array.isArray(res.data) ? res.data : []` per CertificatesList pattern.
 
 **Styling:** Use CSS custom property tokens exclusively. Follow CertificatesList.tsx patterns:
 - Card: `rounded-lg border border-border-primary bg-bg-elevated p-5`
@@ -551,7 +719,7 @@ Add Gateway API tab to the network section's `tabs` array (after EndpointSlices)
 { label: "Gateway API", href: "/networking/gateway-api" },
 ```
 
-No `kind`/`count` — the dashboard fetches its own counts from the dedicated status endpoint.
+No `kind`/`count` — the dashboard fetches its own counts from the dedicated summary endpoint.
 
 ### Step 3.5: Modify `frontend/islands/CommandPalette.tsx`
 
@@ -567,52 +735,51 @@ cd frontend && deno fmt --check && deno lint
 
 ---
 
-## Phase 4: Frontend Detail Routes + Detail Islands (Part 1: Gateway + GatewayClass)
+## Phase 4: Frontend Detail Routes + Detail Islands (Gateway + GatewayClass + Shared Components)
 
-**Files to create:** 4
+**Files to create:** 6
 
-### Step 4.1: `frontend/routes/networking/gateway-api/gatewayclasses/[name].tsx`
+### Step 4.1: Shared UI components
 
-Cluster-scoped detail route (no namespace param):
-```tsx
-export default define.page(function GatewayClassDetailPage(ctx) {
-  const { name } = ctx.params;
-  return (
-    <>
-      <SubNav tabs={section.tabs ?? []} currentPath="/networking/gateway-api" />
-      <GatewayClassDetail name={name} />
-    </>
-  );
-});
-```
+**`frontend/components/gateway/ConditionsTable.tsx`** — SSR component (not an island)
+Renders a conditions table with columns: Type, Status, Reason, Message, Last Transition.
+Used by every detail island. Accepts `conditions: Condition[]` prop.
 
-### Step 4.2: `frontend/routes/networking/gateway-api/[kind]/[ns]/[name].tsx`
+**`frontend/components/gateway/ParentGatewaysTable.tsx`** — SSR component
+Renders parent gateway references with columns: Name, Namespace, Status.
+Each row links to Gateway detail page. Accepts `parentRefs: ParentRef[]` prop.
 
-Parameterized detail route for all namespaced kinds:
-```tsx
-export default define.page(function GatewayResourceDetailPage(ctx) {
-  const { kind, ns, name } = ctx.params;
-  return (
-    <>
-      <SubNav tabs={section.tabs ?? []} currentPath="/networking/gateway-api" />
-      <GatewayResourceDetail kind={kind} namespace={ns} name={name} />
-    </>
-  );
-});
-```
+**`frontend/components/gateway/BackendRefsTable.tsx`** — SSR component
+Renders backend references with columns: Kind, Name, Namespace, Port, Weight, Resolved.
+Service refs link to service detail page. Accepts `backendRefs: BackendRef[]` prop.
 
-Where `GatewayResourceDetail` is a dispatcher island that renders the appropriate detail component based on `kind`.
+**`frontend/components/ui/GatewayBadges.tsx`** — SSR component
+Following PolicyBadges/GitOpsBadges pattern:
+- `ConditionBadge` — True=success, False=danger, Unknown=warning
+- `ProtocolBadge` — HTTP/HTTPS/TLS/TCP/UDP with coloring
+
+### Step 4.2: Detail route files (per-kind, matching project convention)
+
+Create 6 route files. Each is a ~15-line wrapper following `certificates/[namespace]/[name].tsx` pattern:
+
+**`frontend/routes/networking/gateway-api/gatewayclasses/[name].tsx`**
+Cluster-scoped (no namespace). Renders `GatewayClassDetail` island with `name` prop.
+
+**`frontend/routes/networking/gateway-api/gateways/[ns]/[name].tsx`**
+Renders `GatewayDetail` island with `namespace` and `name` props.
+
+All route files set `currentPath="/networking/gateway-api"` for SubNav highlighting.
 
 ### Step 4.3: `frontend/islands/GatewayClassDetail.tsx`
 
 **Props:** `{ name: string }`
 **API:** `GET /api/v1/gateway/gatewayclasses/${name}`
+**IS_BROWSER guard** + loading/error state pattern per CertificateDetail.
 
 **Panels:**
 - Header: name + controller name
 - Description text
-- Conditions table: Type, Status, Reason, Message, Last Transition
-- Supported features (if available in the object)
+- `<ConditionsTable conditions={data.conditions} />`
 
 ### Step 4.4: `frontend/islands/GatewayDetail.tsx`
 
@@ -623,8 +790,8 @@ Where `GatewayResourceDetail` is a dispatcher island that renders the appropriat
 - Header: name + namespace + gateway class (linked to GatewayClass detail)
 - Addresses list
 - Listeners table: Name, Port, Protocol, Hostname, TLS Mode, Certificate Ref, Attached Routes, Status
-- Attached Routes table: Kind, Name, Namespace, Hostnames (each row links to route detail)
-- Conditions table
+- Attached Routes: `<ParentGatewaysTable>` equivalent but for routes (Kind, Name, Namespace — each links to route detail)
+- `<ConditionsTable conditions={data.conditions} />`
 
 ### Verification checkpoint:
 ```bash
@@ -633,23 +800,26 @@ cd frontend && deno fmt --check && deno lint
 
 ---
 
-## Phase 5: Frontend Detail Islands (Part 2: Routes)
+## Phase 5: Frontend Detail Islands (Routes)
 
-**Files to create:** 5
+**Files to create:** 7
 
-### Step 5.1: `frontend/islands/GatewayResourceDetail.tsx`
+### Step 5.1: Route detail route files
 
-Dispatcher island that renders the correct detail component based on `kind` prop:
-```tsx
-switch (kind) {
-  case "httproutes": return <HTTPRouteDetail namespace={namespace} name={name} />;
-  case "grpcroutes": return <GRPCRouteDetail namespace={namespace} name={name} />;
-  case "tcproutes":  return <TCPRouteDetail namespace={namespace} name={name} />;
-  case "tlsroutes":  return <TLSRouteDetail namespace={namespace} name={name} />;
-  case "udproutes":  return <UDPRouteDetail namespace={namespace} name={name} />;
-  default: return <div>Unknown resource kind</div>;
-}
-```
+**`frontend/routes/networking/gateway-api/httproutes/[ns]/[name].tsx`**
+Renders `GatewayHTTPRouteDetail` island.
+
+**`frontend/routes/networking/gateway-api/grpcroutes/[ns]/[name].tsx`**
+Renders `GatewayGRPCRouteDetail` island.
+
+**`frontend/routes/networking/gateway-api/tcproutes/[ns]/[name].tsx`**
+Renders `GatewaySimpleRouteDetail` island with `kind="TCPRoute"`.
+
+**`frontend/routes/networking/gateway-api/tlsroutes/[ns]/[name].tsx`**
+Renders `GatewaySimpleRouteDetail` island with `kind="TLSRoute"`.
+
+**`frontend/routes/networking/gateway-api/udproutes/[ns]/[name].tsx`**
+Renders `GatewaySimpleRouteDetail` island with `kind="UDPRoute"`.
 
 ### Step 5.2: `frontend/islands/GatewayHTTPRouteDetail.tsx`
 
@@ -659,40 +829,37 @@ switch (kind) {
 **Panels:**
 - Header: name + namespace
 - Hostnames list
-- Parent Gateways table: Name, Namespace, Status (each links to Gateway detail). Show Gateway conditions inline.
+- `<ParentGatewaysTable parentRefs={data.parentRefs} />`
 - Rules section (one card per rule):
   - Matches: path type/value, method, headers, query params
   - Filters: type + details
-  - Backend Refs table: Service Name, Namespace, Port, Weight, Resolved status (linked to service detail if resolved)
-- Conditions table
+  - `<BackendRefsTable backendRefs={rule.backendRefs} />`
+- `<ConditionsTable conditions={data.conditions} />`
 
 ### Step 5.3: `frontend/islands/GatewayGRPCRouteDetail.tsx`
 
 **Props:** `{ namespace: string; name: string }`
-**API:** `GET /api/v1/gateway/grpcroutes/${namespace}/${name}`
+**API:** `GET /api/v1/gateway/routes/grpcroutes/${namespace}/${name}`
 
 **Panels:**
 - Header: name + namespace
-- Parent Gateways table (linked)
+- `<ParentGatewaysTable parentRefs={data.parentRefs} />`
 - Rules section:
   - Matches: Service, Method, Headers
-  - Backend Refs table (linked)
-- Conditions table
+  - `<BackendRefsTable backendRefs={rule.backendRefs} />`
+- `<ConditionsTable conditions={data.conditions} />`
 
-### Step 5.4: `frontend/islands/GatewayTCPRouteDetail.tsx`
+### Step 5.4: `frontend/islands/GatewaySimpleRouteDetail.tsx`
 
-Simpler layout (no rules, just backendRefs):
-- Header + Parent Gateways table + Backend Refs table + Conditions
+**Props:** `{ kind: string; namespace: string; name: string }`
+**API:** `GET /api/v1/gateway/routes/${kind.toLowerCase()}s/${namespace}/${name}`
 
-### Step 5.5: `frontend/islands/GatewayTLSRouteDetail.tsx`
-
-Same as TCP but with Hostnames panel.
-
-### Step 5.6: `frontend/islands/GatewayUDPRouteDetail.tsx`
-
-Same structure as TCPRouteDetail.
-
-**Note:** TCP/TLS/UDP detail islands share very similar structure. Consider extracting a shared `SimpleRouteDetail` component that all three use, parameterized by whether to show hostnames.
+Single island handling TCP, TLS, and UDP routes. Layout:
+- Header: name + namespace + kind badge
+- Hostnames panel — **only rendered if `data.hostnames?.length > 0`** (TLS only)
+- `<ParentGatewaysTable parentRefs={data.parentRefs} />`
+- `<BackendRefsTable backendRefs={data.backendRefs} />`
+- `<ConditionsTable conditions={data.conditions} />`
 
 ### Verification checkpoint:
 ```bash
@@ -705,7 +872,7 @@ cd frontend && deno fmt --check && deno lint
 
 ### Step 6.1: Backend type checking
 ```bash
-cd backend && go vet ./... && go build ./...
+cd backend && go vet ./... && go build ./... && go test ./internal/gateway/...
 ```
 
 ### Step 6.2: Frontend linting + formatting
@@ -719,11 +886,12 @@ cd frontend && deno fmt --check && deno lint && deno task build
 2. Navigate to `/networking/gateway-api`
 3. Verify:
    - Status check shows Gateway API availability
-   - Overview cards display correct counts
+   - Overview cards display correct counts from summary endpoint
    - Click each card → list view loads with correct columns
+   - Browser back returns to overview (URL state sync)
    - Click a row → detail page renders with relationship data
    - GatewayClass detail accessible at `/networking/gateway-api/gatewayclasses/:name`
-   - Back navigation works
+   - Shared components render correctly (ConditionsTable, ParentGatewaysTable, BackendRefsTable)
    - Command palette "Gateway API" action works
    - "Not installed" state renders correctly (if no Gateway API CRDs)
 
@@ -736,28 +904,35 @@ make lint && make test && make build
 
 ## File Summary
 
-### New files (18):
+### New files (20):
 | File | Phase |
 |---|---|
 | `backend/internal/gateway/types.go` | 1 |
 | `backend/internal/gateway/discovery.go` | 1 |
 | `backend/internal/gateway/normalize.go` | 1 |
+| `backend/internal/gateway/normalize_test.go` | 1 |
 | `backend/internal/gateway/handler.go` | 2 |
 | `frontend/lib/gateway-types.ts` | 3 |
 | `frontend/routes/networking/gateway-api.tsx` | 3 |
 | `frontend/islands/GatewayAPIDashboard.tsx` | 3 |
+| `frontend/components/gateway/ConditionsTable.tsx` | 4 |
+| `frontend/components/gateway/ParentGatewaysTable.tsx` | 4 |
+| `frontend/components/gateway/BackendRefsTable.tsx` | 4 |
+| `frontend/components/ui/GatewayBadges.tsx` | 4 |
 | `frontend/routes/networking/gateway-api/gatewayclasses/[name].tsx` | 4 |
-| `frontend/routes/networking/gateway-api/[kind]/[ns]/[name].tsx` | 4 |
+| `frontend/routes/networking/gateway-api/gateways/[ns]/[name].tsx` | 4 |
 | `frontend/islands/GatewayClassDetail.tsx` | 4 |
 | `frontend/islands/GatewayDetail.tsx` | 4 |
-| `frontend/islands/GatewayResourceDetail.tsx` | 5 |
+| `frontend/routes/networking/gateway-api/httproutes/[ns]/[name].tsx` | 5 |
+| `frontend/routes/networking/gateway-api/grpcroutes/[ns]/[name].tsx` | 5 |
+| `frontend/routes/networking/gateway-api/tcproutes/[ns]/[name].tsx` | 5 |
+| `frontend/routes/networking/gateway-api/tlsroutes/[ns]/[name].tsx` | 5 |
+| `frontend/routes/networking/gateway-api/udproutes/[ns]/[name].tsx` | 5 |
 | `frontend/islands/GatewayHTTPRouteDetail.tsx` | 5 |
 | `frontend/islands/GatewayGRPCRouteDetail.tsx` | 5 |
-| `frontend/islands/GatewayTCPRouteDetail.tsx` | 5 |
-| `frontend/islands/GatewayTLSRouteDetail.tsx` | 5 |
-| `frontend/islands/GatewayUDPRouteDetail.tsx` | 5 |
+| `frontend/islands/GatewaySimpleRouteDetail.tsx` | 5 |
 
-### Modified files (4):
+### Modified files (5):
 | File | Phase | Change |
 |---|---|---|
 | `backend/internal/server/server.go` | 2 | Add GatewayHandler to Server + Deps structs |
@@ -765,3 +940,15 @@ make lint && make test && make build
 | `backend/cmd/kubecenter/main.go` | 2 | Initialize discoverer + handler, add to Deps |
 | `frontend/lib/constants.ts` | 3 | Add Gateway API tab to network section |
 | `frontend/islands/CommandPalette.tsx` | 3 | Add quick action |
+
+### Key changes from v1 plan (review feedback):
+- **Types consolidated:** Single `ParentRef` (no Summary/Detail split), single `Listener` (no split), single `SimpleRouteDetail` replaces TCP/TLS/UDP detail types
+- **Endpoints reduced:** 15 → 10. Parameterized `GET /routes?kind=X` for GRPC/TCP/TLS/UDP lists, `GET /routes/{kind}/{ns}/{name}` for details
+- **Summary endpoint added:** `GET /gateway/summary` provides counts+health for overview cards in a single call
+- **Islands reduced:** No dispatcher island. TCP/TLS/UDP share `GatewaySimpleRouteDetail`. Total: 5 islands instead of 8
+- **Per-kind route files:** Follow project convention, no `[kind]` parameter ambiguity, each island independently loadable
+- **Shared components extracted:** ConditionsTable, ParentGatewaysTable, BackendRefsTable, GatewayBadges
+- **Tests added:** `normalize_test.go` with table-driven tests for all normalize functions
+- **Typed state:** `GatewayResourceKind` union type, `GatewayListData` discriminated union, no `any`
+- **URL state sync:** `?kind=` query param for browser back navigation
+- **Gateway detail uses cache:** Attached routes resolved from 30s cache, not fresh cluster-wide listing


### PR DESCRIPTION
## Summary
- Add full Gateway API support for all 7 resource kinds (GatewayClass, Gateway, HTTPRoute, GRPCRoute, TCPRoute, TLSRoute, UDPRoute)
- New `internal/gateway/` backend package with CRD auto-detection, singleflight+30s cache, RBAC filtering, 10 HTTP endpoints
- Dashboard overview with health cards, kind-specific list views, and custom detail pages with cross-resource relationship resolution
- Gateway detail resolves attached routes from cache; route details resolve parent gateways and backend services in parallel

## Changes
**Backend (5 new files, 3 modified):**
- `backend/internal/gateway/types.go` — 20 normalized Go types, GVR constants, route kind dispatch
- `backend/internal/gateway/discovery.go` — CRD discovery for v1 + v1alpha2 with 5min cache
- `backend/internal/gateway/normalize.go` — 8 normalize functions + 6 helpers for unstructured conversion
- `backend/internal/gateway/normalize_test.go` — 9 test functions, 22 sub-tests
- `backend/internal/gateway/handler.go` — 10 HTTP handlers with singleflight cache + relationship resolution
- `backend/internal/server/{server,routes}.go` + `cmd/kubecenter/main.go` — integration wiring

**Frontend (21 new files, 2 modified):**
- `frontend/lib/gateway-types.ts` — TypeScript interfaces with discriminated union for list data
- `frontend/islands/GatewayAPIDashboard.tsx` — Overview cards + list views with URL state sync
- 5 detail islands: GatewayClassDetail, GatewayDetail, GatewayHTTPRouteDetail, GatewayGRPCRouteDetail, GatewaySimpleRouteDetail
- 4 shared components: ConditionsTable, ParentGatewaysTable, BackendRefsTable, GatewayBadges
- 7 per-kind route files + 1 dashboard route
- Nav tab + command palette quick action

## Design decisions
- TCP/TLS/UDP share a single `SimpleRouteDetail` type + island (review feedback)
- Parameterized `GET /routes?kind=X` endpoint for non-HTTP route lists (review feedback)
- Gateway detail resolves attached routes from 30s cache, not fresh cluster-wide listing (review feedback)
- Per-kind route files instead of `[kind]` parameter to match project convention and avoid Fresh route ambiguity (review feedback)
- No dispatcher island — dispatch at route level to keep island bundles independent (review feedback)

## Test plan
- [ ] Backend: `go vet`, `go build`, `go test ./internal/gateway/...` — all pass
- [ ] Frontend: `deno fmt --check`, `deno lint`, `deno task build` — all pass
- [ ] Navigate to `/networking/gateway-api` — verify status check and overview cards
- [ ] Click cards to drill into list views — verify kind-specific columns
- [ ] Click rows to navigate to detail pages — verify relationship data
- [ ] Browser back returns to overview (URL state sync)
- [ ] Command palette "Gateway API" action works
- [ ] "Not installed" state renders when no Gateway API CRDs present

🤖 Generated with [Claude Code](https://claude.com/claude-code)