### PR TITLE
fix(adapter): propagate request context, document extractNsName (P2 follow-ups)

### DIFF
--- a/backend/internal/k8s/resources/actions.go
+++ b/backend/internal/k8s/resources/actions.go
@@ -54,7 +54,7 @@ func (h *Handler) HandleScaleResource(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, err := scalable.Scale(cs, ns, name, req.Replicas)
+	result, err := scalable.Scale(r.Context(), cs, ns, name, req.Replicas)
 	if err != nil {
 		h.auditWrite(r, user, audit.ActionUpdate, adapter.DisplayName(), ns, name, audit.ResultFailure)
 		mapK8sError(w, err, "scale", adapter.DisplayName(), ns, name)
@@ -96,7 +96,7 @@ func (h *Handler) HandleRestartResource(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	result, err := restartable.Restart(cs, ns, name)
+	result, err := restartable.Restart(r.Context(), cs, ns, name)
 	if err != nil {
 		h.auditWrite(r, user, audit.ActionUpdate, adapter.DisplayName(), ns, name, audit.ResultFailure)
 		mapK8sError(w, err, "restart", adapter.DisplayName(), ns, name)
@@ -149,7 +149,7 @@ func (h *Handler) HandleSuspendResource(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	result, err := suspendable.Suspend(cs, ns, name, req.Suspend)
+	result, err := suspendable.Suspend(r.Context(), cs, ns, name, req.Suspend)
 	if err != nil {
 		h.auditWrite(r, user, audit.ActionUpdate, adapter.DisplayName(), ns, name, audit.ResultFailure)
 		mapK8sError(w, err, "suspend", adapter.DisplayName(), ns, name)
@@ -191,7 +191,7 @@ func (h *Handler) HandleTriggerResource(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	result, err := triggerable.Trigger(cs, ns, name)
+	result, err := triggerable.Trigger(r.Context(), cs, ns, name)
 	if err != nil {
 		h.auditWrite(r, user, audit.ActionCreate, adapter.DisplayName(), ns, name, audit.ResultFailure)
 		mapK8sError(w, err, "trigger", adapter.DisplayName(), ns, name)
@@ -248,7 +248,7 @@ func (h *Handler) HandleRollbackResource(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	result, err := rollbackable.Rollback(cs, ns, name, req.Revision)
+	result, err := rollbackable.Rollback(r.Context(), cs, ns, name, req.Revision)
 	if err != nil {
 		h.auditWrite(r, user, audit.ActionUpdate, adapter.DisplayName(), ns, name, audit.ResultFailure)
 		mapK8sError(w, err, "rollback", adapter.DisplayName(), ns, name)

--- a/backend/internal/k8s/resources/adapter.go
+++ b/backend/internal/k8s/resources/adapter.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"context"
 	"errors"
 
 	"github.com/kubecenter/kubecenter/internal/k8s"
@@ -34,13 +35,16 @@ type ResourceAdapter interface {
 	GetFromCache(inf *k8s.InformerManager, ns, name string) (any, error)
 
 	// Create creates a new resource from the JSON body using an impersonating client.
-	Create(cs kubernetes.Interface, ns string, body []byte) (any, error)
+	// The context should be the HTTP request context to propagate cancellation and timeouts.
+	Create(ctx context.Context, cs kubernetes.Interface, ns string, body []byte) (any, error)
 
 	// Update updates an existing resource from the JSON body using an impersonating client.
-	Update(cs kubernetes.Interface, ns, name string, body []byte) (any, error)
+	// The context should be the HTTP request context to propagate cancellation and timeouts.
+	Update(ctx context.Context, cs kubernetes.Interface, ns, name string, body []byte) (any, error)
 
 	// Delete removes a resource by namespace and name using an impersonating client.
-	Delete(cs kubernetes.Interface, ns, name string) error
+	// The context should be the HTTP request context to propagate cancellation and timeouts.
+	Delete(ctx context.Context, cs kubernetes.Interface, ns, name string) error
 }
 
 // ReadOnlyAdapter provides default no-op implementations for Create, Update, and Delete
@@ -49,17 +53,17 @@ type ResourceAdapter interface {
 type ReadOnlyAdapter struct{}
 
 // Create is not supported for read-only resources.
-func (ReadOnlyAdapter) Create(_ kubernetes.Interface, _ string, _ []byte) (any, error) {
+func (ReadOnlyAdapter) Create(_ context.Context, _ kubernetes.Interface, _ string, _ []byte) (any, error) {
 	return nil, errReadOnly
 }
 
 // Update is not supported for read-only resources.
-func (ReadOnlyAdapter) Update(_ kubernetes.Interface, _, _ string, _ []byte) (any, error) {
+func (ReadOnlyAdapter) Update(_ context.Context, _ kubernetes.Interface, _, _ string, _ []byte) (any, error) {
 	return nil, errReadOnly
 }
 
 // Delete is not supported for read-only resources.
-func (ReadOnlyAdapter) Delete(_ kubernetes.Interface, _, _ string) error {
+func (ReadOnlyAdapter) Delete(_ context.Context, _ kubernetes.Interface, _, _ string) error {
 	return errReadOnly
 }
 
@@ -72,25 +76,25 @@ var errReadOnly = errors.New("this resource is read-only and does not support th
 
 // Scalable indicates a resource supports scale (e.g. Deployments, StatefulSets, ReplicaSets).
 type Scalable interface {
-	Scale(cs kubernetes.Interface, ns, name string, replicas int32) (any, error)
+	Scale(ctx context.Context, cs kubernetes.Interface, ns, name string, replicas int32) (any, error)
 }
 
 // Restartable indicates a resource supports rolling restart (e.g. Deployments, StatefulSets, DaemonSets).
 type Restartable interface {
-	Restart(cs kubernetes.Interface, ns, name string) (any, error)
+	Restart(ctx context.Context, cs kubernetes.Interface, ns, name string) (any, error)
 }
 
 // Suspendable indicates a resource supports suspend/resume (e.g. CronJobs).
 type Suspendable interface {
-	Suspend(cs kubernetes.Interface, ns, name string, suspend bool) (any, error)
+	Suspend(ctx context.Context, cs kubernetes.Interface, ns, name string, suspend bool) (any, error)
 }
 
 // Triggerable indicates a resource supports manual triggering (e.g. CronJobs → create Job).
 type Triggerable interface {
-	Trigger(cs kubernetes.Interface, ns, name string) (any, error)
+	Trigger(ctx context.Context, cs kubernetes.Interface, ns, name string) (any, error)
 }
 
 // Rollbackable indicates a resource supports rollback to a previous revision (e.g. Deployments).
 type Rollbackable interface {
-	Rollback(cs kubernetes.Interface, ns, name string, revision int64) (any, error)
+	Rollback(ctx context.Context, cs kubernetes.Interface, ns, name string, revision int64) (any, error)
 }

--- a/backend/internal/k8s/resources/adapter_configmaps.go
+++ b/backend/internal/k8s/resources/adapter_configmaps.go
@@ -41,27 +41,27 @@ func (configMapAdapter) GetFromCache(inf *k8s.InformerManager, ns, name string) 
 	return inf.ConfigMaps().ConfigMaps(ns).Get(name)
 }
 
-func (configMapAdapter) Create(cs kubernetes.Interface, ns string, body []byte) (any, error) {
+func (configMapAdapter) Create(ctx context.Context, cs kubernetes.Interface, ns string, body []byte) (any, error) {
 	var obj corev1.ConfigMap
 	if err := json.Unmarshal(body, &obj); err != nil {
 		return nil, err
 	}
 	obj.Namespace = ns
-	return cs.CoreV1().ConfigMaps(ns).Create(context.TODO(), &obj, metav1.CreateOptions{})
+	return cs.CoreV1().ConfigMaps(ns).Create(ctx, &obj, metav1.CreateOptions{})
 }
 
-func (configMapAdapter) Update(cs kubernetes.Interface, ns, name string, body []byte) (any, error) {
+func (configMapAdapter) Update(ctx context.Context, cs kubernetes.Interface, ns, name string, body []byte) (any, error) {
 	var obj corev1.ConfigMap
 	if err := json.Unmarshal(body, &obj); err != nil {
 		return nil, err
 	}
 	obj.Namespace = ns
 	obj.Name = name
-	return cs.CoreV1().ConfigMaps(ns).Update(context.TODO(), &obj, metav1.UpdateOptions{})
+	return cs.CoreV1().ConfigMaps(ns).Update(ctx, &obj, metav1.UpdateOptions{})
 }
 
-func (configMapAdapter) Delete(cs kubernetes.Interface, ns, name string) error {
-	return cs.CoreV1().ConfigMaps(ns).Delete(context.TODO(), name, metav1.DeleteOptions{})
+func (configMapAdapter) Delete(ctx context.Context, cs kubernetes.Interface, ns, name string) error {
+	return cs.CoreV1().ConfigMaps(ns).Delete(ctx, name, metav1.DeleteOptions{})
 }
 
 func init() { Register(configMapAdapter{}) }

--- a/backend/internal/k8s/resources/adapter_namespaces.go
+++ b/backend/internal/k8s/resources/adapter_namespaces.go
@@ -35,21 +35,21 @@ func (namespaceAdapter) GetFromCache(inf *k8s.InformerManager, _, name string) (
 	return inf.Namespaces().Get(name)
 }
 
-func (namespaceAdapter) Create(cs kubernetes.Interface, _ string, body []byte) (any, error) {
+func (namespaceAdapter) Create(ctx context.Context, cs kubernetes.Interface, _ string, body []byte) (any, error) {
 	var obj corev1.Namespace
 	if err := json.Unmarshal(body, &obj); err != nil {
 		return nil, err
 	}
-	return cs.CoreV1().Namespaces().Create(context.TODO(), &obj, metav1.CreateOptions{})
+	return cs.CoreV1().Namespaces().Create(ctx, &obj, metav1.CreateOptions{})
 }
 
 // Update is not supported for namespaces (use YAML apply for metadata changes).
-func (namespaceAdapter) Update(_ kubernetes.Interface, _, _ string, _ []byte) (any, error) {
+func (namespaceAdapter) Update(_ context.Context, _ kubernetes.Interface, _, _ string, _ []byte) (any, error) {
 	return nil, errReadOnly
 }
 
-func (namespaceAdapter) Delete(cs kubernetes.Interface, _, name string) error {
-	return cs.CoreV1().Namespaces().Delete(context.TODO(), name, metav1.DeleteOptions{})
+func (namespaceAdapter) Delete(ctx context.Context, cs kubernetes.Interface, _, name string) error {
+	return cs.CoreV1().Namespaces().Delete(ctx, name, metav1.DeleteOptions{})
 }
 
 func init() { Register(namespaceAdapter{}) }

--- a/backend/internal/k8s/resources/adapter_secrets.go
+++ b/backend/internal/k8s/resources/adapter_secrets.go
@@ -33,27 +33,27 @@ func (secretAdapter) GetFromCache(_ *k8s.InformerManager, _, _ string) (any, err
 	return nil, errSecretsNotCached
 }
 
-func (secretAdapter) Create(cs kubernetes.Interface, ns string, body []byte) (any, error) {
+func (secretAdapter) Create(ctx context.Context, cs kubernetes.Interface, ns string, body []byte) (any, error) {
 	var obj corev1.Secret
 	if err := json.Unmarshal(body, &obj); err != nil {
 		return nil, err
 	}
 	obj.Namespace = ns
-	return cs.CoreV1().Secrets(ns).Create(context.TODO(), &obj, metav1.CreateOptions{})
+	return cs.CoreV1().Secrets(ns).Create(ctx, &obj, metav1.CreateOptions{})
 }
 
-func (secretAdapter) Update(cs kubernetes.Interface, ns, name string, body []byte) (any, error) {
+func (secretAdapter) Update(ctx context.Context, cs kubernetes.Interface, ns, name string, body []byte) (any, error) {
 	var obj corev1.Secret
 	if err := json.Unmarshal(body, &obj); err != nil {
 		return nil, err
 	}
 	obj.Namespace = ns
 	obj.Name = name
-	return cs.CoreV1().Secrets(ns).Update(context.TODO(), &obj, metav1.UpdateOptions{})
+	return cs.CoreV1().Secrets(ns).Update(ctx, &obj, metav1.UpdateOptions{})
 }
 
-func (secretAdapter) Delete(cs kubernetes.Interface, ns, name string) error {
-	return cs.CoreV1().Secrets(ns).Delete(context.TODO(), name, metav1.DeleteOptions{})
+func (secretAdapter) Delete(ctx context.Context, cs kubernetes.Interface, ns, name string) error {
+	return cs.CoreV1().Secrets(ns).Delete(ctx, name, metav1.DeleteOptions{})
 }
 
 func init() { Register(secretAdapter{}) }

--- a/backend/internal/k8s/resources/adapter_test.go
+++ b/backend/internal/k8s/resources/adapter_test.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"context"
 	"testing"
 )
 
@@ -48,13 +49,14 @@ func TestReadOnlyAdaptersRejectWrites(t *testing.T) {
 		if a == nil {
 			t.Fatalf("adapter not registered for kind %q", kind)
 		}
-		if _, err := a.Create(nil, "default", []byte(`{}`)); err == nil {
+		ctx := context.Background()
+		if _, err := a.Create(ctx, nil, "default", []byte(`{}`)); err == nil {
 			t.Errorf("%s: Create should return error for read-only adapter", kind)
 		}
-		if _, err := a.Update(nil, "default", "test", []byte(`{}`)); err == nil {
+		if _, err := a.Update(ctx, nil, "default", "test", []byte(`{}`)); err == nil {
 			t.Errorf("%s: Update should return error for read-only adapter", kind)
 		}
-		if err := a.Delete(nil, "default", "test"); err == nil {
+		if err := a.Delete(ctx, nil, "default", "test"); err == nil {
 			t.Errorf("%s: Delete should return error for read-only adapter", kind)
 		}
 	}
@@ -65,7 +67,7 @@ func TestNamespaceAdapterRejectsUpdate(t *testing.T) {
 	if a == nil {
 		t.Fatal("adapter not registered for kind namespaces")
 	}
-	if _, err := a.Update(nil, "", "test", []byte(`{}`)); err == nil {
+	if _, err := a.Update(context.Background(), nil, "", "test", []byte(`{}`)); err == nil {
 		t.Error("namespaces: Update should return error")
 	}
 }

--- a/backend/internal/k8s/resources/crud.go
+++ b/backend/internal/k8s/resources/crud.go
@@ -112,7 +112,7 @@ func (h *Handler) HandleCreateResource(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, err := adapter.Create(cs, ns, body)
+	result, err := adapter.Create(r.Context(), cs, ns, body)
 	if err != nil {
 		if errors.Is(err, errReadOnly) {
 			writeError(w, http.StatusMethodNotAllowed, adapter.DisplayName()+" is read-only", "")
@@ -157,7 +157,7 @@ func (h *Handler) HandleUpdateResource(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, err := adapter.Update(cs, ns, name, body)
+	result, err := adapter.Update(r.Context(), cs, ns, name, body)
 	if err != nil {
 		if errors.Is(err, errReadOnly) {
 			writeError(w, http.StatusMethodNotAllowed, adapter.DisplayName()+" is read-only", "")
@@ -197,7 +197,7 @@ func (h *Handler) HandleDeleteResource(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = adapter.Delete(cs, ns, name)
+	err = adapter.Delete(r.Context(), cs, ns, name)
 	if err != nil {
 		if errors.Is(err, errReadOnly) {
 			writeError(w, http.StatusMethodNotAllowed, adapter.DisplayName()+" is read-only", "")
@@ -229,7 +229,11 @@ func resolveAdapter(w http.ResponseWriter, r *http.Request) (ResourceAdapter, bo
 }
 
 // extractNsName extracts namespace and name from URL params.
-// For cluster-scoped resources, the first path segment after kind is the name (no namespace).
+// WARNING: For cluster-scoped resources, chi's {namespace} URL param is
+// reinterpreted as the resource name because cluster-scoped GET/DELETE
+// routes use the same 2-segment pattern /resources/{kind}/{name} which
+// chi maps to the {namespace} param. This is a deliberate semantic
+// mismatch to avoid registering separate route handlers.
 func extractNsName(r *http.Request, adapter ResourceAdapter) (ns, name string) {
 	if adapter.ClusterScoped() {
 		// Route: /resources/{kind}/{name} — chi maps first segment to "namespace"


### PR DESCRIPTION
## Summary
Addresses two P2 findings from PR #191 architecture review:

**1. Context propagation** — All adapter interface methods that make Kubernetes API calls (Create, Update, Delete, Scale, Restart, Suspend, Trigger, Rollback) now accept \`context.Context\` as first parameter. CRUD + action handlers pass \`r.Context()\`, replacing \`context.TODO()\`. This ensures HTTP request cancellation and timeouts flow through to k8s API calls.

**2. extractNsName documentation** — Added WARNING comment explaining the deliberate semantic mismatch where chi's \`{namespace}\` URL param is reinterpreted as resource name for cluster-scoped resources.

## Files changed (9)
- \`adapter.go\` — interface + ReadOnlyAdapter + capability interface signatures
- \`crud.go\` — pass \`r.Context()\` to Create/Update/Delete + extractNsName comment
- \`actions.go\` — pass \`r.Context()\` to Scale/Restart/Suspend/Trigger/Rollback
- \`adapter_configmaps.go\`, \`adapter_secrets.go\`, \`adapter_namespaces.go\` — \`ctx\` replaces \`context.TODO()\`
- \`adapter_serviceaccounts.go\`, \`adapter_endpoints.go\` — ReadOnlyAdapter handles signature via embed
- \`adapter_test.go\` — pass \`context.Background()\` to test calls

## Test plan
- [x] \`go build ./...\` — clean
- [x] \`go vet ./...\` — clean
- [x] All 47 tests pass
- [ ] CI + E2E green

🤖 Generated with [Claude Code](https://claude.com/claude-code)