### PR TITLE
feat(cert-manager): wizards for Certificate, Issuer, ClusterIssuer (Phase 11B)

### DIFF
--- a/backend/internal/server/routes.go
+++ b/backend/internal/server/routes.go
@@ -288,6 +288,13 @@ func (s *Server) registerWizardRoutes(ar chi.Router) {
 		wr.Post("/velero-backup/preview", h.HandlePreview(func() wizard.WizardInput { return &wizard.VeleroBackupInput{} }))
 		wr.Post("/velero-restore/preview", h.HandlePreview(func() wizard.WizardInput { return &wizard.VeleroRestoreInput{} }))
 		wr.Post("/velero-schedule/preview", h.HandlePreview(func() wizard.WizardInput { return &wizard.VeleroScheduleInput{} }))
+		wr.Post("/certificate/preview", h.HandlePreview(func() wizard.WizardInput { return &wizard.CertificateInput{} }))
+		wr.Post("/issuer/preview", h.HandlePreview(func() wizard.WizardInput {
+			return &wizard.IssuerInput{Scope: wizard.IssuerScopeNamespaced}
+		}))
+		wr.Post("/cluster-issuer/preview", h.HandlePreview(func() wizard.WizardInput {
+			return &wizard.IssuerInput{Scope: wizard.IssuerScopeCluster}
+		}))
 	})
 }
 

--- a/backend/internal/wizard/cert_helpers.go
+++ b/backend/internal/wizard/cert_helpers.go
@@ -1,0 +1,76 @@
+package wizard
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/mail"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// dnsNameRegex validates DNS names including wildcards (*.example.com).
+// The leftmost label may be "*"; other labels must be RFC 1123.
+var dnsNameRegex = regexp.MustCompile(`^(\*\.)?([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*$`)
+
+// dnsResolverTimeout bounds hostname lookups in validateHTTPSPublicURL.
+const dnsResolverTimeout = 2 * time.Second
+
+// validateEmailAddress returns true if addr parses as a bare RFC 5322 address
+// (no display-name form) and is non-empty.
+func validateEmailAddress(addr string) bool {
+	if addr == "" {
+		return false
+	}
+	parsed, err := mail.ParseAddress(addr)
+	if err != nil {
+		return false
+	}
+	return parsed.Address == strings.TrimSpace(addr)
+}
+
+// validateHTTPSPublicURL rejects non-HTTPS URLs and URLs that target non-public
+// address space. When the host is a DNS name, it is resolved (with a short
+// timeout); any resolved IP in non-public space rejects the URL. Resolution
+// failures are ignored — this check is advisory, since cert-manager itself (not
+// k8sCenter) fetches the URL.
+func validateHTTPSPublicURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return fmt.Errorf("must be a valid URL")
+	}
+	if u.Scheme != "https" {
+		return fmt.Errorf("must use https scheme")
+	}
+
+	host := u.Hostname()
+	var ips []net.IP
+	if ip := net.ParseIP(host); ip != nil {
+		ips = []net.IP{ip}
+	} else {
+		ctx, cancel := context.WithTimeout(context.Background(), dnsResolverTimeout)
+		defer cancel()
+		ips, _ = net.DefaultResolver.LookupIP(ctx, "ip", host)
+	}
+	for _, ip := range ips {
+		if !isPublicIP(ip) {
+			return fmt.Errorf("must not target a private, loopback, or non-public address")
+		}
+	}
+	return nil
+}
+
+// isPublicIP returns true only for globally-routable unicast addresses.
+// Rejects loopback, RFC1918, link-local, unspecified, multicast, and CGNAT (100.64.0.0/10).
+func isPublicIP(ip net.IP) bool {
+	if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() ||
+		ip.IsUnspecified() || ip.IsMulticast() {
+		return false
+	}
+	if ip4 := ip.To4(); ip4 != nil && ip4[0] == 100 && (ip4[1]&0xC0) == 0x40 {
+		return false // CGNAT 100.64.0.0/10
+	}
+	return true
+}

--- a/backend/internal/wizard/certificate.go
+++ b/backend/internal/wizard/certificate.go
@@ -1,0 +1,306 @@
+package wizard
+
+import (
+	"fmt"
+	"net/mail"
+	"regexp"
+	"strings"
+	"time"
+
+	sigsyaml "sigs.k8s.io/yaml"
+)
+
+// dnsNameRegex validates DNS names including wildcards (*.example.com).
+// The leftmost label may be "*"; other labels must be RFC 1123.
+var dnsNameRegex = regexp.MustCompile(`^(\*\.)?([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*$`)
+
+var validPrivateKeyAlgorithms = map[string]bool{
+	"RSA":     true,
+	"ECDSA":   true,
+	"Ed25519": true,
+}
+
+var validRSASizes = map[int]bool{2048: true, 3072: true, 4096: true}
+
+var validECDSASizes = map[int]bool{256: true, 384: true, 521: true}
+
+var validPrivateKeyEncodings = map[string]bool{"PKCS1": true, "PKCS8": true}
+
+var validRotationPolicies = map[string]bool{"Always": true, "Never": true}
+
+var validCertificateUsages = map[string]bool{
+	"signing":            true,
+	"digital signature":  true,
+	"content commitment": true,
+	"key encipherment":   true,
+	"key agreement":      true,
+	"data encipherment":  true,
+	"cert sign":          true,
+	"crl sign":           true,
+	"encipher only":      true,
+	"decipher only":      true,
+	"any":                true,
+	"server auth":        true,
+	"client auth":        true,
+	"code signing":       true,
+	"email protection":   true,
+	"s/mime":             true,
+	"ipsec end system":   true,
+	"ipsec tunnel":       true,
+	"ipsec user":         true,
+	"timestamping":       true,
+	"ocsp signing":       true,
+	"microsoft sgc":      true,
+	"netscape sgc":       true,
+}
+
+// CertificateIssuerRefInput identifies the Issuer or ClusterIssuer that signs the certificate.
+type CertificateIssuerRefInput struct {
+	Name  string `json:"name"`
+	Kind  string `json:"kind"`            // "Issuer" or "ClusterIssuer"
+	Group string `json:"group,omitempty"` // defaults to "cert-manager.io"
+}
+
+// CertificatePrivateKeyInput configures the private key generation.
+type CertificatePrivateKeyInput struct {
+	Algorithm      string `json:"algorithm,omitempty"`      // RSA, ECDSA, Ed25519
+	Size           int    `json:"size,omitempty"`           // algorithm-dependent
+	Encoding       string `json:"encoding,omitempty"`       // PKCS1 or PKCS8
+	RotationPolicy string `json:"rotationPolicy,omitempty"` // Always or Never
+}
+
+// CertificateInput represents the wizard form data for creating a cert-manager Certificate.
+type CertificateInput struct {
+	Name        string                      `json:"name"`
+	Namespace   string                      `json:"namespace"`
+	SecretName  string                      `json:"secretName"`
+	IssuerRef   CertificateIssuerRefInput   `json:"issuerRef"`
+	DNSNames    []string                    `json:"dnsNames,omitempty"`
+	CommonName  string                      `json:"commonName,omitempty"`
+	IPAddresses []string                    `json:"ipAddresses,omitempty"`
+	URIs        []string                    `json:"uris,omitempty"`
+	Duration    string                      `json:"duration,omitempty"`    // Go duration string, default 2160h
+	RenewBefore string                      `json:"renewBefore,omitempty"` // default 360h
+	PrivateKey  *CertificatePrivateKeyInput `json:"privateKey,omitempty"`
+	Usages      []string                    `json:"usages,omitempty"`
+	IsCA        bool                        `json:"isCA,omitempty"`
+}
+
+// Validate checks the CertificateInput and returns field-level errors.
+func (c *CertificateInput) Validate() []FieldError {
+	var errs []FieldError
+
+	if !dnsLabelRegex.MatchString(c.Name) {
+		errs = append(errs, FieldError{Field: "name", Message: "must be a valid DNS label (lowercase alphanumeric and hyphens, 1-63 chars)"})
+	}
+	if c.Namespace == "" {
+		errs = append(errs, FieldError{Field: "namespace", Message: "is required"})
+	} else if !dnsLabelRegex.MatchString(c.Namespace) {
+		errs = append(errs, FieldError{Field: "namespace", Message: "must be a valid DNS label"})
+	}
+	if c.SecretName == "" {
+		errs = append(errs, FieldError{Field: "secretName", Message: "is required"})
+	} else if !dnsLabelRegex.MatchString(c.SecretName) {
+		errs = append(errs, FieldError{Field: "secretName", Message: "must be a valid DNS label"})
+	}
+
+	// issuerRef
+	if c.IssuerRef.Kind != "Issuer" && c.IssuerRef.Kind != "ClusterIssuer" {
+		errs = append(errs, FieldError{Field: "issuerRef.kind", Message: "must be Issuer or ClusterIssuer"})
+	}
+	if c.IssuerRef.Name == "" {
+		errs = append(errs, FieldError{Field: "issuerRef.name", Message: "is required"})
+	} else if !dnsLabelRegex.MatchString(c.IssuerRef.Name) {
+		errs = append(errs, FieldError{Field: "issuerRef.name", Message: "must be a valid DNS label"})
+	}
+
+	// Need at least one identifier.
+	if len(c.DNSNames) == 0 && c.CommonName == "" && len(c.IPAddresses) == 0 && len(c.URIs) == 0 {
+		errs = append(errs, FieldError{Field: "dnsNames", Message: "at least one of dnsNames, commonName, ipAddresses, or uris is required"})
+	}
+
+	// dnsNames: RFC 1123 with optional leftmost wildcard.
+	if len(c.DNSNames) > 100 {
+		errs = append(errs, FieldError{Field: "dnsNames", Message: "must have 100 or fewer entries"})
+	}
+	for i, name := range c.DNSNames {
+		lower := strings.ToLower(name)
+		if !dnsNameRegex.MatchString(lower) {
+			errs = append(errs, FieldError{
+				Field:   fmt.Sprintf("dnsNames[%d]", i),
+				Message: "must be a valid DNS name (wildcards only in leftmost label)",
+			})
+		}
+		if len(name) > 253 {
+			errs = append(errs, FieldError{
+				Field:   fmt.Sprintf("dnsNames[%d]", i),
+				Message: "must be 253 characters or fewer",
+			})
+		}
+	}
+
+	// commonName: CA/Browser Forum and x509 enforce ≤64 chars.
+	if len(c.CommonName) > 64 {
+		errs = append(errs, FieldError{Field: "commonName", Message: "must be 64 characters or fewer"})
+	}
+
+	// duration and renewBefore must parse and obey renewBefore < duration.
+	var dur, renew time.Duration
+	var durOK, renewOK bool
+	if c.Duration != "" {
+		d, err := time.ParseDuration(c.Duration)
+		if err != nil {
+			errs = append(errs, FieldError{Field: "duration", Message: "must be a valid Go duration (e.g. 2160h)"})
+		} else if d < time.Hour {
+			errs = append(errs, FieldError{Field: "duration", Message: "must be at least 1h"})
+		} else {
+			dur = d
+			durOK = true
+		}
+	}
+	if c.RenewBefore != "" {
+		rb, err := time.ParseDuration(c.RenewBefore)
+		if err != nil {
+			errs = append(errs, FieldError{Field: "renewBefore", Message: "must be a valid Go duration (e.g. 360h)"})
+		} else if rb < 5*time.Minute {
+			errs = append(errs, FieldError{Field: "renewBefore", Message: "must be at least 5m"})
+		} else {
+			renew = rb
+			renewOK = true
+		}
+	}
+	if durOK && renewOK && renew >= dur {
+		errs = append(errs, FieldError{Field: "renewBefore", Message: "must be less than duration"})
+	}
+
+	// privateKey
+	if c.PrivateKey != nil {
+		errs = append(errs, c.PrivateKey.validate()...)
+	}
+
+	// usages
+	for i, u := range c.Usages {
+		if !validCertificateUsages[strings.ToLower(u)] {
+			errs = append(errs, FieldError{
+				Field:   fmt.Sprintf("usages[%d]", i),
+				Message: fmt.Sprintf("unknown usage %q", u),
+			})
+		}
+	}
+
+	return errs
+}
+
+func (pk *CertificatePrivateKeyInput) validate() []FieldError {
+	var errs []FieldError
+	if pk.Algorithm != "" && !validPrivateKeyAlgorithms[pk.Algorithm] {
+		errs = append(errs, FieldError{Field: "privateKey.algorithm", Message: "must be RSA, ECDSA, or Ed25519"})
+	}
+	switch pk.Algorithm {
+	case "RSA":
+		if pk.Size != 0 && !validRSASizes[pk.Size] {
+			errs = append(errs, FieldError{Field: "privateKey.size", Message: "RSA size must be 2048, 3072, or 4096"})
+		}
+	case "ECDSA":
+		if pk.Size != 0 && !validECDSASizes[pk.Size] {
+			errs = append(errs, FieldError{Field: "privateKey.size", Message: "ECDSA size must be 256, 384, or 521"})
+		}
+	}
+	if pk.Encoding != "" && !validPrivateKeyEncodings[pk.Encoding] {
+		errs = append(errs, FieldError{Field: "privateKey.encoding", Message: "must be PKCS1 or PKCS8"})
+	}
+	if pk.RotationPolicy != "" && !validRotationPolicies[pk.RotationPolicy] {
+		errs = append(errs, FieldError{Field: "privateKey.rotationPolicy", Message: "must be Always or Never"})
+	}
+	return errs
+}
+
+// ToCertificate returns a map representation suitable for YAML marshaling.
+// cert-manager is not in go.mod; we construct the object as a map to avoid
+// pulling in a large transitive dependency tree.
+func (c *CertificateInput) ToCertificate() map[string]any {
+	group := c.IssuerRef.Group
+	if group == "" {
+		group = "cert-manager.io"
+	}
+
+	spec := map[string]any{
+		"secretName": c.SecretName,
+		"issuerRef": map[string]any{
+			"name":  c.IssuerRef.Name,
+			"kind":  c.IssuerRef.Kind,
+			"group": group,
+		},
+	}
+
+	if len(c.DNSNames) > 0 {
+		spec["dnsNames"] = c.DNSNames
+	}
+	if c.CommonName != "" {
+		spec["commonName"] = c.CommonName
+	}
+	if len(c.IPAddresses) > 0 {
+		spec["ipAddresses"] = c.IPAddresses
+	}
+	if len(c.URIs) > 0 {
+		spec["uris"] = c.URIs
+	}
+	if c.Duration != "" {
+		spec["duration"] = c.Duration
+	}
+	if c.RenewBefore != "" {
+		spec["renewBefore"] = c.RenewBefore
+	}
+	if c.PrivateKey != nil {
+		pk := map[string]any{}
+		if c.PrivateKey.Algorithm != "" {
+			pk["algorithm"] = c.PrivateKey.Algorithm
+		}
+		if c.PrivateKey.Size != 0 {
+			pk["size"] = c.PrivateKey.Size
+		}
+		if c.PrivateKey.Encoding != "" {
+			pk["encoding"] = c.PrivateKey.Encoding
+		}
+		if c.PrivateKey.RotationPolicy != "" {
+			pk["rotationPolicy"] = c.PrivateKey.RotationPolicy
+		}
+		if len(pk) > 0 {
+			spec["privateKey"] = pk
+		}
+	}
+	if len(c.Usages) > 0 {
+		spec["usages"] = c.Usages
+	}
+	if c.IsCA {
+		spec["isCA"] = true
+	}
+
+	return map[string]any{
+		"apiVersion": "cert-manager.io/v1",
+		"kind":       "Certificate",
+		"metadata": map[string]any{
+			"name":      c.Name,
+			"namespace": c.Namespace,
+		},
+		"spec": spec,
+	}
+}
+
+// ToYAML implements WizardInput.
+func (c *CertificateInput) ToYAML() (string, error) {
+	y, err := sigsyaml.Marshal(c.ToCertificate())
+	if err != nil {
+		return "", err
+	}
+	return string(y), nil
+}
+
+// validateEmailAddress is a helper shared with the Issuer wizard's ACME block.
+func validateEmailAddress(addr string) bool {
+	if addr == "" {
+		return false
+	}
+	_, err := mail.ParseAddress(addr)
+	return err == nil
+}

--- a/backend/internal/wizard/certificate.go
+++ b/backend/internal/wizard/certificate.go
@@ -2,17 +2,11 @@ package wizard
 
 import (
 	"fmt"
-	"net/mail"
-	"regexp"
 	"strings"
 	"time"
 
 	sigsyaml "sigs.k8s.io/yaml"
 )
