### PR TITLE
fix(cert-manager): address remaining review followups (332-334)

### DIFF
--- a/backend/internal/wizard/issuer.go
+++ b/backend/internal/wizard/issuer.go
@@ -17,20 +17,18 @@ const (
 )
 
 // IssuerType enumerates the supported cert-manager issuer backends for v1.
+// CA and Vault are deliberately excluded: they have trivial enough specs that
+// operators are better served by the YAML editor than a bespoke wizard.
 type IssuerType string
 
 const (
 	IssuerTypeSelfSigned IssuerType = "selfSigned"
 	IssuerTypeACME       IssuerType = "acme"
-	IssuerTypeCA         IssuerType = "ca"
-	IssuerTypeVault      IssuerType = "vault"
 )
 
 var validIssuerTypes = map[IssuerType]bool{
 	IssuerTypeSelfSigned: true,
 	IssuerTypeACME:       true,
-	IssuerTypeCA:         true,
-	IssuerTypeVault:      true,
 }
 
 // ACMEHTTP01IngressInput configures the HTTP01 ingress solver.
@@ -51,26 +49,6 @@ type ACMEInput struct {
 	Solvers                 []ACMESolverInput `json:"solvers"`
 }
 
-// CAInput configures a CA issuer.
-type CAInput struct {
-	SecretName string `json:"secretName"`
-}
-
-// VaultAuthInput configures one of Vault's authentication methods.
-// Exactly one of the nested fields must be set.
-type VaultAuthInput struct {
-	TokenSecretRefName   string `json:"tokenSecretRefName,omitempty"`
-	AppRoleSecretRefName string `json:"appRoleSecretRefName,omitempty"`
-	KubernetesRole       string `json:"kubernetesRole,omitempty"`
-}
-
-// VaultInput configures a Vault issuer.
-type VaultInput struct {
-	Server string         `json:"server"`
-	Path   string         `json:"path"`
-	Auth   VaultAuthInput `json:"auth"`
-}
-
 // IssuerInput represents the wizard form data for creating a cert-manager
 // Issuer or ClusterIssuer. Scope is intentionally not JSON-tagged so the route
 // remains authoritative — see the HandlePreview factories in routes.go.
@@ -80,10 +58,8 @@ type IssuerInput struct {
 	Namespace string      `json:"namespace,omitempty"` // ignored for cluster scope
 	Type      IssuerType  `json:"type"`
 
-	SelfSigned *struct{}   `json:"selfSigned,omitempty"`
-	ACME       *ACMEInput  `json:"acme,omitempty"`
-	CA         *CAInput    `json:"ca,omitempty"`
-	Vault      *VaultInput `json:"vault,omitempty"`
+	SelfSigned *struct{}  `json:"selfSigned,omitempty"`
+	ACME       *ACMEInput `json:"acme,omitempty"`
 }
 
 // Validate checks the IssuerInput and returns field-level errors.
@@ -107,7 +83,7 @@ func (i *IssuerInput) Validate() []FieldError {
 	}
 
 	if !validIssuerTypes[i.Type] {
-		errs = append(errs, FieldError{Field: "type", Message: "must be selfSigned, acme, ca, or vault"})
+		errs = append(errs, FieldError{Field: "type", Message: "must be selfSigned or acme"})
 		return errs
 	}
 
@@ -117,12 +93,6 @@ func (i *IssuerInput) Validate() []FieldError {
 		populated++
 	}
 	if i.ACME != nil {
-		populated++
-	}
-	if i.CA != nil {
-		populated++
-	}
-	if i.Vault != nil {
 		populated++
 	}
 	if populated != 1 {
@@ -141,18 +111,6 @@ func (i *IssuerInput) Validate() []FieldError {
 			return errs
 		}
 		errs = append(errs, i.ACME.validate()...)
-	case IssuerTypeCA:
-		if i.CA == nil {
-			errs = append(errs, FieldError{Field: "ca", Message: "ca body is required when type=ca"})
-			return errs
-		}
-		errs = append(errs, i.CA.validate()...)
-	case IssuerTypeVault:
-		if i.Vault == nil {
-			errs = append(errs, FieldError{Field: "vault", Message: "vault body is required when type=vault"})
-			return errs
-		}
-		errs = append(errs, i.Vault.validate()...)
 	}
 
 	return errs
@@ -199,42 +157,6 @@ func (a *ACMEInput) validate() []FieldError {
 	return errs
 }
 
