### PR TITLE
fix(types): consolidate KeyValueEntry, add missing Velero field, export StatusBadgeProps (Tier 1 PR-C)

### DIFF
--- a/frontend/components/ui/KeyValueListEditor.tsx
+++ b/frontend/components/ui/KeyValueListEditor.tsx
@@ -1,7 +1,7 @@
 import { Input } from "@/components/ui/Input.tsx";
 import { RemoveButton } from "@/components/ui/RemoveButton.tsx";
 
-interface KeyValueEntry {
+export interface KeyValueEntry {
   key: string;
   value: string;
 }

--- a/frontend/components/ui/StatusBadge.tsx
+++ b/frontend/components/ui/StatusBadge.tsx
@@ -1,7 +1,7 @@
 import { statusStyle } from "@/lib/status-colors.ts";
 import type { StatusVariant } from "@/lib/status-colors.ts";
 
-interface StatusBadgeProps {
+export interface StatusBadgeProps {
   status: string;
   variant?: StatusVariant;
 }

--- a/frontend/islands/ConfigMapWizard.tsx
+++ b/frontend/islands/ConfigMapWizard.tsx
@@ -10,10 +10,7 @@ import { WizardStepper } from "@/components/wizard/WizardStepper.tsx";
 import { WizardReviewStep } from "@/components/wizard/WizardReviewStep.tsx";
 import { Button } from "@/components/ui/Button.tsx";
 
-interface KeyValueEntry {
-  key: string;
-  value: string;
-}
+import type { KeyValueEntry } from "@/components/ui/KeyValueListEditor.tsx";
 
 interface ConfigMapFormState {
   name: string;

--- a/frontend/lib/velero-types.ts
+++ b/frontend/lib/velero-types.ts
@@ -58,6 +58,7 @@ export interface Schedule {
   storageLocation?: string;
   ttl?: string;
   lastBackup?: string;
+  lastBackupPhase?: string;
   nextRunTime?: string;
   validationErrors?: string[];
 }


### PR DESCRIPTION
## Summary
- **KeyValueEntry**: export from `KeyValueListEditor.tsx`, import in `ConfigMapWizard.tsx` (was duplicated identically in both files)
- **Schedule.lastBackupPhase**: add missing `lastBackupPhase?: string` to `lib/velero-types.ts` to match Go backend (`velero/types.go:97`)
- **StatusBadgeProps**: export interface from `StatusBadge.tsx` for external consumers

4 files, net -2 lines. No behavior change.

## Test plan
- [x] `deno lint` — clean (429 files)
- [x] `deno fmt --check` — clean (432 files)
- [ ] CI green
- [ ] Homelab smoke test unnecessary (type-only changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)