### PR TITLE
fix(defensive): remove impossible-error catches, add auth logging (Tier 1 PR-D)

### DIFF
--- a/backend/internal/loki/client.go
+++ b/backend/internal/loki/client.go
@@ -205,7 +205,7 @@ func (c *Client) get(ctx context.Context, path string, params url.Values, result
 		if json.Unmarshal(body, &lokiErr) == nil && lokiErr.Error != "" {
 			return fmt.Errorf("loki error (%d): %s", resp.StatusCode, lokiErr.Error)
 		}
-		return fmt.Errorf("loki returned status %d", resp.StatusCode)
+		return fmt.Errorf("loki returned status %d: %s", resp.StatusCode, body)
 	}
 
 	if err := json.NewDecoder(io.LimitReader(resp.Body, 10<<20)).Decode(result); err != nil {

--- a/backend/internal/websocket/client.go
+++ b/backend/internal/websocket/client.go
@@ -161,7 +161,7 @@ func (c *Client) waitForAuth() bool {
 
 	c.user = auth.UserFromClaims(claims)
 
-	data, _ := json.Marshal(OutgoingMessage{Type: MsgTypeAuthOK})
+	data := mustJSON(OutgoingMessage{Type: MsgTypeAuthOK})
 	c.conn.SetWriteDeadline(time.Now().Add(writeWait))
 	if err := c.conn.WriteMessage(websocket.TextMessage, data); err != nil {
 		return false
@@ -234,7 +234,7 @@ func (c *Client) handleSubscribe(msg IncomingMessage) {
 	c.subCount++
 	c.hub.addSub <- subChange{client: c, key: key, add: true, id: msg.ID}
 
-	data, _ := json.Marshal(OutgoingMessage{Type: MsgTypeSubscribed, ID: msg.ID})
+	data := mustJSON(OutgoingMessage{Type: MsgTypeSubscribed, ID: msg.ID})
 	select {
 	case c.send <- data:
 	default:
@@ -260,7 +260,7 @@ func (c *Client) handleUnsubscribe(msg IncomingMessage) {
 }
 
 func (c *Client) sendError(id string, code int, message string) {
-	data, _ := json.Marshal(OutgoingMessage{
+	data := mustJSON(OutgoingMessage{
 		Type:    MsgTypeError,
 		ID:      id,
 		Code:    code,

--- a/backend/internal/websocket/events.go
+++ b/backend/internal/websocket/events.go
@@ -1,6 +1,9 @@
 package websocket
 
-import "sync"
+import (
+	"encoding/json"
+	"sync"
+)
 
 // ResourceEvent is emitted by informer event handlers and consumed by the Hub.
 type ResourceEvent struct {
@@ -148,4 +151,13 @@ func normalizeKind(kind string) string {
 		return canonical
 	}
 	return kind
+}
+
+// mustJSON marshals v, panicking on error. Only for types with known-safe fields (strings, ints).
+func mustJSON(v any) []byte {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic("websocket: impossible marshal error: " + err.Error())
+	}
+	return data
 }

--- a/backend/internal/websocket/hub.go
+++ b/backend/internal/websocket/hub.go
@@ -318,7 +318,12 @@ func (h *Hub) revalidateSubscriptions(ctx context.Context) {
 			Code:    403,
 			Message: "subscription revoked: access denied",
 		}
-		data := mustJSON(msg)
+		// Hub.Run() has no recover — use explicit error check instead of mustJSON
+		data, err := json.Marshal(msg)
+		if err != nil {
+			h.logger.Error("marshal revocation message", "error", err)
+			continue
+		}
 		select {
 		case r.client.send <- data:
 		default:

--- a/backend/internal/websocket/hub.go
+++ b/backend/internal/websocket/hub.go
@@ -318,11 +318,10 @@ func (h *Hub) revalidateSubscriptions(ctx context.Context) {
 			Code:    403,
 			Message: "subscription revoked: access denied",
 		}
-		if data, err := json.Marshal(msg); err == nil {
-			select {
-			case r.client.send <- data:
-			default:
-			}
+		data := mustJSON(msg)
+		select {
+		case r.client.send <- data:
+		default:
 		}
 		h.logger.Info("subscription revoked by RBAC revalidation",
 			"user", r.client.username(), "kind", r.key.Kind,

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -75,7 +75,8 @@ async function refreshAccessToken(): Promise<boolean> {
       return true;
     }
     return false;
-  } catch {
+  } catch (e) {
+    console.info("token refresh failed:", e);
     return false;
   }
 }

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -136,6 +136,7 @@ export async function refreshPermissions(namespace: string): Promise<void> {
     rbacSignal.value = res.data.rbac;
   } catch (e) {
     console.info("refreshPermissions failed:", e);
+    // null = optimistic (allow all actions until permissions load)
     rbacSignal.value = null;
   }
 }

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -112,7 +112,8 @@ export async function fetchCurrentUser(
     userSignal.value = res.data.user;
     rbacSignal.value = res.data.rbac;
     return res.data.user;
-  } catch {
+  } catch (e) {
+    console.info("fetchCurrentUser failed:", e);
     userSignal.value = null;
     rbacSignal.value = null;
     return null;
@@ -133,10 +134,8 @@ export async function refreshPermissions(namespace: string): Promise<void> {
       { method: "GET" },
     );
     rbacSignal.value = res.data.rbac;
-  } catch {
-    // Clear stale permissions from previous namespace — prevents showing
-    // actions that were valid for namespace A but not namespace B.
-    // canPerform defaults to true when null, so actions show optimistically.
+  } catch (e) {
+    console.info("refreshPermissions failed:", e);
     rbacSignal.value = null;
   }
 }


### PR DESCRIPTION
## Summary
- **websocket/**: Replace 4 impossible-error \`json.Marshal\` patterns with \`mustJSON()\` helper — hardcoded \`OutgoingMessage\` structs (strings + ints) can never fail marshaling
- **loki/client.go**: Preserve raw response body in fallback error when Loki returns non-JSON error response (previously discarded)
- **frontend auth**: Add \`console.info\` logging to 3 silent catch blocks in \`api.ts\` (token refresh) and \`auth.ts\` (fetchCurrentUser, refreshPermissions) — makes debugging auth failures possible

## What was NOT changed (and why)
- \`yaml/parser.go:64\` — \`json.Marshal(obj.Object)\` where \`obj.Object\` is \`map[string]interface{}\` from yaml.Decode. Borderline-legitimate; the map _could_ theoretically contain non-serializable values from malformed YAML. Left as-is.
- All \`recover()\` uses in websocket goroutine boundaries — legitimate panic barriers, confirmed by review.
- All browser storage, WS teardown, and protocol boundary catch blocks — legitimate per research.

## Test plan
- [x] \`go vet ./...\` — clean
- [x] \`deno lint\` — clean (429 files)
- [x] \`deno fmt --check\` — clean (432 files)
- [ ] CI green
- [ ] Homelab smoke test recommended — touches WebSocket auth path and Loki error handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)