-func (c *CAInput) validate() []FieldError {
-	var errs []FieldError
-	if c.SecretName == "" {
-		errs = append(errs, FieldError{Field: "ca.secretName", Message: "is required"})
-	} else if !dnsLabelRegex.MatchString(c.SecretName) {
-		errs = append(errs, FieldError{Field: "ca.secretName", Message: "must be a valid DNS label"})
-	}
-	return errs
-}
-
-func (v *VaultInput) validate() []FieldError {
-	var errs []FieldError
-	if v.Server == "" {
-		errs = append(errs, FieldError{Field: "vault.server", Message: "is required"})
-	} else if err := validateHTTPSPublicURL(v.Server); err != nil {
-		errs = append(errs, FieldError{Field: "vault.server", Message: err.Error()})
-	}
-	if v.Path == "" {
-		errs = append(errs, FieldError{Field: "vault.path", Message: "is required"})
-	}
-	populated := 0
-	if v.Auth.TokenSecretRefName != "" {
-		populated++
-	}
-	if v.Auth.AppRoleSecretRefName != "" {
-		populated++
-	}
-	if v.Auth.KubernetesRole != "" {
-		populated++
-	}
-	if populated != 1 {
-		errs = append(errs, FieldError{Field: "vault.auth", Message: "exactly one of tokenSecretRefName, appRoleSecretRefName, or kubernetesRole must be set"})
-	}
-	return errs
-}
-
 // ToIssuer returns a map representation suitable for YAML marshaling.
 // cert-manager is not in go.mod; map-based construction avoids the dep tree.
 func (i *IssuerInput) ToIssuer() map[string]any {
@@ -264,10 +186,6 @@ func (i *IssuerInput) buildSpec() map[string]any {
 		return map[string]any{"selfSigned": map[string]any{}}
 	case IssuerTypeACME:
 		return map[string]any{"acme": i.ACME.toMap()}
-	case IssuerTypeCA:
-		return map[string]any{"ca": map[string]any{"secretName": i.CA.SecretName}}
-	case IssuerTypeVault:
-		return map[string]any{"vault": i.Vault.toMap()}
 	}
 	return map[string]any{}
 }
@@ -294,26 +212,6 @@ func (a *ACMEInput) toMap() map[string]any {
 	if len(solvers) > 0 {
 		out["solvers"] = solvers
 	}
-	return out
-}
-
-func (v *VaultInput) toMap() map[string]any {
-	out := map[string]any{
-		"server": v.Server,
-		"path":   v.Path,
-	}
-	auth := map[string]any{}
-	switch {
-	case v.Auth.TokenSecretRefName != "":
-		auth["tokenSecretRef"] = map[string]any{"name": v.Auth.TokenSecretRefName}
-	case v.Auth.AppRoleSecretRefName != "":
-		auth["appRole"] = map[string]any{
-			"secretRef": map[string]any{"name": v.Auth.AppRoleSecretRefName},
-		}
-	case v.Auth.KubernetesRole != "":
-		auth["kubernetes"] = map[string]any{"role": v.Auth.KubernetesRole}
-	}
-	out["auth"] = auth
 	return out
 }
 

--- a/backend/internal/wizard/issuer_test.go
+++ b/backend/internal/wizard/issuer_test.go
@@ -202,48 +202,6 @@ func TestACMEValidate_DNS01Rejected(t *testing.T) {
 	}
 }
 
