### PR TITLE
fix: ArgoCD auto-rollout + GitOps detail double-encoding

### DIFF
--- a/argocd/k8scenter-application.yaml
+++ b/argocd/k8scenter-application.yaml
@@ -6,16 +6,30 @@
 # After that, ArgoCD tracks `main` and keeps the cluster in sync with
 # the Helm chart at helm/kubecenter/ using values-homelab.yaml.
 #
-# Image updates are automated by argocd-image-updater — see the
-# k8scenter-image-updater.yaml in this directory for the ImageUpdater
-# CR that drives backend/frontend digest tracking on the `latest` tag.
-# Note: argocd-image-updater v1.x is CRD-based; the legacy
-# argocd-image-updater.argoproj.io/* annotations are no longer read.
+# Image updates are automated by argocd-image-updater via the
+# annotations below.  Strategy: newest-build on sha-<commit> tags so
+# each CI push produces a unique, immutable tag that the updater picks
+# up and writes as a Helm parameter override on this Application CR.
+# Write-back method is "argocd" (no git credentials needed).
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: k8scenter
   namespace: argocd
+  annotations:
+    # -- argocd-image-updater: auto-roll on new sha-* image tags --
+    argocd-image-updater.argoproj.io/image-list: >-
+      backend=ghcr.io/maulepilot117/k8scenter-backend,
+      frontend=ghcr.io/maulepilot117/k8scenter-frontend
+    argocd-image-updater.argoproj.io/backend.update-strategy: newest-build
+    argocd-image-updater.argoproj.io/backend.allow-tags: "regexp:^sha-[0-9a-f]+$"
+    argocd-image-updater.argoproj.io/backend.helm.image-name: backend.image.repository
+    argocd-image-updater.argoproj.io/backend.helm.image-tag: backend.image.tag
+    argocd-image-updater.argoproj.io/frontend.update-strategy: newest-build
+    argocd-image-updater.argoproj.io/frontend.allow-tags: "regexp:^sha-[0-9a-f]+$"
+    argocd-image-updater.argoproj.io/frontend.helm.image-name: frontend.image.repository
+    argocd-image-updater.argoproj.io/frontend.helm.image-tag: frontend.image.tag
+    argocd-image-updater.argoproj.io/write-back-method: argocd
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
@@ -26,13 +40,13 @@ spec:
     path: helm/kubecenter
     targetRevision: main
     helm:
-      releaseName: kubecenter
+      releaseName: k8scenter
       valueFiles:
         - values-homelab.yaml
 
   destination:
     server: https://kubernetes.default.svc
-    namespace: kubecenter
+    namespace: k8scenter
 
   syncPolicy:
     automated:

--- a/argocd/k8scenter-image-updater.yaml
+++ b/argocd/k8scenter-image-updater.yaml
@@ -1,31 +1,27 @@
-# argocd-image-updater v1.1.1 CRD-based configuration.
+# argocd-image-updater CRD-based configuration (v1.x).
 #
-# The v1 operator redesigned image tracking from Application annotations
-# to a dedicated CRD. This ImageUpdater CR tells the controller to watch
-# the k8scenter Application in the argocd namespace and update its
-# backend/frontend images when new digests appear on the `latest` tag in
-# GHCR.
+# This is kept as a secondary mechanism alongside the annotation-based
+# config on the Application CR. The annotations are the primary/stable
+# approach and work with any argocd-image-updater version. This CRD
+# takes effect only if argocd-image-updater v1.x with CRD support is
+# installed.
+#
+# Strategy: newest-build on sha-<commit> tags.  Each CI merge to main
+# pushes images tagged sha-<short-sha>, so the updater detects a new
+# tag, writes the Helm parameter override, and ArgoCD rolls out.
 #
 # Apply with:
 #   kubectl apply -n argocd -f argocd/k8scenter-image-updater.yaml
-#
-# Flow on each reconcile (default every 2 minutes):
-#   1. Controller polls ghcr.io for ghcr.io/maulepilot117/k8scenter-{backend,frontend}
-#   2. Detects a new digest on the `latest` tag
-#   3. Writes new helm parameter overrides to the k8scenter Application CR
-#   4. ArgoCD detects drift, re-renders, applies, pods roll out
 apiVersion: argocd-image-updater.argoproj.io/v1alpha1
 kind: ImageUpdater
 metadata:
   name: k8scenter-images
   namespace: argocd
 spec:
-  # Defaults inherited by every image below.
   commonUpdateSettings:
-    updateStrategy: digest
-    allowTags: "regexp:^latest$"
+    updateStrategy: newest-build
+    allowTags: "regexp:^sha-[0-9a-f]+$"
 