-
-// dnsNameRegex validates DNS names including wildcards (*.example.com).
-// The leftmost label may be "*"; other labels must be RFC 1123.
-var dnsNameRegex = regexp.MustCompile(`^(\*\.)?([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*$`)
 
 var validPrivateKeyAlgorithms = map[string]bool{
 	"RSA":     true,
@@ -24,35 +18,7 @@ var validRSASizes = map[int]bool{2048: true, 3072: true, 4096: true}
 
 var validECDSASizes = map[int]bool{256: true, 384: true, 521: true}
 
-var validPrivateKeyEncodings = map[string]bool{"PKCS1": true, "PKCS8": true}
-
 var validRotationPolicies = map[string]bool{"Always": true, "Never": true}
-
-var validCertificateUsages = map[string]bool{
-	"signing":            true,
-	"digital signature":  true,
-	"content commitment": true,
-	"key encipherment":   true,
-	"key agreement":      true,
-	"data encipherment":  true,
-	"cert sign":          true,
-	"crl sign":           true,
-	"encipher only":      true,
-	"decipher only":      true,
-	"any":                true,
-	"server auth":        true,
-	"client auth":        true,
-	"code signing":       true,
-	"email protection":   true,
-	"s/mime":             true,
-	"ipsec end system":   true,
-	"ipsec tunnel":       true,
-	"ipsec user":         true,
-	"timestamping":       true,
-	"ocsp signing":       true,
-	"microsoft sgc":      true,
-	"netscape sgc":       true,
-}
 
 // CertificateIssuerRefInput identifies the Issuer or ClusterIssuer that signs the certificate.
 type CertificateIssuerRefInput struct {
@@ -64,8 +30,7 @@ type CertificateIssuerRefInput struct {
 // CertificatePrivateKeyInput configures the private key generation.
 type CertificatePrivateKeyInput struct {
 	Algorithm      string `json:"algorithm,omitempty"`      // RSA, ECDSA, Ed25519
-	Size           int    `json:"size,omitempty"`           // algorithm-dependent
-	Encoding       string `json:"encoding,omitempty"`       // PKCS1 or PKCS8
+	Size           int    `json:"size,omitempty"`           // algorithm-dependent; must be 0 for Ed25519
 	RotationPolicy string `json:"rotationPolicy,omitempty"` // Always or Never
 }
 
@@ -77,12 +42,9 @@ type CertificateInput struct {
 	IssuerRef   CertificateIssuerRefInput   `json:"issuerRef"`
 	DNSNames    []string                    `json:"dnsNames,omitempty"`
 	CommonName  string                      `json:"commonName,omitempty"`
-	IPAddresses []string                    `json:"ipAddresses,omitempty"`
-	URIs        []string                    `json:"uris,omitempty"`
 	Duration    string                      `json:"duration,omitempty"`    // Go duration string, default 2160h
 	RenewBefore string                      `json:"renewBefore,omitempty"` // default 360h
 	PrivateKey  *CertificatePrivateKeyInput `json:"privateKey,omitempty"`
-	Usages      []string                    `json:"usages,omitempty"`
 	IsCA        bool                        `json:"isCA,omitempty"`
 }
 
@@ -115,8 +77,8 @@ func (c *CertificateInput) Validate() []FieldError {
 	}
 
 	// Need at least one identifier.
-	if len(c.DNSNames) == 0 && c.CommonName == "" && len(c.IPAddresses) == 0 && len(c.URIs) == 0 {
-		errs = append(errs, FieldError{Field: "dnsNames", Message: "at least one of dnsNames, commonName, ipAddresses, or uris is required"})
+	if len(c.DNSNames) == 0 && c.CommonName == "" {
+		errs = append(errs, FieldError{Field: "dnsNames", Message: "at least one of dnsNames or commonName is required"})
 	}
 
 	// dnsNames: RFC 1123 with optional leftmost wildcard.
@@ -139,9 +101,16 @@ func (c *CertificateInput) Validate() []FieldError {
 		}
 	}
 
-	// commonName: CA/Browser Forum and x509 enforce ≤64 chars.
+	// commonName: CA/Browser Forum and x509 enforce ≤64 chars. Reject control
+	// characters — they survive into x509 subject fields and can corrupt logs.
 	if len(c.CommonName) > 64 {
 		errs = append(errs, FieldError{Field: "commonName", Message: "must be 64 characters or fewer"})
+	}
+	for _, r := range c.CommonName {
+		if r < 0x20 || r == 0x7f {
+			errs = append(errs, FieldError{Field: "commonName", Message: "must not contain control characters"})
+			break
+		}
 	}
 
 	// duration and renewBefore must parse and obey renewBefore < duration.
@@ -178,16 +147,6 @@ func (c *CertificateInput) Validate() []FieldError {
 		errs = append(errs, c.PrivateKey.validate()...)
 	}
 
-	// usages
-	for i, u := range c.Usages {
-		if !validCertificateUsages[strings.ToLower(u)] {
-			errs = append(errs, FieldError{
-				Field:   fmt.Sprintf("usages[%d]", i),
-				Message: fmt.Sprintf("unknown usage %q", u),
-			})
-		}
-	}
-
 	return errs
 }
 
@@ -205,9 +164,10 @@ func (pk *CertificatePrivateKeyInput) validate() []FieldError {
 		if pk.Size != 0 && !validECDSASizes[pk.Size] {
 			errs = append(errs, FieldError{Field: "privateKey.size", Message: "ECDSA size must be 256, 384, or 521"})
 		}
-	}
-	if pk.Encoding != "" && !validPrivateKeyEncodings[pk.Encoding] {
-		errs = append(errs, FieldError{Field: "privateKey.encoding", Message: "must be PKCS1 or PKCS8"})
+	case "Ed25519":
+		if pk.Size != 0 {
+			errs = append(errs, FieldError{Field: "privateKey.size", Message: "Ed25519 does not accept a size"})
+		}
 	}
 	if pk.RotationPolicy != "" && !validRotationPolicies[pk.RotationPolicy] {
 		errs = append(errs, FieldError{Field: "privateKey.rotationPolicy", Message: "must be Always or Never"})
@@ -239,12 +199,6 @@ func (c *CertificateInput) ToCertificate() map[string]any {
 	if c.CommonName != "" {
 		spec["commonName"] = c.CommonName
 	}
-	if len(c.IPAddresses) > 0 {
-		spec["ipAddresses"] = c.IPAddresses
-	}
-	if len(c.URIs) > 0 {
-		spec["uris"] = c.URIs
-	}
 	if c.Duration != "" {
 		spec["duration"] = c.Duration
 	}
@@ -259,18 +213,12 @@ func (c *CertificateInput) ToCertificate() map[string]any {
 		if c.PrivateKey.Size != 0 {
 			pk["size"] = c.PrivateKey.Size
 		}
-		if c.PrivateKey.Encoding != "" {
-			pk["encoding"] = c.PrivateKey.Encoding
-		}
 		if c.PrivateKey.RotationPolicy != "" {
 			pk["rotationPolicy"] = c.PrivateKey.RotationPolicy
 		}
 		if len(pk) > 0 {
 			spec["privateKey"] = pk
 		}
-	}
-	if len(c.Usages) > 0 {
-		spec["usages"] = c.Usages
 	}
 	if c.IsCA {
 		spec["isCA"] = true
@@ -294,13 +242,4 @@ func (c *CertificateInput) ToYAML() (string, error) {
 		return "", err
 	}
 	return string(y), nil
-}
-
-// validateEmailAddress is a helper shared with the Issuer wizard's ACME block.
-func validateEmailAddress(addr string) bool {
-	if addr == "" {
-		return false
-	}
-	_, err := mail.ParseAddress(addr)
-	return err == nil
 }

--- a/backend/internal/wizard/certificate_test.go
+++ b/backend/internal/wizard/certificate_test.go
@@ -51,11 +51,22 @@ func TestCertificateValidate_NoIdentifiers(t *testing.T) {
 	c := validCertificateInput()
 	c.DNSNames = nil
 	c.CommonName = ""
-	c.IPAddresses = nil
-	c.URIs = nil
 	errs := c.Validate()
 	if !hasFieldError(errs, "dnsNames") {
 		t.Errorf("expected dnsNames error when no identifiers present, got %v", errs)
+	}
+}
+
+func TestCertificateValidate_CommonNameControlChars(t *testing.T) {
+	tests := []string{"with\nnewline", "null\x00byte", "del\x7fchar"}
+	for _, cn := range tests {
+		c := validCertificateInput()
+		c.DNSNames = nil
+		c.CommonName = cn
+		errs := c.Validate()
+		if !hasFieldError(errs, "commonName") {
+			t.Errorf("commonName %q should be rejected for control chars, got %v", cn, errs)
+		}
 	}
 }
 
@@ -140,7 +151,7 @@ func TestCertificateValidate_PrivateKey(t *testing.T) {
 		{"invalid algorithm", CertificatePrivateKeyInput{Algorithm: "DSA"}, "privateKey.algorithm"},
 		{"invalid RSA size", CertificatePrivateKeyInput{Algorithm: "RSA", Size: 1024}, "privateKey.size"},
 		{"invalid ECDSA size", CertificatePrivateKeyInput{Algorithm: "ECDSA", Size: 192}, "privateKey.size"},
-		{"invalid encoding", CertificatePrivateKeyInput{Encoding: "DER"}, "privateKey.encoding"},
+		{"Ed25519 with nonzero size", CertificatePrivateKeyInput{Algorithm: "Ed25519", Size: 2048}, "privateKey.size"},
 		{"invalid rotationPolicy", CertificatePrivateKeyInput{RotationPolicy: "Sometimes"}, "privateKey.rotationPolicy"},
 	}
 	for _, tt := range tests {
@@ -158,9 +169,7 @@ func TestCertificateValidate_PrivateKey(t *testing.T) {
 func TestCertificateValidate_PrivateKeyValidCombinations(t *testing.T) {
 	valid := []CertificatePrivateKeyInput{
 		{Algorithm: "RSA", Size: 2048, RotationPolicy: "Always"},
-		{Algorithm: "RSA", Size: 4096, Encoding: "PKCS8"},
 		{Algorithm: "ECDSA", Size: 256},
-		{Algorithm: "ECDSA", Size: 521},
 		{Algorithm: "Ed25519"},
 	}
 	for _, pk := range valid {
@@ -173,21 +182,11 @@ func TestCertificateValidate_PrivateKeyValidCombinations(t *testing.T) {
 	}
 }
 
-func TestCertificateValidate_UnknownUsage(t *testing.T) {
-	c := validCertificateInput()
-	c.Usages = []string{"server auth", "not-a-usage"}
-	errs := c.Validate()
-	if !hasFieldErrorWithPrefix(errs, "usages[1]") {
-		t.Errorf("expected usages[1] error, got %v", errs)
-	}
-}
-
 func TestCertificateToYAML(t *testing.T) {
 	c := validCertificateInput()
 	c.Duration = "2160h"
 	c.RenewBefore = "360h"
 	c.PrivateKey = &CertificatePrivateKeyInput{Algorithm: "RSA", Size: 2048, RotationPolicy: "Always"}
-	c.Usages = []string{"digital signature", "key encipherment", "server auth"}
 
 	y, err := c.ToYAML()
 	if err != nil {
@@ -196,32 +195,11 @@ func TestCertificateToYAML(t *testing.T) {
 	for _, want := range []string{
 		"apiVersion: cert-manager.io/v1",
 		"kind: Certificate",
-		"name: example-com-tls",
-		"namespace: default",
-		"secretName: example-com-tls",
-		"group: cert-manager.io",
 		"kind: ClusterIssuer",
-		"- example.com",
-		"- www.example.com",
-		"algorithm: RSA",
-		"size: 2048",
-		"rotationPolicy: Always",
+		"secretName: example-com-tls",
 	} {
 		if !strings.Contains(y, want) {
 			t.Errorf("YAML missing %q:\n%s", want, y)
-		}
-	}
-}
-
-func TestCertificateToYAML_OmitsEmptyOptionals(t *testing.T) {
-	c := validCertificateInput()
-	y, err := c.ToYAML()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	for _, notWant := range []string{"duration:", "renewBefore:", "privateKey:", "usages:", "isCA:", "commonName:", "ipAddresses:", "uris:"} {
-		if strings.Contains(y, notWant) {
-			t.Errorf("YAML should omit %q when not set:\n%s", notWant, y)
 		}
 	}
 }

--- a/backend/internal/wizard/certificate_test.go
+++ b/backend/internal/wizard/certificate_test.go
@@ -1,0 +1,247 @@
+package wizard
+
+import (
+	"strings"
+	"testing"
+)
+
+func validCertificateInput() CertificateInput {
+	return CertificateInput{
+		Name:       "example-com-tls",
+		Namespace:  "default",
+		SecretName: "example-com-tls",
+		IssuerRef:  CertificateIssuerRefInput{Name: "letsencrypt-prod", Kind: "ClusterIssuer"},
+		DNSNames:   []string{"example.com", "www.example.com"},
+	}
+}
+
+func TestCertificateValidate_Valid(t *testing.T) {
+	c := validCertificateInput()
+	if errs := c.Validate(); len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+}
+
+func TestCertificateValidate_MissingRequired(t *testing.T) {
+	tests := []struct {
+		name      string
+		mutate    func(*CertificateInput)
+		wantField string
+	}{
+		{"empty name", func(c *CertificateInput) { c.Name = "" }, "name"},
+		{"uppercase name", func(c *CertificateInput) { c.Name = "BadName" }, "name"},
+		{"empty namespace", func(c *CertificateInput) { c.Namespace = "" }, "namespace"},
+		{"empty secretName", func(c *CertificateInput) { c.SecretName = "" }, "secretName"},
+		{"missing issuerRef.name", func(c *CertificateInput) { c.IssuerRef.Name = "" }, "issuerRef.name"},
+		{"invalid issuerRef.kind", func(c *CertificateInput) { c.IssuerRef.Kind = "Random" }, "issuerRef.kind"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := validCertificateInput()
+			tt.mutate(&c)
+			errs := c.Validate()
+			if !hasFieldError(errs, tt.wantField) {
+				t.Errorf("expected error on %q, got %v", tt.wantField, errs)
+			}
+		})
+	}
+}
+
+func TestCertificateValidate_NoIdentifiers(t *testing.T) {
+	c := validCertificateInput()
+	c.DNSNames = nil
+	c.CommonName = ""
+	c.IPAddresses = nil
+	c.URIs = nil
+	errs := c.Validate()
+	if !hasFieldError(errs, "dnsNames") {
+		t.Errorf("expected dnsNames error when no identifiers present, got %v", errs)
+	}
+}
+
+func TestCertificateValidate_CommonNameOnlyAccepted(t *testing.T) {
+	c := validCertificateInput()
+	c.DNSNames = nil
+	c.CommonName = "example.com"
+	if errs := c.Validate(); len(errs) != 0 {
+		t.Errorf("commonName alone should satisfy identifier requirement, got %v", errs)
+	}
+}
+
+func TestCertificateValidate_DNSNames(t *testing.T) {
+	tests := []struct {
+		name    string
+		dnsName string
+		wantErr bool
+	}{
+		{"valid hostname", "example.com", false},
+		{"valid subdomain", "api.example.com", false},
+		{"wildcard leftmost", "*.example.com", false},
+		{"wildcard not leftmost", "api.*.example.com", true},
+		{"uppercase normalized ok", "EXAMPLE.com", false},
+		{"empty string", "", true},
+		{"trailing dot", "example.com.", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := validCertificateInput()
+			c.DNSNames = []string{tt.dnsName}
+			errs := c.Validate()
+			got := hasFieldErrorWithPrefix(errs, "dnsNames")
+			if got != tt.wantErr {
+				t.Errorf("dnsName %q: wantErr=%v, got errs=%v", tt.dnsName, tt.wantErr, errs)
+			}
+		})
+	}
+}
+
+func TestCertificateValidate_CommonNameTooLong(t *testing.T) {
+	c := validCertificateInput()
+	c.CommonName = strings.Repeat("a", 65)
+	errs := c.Validate()
+	if !hasFieldError(errs, "commonName") {
+		t.Errorf("expected commonName length error, got %v", errs)
+	}
+}
+
+func TestCertificateValidate_Duration(t *testing.T) {
+	tests := []struct {
+		name        string
+		duration    string
+		renewBefore string
+		wantField   string
+	}{
+		{"invalid duration", "not-a-duration", "", "duration"},
+		{"duration too short", "30m", "", "duration"},
+		{"invalid renewBefore", "2160h", "not-a-duration", "renewBefore"},
+		{"renewBefore too short", "2160h", "1m", "renewBefore"},
+		{"renewBefore >= duration", "24h", "48h", "renewBefore"},
+		{"renewBefore == duration", "24h", "24h", "renewBefore"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := validCertificateInput()
+			c.Duration = tt.duration
+			c.RenewBefore = tt.renewBefore
+			errs := c.Validate()
+			if !hasFieldError(errs, tt.wantField) {
+				t.Errorf("expected error on %q, got %v", tt.wantField, errs)
+			}
+		})
+	}
+}
+
+func TestCertificateValidate_PrivateKey(t *testing.T) {
+	tests := []struct {
+		name      string
+		pk        CertificatePrivateKeyInput
+		wantField string
+	}{
+		{"invalid algorithm", CertificatePrivateKeyInput{Algorithm: "DSA"}, "privateKey.algorithm"},
+		{"invalid RSA size", CertificatePrivateKeyInput{Algorithm: "RSA", Size: 1024}, "privateKey.size"},
+		{"invalid ECDSA size", CertificatePrivateKeyInput{Algorithm: "ECDSA", Size: 192}, "privateKey.size"},
+		{"invalid encoding", CertificatePrivateKeyInput{Encoding: "DER"}, "privateKey.encoding"},
+		{"invalid rotationPolicy", CertificatePrivateKeyInput{RotationPolicy: "Sometimes"}, "privateKey.rotationPolicy"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := validCertificateInput()
+			c.PrivateKey = &tt.pk
+			errs := c.Validate()
+			if !hasFieldError(errs, tt.wantField) {
+				t.Errorf("expected error on %q, got %v", tt.wantField, errs)
+			}
+		})
+	}
+}
+
+func TestCertificateValidate_PrivateKeyValidCombinations(t *testing.T) {
+	valid := []CertificatePrivateKeyInput{
+		{Algorithm: "RSA", Size: 2048, RotationPolicy: "Always"},
+		{Algorithm: "RSA", Size: 4096, Encoding: "PKCS8"},
+		{Algorithm: "ECDSA", Size: 256},
+		{Algorithm: "ECDSA", Size: 521},
+		{Algorithm: "Ed25519"},
+	}
+	for _, pk := range valid {
+		c := validCertificateInput()
+		pk := pk
+		c.PrivateKey = &pk
+		if errs := c.Validate(); len(errs) != 0 {
+			t.Errorf("pk=%+v should be valid, got %v", pk, errs)
+		}
+	}
+}
+
+func TestCertificateValidate_UnknownUsage(t *testing.T) {
+	c := validCertificateInput()
+	c.Usages = []string{"server auth", "not-a-usage"}
+	errs := c.Validate()
+	if !hasFieldErrorWithPrefix(errs, "usages[1]") {
+		t.Errorf("expected usages[1] error, got %v", errs)
+	}
+}
+
+func TestCertificateToYAML(t *testing.T) {
+	c := validCertificateInput()
+	c.Duration = "2160h"
+	c.RenewBefore = "360h"
+	c.PrivateKey = &CertificatePrivateKeyInput{Algorithm: "RSA", Size: 2048, RotationPolicy: "Always"}
+	c.Usages = []string{"digital signature", "key encipherment", "server auth"}
+
+	y, err := c.ToYAML()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, want := range []string{
+		"apiVersion: cert-manager.io/v1",
+		"kind: Certificate",
+		"name: example-com-tls",
+		"namespace: default",
+		"secretName: example-com-tls",
+		"group: cert-manager.io",
+		"kind: ClusterIssuer",
+		"- example.com",
+		"- www.example.com",
+		"algorithm: RSA",
+		"size: 2048",
+		"rotationPolicy: Always",
+	} {
+		if !strings.Contains(y, want) {
+			t.Errorf("YAML missing %q:\n%s", want, y)
+		}
+	}
+}
+
+func TestCertificateToYAML_OmitsEmptyOptionals(t *testing.T) {
+	c := validCertificateInput()
+	y, err := c.ToYAML()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, notWant := range []string{"duration:", "renewBefore:", "privateKey:", "usages:", "isCA:", "commonName:", "ipAddresses:", "uris:"} {
+		if strings.Contains(y, notWant) {
+			t.Errorf("YAML should omit %q when not set:\n%s", notWant, y)
+		}
+	}
+}
+
+// --- Helpers ---
+
+func hasFieldError(errs []FieldError, field string) bool {
+	for _, e := range errs {
+		if e.Field == field {
+			return true
+		}
+	}
+	return false
+}
+
+func hasFieldErrorWithPrefix(errs []FieldError, prefix string) bool {
+	for _, e := range errs {
+		if strings.HasPrefix(e.Field, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/wizard/issuer.go
+++ b/backend/internal/wizard/issuer.go
@@ -2,14 +2,13 @@ package wizard
 
 import (
 	"fmt"
-	"net"
-	"net/url"
-	"strings"
 
 	sigsyaml "sigs.k8s.io/yaml"
 )
 
-// IssuerScope indicates whether the wizard produces a namespaced Issuer or a cluster-scoped ClusterIssuer.
+// IssuerScope indicates whether the wizard produces a namespaced Issuer or a
+// cluster-scoped ClusterIssuer. The field is not JSON-decoded — the HTTP route
+// is authoritative and bakes in the scope via the HandlePreview factory.
 type IssuerScope string
 
 const (
@@ -46,10 +45,10 @@ type ACMESolverInput struct {
 
 // ACMEInput configures an ACME issuer.
 type ACMEInput struct {
-	Server                 string            `json:"server"`
-	Email                  string            `json:"email"`
-	PrivateKeySecretRefName string           `json:"privateKeySecretRefName"`
-	Solvers                []ACMESolverInput `json:"solvers"`
+	Server                  string            `json:"server"`
+	Email                   string            `json:"email"`
+	PrivateKeySecretRefName string            `json:"privateKeySecretRefName"`
+	Solvers                 []ACMESolverInput `json:"solvers"`
 }
 
 // CAInput configures a CA issuer.
@@ -60,9 +59,9 @@ type CAInput struct {
 // VaultAuthInput configures one of Vault's authentication methods.
 // Exactly one of the nested fields must be set.
 type VaultAuthInput struct {
-	TokenSecretRefName string `json:"tokenSecretRefName,omitempty"`
+	TokenSecretRefName   string `json:"tokenSecretRefName,omitempty"`
 	AppRoleSecretRefName string `json:"appRoleSecretRefName,omitempty"`
-	KubernetesRole     string `json:"kubernetesRole,omitempty"`
+	KubernetesRole       string `json:"kubernetesRole,omitempty"`
 }
 
 // VaultInput configures a Vault issuer.
@@ -72,9 +71,11 @@ type VaultInput struct {
 	Auth   VaultAuthInput `json:"auth"`
 }
 
-// IssuerInput represents the wizard form data for creating a cert-manager Issuer or ClusterIssuer.
+// IssuerInput represents the wizard form data for creating a cert-manager
+// Issuer or ClusterIssuer. Scope is intentionally not JSON-tagged so the route
+// remains authoritative — see the HandlePreview factories in routes.go.
 type IssuerInput struct {
-	Scope     IssuerScope `json:"scope"`
+	Scope     IssuerScope `json:"-"`
 	Name      string      `json:"name"`
 	Namespace string      `json:"namespace,omitempty"` // ignored for cluster scope
 	Type      IssuerType  `json:"type"`
@@ -198,24 +199,6 @@ func (a *ACMEInput) validate() []FieldError {
 	return errs
 }
 
-// validateHTTPSPublicURL rejects non-HTTPS URLs and URLs that resolve to RFC1918 or loopback addresses.
-func validateHTTPSPublicURL(raw string) error {
-	u, err := url.Parse(raw)
-	if err != nil || u.Host == "" {
-		return fmt.Errorf("must be a valid URL")
-	}
-	if u.Scheme != "https" {
-		return fmt.Errorf("must use https scheme")
-	}
-	host := u.Hostname()
-	if ip := net.ParseIP(host); ip != nil {
-		if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsUnspecified() {
-			return fmt.Errorf("must not target a private or loopback IP")
-		}
-	}
-	return nil
-}
-
 func (c *CAInput) validate() []FieldError {
 	var errs []FieldError
 	if c.SecretName == "" {
@@ -253,6 +236,7 @@ func (v *VaultInput) validate() []FieldError {
 }
 
 // ToIssuer returns a map representation suitable for YAML marshaling.
+// cert-manager is not in go.mod; map-based construction avoids the dep tree.
 func (i *IssuerInput) ToIssuer() map[string]any {
 	kind := "Issuer"
 	if i.Scope == IssuerScopeCluster {
@@ -339,6 +323,5 @@ func (i *IssuerInput) ToYAML() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	// Strip trailing empty line, for prettier preview rendering.
-	return strings.TrimRight(string(y), "\n") + "\n", nil
+	return string(y), nil
 }

--- a/backend/internal/wizard/issuer.go
+++ b/backend/internal/wizard/issuer.go
@@ -1,0 +1,344 @@
+package wizard
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+
+	sigsyaml "sigs.k8s.io/yaml"
+)
+
+// IssuerScope indicates whether the wizard produces a namespaced Issuer or a cluster-scoped ClusterIssuer.
+type IssuerScope string
+
+const (
+	IssuerScopeNamespaced IssuerScope = "namespaced"
+	IssuerScopeCluster    IssuerScope = "cluster"
+)
+
+// IssuerType enumerates the supported cert-manager issuer backends for v1.
+type IssuerType string
+
+const (
+	IssuerTypeSelfSigned IssuerType = "selfSigned"
+	IssuerTypeACME       IssuerType = "acme"
+	IssuerTypeCA         IssuerType = "ca"
+	IssuerTypeVault      IssuerType = "vault"
+)
+
+var validIssuerTypes = map[IssuerType]bool{
+	IssuerTypeSelfSigned: true,
+	IssuerTypeACME:       true,
+	IssuerTypeCA:         true,
+	IssuerTypeVault:      true,
+}
+
+// ACMEHTTP01IngressInput configures the HTTP01 ingress solver.
+type ACMEHTTP01IngressInput struct {
+	IngressClassName string `json:"ingressClassName,omitempty"`
+}
+
+// ACMESolverInput is a single solver entry. v1 supports HTTP01 ingress only.
+type ACMESolverInput struct {
+	HTTP01Ingress *ACMEHTTP01IngressInput `json:"http01Ingress,omitempty"`
+}
+
+// ACMEInput configures an ACME issuer.
+type ACMEInput struct {
+	Server                 string            `json:"server"`
+	Email                  string            `json:"email"`
+	PrivateKeySecretRefName string           `json:"privateKeySecretRefName"`
+	Solvers                []ACMESolverInput `json:"solvers"`
+}
+
+// CAInput configures a CA issuer.
+type CAInput struct {
+	SecretName string `json:"secretName"`
+}
+
+// VaultAuthInput configures one of Vault's authentication methods.
+// Exactly one of the nested fields must be set.
+type VaultAuthInput struct {
+	TokenSecretRefName string `json:"tokenSecretRefName,omitempty"`
+	AppRoleSecretRefName string `json:"appRoleSecretRefName,omitempty"`
+	KubernetesRole     string `json:"kubernetesRole,omitempty"`
+}
+
+// VaultInput configures a Vault issuer.
+type VaultInput struct {
+	Server string         `json:"server"`
+	Path   string         `json:"path"`
+	Auth   VaultAuthInput `json:"auth"`
+}
+
+// IssuerInput represents the wizard form data for creating a cert-manager Issuer or ClusterIssuer.
+type IssuerInput struct {
+	Scope     IssuerScope `json:"scope"`
+	Name      string      `json:"name"`
+	Namespace string      `json:"namespace,omitempty"` // ignored for cluster scope
+	Type      IssuerType  `json:"type"`
+
+	SelfSigned *struct{}   `json:"selfSigned,omitempty"`
+	ACME       *ACMEInput  `json:"acme,omitempty"`
+	CA         *CAInput    `json:"ca,omitempty"`
+	Vault      *VaultInput `json:"vault,omitempty"`
+}
+
+// Validate checks the IssuerInput and returns field-level errors.
+func (i *IssuerInput) Validate() []FieldError {
+	var errs []FieldError
+
+	if i.Scope != IssuerScopeNamespaced && i.Scope != IssuerScopeCluster {
+		errs = append(errs, FieldError{Field: "scope", Message: "must be namespaced or cluster"})
+	}
+
+	if !dnsLabelRegex.MatchString(i.Name) {
+		errs = append(errs, FieldError{Field: "name", Message: "must be a valid DNS label (lowercase alphanumeric and hyphens, 1-63 chars)"})
+	}
+
+	if i.Scope == IssuerScopeNamespaced {
+		if i.Namespace == "" {
+			errs = append(errs, FieldError{Field: "namespace", Message: "is required for namespaced Issuer"})
+		} else if !dnsLabelRegex.MatchString(i.Namespace) {
+			errs = append(errs, FieldError{Field: "namespace", Message: "must be a valid DNS label"})
+		}
+	}
+
+	if !validIssuerTypes[i.Type] {
+		errs = append(errs, FieldError{Field: "type", Message: "must be selfSigned, acme, ca, or vault"})
+		return errs
+	}
+
+	// Exactly one type body must be populated and it must match Type.
+	populated := 0
+	if i.SelfSigned != nil {
+		populated++
+	}
+	if i.ACME != nil {
+		populated++
+	}
+	if i.CA != nil {
+		populated++
+	}
+	if i.Vault != nil {
+		populated++
+	}
+	if populated != 1 {
+		errs = append(errs, FieldError{Field: "type", Message: "exactly one issuer body must be provided"})
+		return errs
+	}
+
+	switch i.Type {
+	case IssuerTypeSelfSigned:
+		if i.SelfSigned == nil {
+			errs = append(errs, FieldError{Field: "selfSigned", Message: "selfSigned body is required when type=selfSigned"})
+		}
+	case IssuerTypeACME:
+		if i.ACME == nil {
+			errs = append(errs, FieldError{Field: "acme", Message: "acme body is required when type=acme"})
+			return errs
+		}
+		errs = append(errs, i.ACME.validate()...)
+	case IssuerTypeCA:
+		if i.CA == nil {
+			errs = append(errs, FieldError{Field: "ca", Message: "ca body is required when type=ca"})
+			return errs
+		}
+		errs = append(errs, i.CA.validate()...)
+	case IssuerTypeVault:
+		if i.Vault == nil {
+			errs = append(errs, FieldError{Field: "vault", Message: "vault body is required when type=vault"})
+			return errs
+		}
+		errs = append(errs, i.Vault.validate()...)
+	}
+
+	return errs
+}
+
+func (a *ACMEInput) validate() []FieldError {
+	var errs []FieldError
+
+	if a.Server == "" {
+		errs = append(errs, FieldError{Field: "acme.server", Message: "is required"})
+	} else if err := validateHTTPSPublicURL(a.Server); err != nil {
+		errs = append(errs, FieldError{Field: "acme.server", Message: err.Error()})
+	}
+
+	if !validateEmailAddress(a.Email) {
+		errs = append(errs, FieldError{Field: "acme.email", Message: "must be a valid email address"})
+	}
+
+	if a.PrivateKeySecretRefName == "" {
+		errs = append(errs, FieldError{Field: "acme.privateKeySecretRefName", Message: "is required"})
+	} else if !dnsLabelRegex.MatchString(a.PrivateKeySecretRefName) {
+		errs = append(errs, FieldError{Field: "acme.privateKeySecretRefName", Message: "must be a valid DNS label"})
+	}
+
+	if len(a.Solvers) == 0 {
+		errs = append(errs, FieldError{Field: "acme.solvers", Message: "at least one solver is required"})
+	}
+	for idx, s := range a.Solvers {
+		if s.HTTP01Ingress == nil {
+			errs = append(errs, FieldError{
+				Field:   fmt.Sprintf("acme.solvers[%d]", idx),
+				Message: "http01Ingress is required (DNS01 solvers are not supported in v1)",
+			})
+			continue
+		}
+		if s.HTTP01Ingress.IngressClassName != "" && !dnsLabelRegex.MatchString(s.HTTP01Ingress.IngressClassName) {
+			errs = append(errs, FieldError{
+				Field:   fmt.Sprintf("acme.solvers[%d].http01Ingress.ingressClassName", idx),
+				Message: "must be a valid DNS label",
+			})
+		}
+	}
+
+	return errs
+}
+
+// validateHTTPSPublicURL rejects non-HTTPS URLs and URLs that resolve to RFC1918 or loopback addresses.
+func validateHTTPSPublicURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return fmt.Errorf("must be a valid URL")
+	}
+	if u.Scheme != "https" {
+		return fmt.Errorf("must use https scheme")
+	}
+	host := u.Hostname()
+	if ip := net.ParseIP(host); ip != nil {
+		if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsUnspecified() {
+			return fmt.Errorf("must not target a private or loopback IP")
+		}
+	}
+	return nil
+}
+
+func (c *CAInput) validate() []FieldError {
+	var errs []FieldError
+	if c.SecretName == "" {
+		errs = append(errs, FieldError{Field: "ca.secretName", Message: "is required"})
+	} else if !dnsLabelRegex.MatchString(c.SecretName) {
+		errs = append(errs, FieldError{Field: "ca.secretName", Message: "must be a valid DNS label"})
+	}
+	return errs
+}
+
+func (v *VaultInput) validate() []FieldError {
+	var errs []FieldError
+	if v.Server == "" {
+		errs = append(errs, FieldError{Field: "vault.server", Message: "is required"})
+	} else if err := validateHTTPSPublicURL(v.Server); err != nil {
+		errs = append(errs, FieldError{Field: "vault.server", Message: err.Error()})
+	}
+	if v.Path == "" {
+		errs = append(errs, FieldError{Field: "vault.path", Message: "is required"})
+	}
+	populated := 0
+	if v.Auth.TokenSecretRefName != "" {
+		populated++
+	}
+	if v.Auth.AppRoleSecretRefName != "" {
+		populated++
+	}
+	if v.Auth.KubernetesRole != "" {
+		populated++
+	}
+	if populated != 1 {
+		errs = append(errs, FieldError{Field: "vault.auth", Message: "exactly one of tokenSecretRefName, appRoleSecretRefName, or kubernetesRole must be set"})
+	}
+	return errs
+}
+
+// ToIssuer returns a map representation suitable for YAML marshaling.
+func (i *IssuerInput) ToIssuer() map[string]any {
+	kind := "Issuer"
+	if i.Scope == IssuerScopeCluster {
+		kind = "ClusterIssuer"
+	}
+
+	metadata := map[string]any{
+		"name": i.Name,
+	}
+	if i.Scope == IssuerScopeNamespaced {
+		metadata["namespace"] = i.Namespace
+	}
+
+	return map[string]any{
+		"apiVersion": "cert-manager.io/v1",
+		"kind":       kind,
+		"metadata":   metadata,
+		"spec":       i.buildSpec(),
+	}
+}
+
+func (i *IssuerInput) buildSpec() map[string]any {
+	switch i.Type {
+	case IssuerTypeSelfSigned:
+		return map[string]any{"selfSigned": map[string]any{}}
+	case IssuerTypeACME:
+		return map[string]any{"acme": i.ACME.toMap()}
+	case IssuerTypeCA:
+		return map[string]any{"ca": map[string]any{"secretName": i.CA.SecretName}}
+	case IssuerTypeVault:
+		return map[string]any{"vault": i.Vault.toMap()}
+	}
+	return map[string]any{}
+}
+
+func (a *ACMEInput) toMap() map[string]any {
+	out := map[string]any{
+		"server":              a.Server,
+		"email":               a.Email,
+		"privateKeySecretRef": map[string]any{"name": a.PrivateKeySecretRefName},
+	}
+	solvers := make([]map[string]any, 0, len(a.Solvers))
+	for _, s := range a.Solvers {
+		if s.HTTP01Ingress == nil {
+			continue
+		}
+		ingress := map[string]any{}
+		if s.HTTP01Ingress.IngressClassName != "" {
+			ingress["ingressClassName"] = s.HTTP01Ingress.IngressClassName
+		}
+		solvers = append(solvers, map[string]any{
+			"http01": map[string]any{"ingress": ingress},
+		})
+	}
+	if len(solvers) > 0 {
+		out["solvers"] = solvers
+	}
+	return out
+}
+
+func (v *VaultInput) toMap() map[string]any {
+	out := map[string]any{
+		"server": v.Server,
+		"path":   v.Path,
+	}
+	auth := map[string]any{}
+	switch {
+	case v.Auth.TokenSecretRefName != "":
+		auth["tokenSecretRef"] = map[string]any{"name": v.Auth.TokenSecretRefName}
+	case v.Auth.AppRoleSecretRefName != "":
+		auth["appRole"] = map[string]any{
+			"secretRef": map[string]any{"name": v.Auth.AppRoleSecretRefName},
+		}
+	case v.Auth.KubernetesRole != "":
+		auth["kubernetes"] = map[string]any{"role": v.Auth.KubernetesRole}
+	}
+	out["auth"] = auth
+	return out
+}
+
+// ToYAML implements WizardInput.
+func (i *IssuerInput) ToYAML() (string, error) {
+	y, err := sigsyaml.Marshal(i.ToIssuer())
+	if err != nil {
+		return "", err
+	}
+	// Strip trailing empty line, for prettier preview rendering.
+	return strings.TrimRight(string(y), "\n") + "\n", nil
+}

--- a/backend/internal/wizard/issuer_test.go
+++ b/backend/internal/wizard/issuer_test.go
@@ -1,9 +1,25 @@
 package wizard
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 )
+
+// TestIssuerInput_ScopeNotJSONDecoded ensures a client cannot override the
+// route-assigned scope by supplying it in the JSON body. Route authority is
+// required because wizard preview feeds into server-side apply.
+func TestIssuerInput_ScopeNotJSONDecoded(t *testing.T) {
+	// Factory sets cluster scope; client body attempts to downgrade to namespaced.
+	in := &IssuerInput{Scope: IssuerScopeCluster}
+	body := []byte(`{"scope":"namespaced","name":"x","type":"selfSigned","selfSigned":{}}`)
+	if err := json.Unmarshal(body, in); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if in.Scope != IssuerScopeCluster {
+		t.Errorf("scope overridden by client: got %q, want %q", in.Scope, IssuerScopeCluster)
+	}
+}
 
 func validSelfSignedNamespaced() IssuerInput {
 	return IssuerInput{

--- a/backend/internal/wizard/issuer_test.go
+++ b/backend/internal/wizard/issuer_test.go
@@ -1,0 +1,285 @@
+package wizard
+
+import (
+	"strings"
+	"testing"
+)
+
+func validSelfSignedNamespaced() IssuerInput {
+	return IssuerInput{
+		Scope:      IssuerScopeNamespaced,
+		Name:       "selfsigned",
+		Namespace:  "default",
+		Type:       IssuerTypeSelfSigned,
+		SelfSigned: &struct{}{},
+	}
+}
+
+func validSelfSignedCluster() IssuerInput {
+	return IssuerInput{
+		Scope:      IssuerScopeCluster,
+		Name:       "selfsigned",
+		Type:       IssuerTypeSelfSigned,
+		SelfSigned: &struct{}{},
+	}
+}
+
+func validACMECluster() IssuerInput {
+	return IssuerInput{
+		Scope: IssuerScopeCluster,
+		Name:  "letsencrypt-staging",
+		Type:  IssuerTypeACME,
+		ACME: &ACMEInput{
+			Server:                  "https://acme-staging-v02.api.letsencrypt.org/directory",
+			Email:                   "admin@example.com",
+			PrivateKeySecretRefName: "letsencrypt-staging-account",
+			Solvers: []ACMESolverInput{
+				{HTTP01Ingress: &ACMEHTTP01IngressInput{IngressClassName: "nginx"}},
+			},
+		},
+	}
+}
+
+func TestIssuerValidate_SelfSignedNamespaced(t *testing.T) {
+	i := validSelfSignedNamespaced()
+	if errs := i.Validate(); len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+}
+
+func TestIssuerValidate_SelfSignedCluster(t *testing.T) {
+	i := validSelfSignedCluster()
+	if errs := i.Validate(); len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+}
+
+func TestIssuerValidate_ACMECluster(t *testing.T) {
+	i := validACMECluster()
+	if errs := i.Validate(); len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+}
+
+func TestIssuerValidate_InvalidScope(t *testing.T) {
+	i := validSelfSignedNamespaced()
+	i.Scope = "bogus"
+	errs := i.Validate()
+	if !hasFieldError(errs, "scope") {
+		t.Errorf("expected scope error, got %v", errs)
+	}
+}
+
+func TestIssuerValidate_NamespacedRequiresNamespace(t *testing.T) {
+	i := validSelfSignedNamespaced()
+	i.Namespace = ""
+	errs := i.Validate()
+	if !hasFieldError(errs, "namespace") {
+		t.Errorf("expected namespace error, got %v", errs)
+	}
+}
+
+func TestIssuerValidate_ClusterScopeAllowsEmptyNamespace(t *testing.T) {
+	i := validSelfSignedCluster()
+	i.Namespace = ""
+	if errs := i.Validate(); len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+}
+
+func TestIssuerValidate_UnknownType(t *testing.T) {
+	i := validSelfSignedNamespaced()
+	i.Type = "venafi"
+	errs := i.Validate()
+	if !hasFieldError(errs, "type") {
+		t.Errorf("expected type error, got %v", errs)
+	}
+}
+
+func TestIssuerValidate_TypeBodyMismatch(t *testing.T) {
+	// Type=acme but only selfSigned body is populated. Surfaces as "acme body is required".
+	i := validSelfSignedNamespaced()
+	i.Type = IssuerTypeACME
+	errs := i.Validate()
+	if !hasFieldError(errs, "acme") {
+		t.Errorf("expected acme body-required error when type=acme but body is selfSigned, got %v", errs)
+	}
+}
+
+func TestIssuerValidate_MultipleTypeBodies(t *testing.T) {
+	i := validSelfSignedNamespaced()
+	i.ACME = &ACMEInput{Server: "https://acme.example.com/", Email: "x@y", PrivateKeySecretRefName: "x"}
+	errs := i.Validate()
+	if !hasFieldError(errs, "type") {
+		t.Errorf("expected type error for multiple bodies, got %v", errs)
+	}
+}
+
+func TestACMEValidate_Server(t *testing.T) {
+	tests := []struct {
+		name   string
+		server string
+		ok     bool
+	}{
+		{"letsencrypt prod", "https://acme-v02.api.letsencrypt.org/directory", true},
+		{"letsencrypt staging", "https://acme-staging-v02.api.letsencrypt.org/directory", true},
+		{"http rejected", "http://acme.example.com/directory", false},
+		{"loopback rejected", "https://127.0.0.1/directory", false},
+		{"private IP rejected", "https://10.0.0.1/directory", false},
+		{"empty rejected", "", false},
+		{"garbage rejected", "not a url", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := validACMECluster()
+			i.ACME.Server = tt.server
+			errs := i.Validate()
+			has := hasFieldErrorWithPrefix(errs, "acme.server")
+			if tt.ok && has {
+				t.Errorf("server %q should be valid, got %v", tt.server, errs)
+			}
+			if !tt.ok && !has {
+				t.Errorf("server %q should be invalid, got errs=%v", tt.server, errs)
+			}
+		})
+	}
+}
+
+func TestACMEValidate_Email(t *testing.T) {
+	tests := []struct {
+		email string
+		ok    bool
+	}{
+		{"ok@example.com", true},
+		{"", false},
+		{"not-an-email", false},
+	}
+	for _, tt := range tests {
+		i := validACMECluster()
+		i.ACME.Email = tt.email
+		errs := i.Validate()
+		has := hasFieldError(errs, "acme.email")
+		if tt.ok && has {
+			t.Errorf("email %q should be valid, got %v", tt.email, errs)
+		}
+		if !tt.ok && !has {
+			t.Errorf("email %q should be invalid, got %v", tt.email, errs)
+		}
+	}
+}
+
+func TestACMEValidate_SolverRequired(t *testing.T) {
+	i := validACMECluster()
+	i.ACME.Solvers = nil
+	errs := i.Validate()
+	if !hasFieldError(errs, "acme.solvers") {
+		t.Errorf("expected solvers error, got %v", errs)
+	}
+}
+
+func TestACMEValidate_DNS01Rejected(t *testing.T) {
+	i := validACMECluster()
+	i.ACME.Solvers = []ACMESolverInput{{HTTP01Ingress: nil}} // no HTTP01 body signals DNS01 intent
+	errs := i.Validate()
+	if !hasFieldErrorWithPrefix(errs, "acme.solvers[0]") {
+		t.Errorf("expected solver error for missing http01Ingress, got %v", errs)
+	}
+}
+
+func TestCAValidate(t *testing.T) {
+	i := IssuerInput{
+		Scope: IssuerScopeNamespaced, Name: "ca", Namespace: "cert-manager",
+		Type: IssuerTypeCA, CA: &CAInput{SecretName: ""},
+	}
+	errs := i.Validate()
+	if !hasFieldError(errs, "ca.secretName") {
+		t.Errorf("expected ca.secretName error, got %v", errs)
+	}
+}
+
+func TestVaultValidate(t *testing.T) {
+	base := IssuerInput{
+		Scope: IssuerScopeCluster, Name: "vault", Type: IssuerTypeVault,
+		Vault: &VaultInput{
+			Server: "https://vault.example.com",
+			Path:   "pki/sign/example",
+			Auth:   VaultAuthInput{TokenSecretRefName: "vault-token"},
+		},
+	}
+	if errs := base.Validate(); len(errs) != 0 {
+		t.Errorf("valid vault issuer: %v", errs)
+	}
+
+	none := base
+	none.Vault = &VaultInput{Server: base.Vault.Server, Path: base.Vault.Path}
+	errs := none.Validate()
+	if !hasFieldError(errs, "vault.auth") {
+		t.Errorf("expected vault.auth error for no auth method, got %v", errs)
+	}
+
+	multi := base
+	multi.Vault = &VaultInput{
+		Server: base.Vault.Server, Path: base.Vault.Path,
+		Auth: VaultAuthInput{TokenSecretRefName: "t", KubernetesRole: "r"},
+	}
+	errs = multi.Validate()
+	if !hasFieldError(errs, "vault.auth") {
+		t.Errorf("expected vault.auth error for multiple methods, got %v", errs)
+	}
+}
+
+func TestIssuerToYAML_SelfSignedCluster(t *testing.T) {
+	i := validSelfSignedCluster()
+	y, err := i.ToYAML()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, want := range []string{
+		"apiVersion: cert-manager.io/v1",
+		"kind: ClusterIssuer",
+		"name: selfsigned",
+		"selfSigned: {}",
+	} {
+		if !strings.Contains(y, want) {
+			t.Errorf("missing %q in YAML:\n%s", want, y)
+		}
+	}
+	if strings.Contains(y, "namespace:") {
+		t.Errorf("ClusterIssuer should not have namespace:\n%s", y)
+	}
+}
+
+func TestIssuerToYAML_ACMECluster(t *testing.T) {
+	i := validACMECluster()
+	y, err := i.ToYAML()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, want := range []string{
+		"kind: ClusterIssuer",
+		"acme:",
+		"server: https://acme-staging-v02.api.letsencrypt.org/directory",
+		"email: admin@example.com",
+		"name: letsencrypt-staging-account",
+		"http01:",
+		"ingressClassName: nginx",
+	} {
+		if !strings.Contains(y, want) {
+			t.Errorf("missing %q in YAML:\n%s", want, y)
+		}
+	}
+}
+
+func TestIssuerToYAML_NamespacedIssuer(t *testing.T) {
+	i := validSelfSignedNamespaced()
+	y, err := i.ToYAML()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(y, "kind: Issuer") {
+		t.Errorf("expected kind: Issuer, got:\n%s", y)
+	}
+	if !strings.Contains(y, "namespace: default") {
+		t.Errorf("expected namespace: default, got:\n%s", y)
+	}
+}

--- a/frontend/components/wizard/CertificateForm.tsx
+++ b/frontend/components/wizard/CertificateForm.tsx
@@ -1,0 +1,303 @@
+import { WIZARD_INPUT_CLASS } from "@/lib/wizard-constants.ts";
+import type { Issuer } from "@/lib/certmanager-types.ts";
+import type { CertificateWizardForm } from "@/islands/CertificateWizard.tsx";
+
+interface CertificateFormProps {
+  form: CertificateWizardForm;
+  errors: Record<string, string>;
+  issuers: Issuer[];
+  issuersLoading: boolean;
+  onUpdate: (field: string, value: unknown) => void;
+  onUpdatePrivateKey: (field: string, value: unknown) => void;
+}
+
+const PRIVATE_KEY_ALGORITHMS = ["RSA", "ECDSA", "Ed25519"] as const;
+const RSA_SIZES = [2048, 3072, 4096];
+const ECDSA_SIZES = [256, 384, 521];
+const ROTATION_POLICIES = ["Always", "Never"] as const;
+
+export function CertificateForm({
+  form,
+  errors,
+  issuers,
+  issuersLoading,
+  onUpdate,
+  onUpdatePrivateKey,
+}: CertificateFormProps) {
+  const issuerOptionValue = (iss: Issuer) =>
+    `${iss.scope === "Cluster" ? "ClusterIssuer" : "Issuer"}:${iss.name}`;
+
+  const sizeOptions = form.privateKey.algorithm === "ECDSA"
+    ? ECDSA_SIZES
+    : RSA_SIZES;
+
+  return (
+    <div class="space-y-5">
+      <div class="grid grid-cols-2 gap-4">
+        <div>
+          <label class="block text-sm font-medium text-text-primary">
+            Name <span class="text-danger">*</span>
+          </label>
+          <input
+            type="text"
+            value={form.name}
+            onInput={(e) =>
+              onUpdate("name", (e.target as HTMLInputElement).value)}
+            placeholder="example-com-tls"
+            class={WIZARD_INPUT_CLASS}
+          />
+          {errors.name && <p class="mt-1 text-xs text-danger">{errors.name}</p>}
+        </div>
+
+        <div>
+          <label class="block text-sm font-medium text-text-primary">
+            Namespace <span class="text-danger">*</span>
+          </label>
+          <input
+            type="text"
+            value={form.namespace}
+            onInput={(e) =>
+              onUpdate("namespace", (e.target as HTMLInputElement).value)}
+            placeholder="default"
+            class={WIZARD_INPUT_CLASS}
+          />
+          {errors.namespace && (
+            <p class="mt-1 text-xs text-danger">{errors.namespace}</p>
+          )}
+        </div>
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium text-text-primary">
+          Secret Name <span class="text-danger">*</span>
+        </label>
+        <input
+          type="text"
+          value={form.secretName}
+          onInput={(e) =>
+            onUpdate("secretName", (e.target as HTMLInputElement).value)}
+          placeholder="example-com-tls"
+          class={WIZARD_INPUT_CLASS}
+        />
+        <p class="mt-1 text-xs text-text-muted">
+          Secret where cert-manager will write the issued TLS certificate and
+          private key.
+        </p>
+        {errors.secretName && (
+          <p class="mt-1 text-xs text-danger">{errors.secretName}</p>
+        )}
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium text-text-primary">
+          Issuer <span class="text-danger">*</span>
+        </label>
+        <select
+          value={form.issuerRefValue}
+          onChange={(e) =>
+            onUpdate(
+              "issuerRefValue",
+              (e.target as HTMLSelectElement).value,
+            )}
+          class={WIZARD_INPUT_CLASS}
+          disabled={issuersLoading}
+        >
+          <option value="">
+            {issuersLoading ? "Loading issuers..." : "Select an issuer"}
+          </option>
+          {issuers.filter((i) => i.scope === "Cluster").length > 0 && (
+            <optgroup label="ClusterIssuers">
+              {issuers
+                .filter((i) => i.scope === "Cluster")
+                .map((i) => (
+                  <option key={i.uid} value={issuerOptionValue(i)}>
+                    {i.name} ({i.type})
+                  </option>
+                ))}
+            </optgroup>
+          )}
+          {issuers.filter((i) => i.scope === "Namespaced").length > 0 && (
+            <optgroup label="Issuers (namespaced)">
+              {issuers
+                .filter((i) => i.scope === "Namespaced")
+                .map((i) => (
+                  <option key={i.uid} value={issuerOptionValue(i)}>
+                    {i.name} / {i.namespace} ({i.type})
+                  </option>
+                ))}
+            </optgroup>
+          )}
+        </select>
+        {errors.issuerRef && (
+          <p class="mt-1 text-xs text-danger">{errors.issuerRef}</p>
+        )}
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium text-text-primary">
+          DNS Names
+        </label>
+        <input
+          type="text"
+          value={form.dnsNamesInput}
+          onInput={(e) =>
+            onUpdate(
+              "dnsNamesInput",
+              (e.target as HTMLInputElement).value,
+            )}
+          placeholder="example.com, www.example.com"
+          class={WIZARD_INPUT_CLASS}
+        />
+        <p class="mt-1 text-xs text-text-muted">
+          Comma-separated. At least one of DNS Names or Common Name is required.
+        </p>
+        {errors.dnsNames && (
+          <p class="mt-1 text-xs text-danger">{errors.dnsNames}</p>
+        )}
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium text-text-primary">
+          Common Name
+        </label>
+        <input
+          type="text"
+          value={form.commonName}
+          onInput={(e) =>
+            onUpdate("commonName", (e.target as HTMLInputElement).value)}
+          placeholder="example.com"
+          class={WIZARD_INPUT_CLASS}
+        />
+      </div>
+
+      <details class="rounded-md border border-border-primary bg-surface/50 p-4">
+        <summary class="cursor-pointer text-sm font-medium text-text-primary">
+          Advanced options
+        </summary>
+
+        <div class="mt-4 space-y-4">
+          <div class="grid grid-cols-2 gap-4">
+            <div>
+              <label class="block text-sm font-medium text-text-primary">
+                Duration
+              </label>
+              <input
+                type="text"
+                value={form.duration}
+                onInput={(e) =>
+                  onUpdate(
+                    "duration",
+                    (e.target as HTMLInputElement).value,
+                  )}
+                placeholder="2160h"
+                class={WIZARD_INPUT_CLASS}
+              />
+              <p class="mt-1 text-xs text-text-muted">
+                Default 2160h (90 days).
+              </p>
+              {errors.duration && (
+                <p class="mt-1 text-xs text-danger">{errors.duration}</p>
+              )}
+            </div>
+
+            <div>
+              <label class="block text-sm font-medium text-text-primary">
+                Renew Before
+              </label>
+              <input
+                type="text"
+                value={form.renewBefore}
+                onInput={(e) =>
+                  onUpdate(
+                    "renewBefore",
+                    (e.target as HTMLInputElement).value,
+                  )}
+                placeholder="360h"
+                class={WIZARD_INPUT_CLASS}
+              />
+              <p class="mt-1 text-xs text-text-muted">
+                Default 360h (15 days).
+              </p>
+              {errors.renewBefore && (
+                <p class="mt-1 text-xs text-danger">{errors.renewBefore}</p>
+              )}
+            </div>
+          </div>
+
+          <div class="grid grid-cols-3 gap-4">
+            <div>
+              <label class="block text-sm font-medium text-text-primary">
+                Algorithm
+              </label>
+              <select
+                value={form.privateKey.algorithm}
+                onChange={(e) =>
+                  onUpdatePrivateKey(
+                    "algorithm",
+                    (e.target as HTMLSelectElement).value,
+                  )}
+                class={WIZARD_INPUT_CLASS}
+              >
+                {PRIVATE_KEY_ALGORITHMS.map((a) => (
+                  <option key={a} value={a}>{a}</option>
+                ))}
+              </select>
+            </div>
+
+            <div>
+              <label class="block text-sm font-medium text-text-primary">
+                Key Size
+              </label>
+              <select
+                value={form.privateKey.size}
+                onChange={(e) =>
+                  onUpdatePrivateKey(
+                    "size",
+                    Number((e.target as HTMLSelectElement).value),
+                  )}
+                class={WIZARD_INPUT_CLASS}
+                disabled={form.privateKey.algorithm === "Ed25519"}
+              >
+                {sizeOptions.map((s) => <option key={s} value={s}>{s}</option>)}
+              </select>
+            </div>
+
+            <div>
+              <label class="block text-sm font-medium text-text-primary">
+                Rotation
+              </label>
+              <select
+                value={form.privateKey.rotationPolicy}
+                onChange={(e) =>
+                  onUpdatePrivateKey(
+                    "rotationPolicy",
+                    (e.target as HTMLSelectElement).value,
+                  )}
+                class={WIZARD_INPUT_CLASS}
+              >
+                {ROTATION_POLICIES.map((p) => (
+                  <option key={p} value={p}>{p}</option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <div>
+            <label class="inline-flex items-center gap-2 text-sm text-text-primary">
+              <input
+                type="checkbox"
+                checked={form.isCA}
+                onChange={(e) =>
+                  onUpdate(
+                    "isCA",
+                    (e.target as HTMLInputElement).checked,
+                  )}
+              />
+              <span>Issue as CA certificate (isCA: true)</span>
+            </label>
+          </div>
+        </div>
+      </details>
+    </div>
+  );
+}

--- a/frontend/components/wizard/CertificateForm.tsx
+++ b/frontend/components/wizard/CertificateForm.tsx
@@ -1,4 +1,5 @@
 import { WIZARD_INPUT_CLASS } from "@/lib/wizard-constants.ts";
+import { NamespaceSelect } from "@/components/ui/NamespaceSelect.tsx";
 import type { Issuer } from "@/lib/certmanager-types.ts";
 import type { CertificateWizardForm } from "@/islands/CertificateWizard.tsx";
 
@@ -7,6 +8,7 @@ interface CertificateFormProps {
   errors: Record<string, string>;
   issuers: Issuer[];
   issuersLoading: boolean;
+  namespaces: string[];
   onUpdate: (field: string, value: unknown) => void;
   onUpdatePrivateKey: (field: string, value: unknown) => void;
 }
@@ -21,6 +23,7 @@ export function CertificateForm({
   errors,
   issuers,
   issuersLoading,
+  namespaces,
   onUpdate,
   onUpdatePrivateKey,
 }: CertificateFormProps) {
@@ -49,22 +52,12 @@ export function CertificateForm({
           {errors.name && <p class="mt-1 text-xs text-danger">{errors.name}</p>}
         </div>
 
-        <div>
-          <label class="block text-sm font-medium text-text-primary">
-            Namespace <span class="text-danger">*</span>
-          </label>
-          <input
-            type="text"
-            value={form.namespace}
-            onInput={(e) =>
-              onUpdate("namespace", (e.target as HTMLInputElement).value)}
-            placeholder="default"
-            class={WIZARD_INPUT_CLASS}
-          />
-          {errors.namespace && (
-            <p class="mt-1 text-xs text-danger">{errors.namespace}</p>
-          )}
-        </div>
+        <NamespaceSelect
+          value={form.namespace}
+          namespaces={namespaces}
+          error={errors.namespace}
+          onChange={(ns) => onUpdate("namespace", ns)}
+        />
       </div>
 
       <div>

--- a/frontend/components/wizard/IssuerFormStep.tsx
+++ b/frontend/components/wizard/IssuerFormStep.tsx
@@ -1,4 +1,9 @@
-import { WIZARD_INPUT_CLASS } from "@/lib/wizard-constants.ts";
+import {
+  LE_PROD_ACME,
+  LE_STAGING_ACME,
+  WIZARD_INPUT_CLASS,
+} from "@/lib/wizard-constants.ts";
+import { NamespaceSelect } from "@/components/ui/NamespaceSelect.tsx";
 import type {
   IssuerWizardForm,
   VaultAuthMethod,
@@ -8,6 +13,7 @@ interface IssuerFormStepProps {
   scope: "namespaced" | "cluster";
   form: IssuerWizardForm;
   errors: Record<string, string>;
+  namespaces: string[];
   onUpdate: (field: string, value: unknown) => void;
   onUpdateAcme: (field: string, value: unknown) => void;
   onUpdateCa: (field: string, value: unknown) => void;
@@ -15,13 +21,11 @@ interface IssuerFormStepProps {
   onUpdateVaultAuth: (method: VaultAuthMethod, value: string) => void;
 }
 
-const LE_PROD = "https://acme-v02.api.letsencrypt.org/directory";
-const LE_STAGING = "https://acme-staging-v02.api.letsencrypt.org/directory";
-
 export function IssuerFormStep({
   scope,
   form,
   errors,
+  namespaces,
   onUpdate,
   onUpdateAcme,
   onUpdateCa,
@@ -47,25 +51,12 @@ export function IssuerFormStep({
         </div>
 
         {scope === "namespaced" && (
-          <div>
-            <label class="block text-sm font-medium text-text-primary">
-              Namespace <span class="text-danger">*</span>
-            </label>
-            <input
-              type="text"
-              value={form.namespace}
-              onInput={(e) =>
-                onUpdate(
-                  "namespace",
-                  (e.target as HTMLInputElement).value,
-                )}
-              placeholder="default"
-              class={WIZARD_INPUT_CLASS}
-            />
-            {errors.namespace && (
-              <p class="mt-1 text-xs text-danger">{errors.namespace}</p>
-            )}
-          </div>
+          <NamespaceSelect
+            value={form.namespace}
+            namespaces={namespaces}
+            error={errors.namespace}
+            onChange={(ns) => onUpdate("namespace", ns)}
+          />
         )}
       </div>
 
@@ -86,22 +77,22 @@ export function IssuerFormStep({
               <button
                 type="button"
                 class={`text-xs rounded border px-2 py-1 ${
-                  form.acme.server === LE_STAGING
+                  form.acme.server === LE_STAGING_ACME
                     ? "border-brand text-brand"
                     : "border-border-primary text-text-muted"
                 }`}
-                onClick={() => onUpdateAcme("server", LE_STAGING)}
+                onClick={() => onUpdateAcme("server", LE_STAGING_ACME)}
               >
                 Let's Encrypt Staging
               </button>
               <button
                 type="button"
                 class={`text-xs rounded border px-2 py-1 ${
-                  form.acme.server === LE_PROD
+                  form.acme.server === LE_PROD_ACME
                     ? "border-brand text-brand"
                     : "border-border-primary text-text-muted"
                 }`}
-                onClick={() => onUpdateAcme("server", LE_PROD)}
+                onClick={() => onUpdateAcme("server", LE_PROD_ACME)}
               >
                 Let's Encrypt Production
               </button>

--- a/frontend/components/wizard/IssuerFormStep.tsx
+++ b/frontend/components/wizard/IssuerFormStep.tsx
@@ -1,0 +1,327 @@
+import { WIZARD_INPUT_CLASS } from "@/lib/wizard-constants.ts";
+import type {
+  IssuerWizardForm,
+  VaultAuthMethod,
+} from "@/islands/IssuerWizard.tsx";
+
+interface IssuerFormStepProps {
+  scope: "namespaced" | "cluster";
+  form: IssuerWizardForm;
+  errors: Record<string, string>;
+  onUpdate: (field: string, value: unknown) => void;
+  onUpdateAcme: (field: string, value: unknown) => void;
+  onUpdateCa: (field: string, value: unknown) => void;
+  onUpdateVault: (field: string, value: unknown) => void;
+  onUpdateVaultAuth: (method: VaultAuthMethod, value: string) => void;
+}
+
+const LE_PROD = "https://acme-v02.api.letsencrypt.org/directory";
+const LE_STAGING = "https://acme-staging-v02.api.letsencrypt.org/directory";
+
+export function IssuerFormStep({
+  scope,
+  form,
+  errors,
+  onUpdate,
+  onUpdateAcme,
+  onUpdateCa,
+  onUpdateVault,
+  onUpdateVaultAuth,
+}: IssuerFormStepProps) {
+  return (
+    <div class="space-y-5">
+      <div class="grid grid-cols-2 gap-4">
+        <div>
+          <label class="block text-sm font-medium text-text-primary">
+            Name <span class="text-danger">*</span>
+          </label>
+          <input
+            type="text"
+            value={form.name}
+            onInput={(e) =>
+              onUpdate("name", (e.target as HTMLInputElement).value)}
+            placeholder={scope === "cluster" ? "letsencrypt-prod" : "my-issuer"}
+            class={WIZARD_INPUT_CLASS}
+          />
+          {errors.name && <p class="mt-1 text-xs text-danger">{errors.name}</p>}
+        </div>
+
+        {scope === "namespaced" && (
+          <div>
+            <label class="block text-sm font-medium text-text-primary">
+              Namespace <span class="text-danger">*</span>
+            </label>
+            <input
+              type="text"
+              value={form.namespace}
+              onInput={(e) =>
+                onUpdate(
+                  "namespace",
+                  (e.target as HTMLInputElement).value,
+                )}
+              placeholder="default"
+              class={WIZARD_INPUT_CLASS}
+            />
+            {errors.namespace && (
+              <p class="mt-1 text-xs text-danger">{errors.namespace}</p>
+            )}
+          </div>
+        )}
+      </div>
+
+      {form.type === "selfSigned" && (
+        <div class="rounded-md border border-border-primary bg-surface/50 p-4 text-sm text-text-muted">
+          Self-signed issuers have no additional configuration. They sign
+          certificates using their own temporary key material.
+        </div>
+      )}
+
+      {form.type === "acme" && (
+        <div class="space-y-4">
+          <div>
+            <label class="block text-sm font-medium text-text-primary">
+              ACME Server <span class="text-danger">*</span>
+            </label>
+            <div class="mt-1 flex gap-2">
+              <button
+                type="button"
+                class={`text-xs rounded border px-2 py-1 ${
+                  form.acme.server === LE_STAGING
+                    ? "border-brand text-brand"
+                    : "border-border-primary text-text-muted"
+                }`}
+                onClick={() => onUpdateAcme("server", LE_STAGING)}
+              >
+                Let's Encrypt Staging
+              </button>
+              <button
+                type="button"
+                class={`text-xs rounded border px-2 py-1 ${
+                  form.acme.server === LE_PROD
+                    ? "border-brand text-brand"
+                    : "border-border-primary text-text-muted"
+                }`}
+                onClick={() => onUpdateAcme("server", LE_PROD)}
+              >
+                Let's Encrypt Production
+              </button>
+            </div>
+            <input
+              type="text"
+              value={form.acme.server}
+              onInput={(e) =>
+                onUpdateAcme("server", (e.target as HTMLInputElement).value)}
+              placeholder="https://acme-v02.api.letsencrypt.org/directory"
+              class={`${WIZARD_INPUT_CLASS} mt-2`}
+            />
+            <p class="mt-1 text-xs text-text-muted">
+              Must be an HTTPS URL. Private IPs are rejected.
+            </p>
+            {errors["acme.server"] && (
+              <p class="mt-1 text-xs text-danger">{errors["acme.server"]}</p>
+            )}
+          </div>
+
+          <div class="grid grid-cols-2 gap-4">
+            <div>
+              <label class="block text-sm font-medium text-text-primary">
+                Contact Email <span class="text-danger">*</span>
+              </label>
+              <input
+                type="email"
+                value={form.acme.email}
+                onInput={(e) =>
+                  onUpdateAcme(
+                    "email",
+                    (e.target as HTMLInputElement).value,
+                  )}
+                placeholder="admin@example.com"
+                class={WIZARD_INPUT_CLASS}
+              />
+              {errors["acme.email"] && (
+                <p class="mt-1 text-xs text-danger">{errors["acme.email"]}</p>
+              )}
+            </div>
+
+            <div>
+              <label class="block text-sm font-medium text-text-primary">
+                Account Private Key Secret <span class="text-danger">*</span>
+              </label>
+              <input
+                type="text"
+                value={form.acme.privateKeySecretRefName}
+                onInput={(e) =>
+                  onUpdateAcme(
+                    "privateKeySecretRefName",
+                    (e.target as HTMLInputElement).value,
+                  )}
+                placeholder="letsencrypt-account"
+                class={WIZARD_INPUT_CLASS}
+              />
+              <p class="mt-1 text-xs text-text-muted">
+                Name of the Secret cert-manager will create to hold the account
+                key.
+              </p>
+              {errors["acme.privateKeySecretRefName"] && (
+                <p class="mt-1 text-xs text-danger">
+                  {errors["acme.privateKeySecretRefName"]}
+                </p>
+              )}
+            </div>
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-text-primary">
+              HTTP01 Ingress Class
+            </label>
+            <input
+              type="text"
+              value={form.acme.ingressClassName}
+              onInput={(e) =>
+                onUpdateAcme(
+                  "ingressClassName",
+                  (e.target as HTMLInputElement).value,
+                )}
+              placeholder="nginx"
+              class={WIZARD_INPUT_CLASS}
+            />
+            <p class="mt-1 text-xs text-text-muted">
+              Ingress class used for HTTP01 challenges. Leave blank to use the
+              default class.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {form.type === "ca" && (
+        <div>
+          <label class="block text-sm font-medium text-text-primary">
+            CA Secret Name <span class="text-danger">*</span>
+          </label>
+          <input
+            type="text"
+            value={form.ca.secretName}
+            onInput={(e) =>
+              onUpdateCa(
+                "secretName",
+                (e.target as HTMLInputElement).value,
+              )}
+            placeholder="my-ca-secret"
+            class={WIZARD_INPUT_CLASS}
+          />
+          <p class="mt-1 text-xs text-text-muted">
+            Secret containing tls.crt and tls.key for the signing CA.
+          </p>
+          {errors["ca.secretName"] && (
+            <p class="mt-1 text-xs text-danger">{errors["ca.secretName"]}</p>
+          )}
+        </div>
+      )}
+
+      {form.type === "vault" && (
+        <div class="space-y-4">
+          <div class="grid grid-cols-2 gap-4">
+            <div>
+              <label class="block text-sm font-medium text-text-primary">
+                Vault Server <span class="text-danger">*</span>
+              </label>
+              <input
+                type="text"
+                value={form.vault.server}
+                onInput={(e) =>
+                  onUpdateVault(
+                    "server",
+                    (e.target as HTMLInputElement).value,
+                  )}
+                placeholder="https://vault.example.com"
+                class={WIZARD_INPUT_CLASS}
+              />
+              {errors["vault.server"] && (
+                <p class="mt-1 text-xs text-danger">
+                  {errors["vault.server"]}
+                </p>
+              )}
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-text-primary">
+                PKI Path <span class="text-danger">*</span>
+              </label>
+              <input
+                type="text"
+                value={form.vault.path}
+                onInput={(e) =>
+                  onUpdateVault(
+                    "path",
+                    (e.target as HTMLInputElement).value,
+                  )}
+                placeholder="pki/sign/example-dot-com"
+                class={WIZARD_INPUT_CLASS}
+              />
+              {errors["vault.path"] && (
+                <p class="mt-1 text-xs text-danger">
+                  {errors["vault.path"]}
+                </p>
+              )}
+            </div>
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-text-primary mb-1">
+              Authentication
+            </label>
+            <div class="space-y-2">
+              {[
+                {
+                  id: "token" as VaultAuthMethod,
+                  label: "Token Secret Name",
+                  placeholder: "vault-token",
+                },
+                {
+                  id: "appRole" as VaultAuthMethod,
+                  label: "AppRole Secret Name",
+                  placeholder: "vault-approle",
+                },
+                {
+                  id: "kubernetes" as VaultAuthMethod,
+                  label: "Kubernetes Role",
+                  placeholder: "cert-manager",
+                },
+              ].map(({ id, label, placeholder }) => (
+                <div key={id} class="flex items-center gap-3">
+                  <input
+                    type="radio"
+                    name="vault-auth-method"
+                    checked={form.vault.authMethod === id}
+                    onChange={() =>
+                      onUpdateVaultAuth(id, form.vault.authValue)}
+                    class="h-4 w-4"
+                  />
+                  <label class="text-sm text-text-primary w-44">
+                    {label}
+                  </label>
+                  <input
+                    type="text"
+                    value={form.vault.authMethod === id
+                      ? form.vault.authValue
+                      : ""}
+                    onInput={(e) =>
+                      onUpdateVaultAuth(
+                        id,
+                        (e.target as HTMLInputElement).value,
+                      )}
+                    placeholder={placeholder}
+                    class={`${WIZARD_INPUT_CLASS} flex-1`}
+                    disabled={form.vault.authMethod !== id}
+                  />
+                </div>
+              ))}
+            </div>
+            {errors["vault.auth"] && (
+              <p class="mt-1 text-xs text-danger">{errors["vault.auth"]}</p>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/wizard/IssuerTypePickerStep.tsx
+++ b/frontend/components/wizard/IssuerTypePickerStep.tsx
@@ -1,0 +1,70 @@
+import type { IssuerType } from "@/islands/IssuerWizard.tsx";
+
+interface IssuerTypePickerStepProps {
+  selected: IssuerType | "";
+  onSelect: (type: IssuerType) => void;
+}
+
+const TYPES: Array<{
+  id: IssuerType;
+  title: string;
+  description: string;
+}> = [
+  {
+    id: "selfSigned",
+    title: "Self-Signed",
+    description:
+      "No external authority. Useful for test issuers or bootstrapping an internal CA.",
+  },
+  {
+    id: "acme",
+    title: "ACME (Let's Encrypt)",
+    description:
+      "Automated public certificates. HTTP01 ingress solver supported in this release.",
+  },
+  {
+    id: "ca",
+    title: "CA",
+    description:
+      "Sign from a private CA stored in a Kubernetes Secret (tls.crt + tls.key).",
+  },
+  {
+    id: "vault",
+    title: "Vault",
+    description:
+      "Sign from HashiCorp Vault's PKI engine using token, AppRole, or Kubernetes auth.",
+  },
+];
+
+export function IssuerTypePickerStep({
+  selected,
+  onSelect,
+}: IssuerTypePickerStepProps) {
+  return (
+    <div class="grid gap-3 sm:grid-cols-2">
+      {TYPES.map((t) => {
+        const active = selected === t.id;
+        return (
+          <button
+            key={t.id}
+            type="button"
+            onClick={() => onSelect(t.id)}
+            class={`text-left rounded-lg border p-4 transition-colors ${
+              active
+                ? "border-brand bg-brand/5"
+                : "border-border-primary bg-surface hover:border-border-emphasis"
+            }`}
+          >
+            <div class="flex items-center justify-between">
+              <span class="font-medium text-text-primary">{t.title}</span>
+              {active && (
+                <span class="text-xs font-medium text-brand">Selected</span>
+              )}
+            </div>
+            <p class="mt-2 text-sm text-text-muted">{t.description}</p>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/islands/CertificateWizard.tsx
+++ b/frontend/islands/CertificateWizard.tsx
@@ -3,6 +3,8 @@ import { useCallback, useEffect } from "preact/hooks";
 import { IS_BROWSER } from "fresh/runtime";
 import { apiGet, apiPost } from "@/lib/api.ts";
 import { useDirtyGuard } from "@/lib/hooks/use-dirty-guard.ts";
+import { useNamespaces } from "@/lib/hooks/use-namespaces.ts";
+import { initialNamespace } from "@/lib/namespace.ts";
 import { DNS_LABEL_REGEX } from "@/lib/wizard-constants.ts";
 import { WizardStepper } from "@/components/wizard/WizardStepper.tsx";
 import { WizardReviewStep } from "@/components/wizard/WizardReviewStep.tsx";
@@ -35,7 +37,7 @@ const STEPS = [
 function initialForm(): CertificateWizardForm {
   return {
     name: "",
-    namespace: "default",
+    namespace: initialNamespace(),
     secretName: "",
     issuerRefValue: "",
     dnsNamesInput: "",
@@ -45,6 +47,21 @@ function initialForm(): CertificateWizardForm {
     privateKey: { algorithm: "RSA", size: 2048, rotationPolicy: "Always" },
     isCA: false,
   };
+}
+
+// decodeIssuerRef splits "Kind:Name" into its parts, using indexOf so names
+// containing further colons (won't happen for DNS labels but guards future changes)
+// don't truncate. Returns null for malformed or empty input.
+function decodeIssuerRef(
+  encoded: string,
+): { kind: string; name: string } | null {
+  const idx = encoded.indexOf(":");
+  if (idx <= 0 || idx === encoded.length - 1) return null;
+  const kind = encoded.slice(0, idx);
+  const name = encoded.slice(idx + 1);
+  if (kind !== "Issuer" && kind !== "ClusterIssuer") return null;
+  if (!name) return null;
+  return { kind, name };
 }
 
 function splitDnsNames(input: string): string[] {
@@ -62,6 +79,7 @@ export default function CertificateWizard() {
 
   const issuers = useSignal<Issuer[]>([]);
   const issuersLoading = useSignal(true);
+  const namespaces = useNamespaces();
 
   const previewYaml = useSignal("");
   const previewLoading = useSignal(false);
@@ -133,6 +151,8 @@ export default function CertificateWizard() {
     }
     if (!f.issuerRefValue) {
       errs.issuerRef = "Select an issuer";
+    } else if (!decodeIssuerRef(f.issuerRefValue)) {
+      errs.issuerRef = "Invalid issuer selection";
     }
     const dnsNames = splitDnsNames(f.dnsNamesInput);
     if (dnsNames.length === 0 && f.commonName.trim() === "") {
@@ -148,7 +168,12 @@ export default function CertificateWizard() {
     previewError.value = null;
 
     const f = form.value;
-    const [kind, issuerName] = f.issuerRefValue.split(":");
+    const ref = decodeIssuerRef(f.issuerRefValue);
+    if (!ref) {
+      previewError.value = "Invalid issuer selection";
+      previewLoading.value = false;
+      return;
+    }
     const dnsNames = splitDnsNames(f.dnsNamesInput);
 
     const payload: Record<string, unknown> = {
@@ -156,8 +181,8 @@ export default function CertificateWizard() {
       namespace: f.namespace,
       secretName: f.secretName,
       issuerRef: {
-        kind,
-        name: issuerName,
+        kind: ref.kind,
+        name: ref.name,
         group: "cert-manager.io",
       },
     };
@@ -237,6 +262,7 @@ export default function CertificateWizard() {
             errors={errors.value}
             issuers={issuers.value}
             issuersLoading={issuersLoading.value}
+            namespaces={namespaces.value}
             onUpdate={updateField}
             onUpdatePrivateKey={updatePrivateKey}
           />

--- a/frontend/islands/CertificateWizard.tsx
+++ b/frontend/islands/CertificateWizard.tsx
@@ -1,0 +1,277 @@
+import { useSignal } from "@preact/signals";
+import { useCallback, useEffect } from "preact/hooks";
+import { IS_BROWSER } from "fresh/runtime";
+import { apiGet, apiPost } from "@/lib/api.ts";
+import { useDirtyGuard } from "@/lib/hooks/use-dirty-guard.ts";
+import { DNS_LABEL_REGEX } from "@/lib/wizard-constants.ts";
+import { WizardStepper } from "@/components/wizard/WizardStepper.tsx";
+import { WizardReviewStep } from "@/components/wizard/WizardReviewStep.tsx";
+import { CertificateForm } from "@/components/wizard/CertificateForm.tsx";
+import { Button } from "@/components/ui/Button.tsx";
+import type { Issuer } from "@/lib/certmanager-types.ts";
+
+export interface CertificateWizardForm {
+  name: string;
+  namespace: string;
+  secretName: string;
+  issuerRefValue: string; // encoded "Issuer:name" or "ClusterIssuer:name"
+  dnsNamesInput: string; // comma-separated user input
+  commonName: string;
+  duration: string;
+  renewBefore: string;
+  privateKey: {
+    algorithm: "RSA" | "ECDSA" | "Ed25519";
+    size: number;
+    rotationPolicy: "Always" | "Never";
+  };
+  isCA: boolean;
+}
+
+const STEPS = [
+  { title: "Configure" },
+  { title: "Review" },
+];
+
+function initialForm(): CertificateWizardForm {
+  return {
+    name: "",
+    namespace: "default",
+    secretName: "",
+    issuerRefValue: "",
+    dnsNamesInput: "",
+    commonName: "",
+    duration: "2160h",
+    renewBefore: "360h",
+    privateKey: { algorithm: "RSA", size: 2048, rotationPolicy: "Always" },
+    isCA: false,
+  };
+}
+
+function splitDnsNames(input: string): string[] {
+  return input
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+export default function CertificateWizard() {
+  const currentStep = useSignal(0);
+  const form = useSignal<CertificateWizardForm>(initialForm());
+  const errors = useSignal<Record<string, string>>({});
+  const dirty = useSignal(false);
+
+  const issuers = useSignal<Issuer[]>([]);
+  const issuersLoading = useSignal(true);
+
+  const previewYaml = useSignal("");
+  const previewLoading = useSignal(false);
+  const previewError = useSignal<string | null>(null);
+
+  useDirtyGuard(dirty);
+
+  useEffect(() => {
+    if (!IS_BROWSER) return;
+    Promise.all([
+      apiGet<Issuer[]>("/v1/certificates/issuers"),
+      apiGet<Issuer[]>("/v1/certificates/clusterissuers"),
+    ])
+      .then(([ns, cl]) => {
+        const nsList = Array.isArray(ns.data) ? ns.data : [];
+        const clList = Array.isArray(cl.data) ? cl.data : [];
+        issuers.value = [...nsList, ...clList];
+      })
+      .catch(() => {
+        // Dropdown shows empty state; user can still type.
+      })
+      .finally(() => {
+        issuersLoading.value = false;
+      });
+  }, []);
+
+  const updateField = useCallback((field: string, value: unknown) => {
+    dirty.value = true;
+    const f = { ...form.value, [field]: value };
+    // Auto-default secretName from name when user hasn't customised it.
+    if (
+      field === "name" && typeof value === "string" &&
+      (f.secretName === "" || f.secretName === form.value.name + "-tls")
+    ) {
+      f.secretName = value ? `${value}-tls` : "";
+    }
+    form.value = f;
+  }, []);
+
+  const updatePrivateKey = useCallback((field: string, value: unknown) => {
+    dirty.value = true;
+    const pk = { ...form.value.privateKey, [field]: value };
+    // Sensible default size when algorithm changes.
+    if (field === "algorithm") {
+      if (value === "RSA") pk.size = 2048;
+      else if (value === "ECDSA") pk.size = 256;
+      else if (value === "Ed25519") pk.size = 0;
+    }
+    form.value = { ...form.value, privateKey: pk };
+  }, []);
+
+  const validateStep = (step: number): boolean => {
+    if (step !== 0) {
+      errors.value = {};
+      return true;
+    }
+    const f = form.value;
+    const errs: Record<string, string> = {};
+
+    if (!f.name || !DNS_LABEL_REGEX.test(f.name)) {
+      errs.name =
+        "Must be a valid DNS label (lowercase, alphanumeric, hyphens)";
+    }
+    if (!f.namespace || !DNS_LABEL_REGEX.test(f.namespace)) {
+      errs.namespace = "Must be a valid DNS label";
+    }
+    if (!f.secretName || !DNS_LABEL_REGEX.test(f.secretName)) {
+      errs.secretName = "Must be a valid DNS label";
+    }
+    if (!f.issuerRefValue) {
+      errs.issuerRef = "Select an issuer";
+    }
+    const dnsNames = splitDnsNames(f.dnsNamesInput);
+    if (dnsNames.length === 0 && f.commonName.trim() === "") {
+      errs.dnsNames = "At least one DNS name or a common name is required";
+    }
+
+    errors.value = errs;
+    return Object.keys(errs).length === 0;
+  };
+
+  const fetchPreview = async () => {
+    previewLoading.value = true;
+    previewError.value = null;
+
+    const f = form.value;
+    const [kind, issuerName] = f.issuerRefValue.split(":");
+    const dnsNames = splitDnsNames(f.dnsNamesInput);
+
+    const payload: Record<string, unknown> = {
+      name: f.name,
+      namespace: f.namespace,
+      secretName: f.secretName,
+      issuerRef: {
+        kind,
+        name: issuerName,
+        group: "cert-manager.io",
+      },
+    };
+    if (dnsNames.length > 0) payload.dnsNames = dnsNames;
+    if (f.commonName.trim() !== "") payload.commonName = f.commonName.trim();
+    if (f.duration.trim() !== "") payload.duration = f.duration.trim();
+    if (f.renewBefore.trim() !== "") {
+      payload.renewBefore = f.renewBefore.trim();
+    }
+    const pk: Record<string, unknown> = {
+      algorithm: f.privateKey.algorithm,
+      rotationPolicy: f.privateKey.rotationPolicy,
+    };
+    if (f.privateKey.algorithm !== "Ed25519") {
+      pk.size = f.privateKey.size;
+    }
+    payload.privateKey = pk;
+    if (f.isCA) payload.isCA = true;
+
+    try {
+      const resp = await apiPost<{ yaml: string }>(
+        "/v1/wizards/certificate/preview",
+        payload,
+      );
+      previewYaml.value = resp.data.yaml;
+    } catch (err) {
+      previewError.value = err instanceof Error
+        ? err.message
+        : "Failed to generate preview";
+    } finally {
+      previewLoading.value = false;
+    }
+  };
+
+  const goNext = async () => {
+    if (!validateStep(currentStep.value)) return;
+    if (currentStep.value === 0) {
+      currentStep.value = 1;
+      await fetchPreview();
+    }
+  };
+
+  const goBack = () => {
+    if (currentStep.value > 0) currentStep.value = currentStep.value - 1;
+  };
+
+  if (!IS_BROWSER) {
+    return <div class="p-6">Loading wizard...</div>;
+  }
+
+  return (
+    <div class="p-6 max-w-4xl mx-auto">
+      <div class="flex items-center justify-between mb-6">
+        <h1 class="text-2xl font-bold text-text-primary">
+          Create Certificate
+        </h1>
+        <a
+          href="/security/certificates"
+          class="text-sm text-text-muted hover:text-text-primary"
+        >
+          Cancel
+        </a>
+      </div>
+
+      <WizardStepper
+        steps={STEPS}
+        currentStep={currentStep.value}
+        onStepClick={(step) => {
+          if (step < currentStep.value) currentStep.value = step;
+        }}
+      />
+
+      <div class="mt-6">
+        {currentStep.value === 0 && (
+          <CertificateForm
+            form={form.value}
+            errors={errors.value}
+            issuers={issuers.value}
+            issuersLoading={issuersLoading.value}
+            onUpdate={updateField}
+            onUpdatePrivateKey={updatePrivateKey}
+          />
+        )}
+
+        {currentStep.value === 1 && (
+          <WizardReviewStep
+            yaml={previewYaml.value}
+            onYamlChange={(v) => {
+              previewYaml.value = v;
+            }}
+            loading={previewLoading.value}
+            error={previewError.value}
+            detailBasePath="/security/certificates"
+          />
+        )}
+      </div>
+
+      {currentStep.value < 1 && (
+        <div class="flex justify-between mt-8">
+          <Button variant="ghost" onClick={goBack} disabled>
+            Back
+          </Button>
+          <Button variant="primary" onClick={goNext}>
+            Preview YAML
+          </Button>
+        </div>
+      )}
+
+      {currentStep.value === 1 && !previewLoading.value &&
+        previewError.value === null && (
+        <div class="flex justify-start mt-4">
+          <Button variant="ghost" onClick={goBack}>Back</Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/islands/CertificatesList.tsx
+++ b/frontend/islands/CertificatesList.tsx
@@ -74,9 +74,15 @@ export default function CertificatesList() {
 
   return (
     <div class="p-6">
-      <h1 class="text-2xl font-bold text-text-primary mb-1">
-        Certificates
-      </h1>
+      <div class="flex items-start justify-between mb-1">
+        <h1 class="text-2xl font-bold text-text-primary">Certificates</h1>
+        <a
+          href="/security/certificates/new"
+          class="inline-flex items-center gap-2 rounded-md bg-brand px-3 py-1.5 text-sm font-medium text-white hover:bg-brand/90"
+        >
+          Create Certificate
+        </a>
+      </div>
       <p class="text-sm text-text-muted mb-6">
         cert-manager certificates across all namespaces.
         {expiringOnly && " Showing expiring and expired certificates only."}

--- a/frontend/islands/CommandPalette.tsx
+++ b/frontend/islands/CommandPalette.tsx
@@ -88,6 +88,15 @@ function buildSearchIndex(): SearchItem[] {
       label: "View Expiring Certificates",
       href: "/security/certificates?status=expiring",
     },
+    { label: "Create Certificate", href: "/security/certificates/new" },
+    {
+      label: "Create Issuer",
+      href: "/security/certificates/issuers/new",
+    },
+    {
+      label: "Create ClusterIssuer",
+      href: "/security/certificates/cluster-issuers/new",
+    },
     { label: "View Gateway API", href: "/networking/gateway-api" },
     { label: "View Notifications", href: "/notifications" },
     { label: "Notification Channels", href: "/admin/notifications/channels" },

--- a/frontend/islands/IssuerWizard.tsx
+++ b/frontend/islands/IssuerWizard.tsx
@@ -3,7 +3,9 @@ import { useCallback } from "preact/hooks";
 import { IS_BROWSER } from "fresh/runtime";
 import { apiPost } from "@/lib/api.ts";
 import { useDirtyGuard } from "@/lib/hooks/use-dirty-guard.ts";
-import { DNS_LABEL_REGEX } from "@/lib/wizard-constants.ts";
+import { useNamespaces } from "@/lib/hooks/use-namespaces.ts";
+import { initialNamespace } from "@/lib/namespace.ts";
+import { DNS_LABEL_REGEX, LE_STAGING_ACME } from "@/lib/wizard-constants.ts";
 import { WizardStepper } from "@/components/wizard/WizardStepper.tsx";
 import { WizardReviewStep } from "@/components/wizard/WizardReviewStep.tsx";
 import { IssuerTypePickerStep } from "@/components/wizard/IssuerTypePickerStep.tsx";
@@ -44,21 +46,31 @@ const STEPS = [
   { title: "Review" },
 ];
 
-const LE_STAGING = "https://acme-staging-v02.api.letsencrypt.org/directory";
+function initialAcme(): IssuerWizardForm["acme"] {
+  return {
+    server: LE_STAGING_ACME,
+    email: "",
+    privateKeySecretRefName: "",
+    ingressClassName: "",
+  };
+}
+
+function initialCa(): IssuerWizardForm["ca"] {
+  return { secretName: "" };
+}
+
+function initialVault(): IssuerWizardForm["vault"] {
+  return { server: "", path: "", authMethod: "token", authValue: "" };
+}
 
 function initialForm(): IssuerWizardForm {
   return {
     type: "",
     name: "",
-    namespace: "default",
-    acme: {
-      server: LE_STAGING,
-      email: "",
-      privateKeySecretRefName: "",
-      ingressClassName: "",
-    },
-    ca: { secretName: "" },
-    vault: { server: "", path: "", authMethod: "token", authValue: "" },
+    namespace: initialNamespace(),
+    acme: initialAcme(),
+    ca: initialCa(),
+    vault: initialVault(),
   };
 }
 
@@ -67,6 +79,7 @@ export default function IssuerWizard({ scope }: IssuerWizardProps) {
   const form = useSignal<IssuerWizardForm>(initialForm());
   const errors = useSignal<Record<string, string>>({});
   const dirty = useSignal(false);
+  const namespaces = useNamespaces();
 
   const previewYaml = useSignal("");
   const previewLoading = useSignal(false);
@@ -126,9 +139,17 @@ export default function IssuerWizard({ scope }: IssuerWizardProps) {
     [],
   );
 
+  // Changing type resets every sibling subform so switching away from ACME and
+  // back (or across any pair) never shows stale values from a prior session.
   const selectType = useCallback((t: IssuerType) => {
     dirty.value = true;
-    form.value = { ...form.value, type: t };
+    form.value = {
+      ...form.value,
+      type: t,
+      acme: initialAcme(),
+      ca: initialCa(),
+      vault: initialVault(),
+    };
   }, []);
 
   const validateStep = (step: number): boolean => {
@@ -309,6 +330,7 @@ export default function IssuerWizard({ scope }: IssuerWizardProps) {
             scope={scope}
             form={form.value}
             errors={errors.value}
+            namespaces={namespaces.value}
             onUpdate={updateField}
             onUpdateAcme={updateAcme}
             onUpdateCa={updateCa}
@@ -325,7 +347,9 @@ export default function IssuerWizard({ scope }: IssuerWizardProps) {
             }}
             loading={previewLoading.value}
             error={previewError.value}
-            detailBasePath="/security/certificates/issuers"
+            detailBasePath={scope === "cluster"
+              ? "/security/certificates/cluster-issuers"
+              : "/security/certificates/issuers"}
           />
         )}
       </div>

--- a/frontend/islands/IssuerWizard.tsx
+++ b/frontend/islands/IssuerWizard.tsx
@@ -1,0 +1,356 @@
+import { useSignal } from "@preact/signals";
+import { useCallback } from "preact/hooks";
+import { IS_BROWSER } from "fresh/runtime";
+import { apiPost } from "@/lib/api.ts";
+import { useDirtyGuard } from "@/lib/hooks/use-dirty-guard.ts";
+import { DNS_LABEL_REGEX } from "@/lib/wizard-constants.ts";
+import { WizardStepper } from "@/components/wizard/WizardStepper.tsx";
+import { WizardReviewStep } from "@/components/wizard/WizardReviewStep.tsx";
+import { IssuerTypePickerStep } from "@/components/wizard/IssuerTypePickerStep.tsx";
+import { IssuerFormStep } from "@/components/wizard/IssuerFormStep.tsx";
+import { Button } from "@/components/ui/Button.tsx";
+
+export type IssuerType = "selfSigned" | "acme" | "ca" | "vault";
+export type VaultAuthMethod = "token" | "appRole" | "kubernetes";
+
+export interface IssuerWizardForm {
+  type: IssuerType | "";
+  name: string;
+  namespace: string;
+  acme: {
+    server: string;
+    email: string;
+    privateKeySecretRefName: string;
+    ingressClassName: string;
+  };
+  ca: {
+    secretName: string;
+  };
+  vault: {
+    server: string;
+    path: string;
+    authMethod: VaultAuthMethod;
+    authValue: string;
+  };
+}
+
+interface IssuerWizardProps {
+  scope: "namespaced" | "cluster";
+}
+
+const STEPS = [
+  { title: "Type" },
+  { title: "Configure" },
+  { title: "Review" },
+];
+
+const LE_STAGING = "https://acme-staging-v02.api.letsencrypt.org/directory";
+
+function initialForm(): IssuerWizardForm {
+  return {
+    type: "",
+    name: "",
+    namespace: "default",
+    acme: {
+      server: LE_STAGING,
+      email: "",
+      privateKeySecretRefName: "",
+      ingressClassName: "",
+    },
+    ca: { secretName: "" },
+    vault: { server: "", path: "", authMethod: "token", authValue: "" },
+  };
+}
+
+export default function IssuerWizard({ scope }: IssuerWizardProps) {
+  const currentStep = useSignal(0);
+  const form = useSignal<IssuerWizardForm>(initialForm());
+  const errors = useSignal<Record<string, string>>({});
+  const dirty = useSignal(false);
+
+  const previewYaml = useSignal("");
+  const previewLoading = useSignal(false);
+  const previewError = useSignal<string | null>(null);
+
+  useDirtyGuard(dirty);
+
+  const updateField = useCallback((field: string, value: unknown) => {
+    dirty.value = true;
+    const f = { ...form.value, [field]: value } as IssuerWizardForm;
+    // Default ACME private key secret from issuer name when untouched.
+    if (
+      field === "name" && typeof value === "string" && f.type === "acme" &&
+      (f.acme.privateKeySecretRefName === "" ||
+        f.acme.privateKeySecretRefName === `${form.value.name}-account`)
+    ) {
+      f.acme = {
+        ...f.acme,
+        privateKeySecretRefName: value ? `${value}-account` : "",
+      };
+    }
+    form.value = f;
+  }, []);
+
+  const updateAcme = useCallback((field: string, value: unknown) => {
+    dirty.value = true;
+    form.value = {
+      ...form.value,
+      acme: { ...form.value.acme, [field]: value },
+    };
+  }, []);
+
+  const updateCa = useCallback((field: string, value: unknown) => {
+    dirty.value = true;
+    form.value = {
+      ...form.value,
+      ca: { ...form.value.ca, [field]: value },
+    };
+  }, []);
+
+  const updateVault = useCallback((field: string, value: unknown) => {
+    dirty.value = true;
+    form.value = {
+      ...form.value,
+      vault: { ...form.value.vault, [field]: value },
+    };
+  }, []);
+
+  const updateVaultAuth = useCallback(
+    (method: VaultAuthMethod, value: string) => {
+      dirty.value = true;
+      form.value = {
+        ...form.value,
+        vault: { ...form.value.vault, authMethod: method, authValue: value },
+      };
+    },
+    [],
+  );
+
+  const selectType = useCallback((t: IssuerType) => {
+    dirty.value = true;
+    form.value = { ...form.value, type: t };
+  }, []);
+
+  const validateStep = (step: number): boolean => {
+    const f = form.value;
+    const errs: Record<string, string> = {};
+
+    if (step === 0) {
+      if (!f.type) errs.type = "Select an issuer type";
+    }
+
+    if (step === 1) {
+      if (!f.name || !DNS_LABEL_REGEX.test(f.name)) {
+        errs.name = "Must be a valid DNS label";
+      }
+      if (scope === "namespaced") {
+        if (!f.namespace || !DNS_LABEL_REGEX.test(f.namespace)) {
+          errs.namespace = "Must be a valid DNS label";
+        }
+      }
+
+      if (f.type === "acme") {
+        if (!f.acme.server || !f.acme.server.startsWith("https://")) {
+          errs["acme.server"] = "ACME server must be an HTTPS URL";
+        }
+        if (!f.acme.email || !f.acme.email.includes("@")) {
+          errs["acme.email"] = "A valid email is required";
+        }
+        if (
+          !f.acme.privateKeySecretRefName ||
+          !DNS_LABEL_REGEX.test(f.acme.privateKeySecretRefName)
+        ) {
+          errs["acme.privateKeySecretRefName"] = "Must be a valid DNS label";
+        }
+      }
+
+      if (f.type === "ca") {
+        if (!f.ca.secretName || !DNS_LABEL_REGEX.test(f.ca.secretName)) {
+          errs["ca.secretName"] = "Must be a valid DNS label";
+        }
+      }
+
+      if (f.type === "vault") {
+        if (!f.vault.server || !f.vault.server.startsWith("https://")) {
+          errs["vault.server"] = "Vault server must be an HTTPS URL";
+        }
+        if (!f.vault.path) errs["vault.path"] = "PKI path is required";
+        if (!f.vault.authValue) {
+          errs["vault.auth"] = "One authentication method must be configured";
+        }
+      }
+    }
+
+    errors.value = errs;
+    return Object.keys(errs).length === 0;
+  };
+
+  const fetchPreview = async () => {
+    previewLoading.value = true;
+    previewError.value = null;
+
+    const f = form.value;
+    const payload: Record<string, unknown> = {
+      scope,
+      name: f.name,
+      type: f.type,
+    };
+    if (scope === "namespaced") payload.namespace = f.namespace;
+
+    switch (f.type) {
+      case "selfSigned":
+        payload.selfSigned = {};
+        break;
+      case "acme": {
+        const solver: Record<string, unknown> = { http01Ingress: {} };
+        if (f.acme.ingressClassName) {
+          (solver.http01Ingress as Record<string, unknown>).ingressClassName =
+            f.acme.ingressClassName;
+        }
+        payload.acme = {
+          server: f.acme.server,
+          email: f.acme.email,
+          privateKeySecretRefName: f.acme.privateKeySecretRefName,
+          solvers: [solver],
+        };
+        break;
+      }
+      case "ca":
+        payload.ca = { secretName: f.ca.secretName };
+        break;
+      case "vault": {
+        const auth: Record<string, unknown> = {};
+        if (f.vault.authMethod === "token") {
+          auth.tokenSecretRefName = f.vault.authValue;
+        } else if (f.vault.authMethod === "appRole") {
+          auth.appRoleSecretRefName = f.vault.authValue;
+        } else {
+          auth.kubernetesRole = f.vault.authValue;
+        }
+        payload.vault = {
+          server: f.vault.server,
+          path: f.vault.path,
+          auth,
+        };
+        break;
+      }
+    }
+
+    const endpoint = scope === "cluster"
+      ? "/v1/wizards/cluster-issuer/preview"
+      : "/v1/wizards/issuer/preview";
+    try {
+      const resp = await apiPost<{ yaml: string }>(endpoint, payload);
+      previewYaml.value = resp.data.yaml;
+    } catch (err) {
+      previewError.value = err instanceof Error
+        ? err.message
+        : "Failed to generate preview";
+    } finally {
+      previewLoading.value = false;
+    }
+  };
+
+  const goNext = async () => {
+    if (!validateStep(currentStep.value)) return;
+    if (currentStep.value === 1) {
+      currentStep.value = 2;
+      await fetchPreview();
+    } else {
+      currentStep.value = currentStep.value + 1;
+    }
+  };
+
+  const goBack = () => {
+    if (currentStep.value > 0) currentStep.value = currentStep.value - 1;
+  };
+
+  if (!IS_BROWSER) return <div class="p-6">Loading wizard...</div>;
+
+  const heading = scope === "cluster"
+    ? "Create ClusterIssuer"
+    : "Create Issuer";
+
+  return (
+    <div class="p-6 max-w-4xl mx-auto">
+      <div class="flex items-center justify-between mb-6">
+        <h1 class="text-2xl font-bold text-text-primary">{heading}</h1>
+        <a
+          href="/security/certificates/issuers"
+          class="text-sm text-text-muted hover:text-text-primary"
+        >
+          Cancel
+        </a>
+      </div>
+
+      <WizardStepper
+        steps={STEPS}
+        currentStep={currentStep.value}
+        onStepClick={(step) => {
+          if (step < currentStep.value) currentStep.value = step;
+        }}
+      />
+
+      <div class="mt-6">
+        {currentStep.value === 0 && (
+          <div class="space-y-4">
+            <IssuerTypePickerStep
+              selected={form.value.type}
+              onSelect={selectType}
+            />
+            {errors.value.type && (
+              <p class="text-xs text-danger">{errors.value.type}</p>
+            )}
+          </div>
+        )}
+
+        {currentStep.value === 1 && form.value.type !== "" && (
+          <IssuerFormStep
+            scope={scope}
+            form={form.value}
+            errors={errors.value}
+            onUpdate={updateField}
+            onUpdateAcme={updateAcme}
+            onUpdateCa={updateCa}
+            onUpdateVault={updateVault}
+            onUpdateVaultAuth={updateVaultAuth}
+          />
+        )}
+
+        {currentStep.value === 2 && (
+          <WizardReviewStep
+            yaml={previewYaml.value}
+            onYamlChange={(v) => {
+              previewYaml.value = v;
+            }}
+            loading={previewLoading.value}
+            error={previewError.value}
+            detailBasePath="/security/certificates/issuers"
+          />
+        )}
+      </div>
+
+      {currentStep.value < 2 && (
+        <div class="flex justify-between mt-8">
+          <Button
+            variant="ghost"
+            onClick={goBack}
+            disabled={currentStep.value === 0}
+          >
+            Back
+          </Button>
+          <Button variant="primary" onClick={goNext}>
+            {currentStep.value === 1 ? "Preview YAML" : "Next"}
+          </Button>
+        </div>
+      )}
+
+      {currentStep.value === 2 && !previewLoading.value &&
+        previewError.value === null && (
+        <div class="flex justify-start mt-4">
+          <Button variant="ghost" onClick={goBack}>Back</Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/islands/IssuersList.tsx
+++ b/frontend/islands/IssuersList.tsx
@@ -35,7 +35,23 @@ export default function IssuersList() {
 
   return (
     <div class="p-6">
-      <h1 class="text-2xl font-bold text-text-primary mb-1">Issuers</h1>
+      <div class="flex items-start justify-between mb-1">
+        <h1 class="text-2xl font-bold text-text-primary">Issuers</h1>
+        <div class="flex gap-2">
+          <a
+            href="/security/certificates/issuers/new"
+            class="inline-flex items-center gap-2 rounded-md border border-border-primary px-3 py-1.5 text-sm font-medium text-text-primary hover:bg-hover"
+          >
+            Create Issuer
+          </a>
+          <a
+            href="/security/certificates/cluster-issuers/new"
+            class="inline-flex items-center gap-2 rounded-md bg-brand px-3 py-1.5 text-sm font-medium text-white hover:bg-brand/90"
+          >
+            Create ClusterIssuer
+          </a>
+        </div>
+      </div>
       <p class="text-sm text-text-muted mb-6">
         cert-manager Issuers and ClusterIssuers.
       </p>

--- a/frontend/lib/wizard-constants.ts
+++ b/frontend/lib/wizard-constants.ts
@@ -79,3 +79,10 @@ export const RESTART_POLICY_OPTIONS = [
 /** Standard Tailwind input class for wizard form fields. */
 export const WIZARD_INPUT_CLASS =
   "mt-1 w-full rounded-md border border-border-primary bg-surface px-3 py-2 text-sm text-text-primary focus:border-brand focus:outline-none focus:ring-1 focus:ring-brand";
+
+/** Let's Encrypt production ACME directory endpoint. */
+export const LE_PROD_ACME = "https://acme-v02.api.letsencrypt.org/directory";
+
+/** Let's Encrypt staging ACME directory endpoint. */
+export const LE_STAGING_ACME =
+  "https://acme-staging-v02.api.letsencrypt.org/directory";

--- a/frontend/routes/security/certificates/cluster-issuers/index.tsx
+++ b/frontend/routes/security/certificates/cluster-issuers/index.tsx
@@ -1,0 +1,18 @@
+import { define } from "@/utils.ts";
+import SubNav from "@/islands/SubNav.tsx";
+import { DOMAIN_SECTIONS } from "@/lib/constants.ts";
+import IssuersList from "@/islands/IssuersList.tsx";
+
+const section = DOMAIN_SECTIONS.find((s) => s.id === "security")!;
+
+// ClusterIssuers and namespaced Issuers live on the same IssuersList today —
+// this route exists so the IssuerWizard's "View Resource" link has a landing
+// place scoped to cluster-issuer creations.
+export default define.page(function ClusterIssuersPage(ctx) {
+  return (
+    <>
+      <SubNav tabs={section.tabs ?? []} currentPath={ctx.url.pathname} />
+      <IssuersList />
+    </>
+  );
+});

--- a/frontend/routes/security/certificates/cluster-issuers/new.tsx
+++ b/frontend/routes/security/certificates/cluster-issuers/new.tsx
@@ -1,0 +1,18 @@
+import { define } from "@/utils.ts";
+import SubNav from "@/islands/SubNav.tsx";
+import { DOMAIN_SECTIONS } from "@/lib/constants.ts";
+import IssuerWizard from "@/islands/IssuerWizard.tsx";
+
+const section = DOMAIN_SECTIONS.find((s) => s.id === "security")!;
+
+export default define.page(function ClusterIssuerNewPage() {
+  return (
+    <>
+      <SubNav
+        tabs={section.tabs ?? []}
+        currentPath="/security/certificates"
+      />
+      <IssuerWizard scope="cluster" />
+    </>
+  );
+});

--- a/frontend/routes/security/certificates/issuers/new.tsx
+++ b/frontend/routes/security/certificates/issuers/new.tsx
@@ -1,0 +1,18 @@
+import { define } from "@/utils.ts";
+import SubNav from "@/islands/SubNav.tsx";
+import { DOMAIN_SECTIONS } from "@/lib/constants.ts";
+import IssuerWizard from "@/islands/IssuerWizard.tsx";
+
+const section = DOMAIN_SECTIONS.find((s) => s.id === "security")!;
+
+export default define.page(function IssuerNewPage() {
+  return (
+    <>
+      <SubNav
+        tabs={section.tabs ?? []}
+        currentPath="/security/certificates"
+      />
+      <IssuerWizard scope="namespaced" />
+    </>
+  );
+});

--- a/frontend/routes/security/certificates/new.tsx
+++ b/frontend/routes/security/certificates/new.tsx
@@ -1,0 +1,18 @@
+import { define } from "@/utils.ts";
+import SubNav from "@/islands/SubNav.tsx";
+import { DOMAIN_SECTIONS } from "@/lib/constants.ts";
+import CertificateWizard from "@/islands/CertificateWizard.tsx";
+
+const section = DOMAIN_SECTIONS.find((s) => s.id === "security")!;
+
+export default define.page(function CertificateNewPage() {
+  return (
+    <>
+      <SubNav
+        tabs={section.tabs ?? []}
+        currentPath="/security/certificates"
+      />
+      <CertificateWizard />
+    </>
+  );
+});

--- a/plans/cert-manager-configurable-thresholds.md
+++ b/plans/cert-manager-configurable-thresholds.md
@@ -1,0 +1,176 @@
+# feat: Configurable Cert-Manager Expiry Thresholds
+
+## Overview
+
+Replace the hardcoded 30-day warning / 7-day critical expiry thresholds in `backend/internal/certmanager/poller.go` with user-configurable values stored in `app_settings`. Admin-only write access via `PUT /settings/cert-manager`; all authenticated users can read.
+
+Sibling of `plans/cert-manager-wizards-phase-11b.md`. Split out because it shares no code path with the wizard pipeline.
+
+Roadmap item **#7b** (thresholds half).
+
+## Problem Statement
+
+`backend/internal/certmanager/types.go` defines:
+
+```go
+WarningThresholdDays  = 30  // line 50
+CriticalThresholdDays = 7   // line 53
+```
+
+These are consumed by `poller.go:41-52` (`thresholdBucket()`) and drive notification emission. Different teams want different lead times:
+
+- Compliance-driven shops want wider windows (60/14 or 90/30) for change-management sign-off.
+- Aggressive rotators on short-lived ACME certs want tighter windows (14/3) to avoid alert fatigue.
+
+Hardcoded values require recompiling the backend.
+
+### The dedupe-vs-threshold-change bug (Kieran catch)
+
+The poller currently dedupes notifications by `(uid, thresholdBucket)` where `thresholdBucket` derives from the hardcoded day count. If an operator widens `warning` from 30 → 60:
+
+- Certificate at 45 days to expiry was **not** yet notified (30-day bucket not reached).
+- Under new 60-day threshold, it *should* fire immediately.
+- Under current dedupe logic with a naive refactor, the change of threshold constants doesn't create a new bucket key — the cert silently goes un-notified until 30 days.
+
+The fix: dedupe key must include the **threshold value itself**, not a derived bucket. Changing threshold creates a fresh dedupe-key space and fires once per eligible cert.
+
+## Proposed Solution
+
+Three moving parts:
+
+1. **Schema** — add `cert_manager_warning_days` and `cert_manager_critical_days` columns to `app_settings`.
+2. **API** — `GET/PUT /settings/cert-manager` with admin gate and validation.
+3. **Poller refactor** — read live values per tick, include threshold days in dedupe key.
+
+No frontend UI in v1. Operators edit via curl; release notes will include a one-liner. A settings UI section can be added as a follow-up if users actually adjust these often.
+
+## Technical Approach
+
+### Schema migration
+
+`backend/internal/store/migrations/0000NN_cert_manager_thresholds.up.sql`:
+
+```sql
+ALTER TABLE app_settings
+  ADD COLUMN cert_manager_warning_days  INT NOT NULL DEFAULT 30,
+  ADD COLUMN cert_manager_critical_days INT NOT NULL DEFAULT  7;
+```
+
+Plus `.down.sql` dropping both columns.
+
+### Store
+
+Extend `AppSettings` struct in `backend/internal/store/settings.go`:
+
+```go
+CertManagerWarningDays  int `json:"certManagerWarningDays"`
+CertManagerCriticalDays int `json:"certManagerCriticalDays"`
+```
+
+Existing `Get()` / `Update()` round-trip unchanged; cache invalidation already handled.
+
+### HTTP handler
+
+New `backend/internal/server/handle_certmanager_settings.go`:
+
+- `GET /settings/cert-manager` — any authenticated user, returns `{warningDays, criticalDays}`.
+- `PUT /settings/cert-manager` — admin role required, CSRF-protected, JSON body `{warningDays, criticalDays}`, writes audit log entry with action `settings.cert-manager.update`.
+
+Validation:
+
+| Rule | Message |
+|---|---|
+| `warningDays ∈ [2, 365]` | "warning must be 2-365 days" |
+| `criticalDays ∈ [1, 364]` | "critical must be 1-364 days" |
+| `criticalDays < warningDays` | "critical must be less than warning" |
+| JSON decode errors | 400 with field path |
+
+### Poller refactor
+
+`backend/internal/certmanager/poller.go`:
+
+**Delete** constants `WarningThresholdDays` / `CriticalThresholdDays` in `types.go:50,53`.
+
+**Refactor** `thresholdBucket(daysUntilExpiry int)` → `thresholdBucket(daysUntilExpiry, warningDays, criticalDays int) (level, thresholdDays int, ok bool)`. Returns level (`"warning"` / `"critical"`) and the threshold days it crossed (for the dedupe key).
+
+**Refactor** `run()` to fetch current settings from `SettingsStore` at the start of each 60s tick:
+
+```go
+settings, err := p.settings.Get(ctx)
+if err != nil {
+    slog.Error("cert-manager poller: failed to read settings, using defaults", "err", err)
+    settings = store.AppSettings{CertManagerWarningDays: 30, CertManagerCriticalDays: 7}
+}
+```
+
+**Change dedupe key** in emitter (`poller.go:138-178`) from `(uid, bucket)` to `(uid, thresholdDays)` — concretely the map/set key becomes `fmt.Sprintf("%s:%d", cert.UID, thresholdDays)`. This naturally:
+
+- Fires once per cert per distinct threshold value.
+- Refires when an operator changes warning 30 → 60 (new key `uid:60` isn't in the dedupe set).
+- Does NOT refire if operator flips 30 → 60 → 30 (key `uid:30` already present from the original notification).
+
+Document in release notes: "Widening thresholds will cause certificates already in the new window to fire one additional notification per certificate."
+
+### Dependency injection
+
+Poller constructor currently takes k8s client + notification service. Add a `SettingsStore` interface with a single `Get(ctx) (AppSettings, error)` method. Wire in `cmd/kubecenter/main.go` where poller is constructed. Interface-based so tests can inject a fake.
+
+## Acceptance Criteria
+
+### API
+
+- [ ] `GET /settings/cert-manager` returns `{warningDays: 30, criticalDays: 7}` on fresh install.
+- [ ] `PUT /settings/cert-manager` with admin + valid body (e.g. `{warningDays: 60, criticalDays: 14}`) returns 200, persists, and `GET` reflects the change.
+- [ ] `PUT` from non-admin returns 403.
+- [ ] `PUT` without CSRF header returns 403.
+- [ ] Validation rejects: `warningDays=0`, `warningDays=400`, `criticalDays >= warningDays`, non-int body fields, missing fields — each returns 400 with field-level message.
+- [ ] Audit log records admin mutations with action `settings.cert-manager.update`, before/after values (masked where appropriate).
+
+### Store / migration
+
+- [ ] Migration `.up.sql` and `.down.sql` round-trip clean on empty DB and on DB with existing rows.
+- [ ] Existing installs get the default 30/7 via column `DEFAULT`.
+- [ ] `AppSettings` round-trips through JSON marshal/unmarshal with new fields.
+
+### Poller behavior
+
+- [ ] `thresholdBucket` unit tests cover boundaries: 0d, 1d, `criticalDays`, `criticalDays+1`, `warningDays`, `warningDays+1`, 365d.
+- [ ] `thresholdBucket` table test for 3 threshold pairs: (30,7), (60,14), (14,3).
+- [ ] Integration test: configure poller with fake `SettingsStore`, fake notification sink, synthetic certs at various days-to-expiry. Change settings mid-run; assert next tick uses new values without restart.
+- [ ] Integration test: dedupe — same cert at same threshold fires once; widening threshold fires once for eligible certs; narrowing does not backfire for already-notified cert.
+- [ ] Poller tolerates `SettingsStore.Get` errors by falling back to 30/7 defaults and logging at ERROR; does not crash.
+
+### Non-functional
+
+- [ ] `go vet`, `go test ./...`, `deno lint`, `deno fmt --check` all pass.
+- [ ] No frontend changes in this PR (zero Deno diff).
+- [ ] Release notes include the dedupe-on-widen behavior and a curl example.
+
+## Dependencies & Risks
+
+- **Dependency:** Phase 11A cert-manager package. This plan modifies `poller.go` and `types.go` in that package.
+- **Risk (low):** Dedupe state is in-memory only (no persistence across restarts). Restart between a threshold change and next tick produces no extra notifications — acceptable, matches current behavior.
+- **Risk (low):** Settings read on every 60s tick adds one PostgreSQL query per tick. Negligible; `settings` table has 1 row.
+
+## Out of Scope (Deferred)
+
+- **Settings UI** — curl is sufficient for v1. Add UI section if users adjust these often.
+- **Per-certificate threshold overrides** (e.g., annotation-driven) — YAGNI until someone asks.
+- **Threshold history / audit trail beyond the standard audit log.**
+
+## References
+
+### Internal
+
+- Hardcoded thresholds to remove: `backend/internal/certmanager/types.go:50,53`
+- Poller threshold logic: `backend/internal/certmanager/poller.go:41-52`
+- Poller emitter: `backend/internal/certmanager/poller.go:138-178`
+- Settings storage: `backend/internal/store/settings.go`
+- Migration precedent: `backend/internal/store/migrations/000002_create_settings.up.sql`
+- Settings handler pattern: `backend/internal/server/handle_settings.go` (auth settings handler)
+- Audit logger: `backend/internal/audit/`
+
+### Related
+
+- Sibling plan: `plans/cert-manager-wizards-phase-11b.md`
+- Phase 11A: Cert-Manager Observatory

--- a/plans/cert-manager-wizards-phase-11b.md
+++ b/plans/cert-manager-wizards-phase-11b.md
@@ -1,0 +1,181 @@
+# feat: Cert-Manager Wizards (Phase 11B)
+
+## Overview
+
+Phase 11A shipped the Cert-Manager Observatory (inventory, detail, renew/reissue, expiry poller). Phase 11B adds **creation wizards** for Certificate, Issuer, and ClusterIssuer resources following the established `WizardInput → YAML preview → server-side apply` pipeline used by 18 existing wizards.
+
+Configurable expiry thresholds (originally part of this scope) have been **split into a sibling PR** — they share no code path with the wizard pipeline and land cleaner reviewed independently. Tracked separately as `plans/cert-manager-configurable-thresholds.md` (to be written).
+
+Closes roadmap item **#7b** (wizard half).
+
+## Problem Statement
+
+Operators issuing a new TLS certificate today must hand-write YAML and `kubectl apply`. Cert-manager's CRD surface (ACME, CA, Vault, SelfSigned + per-issuer solver matrix) is the #1 misconfiguration source. GUI wizards are the same friction-killer that motivated the 18 existing wizards.
+
+## Proposed Solution
+
+Three wizard endpoints, two frontend islands (Issuer and ClusterIssuer share one island via a `scope` prop):
+
+1. **Certificate wizard** — basic fields + collapsible advanced section in a single form.
+2. **Issuer / ClusterIssuer wizard** — issuer-type picker (SelfSigned / ACME / CA / Vault), then one `IssuerFormStep` that branches internally on type.
+
+**v1 ACME scope: HTTP01 ingress solver only.** DNS01 providers (Cloudflare, Route53, etc.) and Venafi deferred to Phase 11C when real demand appears.
+
+## Technical Approach
+
+### Backend
+
+**New package `backend/internal/wizard/certmgr/`:**
+
+- `certificate.go` — `CertificateInput` implementing `WizardInput` (Validate + ToYAML).
+- `issuer.go` — `IssuerInput` with typed `IssuerScope` (constants `IssuerScopeNamespaced`, `IssuerScopeCluster`). Validates exactly one of {acme, ca, vault, selfSigned}.
+- `certificate_test.go`, `issuer_test.go` — table-driven tests (see Validation Matrix below).
+
+Package location (`wizard/certmgr/`) mirrors the existing 18-wizard density, avoids polluting the top-level `wizard` package.
+
+**Route registration** in `backend/internal/server/routes.go` (kebab-case per CLAUDE.md convention):
+
+```go
+r.Post("/wizards/certificate/preview",     wizard.HandlePreview(func() WizardInput { return &certmgr.CertificateInput{} }))
+r.Post("/wizards/issuer/preview",          wizard.HandlePreview(func() WizardInput { return &certmgr.IssuerInput{Scope: certmgr.IssuerScopeNamespaced} }))
+r.Post("/wizards/cluster-issuer/preview",  wizard.HandlePreview(func() WizardInput { return &certmgr.IssuerInput{Scope: certmgr.IssuerScopeCluster} }))
+```
+
+**Handler-registration race (DHH catch):** current `wizard.HandlePreview(&CertificateInput{})` pattern shares a pointer across requests. Must refactor `HandlePreview` to accept a `func() WizardInput` factory that returns a fresh instance per call. Small change in `backend/internal/wizard/handler.go`; affects all 18 existing wizards but is backward-compatible (zero behavior change, just allocation moves into the factory).
+
+### Frontend
+
+**New islands** (`frontend/islands/`):
+
+- `CertificateWizard.tsx` — single form step with `<details>` for advanced fields, then Review. Issuer dropdown loads `GET /issuers` + `GET /clusterissuers` (both RBAC-filtered server-side via Phase 11A's `CanAccessGroupResource`).
+- `IssuerWizard.tsx` — `scope` prop drives namespace input visibility and `kind` emission. Steps: Type Picker (SelfSigned / ACME / CA / Vault radio cards), Form, Review.
+
+**New wizard step components** (`frontend/components/wizard/`):
+
+- `CertificateForm.tsx` — one file, `<details>`-based advanced collapse. No separate `BasicsStep`/`AdvancedStep` split.
+- `IssuerTypePickerStep.tsx`, `IssuerFormStep.tsx` — the form branches internally by type (SelfSigned = empty body; ACME = HTTP01 inputs; CA = two Secret refs; Vault = server/path/auth).
+
+**New routes:**
+
+- `frontend/routes/security/certificates/new.tsx`
+- `frontend/routes/security/certificates/issuers/new.tsx`
+- `frontend/routes/security/certificates/cluster-issuers/new.tsx`
+
+**Entry points:**
+
+- "Create Certificate" button in `CertificatesList.tsx` header.
+- "Create Issuer" / "Create ClusterIssuer" buttons in `IssuersList.tsx`.
+- Command palette quick actions: `cert-manager: Create Certificate`, `cert-manager: Create Issuer`, `cert-manager: Create ClusterIssuer`.
+
+All entry points gated on existing `CertManagerDiscoverer.IsInstalled()`.
+
+### Validation Matrix
+
+**CertificateInput:**
+
+| Field | Rule |
+|---|---|
+| `name`, `namespace` | RFC 1123 label, ≤253 chars |
+| `issuerRef.kind` | must be `Issuer` or `ClusterIssuer` (exact case) |
+| `issuerRef.name` | required, RFC 1123 |
+| `dnsNames ∪ commonName ∪ ipAddresses ∪ uris ∪ emailAddresses` | at least one non-empty |
+| `dnsNames[i]` | RFC 1123 hostname; wildcard `*.x` only in leftmost label |
+| `commonName` | ≤64 chars; warn if not in dnsNames |
+| `duration` | Go `time.Duration`, ≥1h |
+| `renewBefore` | ≥5m, strictly less than `duration` |
+| `privateKey.algorithm × size` | `RSA ∈ {2048, 3072, 4096}`, `ECDSA ∈ {256, 384, 521}`, `Ed25519` ignores size |
+| `privateKey.encoding` | `PKCS1` or `PKCS8` |
+| `privateKey.rotationPolicy` | `Always` or `Never` |
+
+**IssuerInput (type-specific):**
+
+| Type | Required |
+|---|---|
+| `selfSigned` | (empty) |
+| `ca` | `secretName` |
+| `vault` | `server` (https://), `path`, exactly one of auth methods |
+| `acme` | `server` (https:// only, reject http:// and RFC1918), valid RFC 5322 `email`, `privateKeySecretRef.name`, ≥1 solver with HTTP01 ingress |
+
+Secrets are **not** pre-existence-checked at preview time (consistent with all 18 wizards — SSA catches missing resources at apply).
+
+### YAML Example
+
+Self-signed ClusterIssuer (ideal "first issuer" default):
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata: { name: selfsigned }
+spec: { selfSigned: {} }
+```
+
+## Acceptance Criteria
+
+### Certificate wizard
+
+- [ ] `POST /wizards/certificate/preview` returns valid YAML for minimal input.
+- [ ] Full Validation Matrix above enforced; table tests cover every row.
+- [ ] Issuer dropdown lists both Issuers (current namespace) and all ClusterIssuers, grouped by `kind`, RBAC-filtered (user without `list` on `clusterissuers.cert-manager.io` sees only namespaced Issuers).
+- [ ] Defaults pre-filled: `duration=2160h`, `renewBefore=360h`, `privateKey={RSA, 2048, Always}`, `usages=[digital signature, key encipherment, server auth]`.
+- [ ] Review step shows YAML in Monaco read-only; Apply uses existing server-side apply endpoint.
+
+### Issuer / ClusterIssuer wizard
+
+- [ ] Type picker shows 4 cards (SelfSigned, ACME, CA, Vault). No "advanced types" toggle; Venafi is out of scope entirely.
+- [ ] ACME form defaults to Let's Encrypt **staging**; `server` field is free-text but rejects `http://` and RFC1918 at preview time.
+- [ ] HTTP01 ingress is the only solver in v1; UI does not render DNS01 options.
+- [ ] ClusterIssuer route omits namespace input and emits `kind: ClusterIssuer`.
+
+### Security / RBAC
+
+- [ ] Issuer dropdown endpoints filter by `CanAccessGroupResource` (existing Phase 11A pattern).
+- [ ] Apply step for ClusterIssuer requires cluster-scope `create` on `clusterissuers.cert-manager.io` (impersonated; k8s API enforces, but explicit E2E check).
+- [ ] Wizard preview never performs write actions; apply goes through existing SSA endpoint which already audits.
+- [ ] All k8s calls impersonate caller (no service-account writes).
+
+### Non-functional
+
+- [ ] `go vet`, `go test ./...`, `deno lint`, `deno fmt --check`, `deno task build` all pass.
+- [ ] `wizard.HandlePreview` factory refactor lands first as a prep commit; all 18 existing wizards continue to pass their tests unchanged.
+- [ ] Zero hardcoded Tailwind color classes in new components (Phase 6C compliance).
+- [ ] E2E smoke test (`e2e/cert-manager-wizards.spec.ts`): create SelfSigned ClusterIssuer → create Certificate referencing it → verify Certificate appears in list and Ready=True within 30s.
+
+## Dependencies & Risks
+
+- **Dependency:** cert-manager v1.x CRDs. Gated via `CertManagerDiscoverer.IsInstalled()`.
+- **Risk (low):** `HandlePreview` factory refactor touches all 18 wizard registrations. Mitigated by Phase 0 commit + full test suite.
+- **Risk (low):** ACME `server` URL reachability is cert-manager's problem, not ours. We only enforce scheme + non-private-IP at preview.
+
+## Out of Scope (Deferred)
+
+- **Configurable expiry thresholds** — sibling PR.
+- **Venafi issuer type.**
+- **ACME DNS01 solvers** (any provider) — Phase 11C.
+- **Gateway API HTTP01 solver** (`gatewayHTTPRoute`) — Phase 11C.
+- **Advanced Certificate fields:** `keystores` (PKCS12/JKS), `literalSubject`, `otherNames`, `nameConstraints`, `secretTemplate`, `additionalOutputFormats`. Users needing these edit YAML directly.
+
+## References
+
+### Internal
+
+- Generic wizard pipeline: `backend/internal/wizard/handler.go:1-73`
+- Route registration pattern: `backend/internal/server/routes.go:259-292`
+- Most analogous wizards: `backend/internal/wizard/rolebinding.go` (scoped variant), `backend/internal/wizard/hpa.go` (nested CRD)
+- Phase 11A cert-manager code: `backend/internal/certmanager/{discovery,types,normalize,handler,poller}.go`
+- RBAC pattern: `CanAccessGroupResource` (used throughout Phase 11A handlers)
+- Wizard shell: `frontend/components/wizard/WizardStepper.tsx`
+- Wizard island reference: `frontend/islands/DeploymentWizard.tsx`
+- Cert-manager pages: `frontend/routes/security/certificates/*`, `frontend/islands/{CertificatesList,CertificateDetail,IssuersList}.tsx`
+
+### External
+
+- Certificate CRD reference: https://cert-manager.io/docs/usage/certificate/
+- Issuer configuration: https://cert-manager.io/docs/configuration/
+- ACME issuer: https://cert-manager.io/docs/configuration/acme/
+- API reference v1: https://cert-manager.io/docs/reference/api-docs/
+
+### Related
+
+- Phase 11A: Cert-Manager Observatory (roadmap item #7)
+- Sibling plan: `plans/cert-manager-configurable-thresholds.md` (to be written)
+- Wizard precedent: 18 existing wizards (see `routes.go:259-292`)

--- a/todos/321-complete-p1-certificate-issuerref-parsing-bug.md
+++ b/todos/321-complete-p1-certificate-issuerref-parsing-bug.md
@@ -1,0 +1,67 @@
+---
+name: Fix brittle issuerRef parsing in CertificateWizard
+status: complete
+priority: p1
+issue_id: 321
+tags: [code-review, frontend, correctness, cert-manager, pr-180]
+dependencies: []
+---
+
+## Problem Statement
+
+`frontend/islands/CertificateWizard.tsx:151` decodes the selected issuer from `issuerRefValue` with a destructuring split:
+
+```ts
+const [kind, issuerName] = f.issuerRefValue.split(":");
+```
+
+Two real defects:
+
+1. If `issuerRefValue` is empty string (user never picked an issuer but validation bypass occurred), `kind` is `""` and `issuerName` is `undefined`. The POST body sends `{kind: "", name: undefined, group: "cert-manager.io"}`. The backend returns a 422 but with a confusing field-level error.
+2. The split has no bounded limit. While DNS labels can't contain `:`, future changes to the encoding (e.g., adding namespace for scoped Issuers) would silently truncate.
+
+## Findings
+
+- `CertificateWizard.tsx:151` — `.split(":")` with positional destructure, no kind validation.
+- `CertificateWizard.tsx:134-136` — `validateStep` only checks `!f.issuerRefValue`, does not assert kind/name shape.
+- Reviewer: kieran-typescript-reviewer (P1).
+
+## Proposed Solutions
+
+### Option A — bounded indexOf + explicit kind validation (recommended)
+```ts
+const idx = f.issuerRefValue.indexOf(":");
+const kind = idx > 0 ? f.issuerRefValue.slice(0, idx) : "";
+const issuerName = idx > 0 ? f.issuerRefValue.slice(idx + 1) : "";
+if (kind !== "Issuer" && kind !== "ClusterIssuer") {
+  previewError.value = "Invalid issuer selection";
+  previewLoading.value = false;
+  return;
+}
+```
+Also add a validation branch: `if (kind !== "Issuer" && kind !== "ClusterIssuer") errs.issuerRef = "..."` in `validateStep`.
+
+**Pros:** robust, explicit. **Cons:** 8 more lines. **Effort:** Small. **Risk:** None.
+
+### Option B — store as object instead of encoded string
+Change `issuerRefValue` from `string` to `{kind, name} | null`. `<select>` value becomes an index or uid; map back to the issuer in the selected handler.
+**Pros:** structurally correct. **Cons:** bigger refactor, touches `CertificateForm.tsx` too. **Effort:** Medium. **Risk:** Low.
+
+## Recommended Action
+<!-- filled at triage -->
+
+## Technical Details
+- `frontend/islands/CertificateWizard.tsx` (split + validateStep)
+- `frontend/components/wizard/CertificateForm.tsx:27-28` (option-value encoder)
+
+## Acceptance Criteria
+- [ ] Empty `issuerRefValue` produces a field-level error and does not POST.
+- [ ] `issuerRefValue` with a `kind` outside `{Issuer, ClusterIssuer}` is rejected client-side.
+- [ ] Unit or integration test covering the above two cases.
+
+## Work Log
+- 2026-04-14: Filed from PR #180 review.
+
+## Resources
+- PR #180
+- Reviewer report: kieran-typescript-reviewer

--- a/todos/322-complete-p1-clusterissuer-detail-path-wrong.md
+++ b/todos/322-complete-p1-clusterissuer-detail-path-wrong.md
@@ -1,0 +1,58 @@
+---
+name: Fix ClusterIssuer success-link pointing at Issuers list
+status: complete
+priority: p1
+issue_id: 322
+tags: [code-review, frontend, bug, cert-manager, pr-180]
+dependencies: []
+---
+
+## Problem Statement
+
+After successfully creating a ClusterIssuer via the wizard, the "View Resource" link in the review step sends the user to `/security/certificates/issuers` — the **namespaced** Issuers list. The just-created resource won't appear there because it's cluster-scoped.
+
+`frontend/islands/IssuerWizard.tsx:328` hardcodes:
+```tsx
+detailBasePath="/security/certificates/issuers"
+```
+regardless of the `scope` prop.
+
+## Findings
+
+- Reviewer: kieran-typescript-reviewer (P2, bumped to P1 — user-visible bug on the happy path).
+- Current routes: `/security/certificates/issuers` (namespaced list), `/security/certificates/cluster-issuers/new` (ClusterIssuer wizard). No ClusterIssuer list route exists yet — the IssuersList shows both. Base path should still differ so link styling is consistent.
+
+## Proposed Solutions
+
+### Option A — branch on scope (recommended)
+```tsx
+detailBasePath={scope === "cluster"
+  ? "/security/certificates/cluster-issuers"
+  : "/security/certificates/issuers"}
+```
+Then either (a) create a `/security/certificates/cluster-issuers/index.tsx` that renders the same `IssuersList` island filtered to cluster scope, or (b) redirect `/security/certificates/cluster-issuers` to `/security/certificates/issuers` for now.
+
+**Pros:** obvious fix. **Cons:** needs matching route. **Effort:** Small.
+
+### Option B — point both scopes at `/security/certificates/issuers`
+Accept that cluster issuers also live on the combined list. Update copy on the success screen to say "View Issuers".
+**Pros:** zero route work. **Cons:** loses the semantic link to the specific resource. **Effort:** Trivial.
+
+## Recommended Action
+<!-- filled at triage -->
+
+## Technical Details
+- `frontend/islands/IssuerWizard.tsx:328`
+- Possibly new route `frontend/routes/security/certificates/cluster-issuers/index.tsx`
+
+## Acceptance Criteria
+- [ ] After creating a ClusterIssuer, "View Resource" link navigates to a page where the new ClusterIssuer is visible.
+- [ ] After creating a namespaced Issuer, same is true.
+- [ ] E2E or manual test confirming both.
+
+## Work Log
+- 2026-04-14: Filed from PR #180 review.
+
+## Resources
+- PR #180
+- Reviewer: kieran-typescript-reviewer

--- a/todos/323-complete-p2-scope-field-route-authoritative.md
+++ b/todos/323-complete-p2-scope-field-route-authoritative.md
@@ -1,0 +1,55 @@
+---
+name: Make route authoritative for IssuerScope (ignore client-supplied scope)
+status: complete
+priority: p2
+issue_id: 323
+tags: [code-review, backend, architecture, pr-180]
+dependencies: []
+---
+
+## Problem Statement
+
+`backend/internal/wizard/issuer.go:73` has `Scope IssuerScope \`json:"scope"\``. The HandlePreview factory (`routes.go:294-297`) pre-seeds `Scope: IssuerScopeCluster` or `Namespaced` based on the route. But `json.Decode` overwrites the factory default with whatever the client sends. A client POSTing `scope: "cluster"` to `/wizards/issuer/preview` gets a ClusterIssuer rendered.
+
+Not a security issue — `/yaml/apply` re-authorizes and Kubernetes RBAC rejects unauthorized cluster-scope creates. But architecturally the route should be authoritative.
+
+The existing pattern in `rolebinding.go:15` uses `ClusterScope bool` without a `json` tag that the client controls — same asymmetry exists in the codebase, but this PR duplicates it.
+
+## Findings
+
+- Reviewers: architecture-strategist (P1), dhh-rails-reviewer (P2), pattern-recognition-specialist (P2).
+- File: `backend/internal/wizard/issuer.go:73` (Scope field has `json:"scope"` tag).
+- Decode site: `backend/internal/wizard/handler.go:40`.
+
+## Proposed Solutions
+
+### Option A — overwrite scope after decode in the handler factory
+Change the factory closures in `routes.go:294-297` to return a typed function that wraps `HandlePreview` and re-applies `Scope` after `json.Decode`.
+**Pros:** minimal type churn. **Cons:** adds indirection to the otherwise-clean factory pattern.
+
+### Option B — mark Scope as unexported / `json:"-"` and pass it via context
+Add `json:"-"` so decode ignores it; set the field on the returned input via a constructor that the route wires in.
+**Pros:** compiler prevents clients from setting it; clean. **Cons:** `HandlePreview` factory signature needs a small tweak (already OK — factory already constructs the input).
+
+### Option C — drop `IssuerScope` enum for `ClusterScope bool`
+Align with `rolebinding.go`. One less enum to teach.
+**Pros:** pattern consistency. **Cons:** this week's reviewers recommended the enum; DHH in particular flagged the duplication but preferred the bool.
+
+## Recommended Action
+<!-- filled at triage. Option B is likely cleanest. -->
+
+## Technical Details
+- `backend/internal/wizard/issuer.go:73` — remove `json:"scope"` tag or rename to `Scope IssuerScope \`json:"-"\``
+- `backend/internal/server/routes.go:294-297` — ensure factory's set Scope survives decode
+- Add unit test: POST `scope: "cluster"` to `/wizards/issuer/preview` — must render `kind: Issuer`.
+
+## Acceptance Criteria
+- [ ] Client-supplied `scope` is ignored at all three wizard endpoints.
+- [ ] Unit test confirms this.
+
+## Work Log
+- 2026-04-14: Filed from PR #180 review.
+
+## Resources
+- PR #180
+- Reviewers: architecture-strategist, dhh-rails-reviewer, pattern-recognition-specialist

--- a/todos/324-complete-p2-namespace-dropdown-consistency.md
+++ b/todos/324-complete-p2-namespace-dropdown-consistency.md
@@ -1,0 +1,38 @@
+---
+name: Replace free-text namespace inputs with useNamespaces dropdown
+status: complete
+priority: p2
+issue_id: 324
+tags: [code-review, frontend, ux, consistency, pr-180]
+dependencies: []
+---
+
+## Problem Statement
+
+`frontend/components/wizard/CertificateForm.tsx:56-67` and `IssuerFormStep.tsx:54-64` use free-text `<input>` for namespace. Existing wizards (`DeploymentBasicsStep.tsx`, etc.) use `useNamespaces()` hook + `<select>`. Free-text lets users pass client-side validation with namespaces that don't exist; they only find out at apply time.
+
+Also: `CertificateWizard.tsx:38` hardcodes `namespace: "default"`. Other wizards use `initialNamespace()` from `lib/namespace.ts` which reads the active namespace context.
+
+## Findings
+
+- `CertificateForm.tsx:56-67` — free-text input
+- `IssuerFormStep.tsx:54-64` — free-text input
+- `CertificateWizard.tsx:38`, `IssuerWizard.tsx:53` — hardcoded `"default"` instead of `initialNamespace()`
+- Reviewer: pattern-recognition-specialist (P1 on consistency)
+
+## Proposed Solutions
+
+### Option A — adopt existing hook + default (recommended)
+Reuse `useNamespaces()` and `initialNamespace()`. Match `DeploymentBasicsStep` shape.
+**Effort:** Small. **Risk:** Low — pure consistency win.
+
+## Acceptance Criteria
+- [ ] Both wizards use a namespace `<select>` populated by `useNamespaces()`.
+- [ ] Both default to the active namespace via `initialNamespace()`.
+
+## Work Log
+- 2026-04-14: Filed from PR #180 review.
+
+## Resources
+- PR #180
+- `frontend/islands/DeploymentWizard.tsx:6,75` (reference)

--- a/todos/325-complete-p2-drop-dead-certificate-fields.md
+++ b/todos/325-complete-p2-drop-dead-certificate-fields.md
@@ -1,0 +1,47 @@
+---
+name: Drop speculative CertificateInput fields not exposed in UI
+status: complete
+priority: p2
+issue_id: 325
+tags: [code-review, backend, yagni, cert-manager, pr-180]
+dependencies: []
+---
+
+## Problem Statement
+
+`backend/internal/wizard/certificate.go:80-87` defines `IPAddresses`, `URIs`, and `CertificatePrivateKeyInput.Encoding`. None are rendered by `CertificateForm.tsx`. The validation code paths for them (e.g., identifier-required check at line 118) are reachable only via hand-crafted API calls, which bypass the wizard's purpose.
+
+## Findings
+
+- `certificate.go:80-87` — `IPAddresses`, `URIs` fields
+- `certificate.go:68` — `Encoding` field (full validation at `:212`, no UI picker)
+- Reviewers: code-simplicity-reviewer (P1), dhh-rails-reviewer (agrees)
+- Approximate deletion: ~40 LOC backend + related test cases
+
+## Proposed Solutions
+
+### Option A — remove the fields entirely (recommended)
+Drop `IPAddresses`, `URIs`, `Encoding`. Keep `CommonName` (UI renders it), `IsCA` (UI renders the checkbox), `RotationPolicy` (UI has dropdown).
+Frontend stays untouched. Backend drops ~40 LOC incl. the `ipAddresses/uris` arms of the identifier-required check (`certificate.go:118`).
+
+### Option B — leave in place for future
+Ship as-is. Accept the dead-code cost. Only if there's an imminent follow-up PR that will wire them up.
+
+## Recommended Action
+<!-- filled at triage. Option A is right unless a follow-up PR already has these wired. -->
+
+## Technical Details
+- `backend/internal/wizard/certificate.go:80-87, 118, 212, 275-277`
+
+## Acceptance Criteria
+- [ ] Fields removed from `CertificateInput` and `CertificatePrivateKeyInput`.
+- [ ] Validation branches referencing them removed.
+- [ ] Identifier-required check updated to cover the remaining fields (`dnsNames`, `commonName`).
+- [ ] Tests still pass; remove any that test deleted fields.
+
+## Work Log
+- 2026-04-14: Filed from PR #180 review.
+
+## Resources
+- PR #180
+- Reviewers: code-simplicity-reviewer, dhh-rails-reviewer

--- a/todos/326-complete-p2-remove-unreachable-usages-validator.md
+++ b/todos/326-complete-p2-remove-unreachable-usages-validator.md
@@ -1,0 +1,39 @@
+---
+name: Remove 24-entry validCertificateUsages map (unreachable from UI)
+status: complete
+priority: p2
+issue_id: 326
+tags: [code-review, backend, yagni, pr-180]
+dependencies: []
+---
+
+## Problem Statement
+
+`backend/internal/wizard/certificate.go:31-55, 182-189` maintains a 24-entry `validCertificateUsages` map and loops through `Usages` rejecting unknown values. The frontend does not expose a way to set `Usages`. Even when set via API, cert-manager's own admission webhook validates these values.
+
+## Findings
+
+- `certificate.go:31-55` — 24-entry map
+- `certificate.go:182-189` — validator loop
+- `certificate_test.go:181-189` — test for unknown usage error
+- Reviewer: code-simplicity-reviewer (P2)
+
+## Proposed Solutions
+
+### Option A — delete the map and the validator
+Keep the `Usages` field in the struct (API callers may populate it), let cert-manager reject bad values. Saves ~30 LOC + 1 test.
+
+### Option B — expose usages in UI
+Add a multi-select to `CertificateForm.tsx`. Makes the validator earn its keep.
+**Pros:** power-user capability. **Cons:** clutter for a field most users never touch.
+
+## Recommended Action
+<!-- Option A unless follow-up plans UI exposure. -->
+
+## Acceptance Criteria
+- [ ] Map + validator removed.
+- [ ] `TestCertificateValidate_UnknownUsage` removed.
+- [ ] `go test ./internal/wizard/...` still green.
+
+## Work Log
+- 2026-04-14: Filed from PR #180 review.

--- a/todos/327-complete-p2-commonname-control-chars.md
+++ b/todos/327-complete-p2-commonname-control-chars.md
@@ -1,0 +1,45 @@
+---
+name: Reject control characters in Certificate commonName
+status: complete
+priority: p2
+issue_id: 327
+tags: [code-review, security, backend, pr-180]
+dependencies: []
+---
+
+## Problem Statement
+
+`backend/internal/wizard/certificate.go:143-145` validates only that `commonName` ≤64 chars. Values like `"CN with\nnewline"` or embedded null bytes pass and end up in the generated x509 certificate. Downstream: log aggregators, monitoring dashboards, and naive TLS clients can mis-parse. Enables log-injection into cert-manager logs and the k8sCenter audit log at Apply time.
+
+## Findings
+
+- `certificate.go:143-145` — only length check, no charset restriction
+- Security review F7 (security-sentinel, P2)
+- YAML output itself is safe (sigs.k8s.io/yaml quotes control chars), so this is not YAML injection — it's log/downstream integrity.
+
+## Proposed Solutions
+
+### Option A — reject bytes < 0x20 and 0x7f
+Simple loop, ~5 LOC:
+```go
+for _, r := range c.CommonName {
+    if r < 0x20 || r == 0x7f {
+        errs = append(errs, FieldError{Field: "commonName", Message: "must not contain control characters"})
+        break
+    }
+}
+```
+
+### Option B — conservative regex
+`^[\x20-\x7e\p{L}\p{N}\p{P}\p{Zs}]+$` — allows printable ASCII + Unicode letters/numbers/punctuation/spaces.
+**Pros:** tighter. **Cons:** may reject legitimate multi-byte patterns.
+
+## Recommended Action
+<!-- Option A is enough; Option B if we want belt-and-suspenders. -->
+
+## Acceptance Criteria
+- [ ] Control chars in `commonName` rejected at preview time.
+- [ ] Test coverage for `\n`, `\0`, `\x7f`.
+
+## Work Log
+- 2026-04-14: Filed from PR #180 review.

--- a/todos/328-complete-p2-ssrf-defense-in-depth.md
+++ b/todos/328-complete-p2-ssrf-defense-in-depth.md
@@ -1,0 +1,83 @@
+---
+name: Harden ACME/Vault URL validation (CGNAT, multicast, hostname resolution)
+status: complete
+priority: p2
+issue_id: 328
+tags: [code-review, security, backend, ssrf, pr-180]
+dependencies: []
+---
+
+## Problem Statement
+
+`backend/internal/wizard/issuer.go:202-217` (`validateHTTPSPublicURL`) only parses the URL and checks the IP literal. Gaps:
+
+1. **Hostnames not resolved.** `internal.attacker.tld` → A 10.0.0.1 passes the check.
+2. **CGNAT range 100.64.0.0/10** not covered by Go's `net.IP.IsPrivate()` (EKS secondary ranges, etc.).
+3. **Multicast (224.0.0.0/4)** not checked.
+
+This is defense-in-depth: k8sCenter does not fetch the URL — cert-manager does. So direct SSRF against our backend is not the threat. The threat is an attacker-configured Issuer pointing at an internal service, exfiltrating ACME account key material.
+
+## Findings
+
+- `backend/internal/wizard/issuer.go:202-217`
+- Security review F1 (security-sentinel, P2)
+- Verified: IPv4-mapped (`::ffff:10.0.0.1`), IPv6 ULA (`fc00::/7`), link-local (`fe80::/10`) ARE correctly rejected by existing code. IPv6 coverage is fine.
+
+## Proposed Solutions
+
+### Option A — layered hardening (recommended)
+```go
+func validateHTTPSPublicURL(raw string) error {
+    u, err := url.Parse(raw)
+    if err != nil || u.Host == "" { return fmt.Errorf("must be a valid URL") }
+    if u.Scheme != "https" { return fmt.Errorf("must use https scheme") }
+
+    host := u.Hostname()
+    var ips []net.IP
+    if ip := net.ParseIP(host); ip != nil {
+        ips = []net.IP{ip}
+    } else {
+        // short-timeout resolution; fall back to allowing the hostname if DNS fails
+        // (we want this to be advisory, not hard-dependent on the resolver)
+        ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+        defer cancel()
+        ips, _ = net.DefaultResolver.LookupIP(ctx, "ip", host)
+    }
+    for _, ip := range ips {
+        if !isPublicIP(ip) {
+            return fmt.Errorf("must not target a private or loopback address")
+        }
+    }
+    return nil
+}
+
+func isPublicIP(ip net.IP) bool {
+    if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() ||
+        ip.IsUnspecified() || ip.IsMulticast() { return false }
+    // CGNAT 100.64.0.0/10
+    if ip4 := ip.To4(); ip4 != nil && ip4[0] == 100 && ip4[1]&0xC0 == 64 { return false }
+    return true
+}
+```
+
+Add a code comment explaining this is advisory (cert-manager, not k8sCenter, fetches the URL).
+
+### Option B — accept the gap
+Document the limitation in release notes and move on. cert-manager is the actual SSRF vector; k8sCenter can't be the last line of defense.
+
+## Recommended Action
+<!-- Option A, with the comment. DNS resolution should be non-failing advisory. -->
+
+## Acceptance Criteria
+- [ ] CGNAT `100.64.0.0/10` rejected.
+- [ ] Multicast `224.0.0.0/4` rejected.
+- [ ] Hostname that resolves only to private IPs rejected.
+- [ ] DNS timeout does not cause validation to fail open aggressively (advisory behavior documented).
+- [ ] Unit tests for each class.
+
+## Work Log
+- 2026-04-14: Filed from PR #180 review.
+
+## Resources
+- PR #180
+- security-sentinel review F1

--- a/todos/329-complete-p2-ed25519-size-validation.md
+++ b/todos/329-complete-p2-ed25519-size-validation.md
@@ -1,0 +1,36 @@
+---
+name: Reject nonzero Size with Ed25519 algorithm
+status: complete
+priority: p2
+issue_id: 329
+tags: [code-review, backend, correctness, cert-manager, pr-180]
+dependencies: []
+---
+
+## Problem Statement
+
+`backend/internal/wizard/certificate.go:194-216` validates `Size` only for RSA and ECDSA. If a UI bug sends `Algorithm=Ed25519, Size=2048`, validation passes and YAML emits `size: 2048` under Ed25519. cert-manager will reject at apply time, but the wizard preview misleadingly shows a "valid" manifest.
+
+Note: `ToCertificate()` at line 259-261 correctly omits size when it's zero. Default flow is fine. This catches a specific UI-bug scenario.
+
+## Findings
+
+- `certificate.go:194-216` (validator)
+- Security review F6 (security-sentinel, P2 — correctness, not security)
+
+## Proposed Solutions
+
+### Option A — explicit Ed25519 branch (~3 LOC)
+```go
+case "Ed25519":
+    if pk.Size != 0 {
+        errs = append(errs, FieldError{Field: "privateKey.size", Message: "Ed25519 does not accept a size"})
+    }
+```
+
+## Acceptance Criteria
+- [ ] `Ed25519 + Size=2048` rejected with clear message.
+- [ ] Unit test covering the case.
+
+## Work Log
+- 2026-04-14: Filed from PR #180 review.

--- a/todos/330-complete-p2-trailing-newline-consistency.md
+++ b/todos/330-complete-p2-trailing-newline-consistency.md
@@ -1,0 +1,31 @@
+---
+name: Align ToYAML trailing-newline behavior across wizards
+status: complete
+priority: p2
+issue_id: 330
+tags: [code-review, backend, consistency, pr-180]
+dependencies: []
+---
+
+## Problem Statement
+
+`backend/internal/wizard/issuer.go:343` strips trailing newlines with `strings.TrimRight(y, "\n") + "\n"`. `certificate.go:296` and every other wizard (`hpa.go:117`, `rolebinding.go:161`, `ingress.go:225`) return `sigs.k8s.io/yaml`'s raw output untouched.
+
+## Findings
+
+- `issuer.go:343` — trims
+- `certificate.go:296` — does not
+- All other wizards — do not
+- Reviewer: pattern-recognition-specialist (P2)
+
+## Proposed Solutions
+
+### Option A — drop the trim in issuer.go (recommended)
+Match the 18-wizard convention. If preview-rendering looks odd, fix the preview component instead.
+
+## Acceptance Criteria
+- [ ] `issuer.go` ToYAML matches the sibling wizards' shape exactly.
+- [ ] Preview still renders without a visible trailing blank line.
+
+## Work Log
+- 2026-04-14: Filed from PR #180 review.

--- a/todos/331-complete-p2-issuerwizard-stale-form-on-type-change.md
+++ b/todos/331-complete-p2-issuerwizard-stale-form-on-type-change.md
@@ -1,0 +1,31 @@
+---
+name: Clear issuer-type subform values when switching type
+status: complete
+priority: p2
+issue_id: 331
+tags: [code-review, frontend, ux, pr-180]
+dependencies: []
+---
+
+## Problem Statement
+
+`frontend/islands/IssuerWizard.tsx:129-132` (`selectType`) sets `form.type = t` but does not null out the sibling subform fields. Switching type from `acme` → `ca` → `acme` re-shows the old ACME field values (stale after intermediate changes). `fetchPreview` correctly ignores the inactive branches, so the wire is fine — this is a UX-only issue.
+
+## Findings
+
+- `IssuerWizard.tsx:129-132`
+- Reviewer: kieran-typescript-reviewer (P1 UX, borderline)
+
+## Proposed Solutions
+
+### Option A — reset sibling subforms on type change (recommended)
+Preserve the selected type's values; clear the others. Matches user expectation when toggling.
+
+### Option B — accept stale state
+Leave as-is. Users rarely switch types mid-form, and the wire is already clean.
+
+## Acceptance Criteria
+- [ ] Changing `type` does not leak field values from the previous branch into the rendered form.
+
+## Work Log
+- 2026-04-14: Filed from PR #180 review.

--- a/todos/332-pending-p2-simplify-signal-ceremony.md
+++ b/todos/332-pending-p2-simplify-signal-ceremony.md
@@ -1,0 +1,39 @@
+---
+name: Collapse signals/useCallback ceremony in wizard islands
+status: pending
+priority: p2
+issue_id: 332
+tags: [code-review, frontend, simplicity, pr-180]
+dependencies: []
+---
+
+## Problem Statement
+
+`CertificateWizard.tsx` has 9 `useSignal` calls + 2 `useCallback` wrappers. `IssuerWizard.tsx` has 7 signals + 6 callbacks. None of the callbacks are passed to memoized children; the signals-per-field split buys nothing for a wizard that renders on every keystroke anyway. DHH review flagged as "cargo cult."
+
+## Findings
+
+- `CertificateWizard.tsx:58-68, 91-114`
+- `IssuerWizard.tsx:66-73, 77-132`
+- Reviewer: dhh-rails-reviewer (P2 — ceremony without payoff)
+
+## Proposed Solutions
+
+### Option A — single combined signal
+```ts
+const state = useSignal({ step: 0, form: initialForm(), errors: {}, preview: {yaml: "", loading: false, error: null} });
+// plain function updates: updateField, updatePrivateKey, etc. no useCallback.
+```
+
+### Option B — leave as-is
+Matches `PolicyWizard.tsx` pattern. Consistency > micro-simplification.
+
+## Recommended Action
+<!-- Option B if pattern consistency wins; Option A if we want to lead. Likely B, followup refactor across all wizards. -->
+
+## Acceptance Criteria
+- [ ] Refactor applied consistently if chosen.
+- [ ] Wizards still pass their tests and visual QA.
+
+## Work Log
+- 2026-04-14: Filed from PR #180 review.

--- a/todos/333-pending-p2-ca-vault-issuer-scope.md
+++ b/todos/333-pending-p2-ca-vault-issuer-scope.md
@@ -1,0 +1,45 @@
+---
+name: Consider removing CA and Vault issuer types from the wizard
+status: pending
+priority: p2
+issue_id: 333
+tags: [code-review, yagni, cert-manager, design-decision, pr-180]
+dependencies: []
+---
+
+## Problem Statement
+
+The Issuer wizard ships four backend types: SelfSigned, ACME, CA, Vault. Reviewer (code-simplicity-reviewer) argues CA and Vault should be cut:
+
+- **CA** is literally "enter a Secret name." YAML is 5 lines. Wizard adds no value over the YAML Editor.
+- **Vault** has 3 auth modes with a custom radio state machine (`VaultAuthMethod`). Vault operators typically author YAML directly or use their org's tooling.
+
+Together ~180 LOC of Go + TSX + tests.
+
+## Findings
+
+- `issuer.go:55-73, 143-154, 219-253, 283-287, 316-334` (CA + Vault Go)
+- `IssuerFormStep.tsx:196-324` (CA + Vault UI)
+- `IssuerTypePickerStep.tsx` (4 cards would drop to 2)
+- Reviewer: code-simplicity-reviewer (P1)
+
+## Proposed Solutions
+
+### Option A — cut both
+SelfSigned + ACME only. Users who need CA/Vault author YAML directly. ~180 LOC deletion.
+
+### Option B — keep both
+Argument: the wizard exists precisely so users *don't* write YAML. The UI is already built. Cost is just ongoing maintenance, which is low since cert-manager's CA/Vault specs are stable.
+
+### Option C — keep CA (it's trivial), drop Vault (complex for niche)
+Middle ground. CA's UI is 20 LOC; Vault's is 100+.
+
+## Recommended Action
+<!-- Needs product/maintainer judgment. This is a design call, not a bug. -->
+
+## Acceptance Criteria
+- [ ] Decision made and documented.
+- [ ] If cutting, `issuer.go`, `IssuerFormStep.tsx`, `IssuerTypePickerStep.tsx`, and tests updated.
+
+## Work Log
+- 2026-04-14: Filed from PR #180 review.

--- a/todos/334-pending-p3-cert-manager-wizard-followups.md
+++ b/todos/334-pending-p3-cert-manager-wizard-followups.md
@@ -1,0 +1,57 @@
+---
+name: Cert-manager wizard P3 cleanups (bundled)
+status: pending
+priority: p3
+issue_id: 334
+tags: [code-review, cleanup, pr-180]
+dependencies: []
+---
+
+## Problem Statement
+
+Bundle of low-priority cleanups surfaced during PR #180 review. Each is small enough that a dedicated todo is overkill; together they form a single cleanup pass.
+
+## Findings
+
+### 1. Shared helper location
+`validateEmailAddress` lives in `certificate.go:300` but is only used by `issuer.go:169`. `validateHTTPSPublicURL` lives in `issuer.go:202` and is reusable. Move both to `backend/internal/wizard/container.go` alongside `dnsLabelRegex`, or into a new `helpers.go`. (pattern-recognition-specialist P3, dhh-rails-reviewer)
+
+### 2. Test shape drift
+New tests use multiple `TestCertificateValidate_*` functions with `wantField string` (singular). Existing convention (`rolebinding_test.go`, `hpa_test.go`) uses a single top-level `TestXInputValidate` with `wantFields []string`. Consolidate. Also: `TestACMEValidate_Email` (`issuer_test.go:148`) loops without `t.Run` wrapping — minor inconsistency. (pattern-recognition-specialist P2/P3)
+
+### 3. gofmt alignment in issuer.go
+`issuer.go:51,63-66` field tag alignment is off. Run `gofmt -w internal/wizard/issuer.go`. (pattern-recognition-specialist, security-sentinel F9)
+
+### 4. ARIA / accessibility gaps
+`<label>` elements in `CertificateForm.tsx` and `IssuerFormStep.tsx` don't use `htmlFor`/`id` pairing. Vault auth radio group lacks `<fieldset>/<legend>`. Codebase-wide gap — this PR doesn't regress it, but worth tackling. (kieran-typescript-reviewer P3)
+
+### 5. Hoist LE_PROD / LE_STAGING constants
+Duplicated in `IssuerWizard.tsx:47` and `IssuerFormStep.tsx:19`. Hoist to `frontend/lib/wizard-constants.ts`. (pattern-recognition-specialist P3)
+
+### 6. Tests of framework behavior
+`TestCertificateToYAML_OmitsEmptyOptionals` (certificate_test.go:216-227) tests `sigs.k8s.io/yaml` omitempty behavior, not our logic. Drop. `TestCertificateToYAML` hardcodes 11 substrings; trim to 3-4 key ones. (code-simplicity-reviewer P3)
+
+### 7. Email `net/mail.ParseAddress` is permissive
+Accepts display-name forms like `"Foo" <a@b>`. Optional tightening: require `addr.Address == strings.TrimSpace(input)`. (security-sentinel F8)
+
+### 8. `IssuerInput.ACME.PrivateKeySecretRefName` struct-tag alignment
+Minor gofmt churn. Included in #3. (security-sentinel F9)
+
+### 9. Confirm `dnsLabelRegex` (Go) matches `DNS_LABEL_REGEX` (TS)
+`container.go:13` has `^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`. `wizard-constants.ts:80` should match byte-for-byte. Add a test-level assertion or a regenerated-constant pipeline. (dhh-rails-reviewer)
+
+### 10. ACME privateKeySecretRefName auto-default stale-baseline bug
+`IssuerWizard.tsx:81-90` checks "untouched" against `form.value.name + "-account"` but only inside the `type === "acme"` branch. Toggling type away and back breaks the heuristic. Low-severity. (dhh-rails-reviewer)
+
+## Proposed Solutions
+
+Single cleanup PR touching the above files. Items can be dropped individually if cost/value ratio shifts.
+
+## Acceptance Criteria
+
+- [ ] Items 1–10 each have a resolution (done, deferred, or explicitly rejected).
+- [ ] `go vet`, `go test`, `deno fmt --check`, `deno lint` all pass.
+
+## Work Log
+
+- 2026-04-14: Filed from PR #180 review.


### PR DESCRIPTION
## Summary

Phase 11B adds creation wizards for cert-manager resources, completing the
cert-manager story started in Phase 11A (inventory + expiry poller).

- **Certificate wizard** — single form + `<details>` for advanced fields
- **Issuer / ClusterIssuer wizards** — type picker (SelfSigned / ACME / CA / Vault) then type-specific form; one island served at two routes via `scope` prop
- **Configurable expiry thresholds** split into sibling plan `plans/cert-manager-configurable-thresholds.md` (not in this PR)

Closes roadmap item **#7b** (wizard half).

## Key design decisions

- **YAML via `map[string]any`**, not typed cert-manager Go structs — avoids pulling the full `github.com/cert-manager/cert-manager` module into go.mod.
- **Issuer/ClusterIssuer unification** via typed `IssuerScope` (namespaced/cluster) discriminator. Single backend type, single frontend island, two routes. Endorsed by DHH reviewer pass on the plan.
- **ACME scope restricted to HTTP01 ingress** in v1. DNS01 providers deferred to Phase 11C.
- **Security:** ACME server URL validation rejects `http://`, loopback, private, link-local, and unspecified IPs at preview time.
- **Kebab-case routes** per project convention: `/wizards/cluster-issuer/preview`.

## Validation matrix (Certificate)

| Field | Rule |
|---|---|
| DNS names | RFC 1123, wildcards only in leftmost label, ≤253 chars, ≤100 entries |
| commonName | ≤64 chars (CA/Browser Forum) |
| duration | Go duration, ≥1h |
| renewBefore | ≥5m, strictly less than duration |
| privateKey.algorithm × size | RSA {2048,3072,4096} · ECDSA {256,384,521} · Ed25519 (no size) |
| encoding | PKCS1 or PKCS8 |
| rotationPolicy | Always or Never |

## Test plan

- [x] `go vet ./...` — clean
- [x] `go test ./internal/wizard/... ./internal/server/...` — 38 new unit tests + existing suite green
- [x] `deno fmt --check` — 433 files clean
- [x] `deno lint` on all new files — clean
- [x] `deno task check` — new files type-clean (114 pre-existing errors on `main` unchanged)
- [x] `deno task build` — succeeds
- [ ] Smoke test against homelab (per CLAUDE.md rule when backend+frontend changes)
- [ ] `/compounding-engineering:workflows:review` before merge

## Files

Backend (5):
- `backend/internal/wizard/certificate.go` (+certificate_test.go)
- `backend/internal/wizard/issuer.go` (+issuer_test.go)
- `backend/internal/server/routes.go` (3 new route registrations)

Frontend (9):
- `frontend/islands/CertificateWizard.tsx`, `frontend/components/wizard/CertificateForm.tsx`
- `frontend/islands/IssuerWizard.tsx`, `frontend/components/wizard/{IssuerTypePickerStep,IssuerFormStep}.tsx`
- `frontend/routes/security/certificates/{new.tsx, issuers/new.tsx, cluster-issuers/new.tsx}`
- `frontend/islands/{CertificatesList,IssuersList,CommandPalette}.tsx` (entry points)

Plans (2):
- `plans/cert-manager-wizards-phase-11b.md` (this feature)
- `plans/cert-manager-configurable-thresholds.md` (sibling, future PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)