-func TestCAValidate(t *testing.T) {
-	i := IssuerInput{
-		Scope: IssuerScopeNamespaced, Name: "ca", Namespace: "cert-manager",
-		Type: IssuerTypeCA, CA: &CAInput{SecretName: ""},
-	}
-	errs := i.Validate()
-	if !hasFieldError(errs, "ca.secretName") {
-		t.Errorf("expected ca.secretName error, got %v", errs)
-	}
-}
-
-func TestVaultValidate(t *testing.T) {
-	base := IssuerInput{
-		Scope: IssuerScopeCluster, Name: "vault", Type: IssuerTypeVault,
-		Vault: &VaultInput{
-			Server: "https://vault.example.com",
-			Path:   "pki/sign/example",
-			Auth:   VaultAuthInput{TokenSecretRefName: "vault-token"},
-		},
-	}
-	if errs := base.Validate(); len(errs) != 0 {
-		t.Errorf("valid vault issuer: %v", errs)
-	}
-
-	none := base
-	none.Vault = &VaultInput{Server: base.Vault.Server, Path: base.Vault.Path}
-	errs := none.Validate()
-	if !hasFieldError(errs, "vault.auth") {
-		t.Errorf("expected vault.auth error for no auth method, got %v", errs)
-	}
-
-	multi := base
-	multi.Vault = &VaultInput{
-		Server: base.Vault.Server, Path: base.Vault.Path,
-		Auth: VaultAuthInput{TokenSecretRefName: "t", KubernetesRole: "r"},
-	}
-	errs = multi.Validate()
-	if !hasFieldError(errs, "vault.auth") {
-		t.Errorf("expected vault.auth error for multiple methods, got %v", errs)
-	}
-}
-
 func TestIssuerToYAML_SelfSignedCluster(t *testing.T) {
 	i := validSelfSignedCluster()
 	y, err := i.ToYAML()

--- a/backend/internal/wizard/regex_parity_test.go
+++ b/backend/internal/wizard/regex_parity_test.go
@@ -1,0 +1,14 @@
+package wizard
+
+import "testing"
+
+// TestDnsLabelRegexParity pins the dnsLabelRegex pattern string so any change
+// to the Go side is an explicit signal to update the matching TS regex at
+// frontend/lib/wizard-constants.ts (DNS_LABEL_REGEX). Keeping these in lockstep
+// prevents client-side validation from green-lighting names the server rejects.
+func TestDnsLabelRegexParity(t *testing.T) {
+	const expected = `^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`
+	if got := dnsLabelRegex.String(); got != expected {
+		t.Fatalf("dnsLabelRegex drift: got %q, want %q (update frontend/lib/wizard-constants.ts DNS_LABEL_REGEX to match)", got, expected)
+	}
+}

--- a/frontend/components/wizard/CertificateForm.tsx
+++ b/frontend/components/wizard/CertificateForm.tsx
@@ -38,18 +38,28 @@ export function CertificateForm({
     <div class="space-y-5">
       <div class="grid grid-cols-2 gap-4">
         <div>
-          <label class="block text-sm font-medium text-text-primary">
+          <label
+            for="cert-name"
+            class="block text-sm font-medium text-text-primary"
+          >
             Name <span class="text-danger">*</span>
           </label>
           <input
+            id="cert-name"
             type="text"
             value={form.name}
             onInput={(e) =>
               onUpdate("name", (e.target as HTMLInputElement).value)}
             placeholder="example-com-tls"
             class={WIZARD_INPUT_CLASS}
+            aria-invalid={errors.name ? "true" : undefined}
+            aria-describedby={errors.name ? "cert-name-error" : undefined}
           />
-          {errors.name && <p class="mt-1 text-xs text-danger">{errors.name}</p>}
+          {errors.name && (
+            <p id="cert-name-error" class="mt-1 text-xs text-danger">
+              {errors.name}
+            </p>
+          )}
         </div>
 
         <NamespaceSelect
@@ -61,31 +71,45 @@ export function CertificateForm({
       </div>
 
       <div>
-        <label class="block text-sm font-medium text-text-primary">
+        <label
+          for="cert-secret-name"
+          class="block text-sm font-medium text-text-primary"
+        >
           Secret Name <span class="text-danger">*</span>
         </label>
         <input
+          id="cert-secret-name"
           type="text"
           value={form.secretName}
           onInput={(e) =>
             onUpdate("secretName", (e.target as HTMLInputElement).value)}
           placeholder="example-com-tls"
           class={WIZARD_INPUT_CLASS}
+          aria-invalid={errors.secretName ? "true" : undefined}
+          aria-describedby={errors.secretName
+            ? "cert-secret-name-error"
+            : undefined}
         />
         <p class="mt-1 text-xs text-text-muted">
           Secret where cert-manager will write the issued TLS certificate and
           private key.
         </p>
         {errors.secretName && (
-          <p class="mt-1 text-xs text-danger">{errors.secretName}</p>
+          <p id="cert-secret-name-error" class="mt-1 text-xs text-danger">
+            {errors.secretName}
+          </p>
         )}
       </div>
 
       <div>
-        <label class="block text-sm font-medium text-text-primary">
+        <label
+          for="cert-issuer"
+          class="block text-sm font-medium text-text-primary"
+        >
           Issuer <span class="text-danger">*</span>
         </label>
         <select
+          id="cert-issuer"
           value={form.issuerRefValue}
           onChange={(e) =>
             onUpdate(

--- a/frontend/components/wizard/IssuerFormStep.tsx
+++ b/frontend/components/wizard/IssuerFormStep.tsx
@@ -4,10 +4,7 @@ import {
   WIZARD_INPUT_CLASS,
 } from "@/lib/wizard-constants.ts";
 import { NamespaceSelect } from "@/components/ui/NamespaceSelect.tsx";
-import type {
-  IssuerWizardForm,
-  VaultAuthMethod,
-} from "@/islands/IssuerWizard.tsx";
+import type { IssuerWizardForm } from "@/islands/IssuerWizard.tsx";
 
 interface IssuerFormStepProps {
   scope: "namespaced" | "cluster";
@@ -16,9 +13,6 @@ interface IssuerFormStepProps {
   namespaces: string[];
   onUpdate: (field: string, value: unknown) => void;
   onUpdateAcme: (field: string, value: unknown) => void;
-  onUpdateCa: (field: string, value: unknown) => void;
-  onUpdateVault: (field: string, value: unknown) => void;
-  onUpdateVaultAuth: (method: VaultAuthMethod, value: string) => void;
 }
 
 export function IssuerFormStep({
@@ -28,26 +22,33 @@ export function IssuerFormStep({
   namespaces,
   onUpdate,
   onUpdateAcme,
-  onUpdateCa,
-  onUpdateVault,
-  onUpdateVaultAuth,
 }: IssuerFormStepProps) {
   return (
     <div class="space-y-5">
       <div class="grid grid-cols-2 gap-4">
         <div>
-          <label class="block text-sm font-medium text-text-primary">
+          <label
+            for="issuer-name"
+            class="block text-sm font-medium text-text-primary"
+          >
             Name <span class="text-danger">*</span>
           </label>
           <input
+            id="issuer-name"
             type="text"
             value={form.name}
             onInput={(e) =>
               onUpdate("name", (e.target as HTMLInputElement).value)}
             placeholder={scope === "cluster" ? "letsencrypt-prod" : "my-issuer"}
             class={WIZARD_INPUT_CLASS}
+            aria-invalid={errors.name ? "true" : undefined}
+            aria-describedby={errors.name ? "issuer-name-error" : undefined}
           />
-          {errors.name && <p class="mt-1 text-xs text-danger">{errors.name}</p>}
+          {errors.name && (
+            <p id="issuer-name-error" class="mt-1 text-xs text-danger">
+              {errors.name}
+            </p>
+          )}
         </div>
 
         {scope === "namespaced" && (
@@ -70,7 +71,10 @@ export function IssuerFormStep({
       {form.type === "acme" && (
         <div class="space-y-4">
           <div>
-            <label class="block text-sm font-medium text-text-primary">
+            <label
+              for="acme-server"
+              class="block text-sm font-medium text-text-primary"
+            >
               ACME Server <span class="text-danger">*</span>
             </label>
             <div class="mt-1 flex gap-2">
@@ -98,27 +102,38 @@ export function IssuerFormStep({
               </button>
             </div>
             <input
+              id="acme-server"
               type="text"
               value={form.acme.server}
               onInput={(e) =>
                 onUpdateAcme("server", (e.target as HTMLInputElement).value)}
               placeholder="https://acme-v02.api.letsencrypt.org/directory"
               class={`${WIZARD_INPUT_CLASS} mt-2`}
+              aria-invalid={errors["acme.server"] ? "true" : undefined}
+              aria-describedby={errors["acme.server"]
+                ? "acme-server-error"
+                : undefined}
             />
             <p class="mt-1 text-xs text-text-muted">
-              Must be an HTTPS URL. Private IPs are rejected.
+              Must be an HTTPS URL. Private and loopback addresses are rejected.
             </p>
             {errors["acme.server"] && (
-              <p class="mt-1 text-xs text-danger">{errors["acme.server"]}</p>
+              <p id="acme-server-error" class="mt-1 text-xs text-danger">
+                {errors["acme.server"]}
+              </p>
             )}
           </div>
 
           <div class="grid grid-cols-2 gap-4">
             <div>
-              <label class="block text-sm font-medium text-text-primary">
+              <label
+                for="acme-email"
+                class="block text-sm font-medium text-text-primary"
+              >
                 Contact Email <span class="text-danger">*</span>
               </label>
               <input
+                id="acme-email"
                 type="email"
                 value={form.acme.email}
                 onInput={(e) =>
@@ -128,17 +143,27 @@ export function IssuerFormStep({
                   )}
                 placeholder="admin@example.com"
                 class={WIZARD_INPUT_CLASS}
+                aria-invalid={errors["acme.email"] ? "true" : undefined}
+                aria-describedby={errors["acme.email"]
+                  ? "acme-email-error"
+                  : undefined}
               />
               {errors["acme.email"] && (
-                <p class="mt-1 text-xs text-danger">{errors["acme.email"]}</p>
+                <p id="acme-email-error" class="mt-1 text-xs text-danger">
+                  {errors["acme.email"]}
+                </p>
               )}
             </div>
 
             <div>
-              <label class="block text-sm font-medium text-text-primary">
+              <label
+                for="acme-key-secret"
+                class="block text-sm font-medium text-text-primary"
+              >
                 Account Private Key Secret <span class="text-danger">*</span>
               </label>
               <input
+                id="acme-key-secret"
                 type="text"
                 value={form.acme.privateKeySecretRefName}
                 onInput={(e) =>
@@ -148,13 +173,22 @@ export function IssuerFormStep({
                   )}
                 placeholder="letsencrypt-account"
                 class={WIZARD_INPUT_CLASS}
+                aria-invalid={errors["acme.privateKeySecretRefName"]
+                  ? "true"
+                  : undefined}
+                aria-describedby={errors["acme.privateKeySecretRefName"]
+                  ? "acme-key-secret-error"
+                  : undefined}
               />
               <p class="mt-1 text-xs text-text-muted">
                 Name of the Secret cert-manager will create to hold the account
                 key.
               </p>
               {errors["acme.privateKeySecretRefName"] && (
-                <p class="mt-1 text-xs text-danger">
+                <p
+                  id="acme-key-secret-error"
+                  class="mt-1 text-xs text-danger"
+                >
                   {errors["acme.privateKeySecretRefName"]}
                 </p>
               )}
@@ -162,10 +196,14 @@ export function IssuerFormStep({
           </div>
 
           <div>
-            <label class="block text-sm font-medium text-text-primary">
+            <label
+              for="acme-ingress-class"
+              class="block text-sm font-medium text-text-primary"
+            >
               HTTP01 Ingress Class
             </label>
             <input
+              id="acme-ingress-class"
               type="text"
               value={form.acme.ingressClassName}
               onInput={(e) =>
@@ -180,136 +218,6 @@ export function IssuerFormStep({
               Ingress class used for HTTP01 challenges. Leave blank to use the
               default class.
             </p>
-          </div>
-        </div>
-      )}
-
-      {form.type === "ca" && (
-        <div>
-          <label class="block text-sm font-medium text-text-primary">
-            CA Secret Name <span class="text-danger">*</span>
-          </label>
-          <input
-            type="text"
-            value={form.ca.secretName}
-            onInput={(e) =>
-              onUpdateCa(
-                "secretName",
-                (e.target as HTMLInputElement).value,
-              )}
-            placeholder="my-ca-secret"
-            class={WIZARD_INPUT_CLASS}
-          />
-          <p class="mt-1 text-xs text-text-muted">
-            Secret containing tls.crt and tls.key for the signing CA.
-          </p>
-          {errors["ca.secretName"] && (
-            <p class="mt-1 text-xs text-danger">{errors["ca.secretName"]}</p>
-          )}
-        </div>
-      )}
-
-      {form.type === "vault" && (
-        <div class="space-y-4">
-          <div class="grid grid-cols-2 gap-4">
-            <div>
-              <label class="block text-sm font-medium text-text-primary">
-                Vault Server <span class="text-danger">*</span>
-              </label>
-              <input
-                type="text"
-                value={form.vault.server}
-                onInput={(e) =>
-                  onUpdateVault(
-                    "server",
-                    (e.target as HTMLInputElement).value,
-                  )}
-                placeholder="https://vault.example.com"
-                class={WIZARD_INPUT_CLASS}
-              />
-              {errors["vault.server"] && (
-                <p class="mt-1 text-xs text-danger">
-                  {errors["vault.server"]}
-                </p>
-              )}
-            </div>
-            <div>
-              <label class="block text-sm font-medium text-text-primary">
-                PKI Path <span class="text-danger">*</span>
-              </label>
-              <input
-                type="text"
-                value={form.vault.path}
-                onInput={(e) =>
-                  onUpdateVault(
-                    "path",
-                    (e.target as HTMLInputElement).value,
-                  )}
-                placeholder="pki/sign/example-dot-com"
-                class={WIZARD_INPUT_CLASS}
-              />
-              {errors["vault.path"] && (
-                <p class="mt-1 text-xs text-danger">
-                  {errors["vault.path"]}
-                </p>
-              )}
-            </div>
-          </div>
-
-          <div>
-            <label class="block text-sm font-medium text-text-primary mb-1">
-              Authentication
-            </label>
-            <div class="space-y-2">
-              {[
-                {
-                  id: "token" as VaultAuthMethod,
-                  label: "Token Secret Name",
-                  placeholder: "vault-token",
-                },
-                {
-                  id: "appRole" as VaultAuthMethod,
-                  label: "AppRole Secret Name",
-                  placeholder: "vault-approle",
-                },
-                {
-                  id: "kubernetes" as VaultAuthMethod,
-                  label: "Kubernetes Role",
-                  placeholder: "cert-manager",
-                },
-              ].map(({ id, label, placeholder }) => (
-                <div key={id} class="flex items-center gap-3">
-                  <input
-                    type="radio"
-                    name="vault-auth-method"
-                    checked={form.vault.authMethod === id}
-                    onChange={() =>
-                      onUpdateVaultAuth(id, form.vault.authValue)}
-                    class="h-4 w-4"
-                  />
-                  <label class="text-sm text-text-primary w-44">
-                    {label}
-                  </label>
-                  <input
-                    type="text"
-                    value={form.vault.authMethod === id
-                      ? form.vault.authValue
-                      : ""}
-                    onInput={(e) =>
-                      onUpdateVaultAuth(
-                        id,
-                        (e.target as HTMLInputElement).value,
-                      )}
-                    placeholder={placeholder}
-                    class={`${WIZARD_INPUT_CLASS} flex-1`}
-                    disabled={form.vault.authMethod !== id}
-                  />
-                </div>
-              ))}
-            </div>
-            {errors["vault.auth"] && (
-              <p class="mt-1 text-xs text-danger">{errors["vault.auth"]}</p>
-            )}
           </div>
         </div>
       )}

--- a/frontend/components/wizard/IssuerTypePickerStep.tsx
+++ b/frontend/components/wizard/IssuerTypePickerStep.tsx
@@ -22,18 +22,6 @@ const TYPES: Array<{
     description:
       "Automated public certificates. HTTP01 ingress solver supported in this release.",
   },
-  {
-    id: "ca",
-    title: "CA",
-    description:
-      "Sign from a private CA stored in a Kubernetes Secret (tls.crt + tls.key).",
-  },
-  {
-    id: "vault",
-    title: "Vault",
-    description:
-      "Sign from HashiCorp Vault's PKI engine using token, AppRole, or Kubernetes auth.",
-  },
 ];
 
 export function IssuerTypePickerStep({

--- a/frontend/islands/CertificateWizard.tsx
+++ b/frontend/islands/CertificateWizard.tsx
@@ -1,5 +1,5 @@
 import { useSignal } from "@preact/signals";
-import { useCallback, useEffect } from "preact/hooks";
+import { useEffect } from "preact/hooks";
 import { IS_BROWSER } from "fresh/runtime";
 import { apiGet, apiPost } from "@/lib/api.ts";
 import { useDirtyGuard } from "@/lib/hooks/use-dirty-guard.ts";
@@ -106,7 +106,7 @@ export default function CertificateWizard() {
       });
   }, []);
 
-  const updateField = useCallback((field: string, value: unknown) => {
+  const updateField = (field: string, value: unknown) => {
     dirty.value = true;
     const f = { ...form.value, [field]: value };
     // Auto-default secretName from name when user hasn't customised it.
@@ -117,9 +117,9 @@ export default function CertificateWizard() {
       f.secretName = value ? `${value}-tls` : "";
     }
     form.value = f;
-  }, []);
+  };
 
-  const updatePrivateKey = useCallback((field: string, value: unknown) => {
+  const updatePrivateKey = (field: string, value: unknown) => {
     dirty.value = true;
     const pk = { ...form.value.privateKey, [field]: value };
     // Sensible default size when algorithm changes.
@@ -129,7 +129,7 @@ export default function CertificateWizard() {
       else if (value === "Ed25519") pk.size = 0;
     }
     form.value = { ...form.value, privateKey: pk };
-  }, []);
+  };
 
   const validateStep = (step: number): boolean => {
     if (step !== 0) {

--- a/frontend/islands/IssuerWizard.tsx
+++ b/frontend/islands/IssuerWizard.tsx
@@ -1,5 +1,4 @@
 import { useSignal } from "@preact/signals";
-import { useCallback } from "preact/hooks";
 import { IS_BROWSER } from "fresh/runtime";
 import { apiPost } from "@/lib/api.ts";
 import { useDirtyGuard } from "@/lib/hooks/use-dirty-guard.ts";
@@ -12,8 +11,7 @@ import { IssuerTypePickerStep } from "@/components/wizard/IssuerTypePickerStep.t
 import { IssuerFormStep } from "@/components/wizard/IssuerFormStep.tsx";
 import { Button } from "@/components/ui/Button.tsx";
 
-export type IssuerType = "selfSigned" | "acme" | "ca" | "vault";
-export type VaultAuthMethod = "token" | "appRole" | "kubernetes";
+export type IssuerType = "selfSigned" | "acme";
 
 export interface IssuerWizardForm {
   type: IssuerType | "";
@@ -24,15 +22,9 @@ export interface IssuerWizardForm {
     email: string;
     privateKeySecretRefName: string;
     ingressClassName: string;
-  };
-  ca: {
-    secretName: string;
-  };
-  vault: {
-    server: string;
-    path: string;
-    authMethod: VaultAuthMethod;
-    authValue: string;
+    // True once the user has edited privateKeySecretRefName themselves;
+    // we stop auto-deriving it from `name` after that.
+    privateKeySecretRefNameTouched: boolean;
   };
 }
 
@@ -52,15 +44,8 @@ function initialAcme(): IssuerWizardForm["acme"] {
     email: "",
     privateKeySecretRefName: "",
     ingressClassName: "",
+    privateKeySecretRefNameTouched: false,
   };
-}
-
-function initialCa(): IssuerWizardForm["ca"] {
-  return { secretName: "" };
-}
-
-function initialVault(): IssuerWizardForm["vault"] {
-  return { server: "", path: "", authMethod: "token", authValue: "" };
 }
 
 function initialForm(): IssuerWizardForm {
@@ -69,8 +54,6 @@ function initialForm(): IssuerWizardForm {
     name: "",
     namespace: initialNamespace(),
     acme: initialAcme(),
-    ca: initialCa(),
-    vault: initialVault(),
   };
 }
 
@@ -87,14 +70,15 @@ export default function IssuerWizard({ scope }: IssuerWizardProps) {
 
   useDirtyGuard(dirty);
 
-  const updateField = useCallback((field: string, value: unknown) => {
+  const updateField = (field: string, value: unknown) => {
     dirty.value = true;
     const f = { ...form.value, [field]: value } as IssuerWizardForm;
-    // Default ACME private key secret from issuer name when untouched.
+    // Auto-derive ACME account-key Secret name from the issuer name until the
+    // user explicitly edits it. Uses a touched flag instead of comparing
+    // against `${oldName}-account`, which breaks after switching type.
     if (
       field === "name" && typeof value === "string" && f.type === "acme" &&
-      (f.acme.privateKeySecretRefName === "" ||
-        f.acme.privateKeySecretRefName === `${form.value.name}-account`)
+      !f.acme.privateKeySecretRefNameTouched
     ) {
       f.acme = {
         ...f.acme,
@@ -102,62 +86,30 @@ export default function IssuerWizard({ scope }: IssuerWizardProps) {
       };
     }
     form.value = f;
-  }, []);
+  };
 
-  const updateAcme = useCallback((field: string, value: unknown) => {
+  const updateAcme = (field: string, value: unknown) => {
     dirty.value = true;
-    form.value = {
-      ...form.value,
-      acme: { ...form.value.acme, [field]: value },
-    };
-  }, []);
+    const next = { ...form.value.acme, [field]: value };
+    if (field === "privateKeySecretRefName") {
+      next.privateKeySecretRefNameTouched = true;
+    }
+    form.value = { ...form.value, acme: next };
+  };
 
-  const updateCa = useCallback((field: string, value: unknown) => {
+  // Changing type resets the ACME subform so stale values from a prior session
+  // never surface after toggling back.
+  const selectType = (t: IssuerType) => {
     dirty.value = true;
-    form.value = {
-      ...form.value,
-      ca: { ...form.value.ca, [field]: value },
-    };
-  }, []);
-
-  const updateVault = useCallback((field: string, value: unknown) => {
-    dirty.value = true;
-    form.value = {
-      ...form.value,
-      vault: { ...form.value.vault, [field]: value },
-    };
-  }, []);
-
-  const updateVaultAuth = useCallback(
-    (method: VaultAuthMethod, value: string) => {
-      dirty.value = true;
-      form.value = {
-        ...form.value,
-        vault: { ...form.value.vault, authMethod: method, authValue: value },
-      };
-    },
-    [],
-  );
-
-  // Changing type resets every sibling subform so switching away from ACME and
-  // back (or across any pair) never shows stale values from a prior session.
-  const selectType = useCallback((t: IssuerType) => {
-    dirty.value = true;
-    form.value = {
-      ...form.value,
-      type: t,
-      acme: initialAcme(),
-      ca: initialCa(),
-      vault: initialVault(),
-    };
-  }, []);
+    form.value = { ...form.value, type: t, acme: initialAcme() };
+  };
 
   const validateStep = (step: number): boolean => {
     const f = form.value;
     const errs: Record<string, string> = {};
 
-    if (step === 0) {
-      if (!f.type) errs.type = "Select an issuer type";
+    if (step === 0 && !f.type) {
+      errs.type = "Select an issuer type";
     }
 
     if (step === 1) {
@@ -169,7 +121,6 @@ export default function IssuerWizard({ scope }: IssuerWizardProps) {
           errs.namespace = "Must be a valid DNS label";
         }
       }
-
       if (f.type === "acme") {
         if (!f.acme.server || !f.acme.server.startsWith("https://")) {
           errs["acme.server"] = "ACME server must be an HTTPS URL";
@@ -184,22 +135,6 @@ export default function IssuerWizard({ scope }: IssuerWizardProps) {
           errs["acme.privateKeySecretRefName"] = "Must be a valid DNS label";
         }
       }
-
-      if (f.type === "ca") {
-        if (!f.ca.secretName || !DNS_LABEL_REGEX.test(f.ca.secretName)) {
-          errs["ca.secretName"] = "Must be a valid DNS label";
-        }
-      }
-
-      if (f.type === "vault") {
-        if (!f.vault.server || !f.vault.server.startsWith("https://")) {
-          errs["vault.server"] = "Vault server must be an HTTPS URL";
-        }
-        if (!f.vault.path) errs["vault.path"] = "PKI path is required";
-        if (!f.vault.authValue) {
-          errs["vault.auth"] = "One authentication method must be configured";
-        }
-      }
     }
 
     errors.value = errs;
@@ -212,7 +147,6 @@ export default function IssuerWizard({ scope }: IssuerWizardProps) {
 
     const f = form.value;
     const payload: Record<string, unknown> = {
-      scope,
       name: f.name,
       type: f.type,
     };
@@ -233,25 +167,6 @@ export default function IssuerWizard({ scope }: IssuerWizardProps) {
           email: f.acme.email,
           privateKeySecretRefName: f.acme.privateKeySecretRefName,
           solvers: [solver],
-        };
-        break;
-      }
-      case "ca":
-        payload.ca = { secretName: f.ca.secretName };
-        break;
-      case "vault": {
-        const auth: Record<string, unknown> = {};
-        if (f.vault.authMethod === "token") {
-          auth.tokenSecretRefName = f.vault.authValue;
-        } else if (f.vault.authMethod === "appRole") {
-          auth.appRoleSecretRefName = f.vault.authValue;
-        } else {
-          auth.kubernetesRole = f.vault.authValue;
-        }
-        payload.vault = {
-          server: f.vault.server,
-          path: f.vault.path,
-          auth,
         };
         break;
       }
@@ -333,9 +248,6 @@ export default function IssuerWizard({ scope }: IssuerWizardProps) {
             namespaces={namespaces.value}
             onUpdate={updateField}
             onUpdateAcme={updateAcme}
-            onUpdateCa={updateCa}
-            onUpdateVault={updateVault}
-            onUpdateVaultAuth={updateVaultAuth}
           />
         )}
 

--- a/todos/332-complete-p2-simplify-signal-ceremony.md
+++ b/todos/332-complete-p2-simplify-signal-ceremony.md
@@ -1,6 +1,6 @@
 ---
 name: Collapse signals/useCallback ceremony in wizard islands
-status: pending
+status: complete
 priority: p2
 issue_id: 332
 tags: [code-review, frontend, simplicity, pr-180]

--- a/todos/333-complete-p2-ca-vault-issuer-scope.md
+++ b/todos/333-complete-p2-ca-vault-issuer-scope.md
@@ -1,6 +1,6 @@
 ---
 name: Consider removing CA and Vault issuer types from the wizard
-status: pending
+status: complete
 priority: p2
 issue_id: 333
 tags: [code-review, yagni, cert-manager, design-decision, pr-180]

--- a/todos/334-complete-p3-cert-manager-wizard-followups.md
+++ b/todos/334-complete-p3-cert-manager-wizard-followups.md
@@ -1,6 +1,6 @@
 ---
 name: Cert-manager wizard P3 cleanups (bundled)
-status: pending
+status: complete
 priority: p3
 issue_id: 334
 tags: [code-review, cleanup, pr-180]


### PR DESCRIPTION
## Summary

Completes the three review findings deferred from PR #180 (cert-manager wizards).

### 333 — Remove CA and Vault issuer types
Code-simplicity review recommended cutting these because the YAML editor already handles them well and the wizard's value-add was minimal (CA = 5-line YAML, Vault = 3 auth-mode radio machine). Net ~80 LOC of Go + ~100 LOC of TSX deleted.

### 332 — Drop useCallback wrappers
DHH review flagged these as cargo cult: none were passed to memoized children. Plain arrow assignments now.

### 334 followups
- **ARIA** — htmlFor/id pairing, aria-invalid, aria-describedby on all new labels/inputs
- **Regex parity** — new \`regex_parity_test.go\` pins Go \`dnsLabelRegex\` to catch drift from the TS \`DNS_LABEL_REGEX\`
- **ACME auto-default** — replaced the stale-baseline heuristic (which broke after type switches) with a \"touched\" flag

## Test plan

- [x] \`go vet ./...\` and \`go test ./internal/wizard/... ./internal/server/...\` green
- [x] \`deno fmt --check\` (434 files) and \`deno lint\` clean on changed files
- [x] \`deno task build\` succeeds
- [x] Todos 332, 333, 334 marked complete
- [ ] Smoke test against homelab

## Related

Follows PR #180. Closes review findings documented in \`todos/332-complete-*\`, \`todos/333-complete-*\`, \`todos/334-complete-*\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)