-  # Write parameter overrides back to the Application CR (no git credentials).
   writeBackConfig:
     method: argocd
 
@@ -33,13 +29,13 @@ spec:
     - namePattern: k8scenter
       images:
         - alias: backend
-          imageName: ghcr.io/maulepilot117/k8scenter-backend:latest
+          imageName: ghcr.io/maulepilot117/k8scenter-backend
           manifestTargets:
             helm:
               name: backend.image.repository
               tag: backend.image.tag
         - alias: frontend
-          imageName: ghcr.io/maulepilot117/k8scenter-frontend:latest
+          imageName: ghcr.io/maulepilot117/k8scenter-frontend
           manifestTargets:
             helm:
               name: frontend.image.repository

--- a/frontend/routes/gitops/applications/[id].tsx
+++ b/frontend/routes/gitops/applications/[id].tsx
@@ -6,7 +6,7 @@ import GitOpsAppDetail from "@/islands/GitOpsAppDetail.tsx";
 const section = DOMAIN_SECTIONS.find((s) => s.id === "gitops")!;
 
 export default define.page(function GitOpsAppDetailPage(ctx) {
-  const id = ctx.params.id;
+  const id = decodeURIComponent(ctx.params.id);
   return (
     <>
       <SubNav tabs={section.tabs ?? []} currentPath="/gitops/applications" />

--- a/frontend/routes/gitops/applicationsets/[id].tsx
+++ b/frontend/routes/gitops/applicationsets/[id].tsx
@@ -6,7 +6,7 @@ import GitOpsAppSetDetail from "@/islands/GitOpsAppSetDetail.tsx";
 const section = DOMAIN_SECTIONS.find((s) => s.id === "gitops")!;
 
 export default define.page(function AppSetDetailPage(ctx) {
-  const id = ctx.params.id;
+  const id = decodeURIComponent(ctx.params.id);
   return (
     <>
       <SubNav

--- a/helm/kubecenter/values-homelab.yaml
+++ b/helm/kubecenter/values-homelab.yaml
@@ -4,15 +4,15 @@ replicaCount: 1
 backend:
   image:
     repository: ghcr.io/maulepilot117/k8scenter-backend
-    tag: latest
-    pullPolicy: Always  # always pull latest on upgrade
+    tag: latest  # overridden at runtime by argocd-image-updater → sha-<commit>
+    pullPolicy: Always
   config:
     dev: true  # relaxes rate limiting to 60 req/min for homelab
 
 frontend:
   image:
     repository: ghcr.io/maulepilot117/k8scenter-frontend
-    tag: latest
+    tag: latest  # overridden at runtime by argocd-image-updater → sha-<commit>
     pullPolicy: Always
   resources:
     requests:


### PR DESCRIPTION
## Summary

- **ArgoCD image updater broken**: `digest` strategy with `^latest$` filter produced invalid image refs (`repo:sha256:...` — colons aren't valid digest separators). Switched to `newest-build` strategy tracking `sha-<commit>` tags. Each CI push creates a unique immutable tag the updater detects and writes as a Helm parameter override.
- **Wrong destination namespace**: Application CR targeted `kubecenter` instead of `k8scenter`, creating a duplicate namespace. Fixed `releaseName` and `destination.namespace`.
- **GitOps detail page 400**: Fresh 2.x passes raw URL-encoded route params, so `encodeURIComponent()` in the island double-encoded colons in composite IDs (`argo%3A` → `argo%253A`). Added `decodeURIComponent()` at the route boundary for both application and applicationset detail pages.

## Changes

| File | Change |
|------|--------|
| `argocd/k8scenter-application.yaml` | Added annotation-based image updater config, fixed namespace + releaseName |
| `argocd/k8scenter-image-updater.yaml` | Switched from digest to newest-build strategy with sha-* tags |
| `helm/kubecenter/values-homelab.yaml` | Updated comments to reflect image updater override |
| `frontend/routes/gitops/applications/[id].tsx` | `decodeURIComponent(ctx.params.id)` |
| `frontend/routes/gitops/applicationsets/[id].tsx` | Same fix |

## Test plan

- [x] Applied ArgoCD manifests to cluster — image updater detected `sha-05204e2`, wrote Helm overrides, pods rolled out
- [x] Verified `images_updated=2` in image updater logs (was `images_updated=0` before)
- [x] Confirmed stale `kubecenter` namespace resources pruned
- [x] Frontend builds cleanly (`deno task build`, `deno lint`, `deno fmt --check`)
- [ ] Verify GitOps detail page loads after CI deploys new frontend image
- [ ] Verify next CI push triggers automatic rollout via image updater

🤖 Generated with [Claude Code](https://claude.com/claude-code)