### PR TITLE
feat(frontend): clickable notification navigation

### DIFF
--- a/frontend/components/ui/NotifCenterBadges.tsx
+++ b/frontend/components/ui/NotifCenterBadges.tsx
@@ -14,6 +14,9 @@ const SOURCE_COLORS: Record<NotifSource, string> = {
   scan: "var(--warning)",
   cluster: "var(--success)",
   audit: "var(--text-muted)",
+  limits: "var(--warning)",
+  velero: "var(--accent)",
+  certmanager: "var(--success)",
 };
 
 /** Colored dot indicating notification severity. */

--- a/frontend/islands/NotificationBell.tsx
+++ b/frontend/islands/NotificationBell.tsx
@@ -6,22 +6,11 @@ import { notifApi } from "@/lib/api.ts";
 import { useAuth } from "@/lib/auth.ts";
 import { notifActionUrl } from "@/lib/notif-action.ts";
 import type { AppNotification } from "@/lib/notif-center-types.ts";
+import { timeAgo } from "@/lib/timeAgo.ts";
 import {
   SeverityDot,
   SourceBadge,
 } from "@/components/ui/NotifCenterBadges.tsx";
-
-/** Time-ago helper for relative timestamps. */
-function timeAgo(iso: string): string {
-  const diff = Date.now() - new Date(iso).getTime();
-  const mins = Math.floor(diff / 60000);
-  if (mins < 1) return "just now";
-  if (mins < 60) return `${mins}m ago`;
-  const hours = Math.floor(mins / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
-}
 
 export default function NotificationBell() {
   const unreadCount = useSignal(0);
@@ -122,23 +111,25 @@ export default function NotificationBell() {
     }
   };
 
+  const isAdmin = !!user.value?.roles?.includes("admin");
+
   const handleClickNotification = (n: AppNotification) => {
-    // Fire-and-forget markRead — no await so navigation isn't delayed
+    // Fire-and-forget markRead with keepalive so it survives page navigation
     if (!n.read) {
-      notifApi.markRead(n.id).catch(() => {});
+      notifApi.markReadQuiet(n.id).catch((e) =>
+        console.warn("markRead failed:", e)
+      );
       unreadCount.value = Math.max(0, unreadCount.value - 1);
       recent.value = recent.value.map((item) =>
         item.id === n.id ? { ...item, read: true } : item
       );
     }
     showPanel.value = false;
-    const href = notifActionUrl(n);
+    const href = notifActionUrl(n, { isAdmin });
     if (href) {
       globalThis.location.href = href;
     }
   };
-
-  const isAdmin = user.value?.roles?.includes("admin");
   const viewAllHref = isAdmin ? "/admin/notifications" : "/notifications";
   const badgeCount = unreadCount.value > 99 ? "99+" : unreadCount.value;
 

--- a/frontend/islands/NotificationBell.tsx
+++ b/frontend/islands/NotificationBell.tsx
@@ -4,7 +4,7 @@ import { IS_BROWSER } from "fresh/runtime";
 import { subscribe, wsStatus } from "@/lib/ws.ts";
 import { notifApi } from "@/lib/api.ts";
 import { useAuth } from "@/lib/auth.ts";
-import { resourceHref } from "@/lib/k8s-links.ts";
+import { notifActionUrl } from "@/lib/notif-action.ts";
 import type { AppNotification } from "@/lib/notif-center-types.ts";
 import {
   SeverityDot,
@@ -122,30 +122,20 @@ export default function NotificationBell() {
     }
   };
 
-  const handleClickNotification = async (n: AppNotification) => {
+  const handleClickNotification = (n: AppNotification) => {
+    // Fire-and-forget markRead — no await so navigation isn't delayed
     if (!n.read) {
-      try {
-        await notifApi.markRead(n.id);
-        unreadCount.value = Math.max(0, unreadCount.value - 1);
-        recent.value = recent.value.map((item) =>
-          item.id === n.id ? { ...item, read: true } : item
-        );
-      } catch {
-        // Silently fail
-      }
-    }
-    // Navigate using resourceHref which handles irregular plurals correctly
-    if (n.resourceKind && n.resourceName) {
-      const href = resourceHref(
-        n.resourceKind,
-        n.resourceNamespace,
-        n.resourceName,
+      notifApi.markRead(n.id).catch(() => {});
+      unreadCount.value = Math.max(0, unreadCount.value - 1);
+      recent.value = recent.value.map((item) =>
+        item.id === n.id ? { ...item, read: true } : item
       );
-      if (href) {
-        globalThis.location.href = href;
-      }
     }
     showPanel.value = false;
+    const href = notifActionUrl(n);
+    if (href) {
+      globalThis.location.href = href;
+    }
   };
 
   const isAdmin = user.value?.roles?.includes("admin");

--- a/frontend/islands/NotificationFeed.tsx
+++ b/frontend/islands/NotificationFeed.tsx
@@ -2,6 +2,7 @@ import { useSignal } from "@preact/signals";
 import { useEffect, useRef } from "preact/hooks";
 import { IS_BROWSER } from "fresh/runtime";
 import { notifApi } from "@/lib/api.ts";
+import { useAuth } from "@/lib/auth.ts";
 import { useWsRefetch } from "@/lib/useWsRefetch.ts";
 import { notifActionUrl } from "@/lib/notif-action.ts";
 import {
@@ -93,12 +94,21 @@ export default function NotificationFeed() {
     resetAndFilter();
   }
 
+  const { user } = useAuth();
+  const isAdmin = !!user.value?.roles?.includes("admin");
+
   function handleRowClick(n: AppNotification) {
-    // Fire-and-forget markRead — no await so navigation isn't delayed
+    // Fire-and-forget markRead with keepalive so it survives page navigation
     if (!n.read) {
-      notifApi.markRead(n.id).catch(() => {});
+      notifApi.markReadQuiet(n.id).catch((e) =>
+        console.warn("markRead failed:", e)
+      );
+      // Optimistic read-state update
+      notifications.value = notifications.value.map((item) =>
+        item.id === n.id ? { ...item, read: true } : item
+      );
     }
-    const href = notifActionUrl(n);
+    const href = notifActionUrl(n, { isAdmin });
     if (href) {
       globalThis.location.href = href;
     }
@@ -278,7 +288,7 @@ export default function NotificationFeed() {
                 <tbody>
                   {notifications.value.map((n) => {
                     const isUnread = !n.read;
-                    const href = notifActionUrl(n);
+                    const href = notifActionUrl(n, { isAdmin });
                     return (
                       <tr
                         key={n.id}

--- a/frontend/islands/NotificationFeed.tsx
+++ b/frontend/islands/NotificationFeed.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef } from "preact/hooks";
 import { IS_BROWSER } from "fresh/runtime";
 import { notifApi } from "@/lib/api.ts";
 import { useWsRefetch } from "@/lib/useWsRefetch.ts";
-import { resourceHref } from "@/lib/k8s-links.ts";
+import { notifActionUrl } from "@/lib/notif-action.ts";
 import {
   SeverityDot,
   SourceBadge,
@@ -93,22 +93,14 @@ export default function NotificationFeed() {
     resetAndFilter();
   }
 
-  async function handleRowClick(n: AppNotification) {
-    // Mark as read
+  function handleRowClick(n: AppNotification) {
+    // Fire-and-forget markRead — no await so navigation isn't delayed
     if (!n.read) {
-      await notifApi.markRead(n.id);
+      notifApi.markRead(n.id).catch(() => {});
     }
-    // Navigate to resource detail if possible
-    if (n.resourceKind && n.resourceName) {
-      const href = resourceHref(
-        n.resourceKind,
-        n.resourceNamespace,
-        n.resourceName,
-      );
-      if (href) {
-        globalThis.location.href = href;
-        return;
-      }
+    const href = notifActionUrl(n);
+    if (href) {
+      globalThis.location.href = href;
     }
   }
 
@@ -286,13 +278,7 @@ export default function NotificationFeed() {
                 <tbody>
                   {notifications.value.map((n) => {
                     const isUnread = !n.read;
-                    const href = n.resourceKind && n.resourceName
-                      ? resourceHref(
-                        n.resourceKind,
-                        n.resourceNamespace,
-                        n.resourceName,
-                      )
-                      : null;
+                    const href = notifActionUrl(n);
                     return (
                       <tr
                         key={n.id}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -217,6 +217,12 @@ export const notifApi = {
   unreadCount: () =>
     apiGet<{ data: { count: number } }>("/v1/notifications/unread-count"),
   markRead: (id: string) => apiPost<void>(`/v1/notifications/${id}/read`),
+  /** Fire-and-forget markRead that survives page navigation. */
+  markReadQuiet: (id: string) =>
+    api<void>(`/v1/notifications/${id}/read`, {
+      method: "POST",
+      keepalive: true,
+    }),
   markAllRead: () => apiPost<void>("/v1/notifications/read-all"),
 
   // Channels (admin)

--- a/frontend/lib/notif-action.ts
+++ b/frontend/lib/notif-action.ts
@@ -1,0 +1,51 @@
+import type { AppNotification } from "./notif-center-types.ts";
+
+/**
+ * Compute the in-app navigation URL for a notification based on its source
+ * and resource metadata. Returns null if the notification cannot be linked.
+ */
+export function notifActionUrl(n: AppNotification): string | null {
+  switch (n.source) {
+    case "alert":
+      return "/alerting";
+    case "policy":
+      return "/security/violations";
+    case "gitops":
+      return "/gitops/applications";
+    case "diagnostic":
+      if (n.resourceNamespace && n.resourceKind && n.resourceName) {
+        return `/observability/investigate?namespace=${
+          encodeURIComponent(n.resourceNamespace)
+        }&kind=${encodeURIComponent(n.resourceKind)}&name=${
+          encodeURIComponent(n.resourceName)
+        }`;
+      }
+      return "/observability/investigate";
+    case "scan":
+      return "/security/scanning";
+    case "cluster":
+      return "/admin/clusters";
+    case "audit":
+      return "/admin/audit";
+    case "limits":
+      if (n.resourceNamespace) {
+        return `/governance/limits/namespaces/${
+          encodeURIComponent(n.resourceNamespace)
+        }`;
+      }
+      return "/governance/limits";
+    case "velero":
+      return "/governance/backups";
+    case "certmanager":
+      if (n.resourceNamespace && n.resourceName) {
+        return `/security/certificates/${
+          encodeURIComponent(n.resourceNamespace)
+        }/${encodeURIComponent(n.resourceName)}`;
+      }
+      return "/security/certificates";
+    default: {
+      const _exhaustive: never = n.source;
+      return null;
+    }
+  }
+}

--- a/frontend/lib/notif-action.ts
+++ b/frontend/lib/notif-action.ts
@@ -1,10 +1,18 @@
 import type { AppNotification } from "./notif-center-types.ts";
 
+interface NotifActionOpts {
+  /** When false, admin-only destinations return null. Defaults to false. */
+  isAdmin?: boolean;
+}
+
 /**
  * Compute the in-app navigation URL for a notification based on its source
  * and resource metadata. Returns null if the notification cannot be linked.
  */
-export function notifActionUrl(n: AppNotification): string | null {
+export function notifActionUrl(
+  n: AppNotification,
+  opts: NotifActionOpts = {},
+): string | null {
   switch (n.source) {
     case "alert":
       return "/alerting";
@@ -24,9 +32,9 @@ export function notifActionUrl(n: AppNotification): string | null {
     case "scan":
       return "/security/scanning";
     case "cluster":
-      return "/admin/clusters";
+      return opts.isAdmin ? "/admin/clusters" : null;
     case "audit":
-      return "/admin/audit";
+      return opts.isAdmin ? "/admin/audit" : null;
     case "limits":
       if (n.resourceNamespace) {
         return `/governance/limits/namespaces/${

--- a/frontend/lib/notif-center-types.ts
+++ b/frontend/lib/notif-center-types.ts
@@ -9,7 +9,10 @@ export type NotifSource =
   | "diagnostic"
   | "scan"
   | "cluster"
-  | "audit";
+  | "audit"
+  | "limits"
+  | "velero"
+  | "certmanager";
 
 /** Notification channel types matching backend notifications.ChannelType */
 export type NotifChannelType = "slack" | "email" | "webhook";
@@ -103,6 +106,9 @@ export const NOTIF_SOURCES: NotifSource[] = [
   "scan",
   "cluster",
   "audit",
+  "limits",
+  "velero",
+  "certmanager",
 ];
 
 /** All known notification severities for filter dropdowns. */
@@ -128,4 +134,7 @@ export const SOURCE_LABELS: Record<NotifSource, string> = {
   scan: "Security",
   cluster: "Cluster",
   audit: "Audit",
+  limits: "Limits",
+  velero: "Backup",
+  certmanager: "Certificate",
 };

--- a/plans/feat-clickable-notification-navigation.md
+++ b/plans/feat-clickable-notification-navigation.md
@@ -1,0 +1,218 @@
+# feat: Clickable Notification Navigation
+
+> Click any notification to navigate to its source page (policy, GitOps, alerts, diagnostics, certificates, etc.)
+
+## Overview
+
+Notifications in the Notification Center currently lack reliable click-to-navigate behavior. Only 4 of 10 notification sources populate the resource fields needed for navigation, and the existing `resourceHref()` utility only maps standard Kubernetes kinds — not policy, GitOps, cert-manager, or other custom resource types. This feature adds a dedicated URL-resolution function on the frontend that maps every notification source to its correct destination page.
+
+## Problem Statement
+
+1. **Most notifications are not clickable.** Only `alert`, `diagnostic`, `limits`, and `certmanager/poller` populate `ResourceKind/NS/Name`. The other 6 sources emit notifications with no resource metadata, so `resourceHref()` returns `null` and nothing happens on click.
+2. **Even populated notifications route wrong.** Diagnostic notifications go to the k8s resource detail page instead of `/observability/investigate`. Limits notifications go to `/config/resourcequotas/...` instead of `/governance/limits/namespaces/...`. CertManager uses sentinel kinds like `"certificate.expiring"` which `resourceHref()` can't resolve.
+3. **Database CHECK constraint is broken.** The `nc_notifications.source` CHECK only allows 7 values — `limits`, `velero`, and `certmanager` notifications silently fail on INSERT. (Tracked in Phase B.)
+4. **Frontend type drift.** `NotifSource` union type lists only 7 of 10 sources.
+
+## Proposed Solution
+
+**Frontend-computed action URLs** — no new database column. Add a `notifActionUrl(n: AppNotification): string | null` function that uses an exhaustive `switch` on `n.source` to compute the correct destination. No migration for the URL field, no staleness risk, routing logic lives alongside the frontend router.
+
+## Navigation Map
+
+| Source | Destination | URL Pattern | Resource fields needed |
+|---|---|---|---|
+| `alert` | Alerts page | `/alerting` | None (source-level link) |
+| `policy` | Violations page | `/security/violations` | None (source-level link) |
+| `gitops` | GitOps apps list | `/gitops/applications` | None (composite ID not available at emit time) |
+| `diagnostic` | Investigate page | `/observability/investigate?namespace={ns}&kind={kind}&name={name}` | ResourceKind, ResourceNS, ResourceName |
+| `scan` | Security scanning | `/security/scanning` | None |
+| `cluster` | Cluster management | `/admin/clusters` | None (admin-only) |
+| `audit` | Audit log | `/admin/audit` | None (admin-only) |
+| `limits` | Limits dashboard | `/governance/limits/namespaces/{namespace}` | ResourceNS |
+| `velero` | Backups page | `/governance/backups` | None |
+| `certmanager` | Certificate detail | `/security/certificates/{ns}/{name}` | ResourceNS, ResourceName |
+
+**Fallback:** If `notifActionUrl` returns `null` (missing required fields), the notification remains non-clickable (current behavior).
+
+---
+
+## Phase A: Frontend — Clickable Navigation (5 files)
+
+This is the core feature. No backend changes required.
+
+### A1. Extend NotifSource union + labels + badge colors
+
+**File: `frontend/lib/notif-center-types.ts`**
+
+```typescript
+export type NotifSource =
+  | "alert" | "policy" | "gitops" | "diagnostic"
+  | "scan" | "cluster" | "audit"
+  | "limits" | "velero" | "certmanager";
+```
+
+Update `NOTIF_SOURCES` array and `SOURCE_LABELS` record (typed `Record<NotifSource, string>` — compiler enforces completeness).
+
+**File: `frontend/components/ui/NotifCenterBadges.tsx`**
+
+Add color mappings for `limits`, `velero`, `certmanager` in `SourceBadge`.
+
+### A2. Create the URL resolver
+
+**File: `frontend/lib/notif-action.ts`** (new)
+
+```typescript
+import type { AppNotification, NotifSource } from "./notif-center-types.ts";
+
+export function notifActionUrl(n: AppNotification): string | null {
+  switch (n.source) {
+    case "alert":
+      return "/alerting";
+    case "policy":
+      return "/security/violations";
+    case "gitops":
+      return "/gitops/applications";
+    case "diagnostic":
+      if (n.resourceNamespace && n.resourceKind && n.resourceName) {
+        return `/observability/investigate?namespace=${encodeURIComponent(n.resourceNamespace)}&kind=${encodeURIComponent(n.resourceKind)}&name=${encodeURIComponent(n.resourceName)}`;
+      }
+      return "/observability/investigate";
+    case "scan":
+      return "/security/scanning";
+    case "cluster":
+      return "/admin/clusters";
+    case "audit":
+      return "/admin/audit";
+    case "limits":
+      if (n.resourceNamespace) {
+        return `/governance/limits/namespaces/${encodeURIComponent(n.resourceNamespace)}`;
+      }
+      return "/governance/limits";
+    case "velero":
+      return "/governance/backups";
+    case "certmanager":
+      if (n.resourceNamespace && n.resourceName) {
+        return `/security/certificates/${encodeURIComponent(n.resourceNamespace)}/${encodeURIComponent(n.resourceName)}`;
+      }
+      return "/security/certificates";
+    default: {
+      const _exhaustive: never = n.source;
+      return null;
+    }
+  }
+}
+```
+
+Note: exhaustive `never` check ensures adding a new `NotifSource` variant is a compile error, not a silent fallthrough.
+
+### A3. Replace resourceHref in notification islands
+
+**File: `frontend/islands/NotificationBell.tsx`**
+
+- Replace `resourceHref(n.resourceKind, n.resourceNamespace, n.resourceName)` with `notifActionUrl(n)`
+- Fire-and-forget `markRead` (drop the `await`, add `keepalive: true` to fetch options) then navigate immediately — awaiting markRead before `location.href` assignment creates unnecessary delay
+
+**File: `frontend/islands/NotificationFeed.tsx`**
+
+- Same `notifActionUrl` replacement in `handleRowClick` and the `href` render variable
+- Update `cursor: pointer` conditional to use `notifActionUrl(n) !== null`
+- Same fire-and-forget `markRead` with `keepalive: true`
+
+### A4. Visual affordance (inline, no extra files)
+
+All navigable notification rows:
+- `cursor: pointer` + accent-colored title text (already partially implemented)
+- Subtle hover background using `var(--surface-hover)`
+
+Non-navigable notifications: `cursor: default`, muted title.
+
+### Phase A Files
+
+| File | Change |
+|---|---|
+| `frontend/lib/notif-center-types.ts` | Extend NotifSource union, NOTIF_SOURCES, SOURCE_LABELS |
+| `frontend/components/ui/NotifCenterBadges.tsx` | Add 3 source color mappings |
+| `frontend/lib/notif-action.ts` (new) | `notifActionUrl()` function (~35 lines) |
+| `frontend/islands/NotificationBell.tsx` | Replace resourceHref, fire-and-forget markRead |
+| `frontend/islands/NotificationFeed.tsx` | Replace resourceHref, fire-and-forget markRead |
+
+---
+
+## Phase B: Backend Bug Fixes (separate PR)
+
+These are pre-existing bugs that affect notification persistence and data quality. They do not block Phase A (clickable navigation works regardless) but should be fixed promptly.
+
+### B1. Database migration — expand CHECK constraint
+
+**File: `backend/internal/store/migrations/000010_expand_notification_sources.up.sql`** (new)
+
+```sql
+ALTER TABLE nc_notifications DROP CONSTRAINT IF EXISTS nc_notifications_source_check;
+ALTER TABLE nc_notifications ADD CONSTRAINT nc_notifications_source_check
+  CHECK (source IN ('alert','policy','gitops','diagnostic','scan','cluster','audit','limits','velero','certmanager'));
+```
+
+**File: `backend/internal/store/migrations/000010_expand_notification_sources.down.sql`** (new)
+
+Drops and re-adds with original 7 values.
+
+**Impact:** Without this, all `limits`, `velero`, and `certmanager` notifications are silently dropped on INSERT. This is a data loss bug independent of the navigation feature.
+
+### B2. Fix certmanager poller ResourceKind sentinel
+
+**File: `backend/internal/certmanager/poller.go`**
+
+Change `ResourceKind` from `"certificate.expiring"` / `"certificate.expired"` to `"Certificate"`. The expiry status is already distinguished via the `Title` field. The sentinel value is not a valid Kubernetes kind and produces meaningless data in webhook payloads.
+
+### Phase B Files
+
+| File | Change |
+|---|---|
+| `backend/internal/store/migrations/000010_expand_notification_sources.up.sql` (new) | Expand CHECK constraint |
+| `backend/internal/store/migrations/000010_expand_notification_sources.down.sql` (new) | Down migration |
+| `backend/internal/certmanager/poller.go` | Fix ResourceKind to `"Certificate"` |
+
+---
+
+## Acceptance Criteria
+
+### Phase A
+- [ ] Every notification source has a defined click destination per the Navigation Map
+- [ ] Clicking a notification in the bell dropdown navigates to the correct page
+- [ ] Clicking a notification in the feed page navigates to the correct page
+- [ ] markRead fires with `keepalive: true` (no await before navigation)
+- [ ] Frontend `NotifSource` type includes all 10 sources with correct labels and badge colors
+- [ ] Diagnostic notifications navigate to `/observability/investigate` with pre-filled query params
+- [ ] CertManager notifications navigate to `/security/certificates/{ns}/{name}`
+- [ ] Limits notifications navigate to `/governance/limits/namespaces/{namespace}`
+- [ ] Non-navigable notifications (null URL) remain non-clickable with default cursor
+- [ ] `deno fmt --check` passes on all frontend changes
+
+### Phase B
+- [ ] `limits`, `velero`, and `certmanager` notifications persist to the database
+- [ ] CertManager poller emits `ResourceKind: "Certificate"` (not sentinel values)
+- [ ] `go vet ./...` passes on backend changes
+
+## Dependencies & Risks
+
+- **Phase A has zero backend dependencies.** Can ship immediately.
+- **Phase B should ship before or shortly after Phase A** to unblock limits/velero/certmanager notification persistence.
+- **Existing notifications in DB have old certmanager ResourceKind values** (`"certificate.expiring"`). The `notifActionUrl` function routes by `source`, not `resourceKind`, so old notifications navigate correctly.
+- **Admin-only destinations** (`/admin/clusters`, `/admin/audit`) will 403 for non-admin users. Consistent with how other admin links work throughout the app.
+
+## Out of Scope
+
+- Email digest per-notification links (requires base URL configuration)
+- Slack/webhook payload URLs (same base URL problem)
+- Per-violation policy deep links (requires per-violation notification emission)
+- GitOps deep links to specific applications (requires composite ID at emit time)
+- Client-side RBAC pre-check before navigation
+- Admin-only destination icons (destination page handles 403)
+
+## References
+
+- Notification Center PR: #162
+- Notification types: `backend/internal/notifications/types.go`
+- Frontend notification islands: `frontend/islands/NotificationBell.tsx`, `frontend/islands/NotificationFeed.tsx`
+- URL builder: `frontend/lib/k8s-links.ts` (existing `resourceHref`, supplemented not replaced)
+- DB migration 000007: `backend/internal/store/migrations/000007_create_notification_center.up.sql`


### PR DESCRIPTION
## Summary
- Every notification source now navigates to its relevant page on click (alerts → `/alerting`, policy → `/security/violations`, GitOps → `/gitops/applications`, diagnostics → `/observability/investigate`, certificates → `/security/certificates/{ns}/{name}`, etc.)
- New `notifActionUrl()` function with exhaustive TypeScript switch mapping all 10 notification sources to destination URLs
- Extended `NotifSource` type with `limits`, `velero`, `certmanager` (previously missing from frontend types)
- Switched `markRead` to fire-and-forget pattern so navigation isn't delayed by the API call

## Navigation Map

| Source | Destination |
|---|---|
| alert | `/alerting` |
| policy | `/security/violations` |
| gitops | `/gitops/applications` |
| diagnostic | `/observability/investigate?namespace=&kind=&name=` |
| scan | `/security/scanning` |
| cluster | `/admin/clusters` |
| audit | `/admin/audit` |
| limits | `/governance/limits/namespaces/{namespace}` |
| velero | `/governance/backups` |
| certmanager | `/security/certificates/{ns}/{name}` |

## Phase B (tracked, separate PR)
- DB migration to fix CHECK constraint on `nc_notifications.source` (currently silently drops `limits`/`velero`/`certmanager` notifications)
- Fix certmanager poller `ResourceKind` sentinel values (`"certificate.expiring"` → `"Certificate"`)

## Files Changed (5 frontend files)
- `frontend/lib/notif-action.ts` (new) — `notifActionUrl()` resolver
- `frontend/lib/notif-center-types.ts` — extended NotifSource union + labels
- `frontend/components/ui/NotifCenterBadges.tsx` — 3 new source colors
- `frontend/islands/NotificationBell.tsx` — replaced `resourceHref` with `notifActionUrl`
- `frontend/islands/NotificationFeed.tsx` — replaced `resourceHref` with `notifActionUrl`

## Test plan
- [ ] Click a notification in the bell dropdown — verify it navigates to the correct source page
- [ ] Click a notification in the feed page — verify same navigation
- [ ] Verify diagnostic notifications deep-link with namespace/kind/name query params
- [ ] Verify certmanager notifications link to `/security/certificates/{ns}/{name}`
- [ ] Verify non-navigable notifications (null URL) remain non-clickable
- [ ] Verify unread badge decrements on click without navigation delay
- [ ] Filter by new sources (limits, velero, certmanager) in feed filter dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)