### PR TITLE
fix(cert-manager): apply 337 P3 cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,7 @@ e2e/test-results/
 *.png
 .superpowers/
 .worktrees
+
+# Claude Code scheduling state
+.claude/scheduled_tasks.lock
+.claude/scheduled_tasks.json

--- a/backend/internal/wizard/regex_parity_test.go
+++ b/backend/internal/wizard/regex_parity_test.go
@@ -1,14 +1,45 @@
 package wizard
 
-import "testing"
+import (
+	"regexp"
+	"testing"
+)
 
-// TestDnsLabelRegexParity pins the dnsLabelRegex pattern string so any change
-// to the Go side is an explicit signal to update the matching TS regex at
-// frontend/lib/wizard-constants.ts (DNS_LABEL_REGEX). Keeping these in lockstep
-// prevents client-side validation from green-lighting names the server rejects.
-func TestDnsLabelRegexParity(t *testing.T) {
-	const expected = `^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`
-	if got := dnsLabelRegex.String(); got != expected {
-		t.Fatalf("dnsLabelRegex drift: got %q, want %q (update frontend/lib/wizard-constants.ts DNS_LABEL_REGEX to match)", got, expected)
+// TestRegexParity pins each Go-side regex that has a TypeScript counterpart in
+// frontend/lib/wizard-constants.ts to its expected pattern string. A change on
+// either side without updating the other becomes a test failure here (Go side)
+// or in frontend/lib/wizard-constants_parity_test.ts (TS side).
+//
+// Keeping these in lockstep prevents client-side validation from green-lighting
+// names the server rejects (or vice versa).
+func TestRegexParity(t *testing.T) {
+	cases := []struct {
+		name       string
+		got        *regexp.Regexp
+		wantSource string
+		// tsConstName names the TS constant that must mirror this pattern.
+		tsConstName string
+	}{
+		{
+			name:        "dnsLabelRegex",
+			got:         dnsLabelRegex,
+			wantSource:  `^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`,
+			tsConstName: "DNS_LABEL_REGEX",
+		},
+		{
+			name:        "envVarNameRegex",
+			got:         envVarNameRegex,
+			wantSource:  `^[A-Za-z_][A-Za-z0-9_]*$`,
+			tsConstName: "ENV_VAR_NAME_REGEX",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.got.String() != tc.wantSource {
+				t.Fatalf("%s drift: got %q, want %q (update frontend/lib/wizard-constants.ts %s to match, or update this test)",
+					tc.name, tc.got.String(), tc.wantSource, tc.tsConstName)
+			}
+		})
 	}
 }

--- a/frontend/components/ui/Input.tsx
+++ b/frontend/components/ui/Input.tsx
@@ -1,14 +1,33 @@
 import type { JSX } from "preact";
 
-interface InputProps extends JSX.HTMLAttributes<HTMLInputElement> {
+// Use InputHTMLAttributes for input-specific props (value, type, etc.).
+// HTMLAttributes alone lacks them in this Preact JSX type setup.
+interface InputProps extends JSX.InputHTMLAttributes<HTMLInputElement> {
   label?: string;
   error?: string;
+  /** Renders a red asterisk after the label. */
+  required?: boolean;
+  /** Helper text shown below the input (above any error). */
+  description?: string;
 }
 
 export function Input(
-  { label, error, id, class: className, ...props }: InputProps,
+  {
+    label,
+    error,
+    required,
+    description,
+    id,
+    class: className,
+    ...props
+  }: InputProps,
 ) {
   const inputId = id ?? label?.toLowerCase().replace(/\s+/g, "-");
+  const errorId = error && inputId ? `${inputId}-error` : undefined;
+  const descId = description && inputId ? `${inputId}-desc` : undefined;
+  const describedBy = [descId, errorId].filter(Boolean).join(" ") ||
+    undefined;
+
   return (
     <div class="space-y-1">
       {label && (
@@ -17,10 +36,14 @@ export function Input(
           class="block text-sm font-medium text-text-secondary"
         >
           {label}
+          {required && <span class="ml-0.5 text-danger">*</span>}
         </label>
       )}
       <input
         id={inputId}
+        aria-invalid={error ? "true" : undefined}
+        aria-describedby={describedBy}
+        aria-required={required ? "true" : undefined}
         class={`block w-full rounded-md border px-3 py-2 text-sm shadow-sm transition-colors focus:outline-none focus:ring-2 ${
           error
             ? "border-danger focus:ring-danger/50"
@@ -28,7 +51,10 @@ export function Input(
         } ${className ?? ""}`}
         {...props}
       />
-      {error && <p class="text-sm text-danger">{error}</p>}
+      {description && (
+        <p id={descId} class="text-xs text-text-muted">{description}</p>
+      )}
+      {error && <p id={errorId} class="text-sm text-danger">{error}</p>}
     </div>
   );
 }

--- a/frontend/components/ui/Input.tsx
+++ b/frontend/components/ui/Input.tsx
@@ -31,13 +31,23 @@ export function Input(
   return (
     <div class="space-y-1">
       {label && (
-        <label
-          for={inputId}
-          class="block text-sm font-medium text-text-secondary"
-        >
-          {label}
-          {required && <span class="ml-0.5 text-danger">*</span>}
-        </label>
+        <div class="flex items-baseline gap-0.5">
+          <label
+            for={inputId}
+            class="block text-sm font-medium text-text-secondary"
+          >
+            {label}
+          </label>
+          {
+            /* Asterisk rendered as a sibling — kept OUT of the <label> so the
+              accessible/visible label text is exactly the `label` prop (some
+              test frameworks match label text including descendants).
+              aria-required on the input announces required-ness for AT. */
+          }
+          {required && (
+            <span aria-hidden="true" class="text-sm text-danger">*</span>
+          )}
+        </div>
       )}
       <input
         id={inputId}

--- a/frontend/components/ui/Select.tsx
+++ b/frontend/components/ui/Select.tsx
@@ -36,13 +36,18 @@ export function Select(
   return (
     <div class="space-y-1">
       {label && (
-        <label
-          for={selectId}
-          class="block text-sm font-medium text-text-secondary"
-        >
-          {label}
-          {required && <span class="ml-0.5 text-danger">*</span>}
-        </label>
+        <div class="flex items-baseline gap-0.5">
+          <label
+            for={selectId}
+            class="block text-sm font-medium text-text-secondary"
+          >
+            {label}
+          </label>
+          {/* Asterisk rendered as a sibling — see Input.tsx for rationale. */}
+          {required && (
+            <span aria-hidden="true" class="text-sm text-danger">*</span>
+          )}
+        </div>
       )}
       <select
         id={selectId}

--- a/frontend/components/ui/Select.tsx
+++ b/frontend/components/ui/Select.tsx
@@ -1,15 +1,38 @@
-import type { JSX } from "preact";
+import type { ComponentChildren, JSX } from "preact";
 
-interface SelectProps extends JSX.HTMLAttributes<HTMLSelectElement> {
+// SelectHTMLAttributes provides value/multiple/etc.; HTMLAttributes alone does not.
+interface SelectProps extends JSX.SelectHTMLAttributes<HTMLSelectElement> {
   label?: string;
   error?: string;
-  options: Array<{ value: string; label: string }>;
+  /** Renders a red asterisk after the label. */
+  required?: boolean;
+  /** Helper text shown below the select (above any error). */
+  description?: string;
+  /** Simple option list. Mutually exclusive with children. */
+  options?: Array<{ value: string; label: string }>;
+  /** Use children for richer markup like <optgroup>. */
+  children?: ComponentChildren;
 }
 
 export function Select(
-  { label, error, id, options, class: className, ...props }: SelectProps,
+  {
+    label,
+    error,
+    required,
+    description,
+    id,
+    options,
+    children,
+    class: className,
+    ...props
+  }: SelectProps,
 ) {
   const selectId = id ?? label?.toLowerCase().replace(/\s+/g, "-");
+  const errorId = error && selectId ? `${selectId}-error` : undefined;
+  const descId = description && selectId ? `${selectId}-desc` : undefined;
+  const describedBy = [descId, errorId].filter(Boolean).join(" ") ||
+    undefined;
+
   return (
     <div class="space-y-1">
       {label && (
@@ -18,24 +41,33 @@ export function Select(
           class="block text-sm font-medium text-text-secondary"
         >
           {label}
+          {required && <span class="ml-0.5 text-danger">*</span>}
         </label>
       )}
       <select
         id={selectId}
+        aria-invalid={error ? "true" : undefined}
+        aria-describedby={describedBy}
+        aria-required={required ? "true" : undefined}
         class={`block w-full rounded-md border px-3 py-2 text-sm shadow-sm transition-colors focus:outline-none focus:ring-2 ${
           error
             ? "border-danger focus:ring-danger/50"
-            : "border-border-primary focus:border-brand focus:ring-brand/50 border-border-primary bg-surface text-text-primary"
+            : "border-border-primary focus:border-brand focus:ring-brand/50 bg-surface text-text-primary"
         } ${className ?? ""}`}
         {...props}
       >
-        {options.map((opt) => (
-          <option key={opt.value} value={opt.value}>
-            {opt.label}
-          </option>
-        ))}
+        {options
+          ? options.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))
+          : children}
       </select>
-      {error && <p class="text-sm text-danger">{error}</p>}
+      {description && (
+        <p id={descId} class="text-xs text-text-muted">{description}</p>
+      )}
+      {error && <p id={errorId} class="text-sm text-danger">{error}</p>}
     </div>
   );
 }

--- a/frontend/components/wizard/CertificateForm.tsx
+++ b/frontend/components/wizard/CertificateForm.tsx
@@ -1,4 +1,5 @@
-import { WIZARD_INPUT_CLASS } from "@/lib/wizard-constants.ts";
+import { Input } from "@/components/ui/Input.tsx";
+import { Select } from "@/components/ui/Select.tsx";
 import { NamespaceSelect } from "@/components/ui/NamespaceSelect.tsx";
 import type { Issuer } from "@/lib/certmanager-types.ts";
 import type { CertificateWizardForm } from "@/islands/CertificateWizard.tsx";
@@ -34,33 +35,22 @@ export function CertificateForm({
     ? ECDSA_SIZES
     : RSA_SIZES;
 
+  const clusterIssuers = issuers.filter((i) => i.scope === "Cluster");
+  const namespacedIssuers = issuers.filter((i) => i.scope === "Namespaced");
+
   return (
     <div class="space-y-5">
       <div class="grid grid-cols-2 gap-4">
-        <div>
-          <label
-            for="cert-name"
-            class="block text-sm font-medium text-text-primary"
-          >
-            Name <span class="text-danger">*</span>
-          </label>
-          <input
-            id="cert-name"
-            type="text"
-            value={form.name}
-            onInput={(e) =>
-              onUpdate("name", (e.target as HTMLInputElement).value)}
-            placeholder="example-com-tls"
-            class={WIZARD_INPUT_CLASS}
-            aria-invalid={errors.name ? "true" : undefined}
-            aria-describedby={errors.name ? "cert-name-error" : undefined}
-          />
-          {errors.name && (
-            <p id="cert-name-error" class="mt-1 text-xs text-danger">
-              {errors.name}
-            </p>
-          )}
-        </div>
+        <Input
+          id="cert-name"
+          label="Name"
+          required
+          value={form.name}
+          onInput={(e) =>
+            onUpdate("name", (e.target as HTMLInputElement).value)}
+          placeholder="example-com-tls"
+          error={errors.name}
+        />
 
         <NamespaceSelect
           value={form.namespace}
@@ -70,122 +60,73 @@ export function CertificateForm({
         />
       </div>
 
-      <div>
-        <label
-          for="cert-secret-name"
-          class="block text-sm font-medium text-text-primary"
-        >
-          Secret Name <span class="text-danger">*</span>
-        </label>
-        <input
-          id="cert-secret-name"
-          type="text"
-          value={form.secretName}
-          onInput={(e) =>
-            onUpdate("secretName", (e.target as HTMLInputElement).value)}
-          placeholder="example-com-tls"
-          class={WIZARD_INPUT_CLASS}
-          aria-invalid={errors.secretName ? "true" : undefined}
-          aria-describedby={errors.secretName
-            ? "cert-secret-name-error"
-            : undefined}
-        />
-        <p class="mt-1 text-xs text-text-muted">
-          Secret where cert-manager will write the issued TLS certificate and
-          private key.
-        </p>
-        {errors.secretName && (
-          <p id="cert-secret-name-error" class="mt-1 text-xs text-danger">
-            {errors.secretName}
-          </p>
-        )}
-      </div>
+      <Input
+        id="cert-secret-name"
+        label="Secret Name"
+        required
+        value={form.secretName}
+        onInput={(e) =>
+          onUpdate("secretName", (e.target as HTMLInputElement).value)}
+        placeholder="example-com-tls"
+        description="Secret where cert-manager will write the issued TLS certificate and private key."
+        error={errors.secretName}
+      />
 
-      <div>
-        <label
-          for="cert-issuer"
-          class="block text-sm font-medium text-text-primary"
-        >
-          Issuer <span class="text-danger">*</span>
-        </label>
-        <select
-          id="cert-issuer"
-          value={form.issuerRefValue}
-          onChange={(e) =>
-            onUpdate(
-              "issuerRefValue",
-              (e.target as HTMLSelectElement).value,
-            )}
-          class={WIZARD_INPUT_CLASS}
-          disabled={issuersLoading}
-        >
-          <option value="">
-            {issuersLoading ? "Loading issuers..." : "Select an issuer"}
-          </option>
-          {issuers.filter((i) => i.scope === "Cluster").length > 0 && (
-            <optgroup label="ClusterIssuers">
-              {issuers
-                .filter((i) => i.scope === "Cluster")
-                .map((i) => (
-                  <option key={i.uid} value={issuerOptionValue(i)}>
-                    {i.name} ({i.type})
-                  </option>
-                ))}
-            </optgroup>
+      <Select
+        id="cert-issuer"
+        label="Issuer"
+        required
+        value={form.issuerRefValue}
+        onChange={(e) =>
+          onUpdate(
+            "issuerRefValue",
+            (e.target as HTMLSelectElement).value,
           )}
-          {issuers.filter((i) => i.scope === "Namespaced").length > 0 && (
-            <optgroup label="Issuers (namespaced)">
-              {issuers
-                .filter((i) => i.scope === "Namespaced")
-                .map((i) => (
-                  <option key={i.uid} value={issuerOptionValue(i)}>
-                    {i.name} / {i.namespace} ({i.type})
-                  </option>
-                ))}
-            </optgroup>
-          )}
-        </select>
-        {errors.issuerRef && (
-          <p class="mt-1 text-xs text-danger">{errors.issuerRef}</p>
+        disabled={issuersLoading}
+        error={errors.issuerRef}
+      >
+        <option value="">
+          {issuersLoading ? "Loading issuers..." : "Select an issuer"}
+        </option>
+        {clusterIssuers.length > 0 && (
+          <optgroup label="ClusterIssuers">
+            {clusterIssuers.map((i) => (
+              <option key={i.uid} value={issuerOptionValue(i)}>
+                {i.name} ({i.type})
+              </option>
+            ))}
+          </optgroup>
         )}
-      </div>
-
-      <div>
-        <label class="block text-sm font-medium text-text-primary">
-          DNS Names
-        </label>
-        <input
-          type="text"
-          value={form.dnsNamesInput}
-          onInput={(e) =>
-            onUpdate(
-              "dnsNamesInput",
-              (e.target as HTMLInputElement).value,
-            )}
-          placeholder="example.com, www.example.com"
-          class={WIZARD_INPUT_CLASS}
-        />
-        <p class="mt-1 text-xs text-text-muted">
-          Comma-separated. At least one of DNS Names or Common Name is required.
-        </p>
-        {errors.dnsNames && (
-          <p class="mt-1 text-xs text-danger">{errors.dnsNames}</p>
+        {namespacedIssuers.length > 0 && (
+          <optgroup label="Issuers (namespaced)">
+            {namespacedIssuers.map((i) => (
+              <option key={i.uid} value={issuerOptionValue(i)}>
+                {i.name} / {i.namespace} ({i.type})
+              </option>
+            ))}
+          </optgroup>
         )}
-      </div>
+      </Select>
 
-      <div>
-        <label class="block text-sm font-medium text-text-primary">
-          Common Name
-        </label>
-        <input
-          type="text"
-          value={form.commonName}
-          onInput={(e) =>
-            onUpdate("commonName", (e.target as HTMLInputElement).value)}
-          placeholder="example.com"
-          class={WIZARD_INPUT_CLASS}
-        />
-      </div>
+      <Input
+        id="cert-dns-names"
+        label="DNS Names"
+        value={form.dnsNamesInput}
+        onInput={(e) =>
+          onUpdate("dnsNamesInput", (e.target as HTMLInputElement).value)}
+        placeholder="example.com, www.example.com"
+        description="Comma-separated. At least one of DNS Names or Common Name is required."
+        error={errors.dnsNames}
+      />
+
+      <Input
+        id="cert-common-name"
+        label="Common Name"
+        value={form.commonName}
+        onInput={(e) =>
+          onUpdate("commonName", (e.target as HTMLInputElement).value)}
+        placeholder="example.com"
+      />
 
       <details class="rounded-md border border-border-primary bg-surface/50 p-4">
         <summary class="cursor-pointer text-sm font-medium text-text-primary">
@@ -194,109 +135,72 @@ export function CertificateForm({
 
         <div class="mt-4 space-y-4">
           <div class="grid grid-cols-2 gap-4">
-            <div>
-              <label class="block text-sm font-medium text-text-primary">
-                Duration
-              </label>
-              <input
-                type="text"
-                value={form.duration}
-                onInput={(e) =>
-                  onUpdate(
-                    "duration",
-                    (e.target as HTMLInputElement).value,
-                  )}
-                placeholder="2160h"
-                class={WIZARD_INPUT_CLASS}
-              />
-              <p class="mt-1 text-xs text-text-muted">
-                Default 2160h (90 days).
-              </p>
-              {errors.duration && (
-                <p class="mt-1 text-xs text-danger">{errors.duration}</p>
-              )}
-            </div>
-
-            <div>
-              <label class="block text-sm font-medium text-text-primary">
-                Renew Before
-              </label>
-              <input
-                type="text"
-                value={form.renewBefore}
-                onInput={(e) =>
-                  onUpdate(
-                    "renewBefore",
-                    (e.target as HTMLInputElement).value,
-                  )}
-                placeholder="360h"
-                class={WIZARD_INPUT_CLASS}
-              />
-              <p class="mt-1 text-xs text-text-muted">
-                Default 360h (15 days).
-              </p>
-              {errors.renewBefore && (
-                <p class="mt-1 text-xs text-danger">{errors.renewBefore}</p>
-              )}
-            </div>
+            <Input
+              id="cert-duration"
+              label="Duration"
+              value={form.duration}
+              onInput={(e) =>
+                onUpdate("duration", (e.target as HTMLInputElement).value)}
+              placeholder="2160h"
+              description="Default 2160h (90 days)."
+              error={errors.duration}
+            />
+            <Input
+              id="cert-renew-before"
+              label="Renew Before"
+              value={form.renewBefore}
+              onInput={(e) =>
+                onUpdate(
+                  "renewBefore",
+                  (e.target as HTMLInputElement).value,
+                )}
+              placeholder="360h"
+              description="Default 360h (15 days)."
+              error={errors.renewBefore}
+            />
           </div>
 
           <div class="grid grid-cols-3 gap-4">
-            <div>
-              <label class="block text-sm font-medium text-text-primary">
-                Algorithm
-              </label>
-              <select
-                value={form.privateKey.algorithm}
-                onChange={(e) =>
-                  onUpdatePrivateKey(
-                    "algorithm",
-                    (e.target as HTMLSelectElement).value,
-                  )}
-                class={WIZARD_INPUT_CLASS}
-              >
-                {PRIVATE_KEY_ALGORITHMS.map((a) => (
-                  <option key={a} value={a}>{a}</option>
-                ))}
-              </select>
-            </div>
-
-            <div>
-              <label class="block text-sm font-medium text-text-primary">
-                Key Size
-              </label>
-              <select
-                value={form.privateKey.size}
-                onChange={(e) =>
-                  onUpdatePrivateKey(
-                    "size",
-                    Number((e.target as HTMLSelectElement).value),
-                  )}
-                class={WIZARD_INPUT_CLASS}
-                disabled={form.privateKey.algorithm === "Ed25519"}
-              >
-                {sizeOptions.map((s) => <option key={s} value={s}>{s}</option>)}
-              </select>
-            </div>
-
-            <div>
-              <label class="block text-sm font-medium text-text-primary">
-                Rotation
-              </label>
-              <select
-                value={form.privateKey.rotationPolicy}
-                onChange={(e) =>
-                  onUpdatePrivateKey(
-                    "rotationPolicy",
-                    (e.target as HTMLSelectElement).value,
-                  )}
-                class={WIZARD_INPUT_CLASS}
-              >
-                {ROTATION_POLICIES.map((p) => (
-                  <option key={p} value={p}>{p}</option>
-                ))}
-              </select>
-            </div>
+            <Select
+              id="cert-pk-algorithm"
+              label="Algorithm"
+              value={form.privateKey.algorithm}
+              onChange={(e) =>
+                onUpdatePrivateKey(
+                  "algorithm",
+                  (e.target as HTMLSelectElement).value,
+                )}
+              options={PRIVATE_KEY_ALGORITHMS.map((a) => ({
+                value: a,
+                label: a,
+              }))}
+            />
+            <Select
+              id="cert-pk-size"
+              label="Key Size"
+              value={String(form.privateKey.size)}
+              onChange={(e) =>
+                onUpdatePrivateKey(
+                  "size",
+                  Number((e.target as HTMLSelectElement).value),
+                )}
+              disabled={form.privateKey.algorithm === "Ed25519"}
+              options={sizeOptions.map((s) => ({
+                value: String(s),
+                label: String(s),
+              }))}
+            />
+            <Select
+              id="cert-pk-rotation"
+              label="Rotation"
+              value={form.privateKey.rotationPolicy}
+              onChange={(e) =>
+                onUpdatePrivateKey(
+                  "rotationPolicy",
+                  (e.target as HTMLSelectElement).value,
+                )}
+              options={ROTATION_POLICIES.map((p) => ({ value: p, label: p }))}
+            />
           </div>
 
           <div>

--- a/frontend/components/wizard/IssuerFormStep.tsx
+++ b/frontend/components/wizard/IssuerFormStep.tsx
@@ -1,8 +1,5 @@
-import {
-  LE_PROD_ACME,
-  LE_STAGING_ACME,
-  WIZARD_INPUT_CLASS,
-} from "@/lib/wizard-constants.ts";
+import { LE_PROD_ACME, LE_STAGING_ACME } from "@/lib/wizard-constants.ts";
+import { Input } from "@/components/ui/Input.tsx";
 import { NamespaceSelect } from "@/components/ui/NamespaceSelect.tsx";
 import type { IssuerWizardForm } from "@/islands/IssuerWizard.tsx";
 
@@ -26,30 +23,16 @@ export function IssuerFormStep({
   return (
     <div class="space-y-5">
       <div class="grid grid-cols-2 gap-4">
-        <div>
-          <label
-            for="issuer-name"
-            class="block text-sm font-medium text-text-primary"
-          >
-            Name <span class="text-danger">*</span>
-          </label>
-          <input
-            id="issuer-name"
-            type="text"
-            value={form.name}
-            onInput={(e) =>
-              onUpdate("name", (e.target as HTMLInputElement).value)}
-            placeholder={scope === "cluster" ? "letsencrypt-prod" : "my-issuer"}
-            class={WIZARD_INPUT_CLASS}
-            aria-invalid={errors.name ? "true" : undefined}
-            aria-describedby={errors.name ? "issuer-name-error" : undefined}
-          />
-          {errors.name && (
-            <p id="issuer-name-error" class="mt-1 text-xs text-danger">
-              {errors.name}
-            </p>
-          )}
-        </div>
+        <Input
+          id="issuer-name"
+          label="Name"
+          required
+          value={form.name}
+          onInput={(e) =>
+            onUpdate("name", (e.target as HTMLInputElement).value)}
+          placeholder={scope === "cluster" ? "letsencrypt-prod" : "my-issuer"}
+          error={errors.name}
+        />
 
         {scope === "namespaced" && (
           <NamespaceSelect
@@ -71,13 +54,7 @@ export function IssuerFormStep({
       {form.type === "acme" && (
         <div class="space-y-4">
           <div>
-            <label
-              for="acme-server"
-              class="block text-sm font-medium text-text-primary"
-            >
-              ACME Server <span class="text-danger">*</span>
-            </label>
-            <div class="mt-1 flex gap-2">
+            <div class="flex gap-2 mb-1">
               <button
                 type="button"
                 class={`text-xs rounded border px-2 py-1 ${
@@ -101,124 +78,59 @@ export function IssuerFormStep({
                 Let's Encrypt Production
               </button>
             </div>
-            <input
+            <Input
               id="acme-server"
-              type="text"
+              label="ACME Server"
+              required
               value={form.acme.server}
               onInput={(e) =>
                 onUpdateAcme("server", (e.target as HTMLInputElement).value)}
               placeholder="https://acme-v02.api.letsencrypt.org/directory"
-              class={`${WIZARD_INPUT_CLASS} mt-2`}
-              aria-invalid={errors["acme.server"] ? "true" : undefined}
-              aria-describedby={errors["acme.server"]
-                ? "acme-server-error"
-                : undefined}
+              description="Must be an HTTPS URL. Private and loopback addresses are rejected."
+              error={errors["acme.server"]}
             />
-            <p class="mt-1 text-xs text-text-muted">
-              Must be an HTTPS URL. Private and loopback addresses are rejected.
-            </p>
-            {errors["acme.server"] && (
-              <p id="acme-server-error" class="mt-1 text-xs text-danger">
-                {errors["acme.server"]}
-              </p>
-            )}
           </div>
 
           <div class="grid grid-cols-2 gap-4">
-            <div>
-              <label
-                for="acme-email"
-                class="block text-sm font-medium text-text-primary"
-              >
-                Contact Email <span class="text-danger">*</span>
-              </label>
-              <input
-                id="acme-email"
-                type="email"
-                value={form.acme.email}
-                onInput={(e) =>
-                  onUpdateAcme(
-                    "email",
-                    (e.target as HTMLInputElement).value,
-                  )}
-                placeholder="admin@example.com"
-                class={WIZARD_INPUT_CLASS}
-                aria-invalid={errors["acme.email"] ? "true" : undefined}
-                aria-describedby={errors["acme.email"]
-                  ? "acme-email-error"
-                  : undefined}
-              />
-              {errors["acme.email"] && (
-                <p id="acme-email-error" class="mt-1 text-xs text-danger">
-                  {errors["acme.email"]}
-                </p>
-              )}
-            </div>
-
-            <div>
-              <label
-                for="acme-key-secret"
-                class="block text-sm font-medium text-text-primary"
-              >
-                Account Private Key Secret <span class="text-danger">*</span>
-              </label>
-              <input
-                id="acme-key-secret"
-                type="text"
-                value={form.acme.privateKeySecretRefName}
-                onInput={(e) =>
-                  onUpdateAcme(
-                    "privateKeySecretRefName",
-                    (e.target as HTMLInputElement).value,
-                  )}
-                placeholder="letsencrypt-account"
-                class={WIZARD_INPUT_CLASS}
-                aria-invalid={errors["acme.privateKeySecretRefName"]
-                  ? "true"
-                  : undefined}
-                aria-describedby={errors["acme.privateKeySecretRefName"]
-                  ? "acme-key-secret-error"
-                  : undefined}
-              />
-              <p class="mt-1 text-xs text-text-muted">
-                Name of the Secret cert-manager will create to hold the account
-                key.
-              </p>
-              {errors["acme.privateKeySecretRefName"] && (
-                <p
-                  id="acme-key-secret-error"
-                  class="mt-1 text-xs text-danger"
-                >
-                  {errors["acme.privateKeySecretRefName"]}
-                </p>
-              )}
-            </div>
-          </div>
-
-          <div>
-            <label
-              for="acme-ingress-class"
-              class="block text-sm font-medium text-text-primary"
-            >
-              HTTP01 Ingress Class
-            </label>
-            <input
-              id="acme-ingress-class"
-              type="text"
-              value={form.acme.ingressClassName}
+            <Input
+              id="acme-email"
+              label="Contact Email"
+              required
+              type="email"
+              value={form.acme.email}
+              onInput={(e) =>
+                onUpdateAcme("email", (e.target as HTMLInputElement).value)}
+              placeholder="admin@example.com"
+              error={errors["acme.email"]}
+            />
+            <Input
+              id="acme-key-secret"
+              label="Account Private Key Secret"
+              required
+              value={form.acme.privateKeySecretRefName}
               onInput={(e) =>
                 onUpdateAcme(
-                  "ingressClassName",
+                  "privateKeySecretRefName",
                   (e.target as HTMLInputElement).value,
                 )}
-              placeholder="nginx"
-              class={WIZARD_INPUT_CLASS}
+              placeholder="letsencrypt-account"
+              description="Name of the Secret cert-manager will create to hold the account key."
+              error={errors["acme.privateKeySecretRefName"]}
             />
-            <p class="mt-1 text-xs text-text-muted">
-              Ingress class used for HTTP01 challenges. Leave blank to use the
-              default class.
-            </p>
           </div>
+
+          <Input
+            id="acme-ingress-class"
+            label="HTTP01 Ingress Class"
+            value={form.acme.ingressClassName}
+            onInput={(e) =>
+              onUpdateAcme(
+                "ingressClassName",
+                (e.target as HTMLInputElement).value,
+              )}
+            placeholder="nginx"
+            description="Ingress class used for HTTP01 challenges. Leave blank to use the default class."
+          />
         </div>
       )}
     </div>

--- a/frontend/deno.lock
+++ b/frontend/deno.lock
@@ -9,6 +9,7 @@
     "jsr:@fresh/core@^2.2.0": "2.2.0",
     "jsr:@fresh/plugin-tailwind@1": "1.0.0",
     "jsr:@fresh/plugin-vite@1": "1.0.8",
+    "jsr:@std/assert@*": "1.0.19",
     "jsr:@std/bytes@^1.0.6": "1.0.6",
     "jsr:@std/dotenv@~0.225.5": "0.225.6",
     "jsr:@std/encoding@^1.0.10": "1.0.10",
@@ -127,6 +128,12 @@
         "npm:@prefresh/vite",
         "npm:rollup",
         "npm:vite"
+      ]
+    },
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal"
       ]
     },
     "@std/bytes@1.0.6": {

--- a/frontend/islands/CertificateWizard.tsx
+++ b/frontend/islands/CertificateWizard.tsx
@@ -109,12 +109,14 @@ export default function CertificateWizard() {
   const updateField = (field: string, value: unknown) => {
     dirty.value = true;
     const f = { ...form.value, [field]: value };
-    // Auto-default secretName from name when user hasn't customised it.
+    // Auto-derive secretName from name as long as it still matches the
+    // previously-derived value. Only fires for non-empty new names so clearing
+    // `name` doesn't wipe the user's secretName entry alongside it.
     if (
-      field === "name" && typeof value === "string" &&
+      field === "name" && typeof value === "string" && value !== "" &&
       (f.secretName === "" || f.secretName === form.value.name + "-tls")
     ) {
-      f.secretName = value ? `${value}-tls` : "";
+      f.secretName = `${value}-tls`;
     }
     form.value = f;
   };

--- a/frontend/islands/IssuerWizard.tsx
+++ b/frontend/islands/IssuerWizard.tsx
@@ -146,6 +146,12 @@ export default function IssuerWizard({ scope }: IssuerWizardProps) {
     previewError.value = null;
 
     const f = form.value;
+    if (!f.type) {
+      previewError.value = "Issuer type is not selected";
+      previewLoading.value = false;
+      return;
+    }
+
     const payload: Record<string, unknown> = {
       name: f.name,
       type: f.type,
@@ -169,6 +175,14 @@ export default function IssuerWizard({ scope }: IssuerWizardProps) {
           solvers: [solver],
         };
         break;
+      }
+      default: {
+        // Exhaustiveness check: adding a new IssuerType without a switch arm
+        // here becomes a compile error.
+        const _exhaustive: never = f.type;
+        previewError.value = `Unsupported issuer type: ${_exhaustive}`;
+        previewLoading.value = false;
+        return;
       }
     }
 

--- a/frontend/islands/IssuerWizard.tsx
+++ b/frontend/islands/IssuerWizard.tsx
@@ -98,8 +98,10 @@ export default function IssuerWizard({ scope }: IssuerWizardProps) {
   };
 
   // Changing type resets the ACME subform so stale values from a prior session
-  // never surface after toggling back.
+  // never surface after toggling back. Re-selecting the same type is a no-op
+  // — don't wipe what the user is currently editing.
   const selectType = (t: IssuerType) => {
+    if (t === form.value.type) return;
     dirty.value = true;
     form.value = { ...form.value, type: t, acme: initialAcme() };
   };

--- a/frontend/lib/wizard-constants_test.ts
+++ b/frontend/lib/wizard-constants_test.ts
@@ -1,0 +1,21 @@
+import { assertEquals } from "jsr:@std/assert@1";
+import { DNS_LABEL_REGEX, ENV_VAR_NAME_REGEX } from "./wizard-constants.ts";
+
+// Mirrors backend/internal/wizard/regex_parity_test.go (TestRegexParity).
+// A drift between Go and TypeScript regex sources produces a failure on
+// whichever side was changed, so the next reader knows to update the other.
+Deno.test("DNS_LABEL_REGEX matches Go dnsLabelRegex source", () => {
+  assertEquals(
+    DNS_LABEL_REGEX.source,
+    "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
+    "DNS_LABEL_REGEX drifted from backend/internal/wizard/container.go dnsLabelRegex",
+  );
+});
+
+Deno.test("ENV_VAR_NAME_REGEX matches Go envVarNameRegex source", () => {
+  assertEquals(
+    ENV_VAR_NAME_REGEX.source,
+    "^[A-Za-z_][A-Za-z0-9_]*$",
+    "ENV_VAR_NAME_REGEX drifted from backend/internal/wizard/container.go envVarNameRegex",
+  );
+});

--- a/todos/335-complete-p2-aria-consistency-and-input-component.md
+++ b/todos/335-complete-p2-aria-consistency-and-input-component.md
@@ -1,0 +1,41 @@
+---
+name: ARIA inconsistency in cert-manager forms; extend Input component
+status: complete
+priority: p2
+issue_id: 335
+tags: [code-review, frontend, accessibility, simplicity, pr-181]
+dependencies: []
+---
+
+## Problem Statement
+
+PR #181 added `htmlFor`/`id`/`aria-invalid`/`aria-describedby` pairing to the Name, Secret Name, and Issuer fields in `CertificateForm.tsx` and to the Name, ACME server, ACME email, ACME private-key-secret, ACME ingress-class fields in `IssuerFormStep.tsx`. But the same `CertificateForm.tsx` skipped DNS Names, Common Name, Duration, Renew Before, Algorithm, Key Size, and Rotation — even though `errors.dnsNames`, `errors.duration`, `errors.renewBefore` are rendered. Inconsistent within one file, and the verbose 8-lines-per-input pattern is now copy-pasted across two files.
+
+A shared `<Input>` component already exists at `frontend/components/ui/Input.tsx` but does not yet wire `aria-invalid`/`aria-describedby` itself.
+
+## Findings
+
+- `CertificateForm.tsx:153-188, 201-240` — fields without ARIA pairing
+- `frontend/components/ui/Input.tsx:22-30` — has `label` and `error` but no ARIA attributes
+- Reviewers: kieran-typescript-reviewer (P3), pattern-recognition-specialist (P3), code-simplicity-reviewer (calls this a "regression-in-disguise" — locks in copy-paste boilerplate)
+
+## Proposed Solutions
+
+### Option A — extend Input.tsx, migrate fields (recommended)
+Add `aria-invalid` and `aria-describedby` (with auto-generated id) to `Input.tsx`. Add equivalent `Select.tsx` if it doesn't exist. Migrate `CertificateForm` and `IssuerFormStep` to use them — the wizard files become much shorter.
+
+**Pros:** systematic; one fix benefits every wizard. **Cons:** touches more files. **Effort:** Medium.
+
+### Option B — apply pattern uniformly in cert-manager forms only
+Add the htmlFor/id/aria triplet to the remaining CertificateForm fields. Faster, but perpetuates the boilerplate.
+
+**Pros:** small. **Cons:** establishes the wrong precedent. **Effort:** Small.
+
+## Acceptance Criteria
+- [ ] `Input.tsx` (and a `Select.tsx` if added) emit correct ARIA attributes when `error` prop is set.
+- [ ] `CertificateForm.tsx` and `IssuerFormStep.tsx` use the shared component for all fields.
+- [ ] No copy-pasted ARIA boilerplate in either wizard form.
+- [ ] Manual screen-reader spot check still announces validation errors.
+
+## Work Log
+- 2026-04-15: Filed from PR #181 review.

--- a/todos/336-complete-p2-non-exhaustive-issuer-type-switch.md
+++ b/todos/336-complete-p2-non-exhaustive-issuer-type-switch.md
@@ -1,0 +1,42 @@
+---
+name: Add exhaustiveness check to IssuerType switch in fetchPreview
+status: complete
+priority: p2
+issue_id: 336
+tags: [code-review, frontend, type-safety, pr-181]
+dependencies: []
+---
+
+## Problem Statement
+
+`frontend/islands/IssuerWizard.tsx:155-172` switches on `f.type` for selfSigned/acme. No `default` arm, no exhaustiveness guard. `f.type` is `IssuerType | ""`. The empty string is unreachable here by construction, but TypeScript can't prove it. When a third `IssuerType` is added (e.g., CA/Vault returning, or a new backend), the switch silently emits a payload missing the type-discriminant block, and the bug surfaces only at apply time.
+
+## Findings
+
+- `IssuerWizard.tsx:155-172`
+- Reviewer: kieran-typescript-reviewer (P2)
+
+## Proposed Solutions
+
+### Option A — exhaustive default with `never` (recommended)
+```ts
+if (!f.type) return; // narrow out ""
+switch (f.type) {
+  case "selfSigned": ...; break;
+  case "acme":       ...; break;
+  default: {
+    const _exhaustive: never = f.type;
+    throw new Error(`unsupported issuer type: ${_exhaustive}`);
+  }
+}
+```
+
+### Option B — typed record map
+Replace switch with a `Record<IssuerType, (form) => payload>` map. Compiler enforces full coverage by construction.
+
+## Acceptance Criteria
+- [ ] Adding a new `IssuerType` member without updating fetchPreview produces a TS compile error.
+- [ ] `deno task check` still passes on this PR's files.
+
+## Work Log
+- 2026-04-15: Filed from PR #181 review.

--- a/todos/337-complete-p3-pr-181-minor-followups.md
+++ b/todos/337-complete-p3-pr-181-minor-followups.md
@@ -1,6 +1,6 @@
 ---
 name: PR #181 P3 minor cleanups (bundled)
-status: pending
+status: complete
 priority: p3
 issue_id: 337
 tags: [code-review, cleanup, pr-181]

--- a/todos/337-pending-p3-pr-181-minor-followups.md
+++ b/todos/337-pending-p3-pr-181-minor-followups.md
@@ -1,0 +1,45 @@
+---
+name: PR #181 P3 minor cleanups (bundled)
+status: pending
+priority: p3
+issue_id: 337
+tags: [code-review, cleanup, pr-181]
+dependencies: []
+---
+
+## Problem Statement
+
+Bundle of low-priority observations from PR #181 review. Each is small enough that a dedicated todo would be overkill.
+
+## Findings
+
+### 1. TS-side regex parity test missing
+`backend/internal/wizard/regex_parity_test.go` pins the Go `dnsLabelRegex` to a string literal. Catches Go-side drift. A symmetric Deno test pinning `DNS_LABEL_REGEX.source` would close the loop on TS-side edits. Currently a one-sided tripwire. (code-simplicity-reviewer)
+
+### 2. secretName cleared when name cleared
+`CertificateWizard.tsx:113-118` — clearing `name` sets `secretName = ""`, then `validateStep` flags both as invalid. Surprising UX. Suggested fix: only auto-derive on non-empty name; leave the prior value intact otherwise. Consider adopting the `touched`-flag pattern from the issuer wizard for consistency. (kieran-typescript-reviewer)
+
+### 3. selectType resets ACME on every selection
+`IssuerWizard.tsx:102-105` resets `acme` to `initialAcme()` even when re-selecting the already-active type. Harmless but mildly surprising. Skip if `t === form.value.type`. (dhh-rails-reviewer)
+
+### 4. Backport useCallback removal
+24 other wizard islands still use `useCallback` wrappers identified as cargo cult by the DHH review. Acceptable local drift in PR #181, but worth a follow-up sweep — batch removal in one PR, not piecemeal. (pattern-recognition-specialist)
+
+### 5. `privateKeySecretRefNameTouched` placement
+Reviewers split: DHH endorsed it as the canonical "touched" pattern. Kieran flagged mixing UI state into the form payload as a smell, suggested a separate `useSignal` or a `meta:` namespace excluded from serialization. The current `fetchPreview` cherry-picks fields so the leak is hidden today, but it's a footgun for the next dev who does `{ ...f.acme }`. Worth a small cleanup if we touch this code again.
+
+### 6. Auto-default heuristic itself
+Simplicity reviewer asks: is the auto-default `<name>-account` even worth keeping? Could delete the heuristic and the touched flag in one swoop. Marginal value, modest cost.
+
+### 7. Extend regex parity table
+If we add the TS-side test (item #1), make both files table-driven over the 10+ shared regexes (`container.go:13,16`, `ingress.go:15`, etc.) rather than test-per-regex.
+
+## Proposed Solutions
+Address as part of any future cert-manager wizard work, or as a single bundled cleanup PR.
+
+## Acceptance Criteria
+- [ ] Each item has a resolution (done, deferred, or rejected).
+- [ ] Related tests still pass.
+
+## Work Log
+- 2026-04-15: Filed from PR #181 review.


### PR DESCRIPTION
## Summary

Addresses the bundled P3 todos from PR #181 review (todo 337).

**Stacked on PR #182** — base branch is `main` once #182 merges, but this PR's diff currently includes #182's changes too. Once #182 lands, GitHub will recompute the diff to show only the cleanups below.

## Items addressed

### CertificateWizard — secretName auto-clear UX
Don't wipe `secretName` when `name` is cleared. Auto-derive only fires for non-empty new names; clearing `name` leaves prior `secretName` alone, so users see one error not two.

### IssuerWizard — selectType no-op on re-selection
Skip the ACME-subform reset when the user clicks the already-active type card. Previously wiped in-progress edits for no reason.

### regex_parity_test.go — table-driven, 2 regexes
Now pins both `dnsLabelRegex` and `envVarNameRegex` to TS counterparts. Refactored as table-driven for easy future additions.

### frontend/lib/wizard-constants_test.ts — TS-side mirror (new)
First TypeScript test in the codebase. Mirrors `regex_parity_test.go` so a TS-side regex edit triggers the same failure mode. `deno test -A` was already wired in `deno.json`.

## Items intentionally skipped

- **useCallback backport across 24 wizards** — separate sweep PR per todo
- **`privateKeySecretRefNameTouched` placement** — DHH endorsed current shape, Kieran disagreed; kept as-is
- **Deleting the auto-default heuristic** — design question, out of scope

## Test plan

- [x] `go test ./internal/wizard/...` green (regex parity test passes)
- [x] `deno test -A frontend/lib/wizard-constants_test.ts` green (2 passed)
- [x] `deno fmt --check`, `deno lint`, `deno task build` all pass
- [x] Todo 337 marked complete
- [ ] Smoke test against homelab

🤖 Generated with [Claude Code](https://claude.com/claude-code)