### PR TITLE
fix(backend): URL-decode composite IDs in GitOps handler

### DIFF
--- a/backend/internal/gitops/handler.go
+++ b/backend/internal/gitops/handler.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"regexp"
 	"sort"
 	"strings"
@@ -377,10 +378,15 @@ func (h *Handler) filterAppsByRBAC(ctx context.Context, user *auth.User, apps []
 }
 
 // parseCompositeID splits "argo:namespace:name" into (tool, namespace, name).
+// The id may arrive URL-encoded from chi.URLParam, so unescape first.
 func parseCompositeID(id string) (tool, namespace, name string, err error) {
-	parts := strings.SplitN(id, ":", 3)
+	decoded, uerr := url.PathUnescape(id)
+	if uerr != nil {
+		decoded = id // fall back to raw value
+	}
+	parts := strings.SplitN(decoded, ":", 3)
 	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
-		return "", "", "", fmt.Errorf("invalid composite ID: %q (expected tool:namespace:name)", id)
+		return "", "", "", fmt.Errorf("invalid composite ID: %q (expected tool:namespace:name)", decoded)
 	}
 	return parts[0], parts[1], parts[2], nil
 }


### PR DESCRIPTION
## Summary

- `chi.URLParam` returns raw URL-encoded path parameters — composite IDs like `argo%3Aargocd%3Ak8scenter` were passed to `parseCompositeID` with literal `%3A` instead of `:`, failing the split and returning 400
- Added `url.PathUnescape` in `parseCompositeID` before splitting, fixing all 4 handler call sites (app detail, app actions, appset detail, appset actions)
- Companion to frontend fix in #177 — both sides now handle encoded colons correctly

## Test plan

- [x] Existing `TestParseCompositeID` tests pass
- [x] `go vet` clean
- [x] Verified API returns 200 with `curl` using `argo:argocd:k8scenter` (unencoded)
- [ ] Verify GitOps detail page loads in browser after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)