### PR TITLE
Service mesh observability — Phase A (Istio + Linkerd inventory)

### DIFF
--- a/backend/cmd/kubecenter/main.go
+++ b/backend/cmd/kubecenter/main.go
@@ -40,6 +40,7 @@ import (
 	"github.com/kubecenter/kubecenter/internal/scanning"
 	"github.com/kubecenter/kubecenter/internal/server"
 	"github.com/kubecenter/kubecenter/internal/server/middleware"
+	"github.com/kubecenter/kubecenter/internal/servicemesh"
 	"github.com/kubecenter/kubecenter/internal/storage"
 	appstore "github.com/kubecenter/kubecenter/internal/store"
 	"github.com/kubecenter/kubecenter/internal/topology"
@@ -672,6 +673,15 @@ func main() {
 	gwDisc := gateway.NewDiscoverer(k8sClient, logger)
 	gwHandler := gateway.NewHandler(k8sClient, gwDisc, accessChecker, logger)
 
+	// Service Mesh integration (Istio + Linkerd)
+	meshDisc := servicemesh.NewDiscoverer(k8sClient, logger)
+	meshHandler := &servicemesh.Handler{
+		K8sClient:     k8sClient,
+		Discoverer:    meshDisc,
+		AccessChecker: accessChecker,
+		Logger:        logger,
+	}
+
 	// Ready state: true after informer sync, false during shutdown
 	var ready atomic.Bool
 	ready.Store(true)
@@ -713,6 +723,7 @@ func main() {
 		VeleroHandler:      veleroHandler,
 		CertManagerHandler: cmHandler,
 		GatewayHandler:     gwHandler,
+		ServiceMeshHandler: meshHandler,
 		CRDHandler:         crdHandler,
 		LogQueryLimiter:    logQueryLimiter,
 		WebhookRateLimiter: webhookRateLimiter,

--- a/backend/internal/server/routes.go
+++ b/backend/internal/server/routes.go
@@ -176,6 +176,11 @@ func (s *Server) registerRoutes() {
 				s.registerGatewayRoutes(ar)
 			}
 
+			// Service Mesh routes — only registered if service mesh handler is available
+			if s.ServiceMeshHandler != nil {
+				s.registerServiceMeshRoutes(ar)
+			}
+
 			// Notification center routes
 			if s.NotifCenterHandler != nil {
 				s.registerNotifCenterRoutes(ar)
@@ -631,6 +636,21 @@ func (s *Server) registerGatewayRoutes(ar chi.Router) {
 		gr.With(middleware.RateLimit(rl), resources.ValidateURLParams).Get("/gateways/{namespace}/{name}", h.HandleGetGateway)
 		gr.With(middleware.RateLimit(rl), resources.ValidateURLParams).Get("/httproutes/{namespace}/{name}", h.HandleGetHTTPRoute)
 		gr.With(middleware.RateLimit(rl), resources.ValidateURLParams).Get("/routes/{kind}/{namespace}/{name}", h.HandleGetRoute)
+	})
+}
+
+func (s *Server) registerServiceMeshRoutes(ar chi.Router) {
+	h := s.ServiceMeshHandler
+	ar.Route("/mesh", func(mr chi.Router) {
+		rl := s.YAMLRateLimiter
+		if rl == nil {
+			rl = s.RateLimiter
+		}
+		mr.Use(middleware.RateLimit(rl))
+		mr.Get("/status", h.HandleStatus)
+		mr.Get("/routing", h.HandleListRoutes)
+		mr.Get("/routing/{id}", h.HandleGetRoute)
+		mr.Get("/policies", h.HandleListPolicies)
 	})
 }
 

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -28,6 +28,7 @@ import (
 	"github.com/kubecenter/kubecenter/internal/certmanager"
 	"github.com/kubecenter/kubecenter/internal/scanning"
 	"github.com/kubecenter/kubecenter/internal/server/middleware" // used by Deps type
+	"github.com/kubecenter/kubecenter/internal/servicemesh"
 	"github.com/kubecenter/kubecenter/internal/storage"
 	"github.com/kubecenter/kubecenter/internal/store"
 	"github.com/kubecenter/kubecenter/internal/topology"
@@ -75,6 +76,7 @@ type Server struct {
 	VeleroHandler      *velero.Handler
 	CertManagerHandler *certmanager.Handler
 	GatewayHandler     *gateway.Handler
+	ServiceMeshHandler *servicemesh.Handler
 	CRDHandler         *resources.GenericCRDHandler
 	NotifCenterHandler *notifications.Handler
 	NotifCenterService *notifications.NotificationService
@@ -120,6 +122,7 @@ type Deps struct {
 	VeleroHandler      *velero.Handler
 	CertManagerHandler *certmanager.Handler
 	GatewayHandler     *gateway.Handler
+	ServiceMeshHandler *servicemesh.Handler
 	CRDHandler         *resources.GenericCRDHandler
 	NotifCenterHandler *notifications.Handler
 	NotifCenterService *notifications.NotificationService
@@ -275,6 +278,11 @@ func New(deps Deps) *Server {
 	// Gateway API handler
 	if deps.GatewayHandler != nil {
 		s.GatewayHandler = deps.GatewayHandler
+	}
+
+	// Service Mesh handler (Istio + Linkerd observability)
+	if deps.ServiceMeshHandler != nil {
+		s.ServiceMeshHandler = deps.ServiceMeshHandler
 	}
 
 	// Notification center

--- a/backend/internal/servicemesh/discovery.go
+++ b/backend/internal/servicemesh/discovery.go
@@ -1,0 +1,257 @@
+package servicemesh
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/kubecenter/kubecenter/internal/k8s"
+)
+
+const (
+	staleDuration    = 5 * time.Minute
+	istioSystemNS    = "istio-system"
+	linkerdControlNS = "linkerd"
+	istioDeployLabel = "app=istiod"
+	linkerdDeployLbl = "linkerd.io/control-plane-component=identity"
+	versionUnknown   = "unknown"
+)
+
+// Discoverer probes the cluster for Istio and Linkerd control planes
+// and maintains cached mesh-status state with a lazy re-probe on stale reads.
+type Discoverer struct {
+	cs     kubernetes.Interface
+	disco  discovery.DiscoveryInterface
+	logger *slog.Logger
+
+	mu     sync.RWMutex
+	status MeshStatus
+}
+
+// NewDiscoverer creates a new service-mesh discoverer. Passing a nil
+// ClientFactory is supported for tests that exercise state-machine behavior;
+// Probe will short-circuit to an empty status in that case.
+func NewDiscoverer(k8sClient *k8s.ClientFactory, logger *slog.Logger) *Discoverer {
+	d := &Discoverer{
+		logger: logger,
+		status: MeshStatus{LastChecked: time.Now().UTC()},
+	}
+	if k8sClient != nil {
+		d.cs = k8sClient.BaseClientset()
+		d.disco = k8sClient.DiscoveryClient()
+	}
+	return d
+}
+
+// newDiscovererForTest wires a Discoverer directly to fake clients. Used only
+// by unit tests in this package.
+func newDiscovererForTest(cs kubernetes.Interface, disco discovery.DiscoveryInterface, logger *slog.Logger) *Discoverer {
+	return &Discoverer{
+		cs:     cs,
+		disco:  disco,
+		logger: logger,
+		status: MeshStatus{LastChecked: time.Now().UTC()},
+	}
+}
+
+// Status returns the cached mesh status. If the cache is older than
+// staleDuration, Status triggers a Probe on the calling goroutine.
+func (d *Discoverer) Status(ctx context.Context) MeshStatus {
+	d.mu.RLock()
+	if time.Since(d.status.LastChecked) < staleDuration {
+		status := d.status
+		d.mu.RUnlock()
+		return status
+	}
+	d.mu.RUnlock()
+
+	return d.Probe(ctx)
+}
+
+// IsInstalled returns true if either mesh was detected.
+func (d *Discoverer) IsInstalled(ctx context.Context) bool {
+	s := d.Status(ctx)
+	return s.Istio != nil || s.Linkerd != nil
+}
+
+// Probe runs CRD discovery + control-plane deployment probes and refreshes
+// the cached status. Callers may invoke Probe directly to force a refresh.
+//
+// When a mesh probe hits a transient discovery error (anything other than
+// "GroupVersion not found"), the previous cached MeshInfo is preserved so
+// temporary API-server hiccups do not flap the UI's detection state.
+func (d *Discoverer) Probe(ctx context.Context) MeshStatus {
+	// Short-circuit for the test constructor with nil client.
+	if d.disco == nil {
+		d.mu.Lock()
+		defer d.mu.Unlock()
+		d.status = MeshStatus{LastChecked: time.Now().UTC()}
+		return d.status
+	}
+
+	istioInfo, istioErr := d.probeIstio(ctx)
+	linkerdInfo, linkerdErr := d.probeLinkerd(ctx)
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	prev := d.status
+	status := MeshStatus{LastChecked: time.Now().UTC()}
+
+	if istioErr != nil {
+		d.logger.Warn("istio discovery failed; preserving cached state", "error", istioErr)
+		status.Istio = prev.Istio
+	} else {
+		status.Istio = istioInfo
+	}
+	if linkerdErr != nil {
+		d.logger.Warn("linkerd discovery failed; preserving cached state", "error", linkerdErr)
+		status.Linkerd = prev.Linkerd
+	} else {
+		status.Linkerd = linkerdInfo
+	}
+	status.Detected = detectionFrom(status.Istio, status.Linkerd)
+
+	d.status = status
+	d.logger.Info("service mesh discovery completed",
+		"detected", status.Detected,
+		"istioInstalled", status.Istio != nil && status.Istio.Installed,
+		"linkerdInstalled", status.Linkerd != nil && status.Linkerd.Installed,
+	)
+	return status
+}
+
+// probeIstio returns (nil, nil) when Istio is not installed, (info, nil) when
+// detected, and (nil, err) on a hard discovery error that the caller should
+// treat as transient.
+func (d *Discoverer) probeIstio(ctx context.Context) (*MeshInfo, error) {
+	present, err := d.hasGroupVersionKind("networking.istio.io/v1", "VirtualService")
+	if err != nil {
+		return nil, err
+	}
+	if !present {
+		return nil, nil
+	}
+
+	// CRDs imply install; default to Version=unknown and fill in from the
+	// istiod deployment when it is reachable.
+	info := &MeshInfo{Installed: true, Version: versionUnknown, Mode: MeshModeSidecar}
+
+	deps, err := d.cs.AppsV1().Deployments(istioSystemNS).List(ctx, metav1.ListOptions{
+		LabelSelector: istioDeployLabel,
+	})
+	if err == nil && len(deps.Items) > 0 {
+		info.Namespace = istioSystemNS
+		if v := versionForDeployment(deps.Items[0], "app.kubernetes.io/version"); v != "" {
+			info.Version = v
+		}
+	}
+
+	// Ambient mode heuristic: ztunnel DaemonSet in istio-system.
+	ds, err := d.cs.AppsV1().DaemonSets(istioSystemNS).List(ctx, metav1.ListOptions{
+		LabelSelector: "app=ztunnel",
+	})
+	if err == nil && len(ds.Items) > 0 {
+		info.Mode = MeshModeAmbient
+	}
+
+	return info, nil
+}
+
+func (d *Discoverer) probeLinkerd(ctx context.Context) (*MeshInfo, error) {
+	present, err := d.hasGroupVersionKind("policy.linkerd.io/v1beta3", "Server")
+	if err != nil {
+		return nil, err
+	}
+	if !present {
+		return nil, nil
+	}
+
+	info := &MeshInfo{Installed: true, Version: versionUnknown}
+
+	deps, err := d.cs.AppsV1().Deployments(linkerdControlNS).List(ctx, metav1.ListOptions{
+		LabelSelector: linkerdDeployLbl,
+	})
+	if err == nil && len(deps.Items) > 0 {
+		info.Namespace = linkerdControlNS
+		if v := versionForDeployment(deps.Items[0], "linkerd.io/control-plane-version"); v != "" {
+			info.Version = v
+		}
+	}
+
+	return info, nil
+}
+
+// hasGroupVersionKind returns whether the cluster's discovery layer reports
+// a named Kind under the given GroupVersion. A missing GroupVersion is
+// returned as (false, nil); any other discovery error is returned verbatim
+// so the caller can preserve cached state instead of flipping to "not installed".
+func (d *Discoverer) hasGroupVersionKind(groupVersion, kind string) (bool, error) {
+	resources, err := d.disco.ServerResourcesForGroupVersion(groupVersion)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	if resources == nil {
+		return false, nil
+	}
+	for _, r := range resources.APIResources {
+		if r.Kind == kind {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// detectionFrom collapses per-mesh detection into the MeshType discriminator.
+func detectionFrom(istio, linkerd *MeshInfo) MeshType {
+	switch {
+	case istio != nil && linkerd != nil:
+		return MeshBoth
+	case istio != nil:
+		return MeshIstio
+	case linkerd != nil:
+		return MeshLinkerd
+	default:
+		return MeshNone
+	}
+}
+
+// versionFromDeploymentImage extracts the tag from the first container image
+// (e.g., "docker.io/istio/pilot:1.24.0" -> "1.24.0"). Returns empty if the
+// image has no tag or the container list is empty.
+func versionFromDeploymentImage(containers []corev1.Container) string {
+	if len(containers) == 0 {
+		return ""
+	}
+	img := containers[0].Image
+	idx := strings.LastIndexByte(img, ':')
+	if idx < 0 || idx == len(img)-1 {
+		return ""
+	}
+	return img[idx+1:]
+}
+
+// versionForDeployment prefers the image tag and falls back to the named
+// label. Returns empty when neither is usable — callers should default to
+// versionUnknown in that case.
+func versionForDeployment(dep appsv1.Deployment, fallbackLabel string) string {
+	if v := versionFromDeploymentImage(dep.Spec.Template.Spec.Containers); v != "" {
+		return v
+	}
+	if v, ok := dep.Labels[fallbackLabel]; ok {
+		return v
+	}
+	return ""
+}

--- a/backend/internal/servicemesh/discovery_test.go
+++ b/backend/internal/servicemesh/discovery_test.go
@@ -1,0 +1,311 @@
+package servicemesh
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+// --- fixtures ---------------------------------------------------------------
+
+func istioCRDList() *metav1.APIResourceList {
+	return &metav1.APIResourceList{
+		GroupVersion: "networking.istio.io/v1",
+		APIResources: []metav1.APIResource{{Name: "virtualservices", Kind: "VirtualService"}},
+	}
+}
+
+func linkerdCRDList() *metav1.APIResourceList {
+	return &metav1.APIResourceList{
+		GroupVersion: "policy.linkerd.io/v1beta3",
+		APIResources: []metav1.APIResource{{Name: "servers", Kind: "Server"}},
+	}
+}
+
+func istiodDeployment(image string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "istiod",
+			Namespace: istioSystemNS,
+			Labels:    map[string]string{"app": "istiod"},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "discovery", Image: image}},
+				},
+			},
+		},
+	}
+}
+
+func linkerdIdentityDeployment(image string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "linkerd-identity",
+			Namespace: linkerdControlNS,
+			Labels:    map[string]string{"linkerd.io/control-plane-component": "identity"},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "identity", Image: image}},
+				},
+			},
+		},
+	}
+}
+
+func ztunnelDaemonSet() *appsv1.DaemonSet {
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ztunnel",
+			Namespace: istioSystemNS,
+			Labels:    map[string]string{"app": "ztunnel"},
+		},
+	}
+}
+
+// newFakeClients returns a kubernetes.Interface / discovery.DiscoveryInterface
+// pair with pre-populated objects and a controllable discovery resource list.
+func newFakeClients(gvs []*metav1.APIResourceList, objects ...runtime.Object) *fake.Clientset {
+	cs := fake.NewClientset(objects...)
+	cs.Resources = gvs
+	return cs
+}
+
+// --- tests ------------------------------------------------------------------
+
+func TestDiscoverer_InitialStatus(t *testing.T) {
+	d := NewDiscoverer(nil, slog.Default())
+	if d == nil {
+		t.Fatal("expected non-nil discoverer")
+	}
+
+	status := d.Status(context.Background())
+	if status.Istio != nil {
+		t.Error("expected Istio detail to be nil before first probe")
+	}
+	if status.Linkerd != nil {
+		t.Error("expected Linkerd detail to be nil before first probe")
+	}
+	if status.Detected != MeshNone {
+		t.Errorf("expected detected=%q, got %q", MeshNone, status.Detected)
+	}
+	if status.LastChecked.IsZero() {
+		t.Error("expected LastChecked to be set on construction")
+	}
+}
+
+func TestDiscoverer_StaleCacheTriggersReprobe(t *testing.T) {
+	// With a nil ClientFactory, Probe() short-circuits and refreshes only
+	// LastChecked. The test verifies the lazy-re-probe path fires when
+	// the cache is older than staleDuration.
+	d := NewDiscoverer(nil, slog.Default())
+
+	d.mu.Lock()
+	d.status.LastChecked = time.Now().Add(-2 * staleDuration).UTC()
+	originalTS := d.status.LastChecked
+	d.mu.Unlock()
+
+	status := d.Status(context.Background())
+	if !status.LastChecked.After(originalTS) {
+		t.Errorf("expected stale cache to trigger re-probe; original=%v new=%v",
+			originalTS, status.LastChecked)
+	}
+}
+
+func TestDetectionFrom(t *testing.T) {
+	tests := []struct {
+		name    string
+		istio   *MeshInfo
+		linkerd *MeshInfo
+		want    MeshType
+	}{
+		{"none", nil, nil, MeshNone},
+		{"istio only", &MeshInfo{Installed: true}, nil, MeshIstio},
+		{"linkerd only", nil, &MeshInfo{Installed: true}, MeshLinkerd},
+		{"both", &MeshInfo{Installed: true}, &MeshInfo{Installed: true}, MeshBoth},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectionFrom(tt.istio, tt.linkerd); got != tt.want {
+				t.Errorf("detectionFrom(%v, %v) = %q, want %q", tt.istio, tt.linkerd, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVersionFromDeploymentImage(t *testing.T) {
+	tests := []struct {
+		name       string
+		containers []corev1.Container
+		want       string
+	}{
+		{"empty", nil, ""},
+		{"no tag", []corev1.Container{{Image: "docker.io/istio/pilot"}}, ""},
+		{"tagged", []corev1.Container{{Image: "docker.io/istio/pilot:1.24.0"}}, "1.24.0"},
+		{"registry with port + tag", []corev1.Container{{Image: "ghcr.io:5000/linkerd/proxy:v2.15.1"}}, "v2.15.1"},
+		{"trailing colon", []corev1.Container{{Image: "docker.io/istio/pilot:"}}, ""},
+		{"multi-container picks first", []corev1.Container{
+			{Image: "docker.io/istio/pilot:1.24.0"},
+			{Image: "docker.io/istio/sidecar:1.23.0"},
+		}, "1.24.0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := versionFromDeploymentImage(tt.containers); got != tt.want {
+				t.Errorf("versionFromDeploymentImage(%v) = %q, want %q", tt.containers, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDiscoverer_Probe_BothMeshesInstalled(t *testing.T) {
+	cs := newFakeClients(
+		[]*metav1.APIResourceList{istioCRDList(), linkerdCRDList()},
+		istiodDeployment("docker.io/istio/pilot:1.24.0"),
+		linkerdIdentityDeployment("cr.l5d.io/linkerd/identity:v2.15.1"),
+	)
+	d := newDiscovererForTest(cs, cs.Discovery(), slog.Default())
+
+	status := d.Probe(context.Background())
+
+	if status.Detected != MeshBoth {
+		t.Errorf("Detected = %q, want %q", status.Detected, MeshBoth)
+	}
+	if status.Istio == nil || !status.Istio.Installed || status.Istio.Version != "1.24.0" {
+		t.Errorf("Istio = %+v, want installed + version 1.24.0", status.Istio)
+	}
+	if status.Istio.Namespace != istioSystemNS {
+		t.Errorf("Istio.Namespace = %q, want %q", status.Istio.Namespace, istioSystemNS)
+	}
+	if status.Istio.Mode != MeshModeSidecar {
+		t.Errorf("Istio.Mode = %q, want %q (no ztunnel)", status.Istio.Mode, MeshModeSidecar)
+	}
+	if status.Linkerd == nil || !status.Linkerd.Installed || status.Linkerd.Version != "v2.15.1" {
+		t.Errorf("Linkerd = %+v, want installed + version v2.15.1", status.Linkerd)
+	}
+	if status.Linkerd.Namespace != linkerdControlNS {
+		t.Errorf("Linkerd.Namespace = %q, want %q", status.Linkerd.Namespace, linkerdControlNS)
+	}
+}
+
+func TestDiscoverer_Probe_OnlyIstioInstalled(t *testing.T) {
+	cs := newFakeClients(
+		[]*metav1.APIResourceList{istioCRDList()},
+		istiodDeployment("docker.io/istio/pilot:1.24.0"),
+	)
+	d := newDiscovererForTest(cs, cs.Discovery(), slog.Default())
+
+	status := d.Probe(context.Background())
+
+	if status.Detected != MeshIstio {
+		t.Errorf("Detected = %q, want %q", status.Detected, MeshIstio)
+	}
+	if status.Istio == nil || !status.Istio.Installed {
+		t.Fatalf("expected Istio installed, got %+v", status.Istio)
+	}
+	if status.Linkerd != nil {
+		t.Errorf("expected Linkerd nil when its CRDs are absent, got %+v", status.Linkerd)
+	}
+}
+
+// TestDiscoverer_Probe_CRDsWithoutControlPlane covers the plan's scenario: Istio CRDs are
+// installed but istiod is missing (crashed or deleted). The mesh should still
+// report Installed=true with Version="unknown" — CRD presence implies install
+// intent.
+func TestDiscoverer_Probe_CRDsWithoutControlPlane(t *testing.T) {
+	cs := newFakeClients([]*metav1.APIResourceList{istioCRDList()})
+	d := newDiscovererForTest(cs, cs.Discovery(), slog.Default())
+
+	status := d.Probe(context.Background())
+
+	if status.Istio == nil {
+		t.Fatal("expected Istio info present when only CRDs exist")
+	}
+	if !status.Istio.Installed {
+		t.Error("expected Installed=true when CRDs present")
+	}
+	if status.Istio.Version != versionUnknown {
+		t.Errorf("Istio.Version = %q, want %q", status.Istio.Version, versionUnknown)
+	}
+	if status.Istio.Namespace != "" {
+		t.Errorf("Istio.Namespace = %q, want empty (istiod absent)", status.Istio.Namespace)
+	}
+}
+
+// TestDiscoverer_Probe_DiscoveryError_PreservesCache covers the plan's edge case: a
+// transient discovery error (not a 404) must not flip the detected state —
+// the previous cached MeshInfo is preserved and the caller sees a warning
+// log instead of a failed request.
+func TestDiscoverer_Probe_DiscoveryError_PreservesCache(t *testing.T) {
+	cs := newFakeClients(nil)
+	// Force every ServerResourcesForGroupVersion call to fail with a
+	// non-NotFound error, simulating ErrGroupDiscoveryFailed.
+	cs.PrependReactor("get", "resource", func(_ clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("boom: api server unavailable")
+	})
+
+	d := newDiscovererForTest(cs, cs.Discovery(), slog.Default())
+
+	// Seed cache as if a previous probe had detected Istio.
+	seededIstio := &MeshInfo{
+		Installed: true,
+		Namespace: istioSystemNS,
+		Version:   "1.24.0",
+		Mode:      MeshModeSidecar,
+	}
+	d.mu.Lock()
+	d.status = MeshStatus{
+		Detected:    MeshIstio,
+		Istio:       seededIstio,
+		LastChecked: time.Now().Add(-time.Hour).UTC(),
+	}
+	d.mu.Unlock()
+
+	status := d.Probe(context.Background())
+
+	if status.Istio == nil {
+		t.Fatal("expected cached Istio to be preserved through discovery error")
+	}
+	if status.Istio.Version != "1.24.0" {
+		t.Errorf("Istio.Version = %q, want cached %q", status.Istio.Version, "1.24.0")
+	}
+	if status.Detected != MeshIstio {
+		t.Errorf("Detected = %q, want cached %q", status.Detected, MeshIstio)
+	}
+	// LastChecked should still advance — the probe ran, it just preserved
+	// detection state.
+	if !status.LastChecked.After(time.Now().Add(-time.Minute)) {
+		t.Error("expected LastChecked to advance even on preserved-cache path")
+	}
+}
+
+func TestDiscoverer_Probe_AmbientModeDetection(t *testing.T) {
+	cs := newFakeClients(
+		[]*metav1.APIResourceList{istioCRDList()},
+		istiodDeployment("docker.io/istio/pilot:1.24.0"),
+		ztunnelDaemonSet(),
+	)
+	d := newDiscovererForTest(cs, cs.Discovery(), slog.Default())
+
+	status := d.Probe(context.Background())
+
+	if status.Istio == nil {
+		t.Fatal("expected Istio installed")
+	}
+	if status.Istio.Mode != MeshModeAmbient {
+		t.Errorf("Istio.Mode = %q, want %q (ztunnel DaemonSet present)",
+			status.Istio.Mode, MeshModeAmbient)
+	}
+}

--- a/backend/internal/servicemesh/handler.go
+++ b/backend/internal/servicemesh/handler.go
@@ -1,0 +1,497 @@
+package servicemesh
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"slices"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"golang.org/x/sync/singleflight"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/kubecenter/kubecenter/internal/auth"
+	"github.com/kubecenter/kubecenter/internal/httputil"
+	"github.com/kubecenter/kubecenter/internal/k8s"
+	"github.com/kubecenter/kubecenter/internal/k8s/resources"
+)
+
+const meshCacheTTL = 30 * time.Second
+
+// Handler serves service-mesh HTTP endpoints.
+//
+// The struct mirrors gitops.Handler and policy.Handler: service-account
+// clients populate a shared cache, then per-user RBAC filtering runs on
+// every request. Writes are deferred to a later phase; v1 is read-only.
+type Handler struct {
+	K8sClient     *k8s.ClientFactory
+	Discoverer    *Discoverer
+	AccessChecker *resources.AccessChecker
+	Logger        *slog.Logger
+
+	fetchGroup singleflight.Group
+	cacheMu    sync.RWMutex
+	cache      *cachedMeshData
+	cacheGen   uint64 // incremented on invalidation; prevents stale writes
+
+	// dynOverride, when non-nil, replaces K8sClient.BaseDynamicClient() for
+	// cache-population reads. Exposed only to tests in this package.
+	dynOverride dynamic.Interface
+}
+
+type cachedMeshData struct {
+	routes    []TrafficRoute
+	policies  []MeshedPolicy
+	errors    map[string]string // "{mesh}/{Kind}" → error message
+	fetchedAt time.Time
+}
+
+// namespacedResource is implemented by the mesh types so the RBAC filter can
+// pull the item's namespace without reflection. Cluster-scoped resources
+// return "" and are delegated to admin-only visibility.
+type namespacedResource interface {
+	getNamespace() string
+	getMesh() MeshType
+	getKind() string
+}
+
+func (r TrafficRoute) getNamespace() string { return r.Namespace }
+func (r TrafficRoute) getMesh() MeshType    { return r.Mesh }
+func (r TrafficRoute) getKind() string      { return r.Kind }
+
+func (p MeshedPolicy) getNamespace() string { return p.Namespace }
+func (p MeshedPolicy) getMesh() MeshType    { return p.Mesh }
+func (p MeshedPolicy) getKind() string      { return p.Kind }
+
+// meshKindDispatch maps (mesh, kind) pairs to the Kubernetes API group,
+// resource name, and GroupVersionResource needed for RBAC checks and
+// dynamic-client reads. A missing entry means the kind is unknown and the
+// caller should return 400 — never silently fall through, since an unknown
+// kind would bypass the access check.
+type meshKindEntry struct {
+	APIGroup string
+	Resource string
+	GVR      schema.GroupVersionResource
+}
+
+var meshKindDispatch = map[string]meshKindEntry{
+	// Istio routing (networking.istio.io)
+	"istio/VirtualService":  {APIGroup: "networking.istio.io", Resource: "virtualservices", GVR: IstioVirtualServiceGVR},
+	"istio/DestinationRule": {APIGroup: "networking.istio.io", Resource: "destinationrules", GVR: IstioDestinationRuleGVR},
+	"istio/Gateway":         {APIGroup: "networking.istio.io", Resource: "gateways", GVR: IstioGatewayGVR},
+	// Istio policy (security.istio.io)
+	"istio/PeerAuthentication":  {APIGroup: "security.istio.io", Resource: "peerauthentications", GVR: IstioPeerAuthenticationGVR},
+	"istio/AuthorizationPolicy": {APIGroup: "security.istio.io", Resource: "authorizationpolicies", GVR: IstioAuthorizationPolicyGVR},
+	// Linkerd routing
+	"linkerd/ServiceProfile": {APIGroup: "linkerd.io", Resource: "serviceprofiles", GVR: LinkerdServiceProfileGVR},
+	"linkerd/Server":         {APIGroup: "policy.linkerd.io", Resource: "servers", GVR: LinkerdServerGVR},
+	"linkerd/HTTPRoute":      {APIGroup: "policy.linkerd.io", Resource: "httproutes", GVR: LinkerdHTTPRouteGVR},
+	// Linkerd policy
+	"linkerd/AuthorizationPolicy":   {APIGroup: "policy.linkerd.io", Resource: "authorizationpolicies", GVR: LinkerdAuthorizationPolicyGVR},
+	"linkerd/MeshTLSAuthentication": {APIGroup: "policy.linkerd.io", Resource: "meshtlsauthentications", GVR: LinkerdMeshTLSAuthenticationGVR},
+}
+
+// kindCodeLookup reverses the composite-ID shortcodes back to the Kind name.
+// Keyed by "{mesh}:{code}" so "istio:ap" and "linkerd:ap" disambiguate.
+var kindCodeLookup = map[string]string{
+	"istio:vs":     "VirtualService",
+	"istio:dr":     "DestinationRule",
+	"istio:gw":     "Gateway",
+	"istio:pa":     "PeerAuthentication",
+	"istio:ap":     "AuthorizationPolicy",
+	"linkerd:sp":   "ServiceProfile",
+	"linkerd:srv":  "Server",
+	"linkerd:hr":   "HTTPRoute",
+	"linkerd:ap":   "AuthorizationPolicy",
+	"linkerd:mtls": "MeshTLSAuthentication",
+}
+
+// resolveKind returns the dispatch entry for a composite-ID shortcode.
+// Unknown mesh/code pairs return ok=false so handlers can emit 400.
+func resolveKind(mesh, code string) (kind string, entry meshKindEntry, ok bool) {
+	kind, kok := kindCodeLookup[mesh+":"+code]
+	if !kok {
+		return "", meshKindEntry{}, false
+	}
+	entry, eok := meshKindDispatch[mesh+"/"+kind]
+	if !eok {
+		return "", meshKindEntry{}, false
+	}
+	return kind, entry, true
+}
+
+// fetchData returns cached routes/policies, refreshing if stale.
+// Concurrent callers coalesce via singleflight. The cache is populated with
+// the service account (cluster-wide visibility); callers must filter by RBAC
+// before exposing to users.
+func (h *Handler) fetchData(ctx context.Context) (*cachedMeshData, error) {
+	h.cacheMu.RLock()
+	if h.cache != nil && time.Since(h.cache.fetchedAt) < meshCacheTTL {
+		data := h.cache
+		h.cacheMu.RUnlock()
+		return data, nil
+	}
+	h.cacheMu.RUnlock()
+
+	result, err, _ := h.fetchGroup.Do("mesh-fetch", func() (any, error) {
+		return h.doFetch(ctx)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*cachedMeshData), nil
+}
+
+// doFetch queries both mesh adapters based on discovery status and merges
+// results. Kinds that return per-CRD errors (e.g., 403) are recorded in the
+// errors map rather than failing the whole fetch — partial data is a better
+// UX than a 500.
+func (h *Handler) doFetch(ctx context.Context) (*cachedMeshData, error) {
+	h.cacheMu.RLock()
+	gen := h.cacheGen
+	h.cacheMu.RUnlock()
+
+	dynClient := h.dynClient()
+	if dynClient == nil {
+		return &cachedMeshData{errors: map[string]string{}, fetchedAt: time.Now()}, nil
+	}
+
+	status := h.Discoverer.Status(ctx)
+
+	var (
+		istio   IstioListResult
+		linkerd LinkerdListResult
+		wg      sync.WaitGroup
+	)
+
+	if status.Istio != nil && status.Istio.Installed {
+		wg.Go(func() {
+			istio = ListIstio(ctx, dynClient, "")
+		})
+	}
+	if status.Linkerd != nil && status.Linkerd.Installed {
+		wg.Go(func() {
+			linkerd = ListLinkerd(ctx, dynClient, "")
+		})
+	}
+	wg.Wait()
+
+	errs := map[string]string{}
+	for kind, msg := range istio.Errors {
+		errs["istio/"+kind] = msg
+	}
+	for kind, msg := range linkerd.Errors {
+		errs["linkerd/"+kind] = msg
+	}
+
+	data := &cachedMeshData{
+		routes:    append(append([]TrafficRoute(nil), istio.Routes...), linkerd.Routes...),
+		policies:  append(append([]MeshedPolicy(nil), istio.Policies...), linkerd.Policies...),
+		errors:    errs,
+		fetchedAt: time.Now(),
+	}
+
+	h.cacheMu.Lock()
+	if h.cacheGen == gen {
+		h.cache = data
+	}
+	h.cacheMu.Unlock()
+
+	return data, nil
+}
+
+// InvalidateCache clears the cache so the next call re-fetches. Exported for
+// CRD event handlers to hook into, mirroring gitops/policy.
+func (h *Handler) InvalidateCache() {
+	h.cacheMu.Lock()
+	h.cache = nil
+	h.cacheGen++
+	h.cacheMu.Unlock()
+}
+
+func (h *Handler) dynClient() dynamic.Interface {
+	if h.dynOverride != nil {
+		return h.dynOverride
+	}
+	if h.K8sClient == nil {
+		return nil
+	}
+	return h.K8sClient.BaseDynamicClient()
+}
+
+// filterByRBAC returns only items in namespaces the user can list the
+// corresponding CRD in. Cache key is per-(mesh/kind, namespace) so a single
+// namespace visited by multiple kinds only triggers one SSAR per kind group.
+// Cluster-scoped items (empty namespace) are admin-only.
+func filterByRBAC[T namespacedResource](ctx context.Context, h *Handler, user *auth.User, items []T) []T {
+	type accessKey struct {
+		apiGroup  string
+		resource  string
+		namespace string
+	}
+	access := map[accessKey]bool{}
+	out := make([]T, 0, len(items))
+
+	for _, item := range items {
+		ns := item.getNamespace()
+		if ns == "" {
+			if auth.IsAdmin(user) {
+				out = append(out, item)
+			}
+			continue
+		}
+
+		entry, ok := meshKindDispatch[string(item.getMesh())+"/"+item.getKind()]
+		if !ok {
+			// Unknown kind: fail closed rather than leaking unchecked data.
+			continue
+		}
+		key := accessKey{entry.APIGroup, entry.Resource, ns}
+		allowed, checked := access[key]
+		if !checked {
+			can, err := h.AccessChecker.CanAccessGroupResource(ctx, user.KubernetesUsername, user.KubernetesGroups, "list", entry.APIGroup, entry.Resource, ns)
+			allowed = err == nil && can
+			access[key] = allowed
+		}
+		if allowed {
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
+// HandleStatus returns detected mesh installations. Non-admin users see a
+// stripped view without control-plane namespace details, matching the
+// gitops/policy precedent.
+func (h *Handler) HandleStatus(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	status := h.Discoverer.Status(r.Context())
+
+	if !auth.IsAdmin(user) {
+		if status.Istio != nil {
+			stripped := *status.Istio
+			stripped.Namespace = ""
+			status.Istio = &stripped
+		}
+		if status.Linkerd != nil {
+			stripped := *status.Linkerd
+			stripped.Namespace = ""
+			status.Linkerd = &stripped
+		}
+	}
+
+	httputil.WriteData(w, status)
+}
+
+// routingResponse is the envelope for GET /mesh/routing. When no mesh is
+// installed, `Status.Detected == MeshNone` and `Routes` is an empty slice —
+// never nil — so the frontend can treat this as a normal empty-state.
+type routingResponse struct {
+	Status MeshStatus        `json:"status"`
+	Routes []TrafficRoute    `json:"routes"`
+	Errors map[string]string `json:"errors,omitempty"`
+}
+
+type policiesResponse struct {
+	Status   MeshStatus        `json:"status"`
+	Policies []MeshedPolicy    `json:"policies"`
+	Errors   map[string]string `json:"errors,omitempty"`
+}
+
+// HandleListRoutes returns RBAC-filtered traffic routes across both meshes.
+// The optional ?namespace= query parameter further scopes the list.
+func (h *Handler) HandleListRoutes(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	status := h.Discoverer.Status(r.Context())
+
+	data, err := h.fetchData(r.Context())
+	if err != nil {
+		h.Logger.Error("failed to fetch mesh data", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to fetch mesh data", "")
+		return
+	}
+
+	routes := data.routes
+	if ns := r.URL.Query().Get("namespace"); ns != "" {
+		scoped := make([]TrafficRoute, 0, len(routes))
+		for _, tr := range routes {
+			if tr.Namespace == ns {
+				scoped = append(scoped, tr)
+			}
+		}
+		routes = scoped
+	}
+
+	routes = filterByRBAC(r.Context(), h, user, routes)
+	sort.Slice(routes, func(i, j int) bool {
+		if routes[i].Namespace != routes[j].Namespace {
+			return routes[i].Namespace < routes[j].Namespace
+		}
+		if routes[i].Kind != routes[j].Kind {
+			return routes[i].Kind < routes[j].Kind
+		}
+		return routes[i].Name < routes[j].Name
+	})
+
+	if routes == nil {
+		routes = []TrafficRoute{}
+	}
+
+	httputil.WriteData(w, routingResponse{
+		Status: status,
+		Routes: routes,
+		Errors: data.errors,
+	})
+}
+
+// HandleListPolicies returns RBAC-filtered mesh-security CRDs across both meshes.
+func (h *Handler) HandleListPolicies(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	status := h.Discoverer.Status(r.Context())
+
+	data, err := h.fetchData(r.Context())
+	if err != nil {
+		h.Logger.Error("failed to fetch mesh data", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to fetch mesh data", "")
+		return
+	}
+
+	policies := data.policies
+	if ns := r.URL.Query().Get("namespace"); ns != "" {
+		scoped := make([]MeshedPolicy, 0, len(policies))
+		for _, p := range policies {
+			if p.Namespace == ns {
+				scoped = append(scoped, p)
+			}
+		}
+		policies = scoped
+	}
+
+	policies = filterByRBAC(r.Context(), h, user, policies)
+	sort.Slice(policies, func(i, j int) bool {
+		if policies[i].Namespace != policies[j].Namespace {
+			return policies[i].Namespace < policies[j].Namespace
+		}
+		if policies[i].Kind != policies[j].Kind {
+			return policies[i].Kind < policies[j].Kind
+		}
+		return policies[i].Name < policies[j].Name
+	})
+
+	if policies == nil {
+		policies = []MeshedPolicy{}
+	}
+
+	httputil.WriteData(w, policiesResponse{
+		Status:   status,
+		Policies: policies,
+		Errors:   data.errors,
+	})
+}
+
+// HandleGetRoute returns a single normalized route by composite ID.
+// The ID format is "{mesh}:{namespace}:{kindCode}:{name}", URL-encoded on the wire.
+// Uses user impersonation for the fetch, so Kubernetes RBAC is authoritative.
+func (h *Handler) HandleGetRoute(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	mesh, ns, code, name, err := parseMeshCompositeID(chi.URLParam(r, "id"))
+	if err != nil {
+		httputil.WriteError(w, http.StatusBadRequest, "invalid route ID", err.Error())
+		return
+	}
+
+	kind, entry, ok := resolveKind(mesh, code)
+	if !ok {
+		httputil.WriteError(w, http.StatusBadRequest, "unknown mesh or kind", mesh+":"+code)
+		return
+	}
+
+	can, err := h.AccessChecker.CanAccessGroupResource(r.Context(), user.KubernetesUsername, user.KubernetesGroups, "get", entry.APIGroup, entry.Resource, ns)
+	if err != nil || !can {
+		httputil.WriteError(w, http.StatusForbidden, "you do not have permission to view this resource", "")
+		return
+	}
+
+	dynClient, derr := h.K8sClient.DynamicClientForUser(user.KubernetesUsername, user.KubernetesGroups)
+	if derr != nil {
+		h.Logger.Error("failed to create impersonating client", "error", derr)
+		httputil.WriteError(w, http.StatusInternalServerError, "internal error", "")
+		return
+	}
+
+	obj, gerr := dynClient.Resource(entry.GVR).Namespace(ns).Get(r.Context(), name, metav1.GetOptions{})
+	if gerr != nil {
+		if apierrors.IsNotFound(gerr) {
+			httputil.WriteError(w, http.StatusNotFound, "mesh resource not found", "")
+			return
+		}
+		h.Logger.Error("failed to get mesh resource", "mesh", mesh, "kind", kind, "namespace", ns, "name", name, "error", gerr)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to fetch mesh resource", "")
+		return
+	}
+
+	route := normalizeRouteByMesh(MeshType(mesh), kind, obj)
+	httputil.WriteData(w, route)
+}
+
+// normalizeRouteByMesh dispatches to the per-mesh normalizer. Callers must
+// ensure mesh/kind are valid (handled upstream via resolveKind).
+func normalizeRouteByMesh(mesh MeshType, kind string, obj *unstructured.Unstructured) TrafficRoute {
+	switch mesh {
+	case MeshIstio:
+		return normalizeIstioRoute(obj, kind)
+	case MeshLinkerd:
+		return normalizeLinkerdRoute(obj, kind)
+	}
+	return TrafficRoute{
+		Mesh:      mesh,
+		Kind:      kind,
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+		Raw:       obj.Object,
+	}
+}
+
+// parseMeshCompositeID splits "{mesh}:{namespace}:{kindCode}:{name}" into
+// its four parts. The id may arrive URL-encoded from chi.URLParam.
+func parseMeshCompositeID(id string) (mesh, namespace, code, name string, err error) {
+	decoded, uerr := url.PathUnescape(id)
+	if uerr != nil {
+		decoded = id
+	}
+	parts := strings.SplitN(decoded, ":", 4)
+	if len(parts) != 4 {
+		return "", "", "", "", fmt.Errorf("invalid composite ID %q (expected mesh:namespace:kind:name)", decoded)
+	}
+	if slices.Contains(parts, "") {
+		return "", "", "", "", errors.New("composite ID parts must be non-empty")
+	}
+	return parts[0], parts[1], parts[2], parts[3], nil
+}

--- a/backend/internal/servicemesh/handler_test.go
+++ b/backend/internal/servicemesh/handler_test.go
@@ -1,0 +1,318 @@
+package servicemesh
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"k8s.io/apimachinery/pkg/runtime"
+	clienttesting "k8s.io/client-go/testing"
+
+	"github.com/kubecenter/kubecenter/internal/auth"
+	"github.com/kubecenter/kubecenter/internal/k8s/resources"
+)
+
+// --- parse / dispatch unit tests -------------------------------------------
+
+func TestParseMeshCompositeID(t *testing.T) {
+	tests := []struct {
+		in        string
+		wantMesh  string
+		wantNS    string
+		wantCode  string
+		wantName  string
+		wantError bool
+	}{
+		{"istio:shop:vs:cart", "istio", "shop", "vs", "cart", false},
+		{"linkerd:default:sp:books", "linkerd", "default", "sp", "books", false},
+		// SplitN(4) keeps extra colons in the name — a valid resource name may contain ":".
+		{"istio:ns:vs:name-with-colons:extra", "istio", "ns", "vs", "name-with-colons:extra", false},
+		// URL-encoded composites decode correctly.
+		{"istio%3Ashop%3Avs%3Acart", "istio", "shop", "vs", "cart", false},
+		// Invalid shapes all return errors — handler emits 400.
+		{"", "", "", "", "", true},
+		{"istio:ns", "", "", "", "", true},
+		{"istio:ns:vs", "", "", "", "", true},
+		{":ns:vs:name", "", "", "", "", true},
+		{"istio::vs:name", "", "", "", "", true},
+		{"istio:ns::name", "", "", "", "", true},
+		{"istio:ns:vs:", "", "", "", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			mesh, ns, code, name, err := parseMeshCompositeID(tt.in)
+			if tt.wantError {
+				if err == nil {
+					t.Fatalf("expected error for %q", tt.in)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if mesh != tt.wantMesh || ns != tt.wantNS || code != tt.wantCode || name != tt.wantName {
+				t.Errorf("got (%q,%q,%q,%q), want (%q,%q,%q,%q)",
+					mesh, ns, code, name, tt.wantMesh, tt.wantNS, tt.wantCode, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestResolveKind(t *testing.T) {
+	tests := []struct {
+		mesh, code string
+		wantKind   string
+		wantGroup  string
+		wantOK     bool
+	}{
+		{"istio", "vs", "VirtualService", "networking.istio.io", true},
+		{"istio", "pa", "PeerAuthentication", "security.istio.io", true},
+		// The "ap" code is shared between Istio and Linkerd; resolution must
+		// disambiguate on the mesh prefix.
+		{"istio", "ap", "AuthorizationPolicy", "security.istio.io", true},
+		{"linkerd", "ap", "AuthorizationPolicy", "policy.linkerd.io", true},
+		{"linkerd", "sp", "ServiceProfile", "linkerd.io", true},
+		{"linkerd", "srv", "Server", "policy.linkerd.io", true},
+		{"istio", "unknown", "", "", false},
+		{"bogus", "vs", "", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.mesh+":"+tt.code, func(t *testing.T) {
+			kind, entry, ok := resolveKind(tt.mesh, tt.code)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if kind != tt.wantKind || entry.APIGroup != tt.wantGroup {
+				t.Errorf("got (%q,%q), want (%q,%q)", kind, entry.APIGroup, tt.wantKind, tt.wantGroup)
+			}
+		})
+	}
+}
+
+// --- handler integration tests --------------------------------------------
+
+func seededDiscoverer(status MeshStatus) *Discoverer {
+	return &Discoverer{
+		logger: slog.Default(),
+		status: MeshStatus{
+			Detected:    status.Detected,
+			Istio:       status.Istio,
+			Linkerd:     status.Linkerd,
+			LastChecked: time.Now().UTC(),
+		},
+	}
+}
+
+// TestHandler_NoMeshInstalled covers the plan's error-path scenario: when
+// neither mesh is installed, HandleListRoutes returns {routes: []} with
+// status.detected = "none", not a 500.
+func TestHandler_NoMeshInstalled(t *testing.T) {
+	h := &Handler{
+		Discoverer:    seededDiscoverer(MeshStatus{Detected: MeshNone}),
+		AccessChecker: resources.NewAlwaysAllowAccessChecker(),
+		Logger:        slog.Default(),
+	}
+
+	w := doGet(t, h.HandleListRoutes, nil)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var env struct {
+		Data routingResponse `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if env.Data.Status.Detected != MeshNone {
+		t.Errorf("Status.Detected = %q, want %q", env.Data.Status.Detected, MeshNone)
+	}
+	if env.Data.Routes == nil {
+		t.Error("Routes is nil; frontend treats null as error — want empty slice")
+	}
+	if len(env.Data.Routes) != 0 {
+		t.Errorf("Routes = %d, want 0", len(env.Data.Routes))
+	}
+}
+
+// TestHandler_ListRoutes_AllVisibleWithFullAccess covers the plan's happy path:
+// an authenticated user with cluster-wide RBAC sees every route.
+func TestHandler_ListRoutes_AllVisibleWithFullAccess(t *testing.T) {
+	vsFoo := virtualService("foo", "a", []string{"a.foo"}, nil)
+	vsBar := virtualService("bar", "b", []string{"b.bar"}, nil)
+
+	h := &Handler{
+		Discoverer:    seededDiscoverer(MeshStatus{Detected: MeshIstio, Istio: &MeshInfo{Installed: true, Version: "1.24.0"}}),
+		AccessChecker: resources.NewAlwaysAllowAccessChecker(),
+		Logger:        slog.Default(),
+		dynOverride:   newIstioFakeDynClient(vsFoo, vsBar),
+	}
+
+	w := doGet(t, h.HandleListRoutes, &auth.User{KubernetesUsername: "u", KubernetesGroups: []string{"g"}})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var env struct {
+		Data routingResponse `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got := len(env.Data.Routes); got != 2 {
+		t.Errorf("Routes = %d, want 2", got)
+	}
+}
+
+// TestHandler_ListRoutes_DeniedUserSeesNothing covers the plan's RBAC scenario:
+// a user whose access checker denies every namespace gets an empty list, not
+// a 403. This is the canonical partial-access shape — the handler never leaks
+// unchecked rows.
+func TestHandler_ListRoutes_DeniedUserSeesNothing(t *testing.T) {
+	vs := virtualService("foo", "a", []string{"a"}, nil)
+
+	h := &Handler{
+		Discoverer:    seededDiscoverer(MeshStatus{Detected: MeshIstio, Istio: &MeshInfo{Installed: true, Version: "1.24.0"}}),
+		AccessChecker: resources.NewAlwaysDenyAccessChecker(),
+		Logger:        slog.Default(),
+		dynOverride:   newIstioFakeDynClient(vs),
+	}
+
+	w := doGet(t, h.HandleListRoutes, &auth.User{KubernetesUsername: "u", KubernetesGroups: []string{"g"}})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (denial yields empty list, not 403)", w.Code)
+	}
+	var env struct {
+		Data routingResponse `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(env.Data.Routes) != 0 {
+		t.Errorf("Routes = %d, want 0 (denied user sees nothing)", len(env.Data.Routes))
+	}
+}
+
+// TestHandler_GetRouteBadID covers the plan's error-path scenario for
+// malformed composite IDs → 400 with a structured error message.
+func TestHandler_GetRouteBadID(t *testing.T) {
+	h := &Handler{
+		AccessChecker: resources.NewAlwaysAllowAccessChecker(),
+		Logger:        slog.Default(),
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/mesh/routing/bogus", nil)
+	req = req.WithContext(auth.ContextWithUser(req.Context(), &auth.User{KubernetesUsername: "u"}))
+	req = withURLParam(req, "id", "bogus")
+
+	w := httptest.NewRecorder()
+	h.HandleGetRoute(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+// TestHandler_GetRouteUnknownKind covers the plan's error-path scenario: a
+// well-formed composite ID with an unknown kind code must return 400 rather
+// than bypass the access check.
+func TestHandler_GetRouteUnknownKind(t *testing.T) {
+	h := &Handler{
+		AccessChecker: resources.NewAlwaysAllowAccessChecker(),
+		Logger:        slog.Default(),
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/mesh/routing/", nil)
+	req = req.WithContext(auth.ContextWithUser(req.Context(), &auth.User{KubernetesUsername: "u"}))
+	req = withURLParam(req, "id", "istio:ns:xx:name") // parses, kind code "xx" is unknown
+
+	w := httptest.NewRecorder()
+	h.HandleGetRoute(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for unknown kind code", w.Code)
+	}
+}
+
+// TestHandler_SingleflightCoalesces covers the plan's cache scenario: two (or
+// more) concurrent list requests collapse into a single upstream fetch. The
+// reactor counter increments on every live List call; under singleflight, the
+// count after N concurrent requests should stay well below N.
+func TestHandler_SingleflightCoalesces(t *testing.T) {
+	vs := virtualService("foo", "a", []string{"a"}, nil)
+
+	var listCalls int64
+	client := newIstioFakeDynClient(vs)
+	// One reactor per CRD kind so the count reflects actual fan-out, not just
+	// a single probe. Counting on virtualservices is enough — doFetch always
+	// lists every kind as part of the same singleflight shot.
+	client.PrependReactor("list", "virtualservices", func(_ clienttesting.Action) (bool, runtime.Object, error) {
+		atomic.AddInt64(&listCalls, 1)
+		return false, nil, nil // let the default reactor service the request
+	})
+
+	h := &Handler{
+		Discoverer:    seededDiscoverer(MeshStatus{Detected: MeshIstio, Istio: &MeshInfo{Installed: true, Version: "1.24.0"}}),
+		AccessChecker: resources.NewAlwaysAllowAccessChecker(),
+		Logger:        slog.Default(),
+		dynOverride:   client,
+	}
+	h.InvalidateCache() // in case a previous test left something cached
+
+	const n = 20
+	start := make(chan struct{})
+	done := make(chan struct{}, n)
+	for range n {
+		go func() {
+			<-start
+			w := doGet(t, h.HandleListRoutes, &auth.User{KubernetesUsername: "u"})
+			if w.Code != http.StatusOK {
+				t.Errorf("status = %d, want 200", w.Code)
+			}
+			done <- struct{}{}
+		}()
+	}
+	close(start)
+	for range n {
+		<-done
+	}
+
+	// Under singleflight, the listCalls counter should be small regardless of
+	// N. We assert strictly less than N to stay resilient to goroutine
+	// scheduling that might let a second fetch start before the first caches.
+	got := atomic.LoadInt64(&listCalls)
+	if got >= int64(n) {
+		t.Errorf("virtualservices List calls = %d, want < %d (singleflight not coalescing)", got, n)
+	}
+}
+
+// --- helpers ---------------------------------------------------------------
+
+func doGet(t *testing.T, handler http.HandlerFunc, user *auth.User) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/mesh/routing", nil)
+	if user == nil {
+		user = &auth.User{KubernetesUsername: "u", KubernetesGroups: []string{"g"}}
+	}
+	req = req.WithContext(auth.ContextWithUser(req.Context(), user))
+	w := httptest.NewRecorder()
+	handler(w, req)
+	return w
+}
+
+func withURLParam(r *http.Request, key, val string) *http.Request {
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add(key, val)
+	return r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+}

--- a/backend/internal/servicemesh/istio.go
+++ b/backend/internal/servicemesh/istio.go
@@ -1,0 +1,119 @@
+package servicemesh
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+const (
+	meshListTimeout = 5 * time.Second
+	meshListCap     = 2000
+)
+
+// istioCRD bundles a GVR with the Kind name used for composite IDs and
+// the per-kind normalizer dispatch. Keeping the two together prevents
+// the list path and the normalize path from drifting out of sync.
+type istioCRD struct {
+	GVR  schema.GroupVersionResource
+	Kind string
+}
+
+var (
+	// istioRouteCRDs are the routing-shaped CRDs normalized into TrafficRoute.
+	istioRouteCRDs = []istioCRD{
+		{IstioVirtualServiceGVR, "VirtualService"},
+		{IstioDestinationRuleGVR, "DestinationRule"},
+		{IstioGatewayGVR, "Gateway"},
+	}
+
+	// istioPolicyCRDs are the security-shaped CRDs normalized into MeshedPolicy.
+	istioPolicyCRDs = []istioCRD{
+		{IstioPeerAuthenticationGVR, "PeerAuthentication"},
+		{IstioAuthorizationPolicyGVR, "AuthorizationPolicy"},
+	}
+)
+
+// IstioListResult carries partial results from a parallel list across all
+// Istio CRDs. Per-CRD errors (e.g., 403 for one kind) are collected in Errors
+// so the caller can surface an error annotation without failing the request.
+type IstioListResult struct {
+	Routes   []TrafficRoute
+	Policies []MeshedPolicy
+	Errors   map[string]string // Kind → error message
+}
+
+// ListIstio fetches every Istio route and policy CRD from the given namespace
+// (pass "" for cluster-wide) in parallel. Each list call has a meshListTimeout
+// budget and a meshListCap limit; errors for any individual CRD are recorded
+// in the result's Errors map so partial data still flows to the UI.
+func ListIstio(ctx context.Context, dynClient dynamic.Interface, namespace string) IstioListResult {
+	result := IstioListResult{Errors: map[string]string{}}
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	listOpts := metav1.ListOptions{Limit: meshListCap}
+
+	for _, c := range istioRouteCRDs {
+		wg.Add(1)
+		go func(c istioCRD) {
+			defer wg.Done()
+			items, err := listCRD(ctx, dynClient, c.GVR, namespace, listOpts)
+
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				result.Errors[c.Kind] = err.Error()
+				return
+			}
+			for i := range items {
+				result.Routes = append(result.Routes, normalizeIstioRoute(&items[i], c.Kind))
+			}
+		}(c)
+	}
+
+	for _, c := range istioPolicyCRDs {
+		wg.Add(1)
+		go func(c istioCRD) {
+			defer wg.Done()
+			items, err := listCRD(ctx, dynClient, c.GVR, namespace, listOpts)
+
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				result.Errors[c.Kind] = err.Error()
+				return
+			}
+			for i := range items {
+				result.Policies = append(result.Policies, normalizeIstioPolicy(&items[i], c.Kind))
+			}
+		}(c)
+	}
+
+	wg.Wait()
+	return result
+}
+
+// listCRD performs a single dynamic-client List with a per-call timeout and
+// enforces the mesh-wide item cap. It's shared across Istio and (eventually)
+// Linkerd adapters because both have the same rate-limit + timeout + cap
+// requirements per the plan.
+func listCRD(ctx context.Context, dynClient dynamic.Interface, gvr schema.GroupVersionResource, namespace string, opts metav1.ListOptions) ([]unstructured.Unstructured, error) {
+	callCtx, cancel := context.WithTimeout(ctx, meshListTimeout)
+	defer cancel()
+
+	list, err := dynClient.Resource(gvr).Namespace(namespace).List(callCtx, opts)
+	if err != nil {
+		return nil, err
+	}
+	items := list.Items
+	if len(items) > meshListCap {
+		items = items[:meshListCap]
+	}
+	return items, nil
+}

--- a/backend/internal/servicemesh/istio_test.go
+++ b/backend/internal/servicemesh/istio_test.go
@@ -1,0 +1,314 @@
+package servicemesh
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+// --- fake dynamic client ----------------------------------------------------
+
+func istioScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	for gvr, kind := range map[schema.GroupVersionResource]string{
+		IstioVirtualServiceGVR:      "VirtualService",
+		IstioDestinationRuleGVR:     "DestinationRule",
+		IstioGatewayGVR:             "Gateway",
+		IstioPeerAuthenticationGVR:  "PeerAuthentication",
+		IstioAuthorizationPolicyGVR: "AuthorizationPolicy",
+	} {
+		gvk := schema.GroupVersionKind{Group: gvr.Group, Version: gvr.Version, Kind: kind}
+		s.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+		s.AddKnownTypeWithName(
+			schema.GroupVersionKind{Group: gvr.Group, Version: gvr.Version, Kind: kind + "List"},
+			&unstructured.UnstructuredList{},
+		)
+	}
+	return s
+}
+
+func newIstioFakeDynClient(objects ...runtime.Object) *dynamicfake.FakeDynamicClient {
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		IstioVirtualServiceGVR:      "VirtualServiceList",
+		IstioDestinationRuleGVR:     "DestinationRuleList",
+		IstioGatewayGVR:             "GatewayList",
+		IstioPeerAuthenticationGVR:  "PeerAuthenticationList",
+		IstioAuthorizationPolicyGVR: "AuthorizationPolicyList",
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(istioScheme(), gvrToListKind, objects...)
+}
+
+// --- fixtures ---------------------------------------------------------------
+
+func virtualService(ns, name string, hosts []string, dests []map[string]any) *unstructured.Unstructured {
+	// unstructured.Unstructured requires []any for nested lists — not
+	// []map[string]any — because DeepCopyJSONValue is strict about JSON types.
+	destsAny := make([]any, len(dests))
+	for i, d := range dests {
+		destsAny[i] = d
+	}
+	hostsAny := make([]any, len(hosts))
+	for i, h := range hosts {
+		hostsAny[i] = h
+	}
+	spec := map[string]any{"hosts": hostsAny}
+	if len(destsAny) > 0 {
+		spec["http"] = []any{map[string]any{"route": destsAny}}
+	}
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "networking.istio.io/v1",
+			"kind":       "VirtualService",
+			"metadata":   map[string]any{"name": name, "namespace": ns},
+			"spec":       spec,
+		},
+	}
+}
+
+func destinationRule(ns, name, host string, subsets []string) *unstructured.Unstructured {
+	subsetsAny := make([]any, len(subsets))
+	for i, s := range subsets {
+		subsetsAny[i] = map[string]any{"name": s, "labels": map[string]any{"version": s}}
+	}
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "networking.istio.io/v1",
+			"kind":       "DestinationRule",
+			"metadata":   map[string]any{"name": name, "namespace": ns},
+			"spec": map[string]any{
+				"host":    host,
+				"subsets": subsetsAny,
+			},
+		},
+	}
+}
+
+func authzPolicy(ns, name, action string, rules []any) *unstructured.Unstructured {
+	spec := map[string]any{"selector": map[string]any{"matchLabels": map[string]any{"app": "api"}}}
+	if action != "" {
+		spec["action"] = action
+	}
+	if rules != nil {
+		spec["rules"] = rules
+	}
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "security.istio.io/v1",
+			"kind":       "AuthorizationPolicy",
+			"metadata":   map[string]any{"name": name, "namespace": ns},
+			"spec":       spec,
+		},
+	}
+}
+
+// --- normalizer unit tests --------------------------------------------------
+
+func TestIstioNormalize_VirtualServiceTwoDestinations(t *testing.T) {
+	vs := virtualService("shop", "cart-vs", []string{"cart.shop.svc.cluster.local", "cart.example.com"},
+		[]map[string]any{
+			{"destination": map[string]any{"host": "cart-v1", "port": map[string]any{"number": int64(8080)}}, "weight": int64(80)},
+			{"destination": map[string]any{"host": "cart-v2", "subset": "canary"}, "weight": int64(20)},
+		})
+
+	tr := normalizeIstioVirtualService(vs)
+
+	if tr.Mesh != MeshIstio || tr.Kind != "VirtualService" {
+		t.Errorf("Mesh/Kind = %q/%q, want istio/VirtualService", tr.Mesh, tr.Kind)
+	}
+	if tr.ID != "istio:shop:vs:cart-vs" {
+		t.Errorf("ID = %q, want istio:shop:vs:cart-vs", tr.ID)
+	}
+	if len(tr.Hosts) != 2 || tr.Hosts[0] != "cart.shop.svc.cluster.local" || tr.Hosts[1] != "cart.example.com" {
+		t.Errorf("Hosts = %v, want both hostnames preserved in order", tr.Hosts)
+	}
+	if len(tr.Destinations) != 2 {
+		t.Fatalf("Destinations = %d, want 2", len(tr.Destinations))
+	}
+	if tr.Destinations[0].Host != "cart-v1" || tr.Destinations[0].Port != 8080 || tr.Destinations[0].Weight != 80 {
+		t.Errorf("Destinations[0] = %+v, want {cart-v1, port 8080, weight 80}", tr.Destinations[0])
+	}
+	if tr.Destinations[1].Host != "cart-v2" || tr.Destinations[1].Subset != "canary" || tr.Destinations[1].Weight != 20 {
+		t.Errorf("Destinations[1] = %+v, want {cart-v2, subset canary, weight 20}", tr.Destinations[1])
+	}
+}
+
+func TestIstioNormalize_DestinationRuleSubsets(t *testing.T) {
+	dr := destinationRule("shop", "cart-dr", "cart", []string{"v1", "v2", "canary"})
+
+	tr := normalizeIstioDestinationRule(dr)
+
+	if tr.ID != "istio:shop:dr:cart-dr" {
+		t.Errorf("ID = %q, want istio:shop:dr:cart-dr", tr.ID)
+	}
+	if len(tr.Hosts) != 1 || tr.Hosts[0] != "cart" {
+		t.Errorf("Hosts = %v, want [cart]", tr.Hosts)
+	}
+	if len(tr.Subsets) != 3 || tr.Subsets[0] != "v1" || tr.Subsets[2] != "canary" {
+		t.Errorf("Subsets = %v, want [v1 v2 canary]", tr.Subsets)
+	}
+}
+
+func TestIstioNormalize_AuthzPolicyEffects(t *testing.T) {
+	tests := []struct {
+		name       string
+		action     string
+		rules      []any
+		wantAction string
+		wantEffect string
+		wantCount  int
+	}{
+		{"default action + empty rules → deny_all", "", nil, "ALLOW", "deny_all", 0},
+		{"ALLOW + empty rules → deny_all", "ALLOW", []any{}, "ALLOW", "deny_all", 0},
+		{"DENY + empty rules → allow_all", "DENY", []any{}, "DENY", "allow_all", 0},
+		{"ALLOW + one rule → no computed effect", "ALLOW", []any{map[string]any{"from": []any{}}}, "ALLOW", "", 1},
+		{"AUDIT + empty rules → no computed effect", "AUDIT", []any{}, "AUDIT", "", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := normalizeIstioAuthzPolicy(authzPolicy("prod", "api-authz", tt.action, tt.rules))
+			if p.Action != tt.wantAction {
+				t.Errorf("Action = %q, want %q", p.Action, tt.wantAction)
+			}
+			if p.Effect != tt.wantEffect {
+				t.Errorf("Effect = %q, want %q", p.Effect, tt.wantEffect)
+			}
+			if p.RuleCount != tt.wantCount {
+				t.Errorf("RuleCount = %d, want %d", p.RuleCount, tt.wantCount)
+			}
+			if p.Selector != "app=api" {
+				t.Errorf("Selector = %q, want app=api", p.Selector)
+			}
+			if p.ID != "istio:prod:ap:api-authz" {
+				t.Errorf("ID = %q, want istio:prod:ap:api-authz", p.ID)
+			}
+		})
+	}
+}
+
+func TestIstioNormalize_PeerAuthModeUnset(t *testing.T) {
+	// PeerAuthentication with no mtls.mode falls through to UNSET so the UI
+	// can distinguish "explicitly permissive" from "mesh default applies".
+	pa := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "security.istio.io/v1",
+		"kind":       "PeerAuthentication",
+		"metadata":   map[string]any{"name": "default", "namespace": "istio-system"},
+		"spec":       map[string]any{},
+	}}
+	p := normalizeIstioPeerAuth(pa)
+	if p.MTLSMode != "UNSET" {
+		t.Errorf("MTLSMode = %q, want UNSET", p.MTLSMode)
+	}
+}
+
+func TestIstioNormalize_GatewayHostsFlattenDedupe(t *testing.T) {
+	gw := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "networking.istio.io/v1",
+		"kind":       "Gateway",
+		"metadata":   map[string]any{"name": "edge", "namespace": "istio-system"},
+		"spec": map[string]any{
+			"servers": []any{
+				map[string]any{"hosts": []any{"api.example.com", "www.example.com"}},
+				map[string]any{"hosts": []any{"api.example.com", "admin.example.com"}}, // dup on purpose
+			},
+		},
+	}}
+
+	tr := normalizeIstioGateway(gw)
+	if len(tr.Hosts) != 3 {
+		t.Fatalf("Hosts = %v, want 3 deduped entries", tr.Hosts)
+	}
+	// Hosts are sorted for stability — assert exact order.
+	want := []string{"admin.example.com", "api.example.com", "www.example.com"}
+	for i, h := range want {
+		if tr.Hosts[i] != h {
+			t.Errorf("Hosts[%d] = %q, want %q", i, tr.Hosts[i], h)
+		}
+	}
+}
+
+// --- adapter integration tests ---------------------------------------------
+
+func TestIstioList_HappyPathCollectsRoutesAndPolicies(t *testing.T) {
+	vs := virtualService("shop", "cart-vs", []string{"cart"},
+		[]map[string]any{{"destination": map[string]any{"host": "cart"}, "weight": int64(100)}})
+	dr := destinationRule("shop", "cart-dr", "cart", []string{"v1"})
+	ap := authzPolicy("shop", "deny-public", "ALLOW", nil)
+
+	client := newIstioFakeDynClient(vs, dr, ap)
+	out := ListIstio(context.Background(), client, "")
+
+	if len(out.Errors) != 0 {
+		t.Errorf("Errors = %v, want empty", out.Errors)
+	}
+	if len(out.Routes) != 2 {
+		t.Errorf("Routes = %d, want 2 (VS + DR)", len(out.Routes))
+	}
+	if len(out.Policies) != 1 {
+		t.Errorf("Policies = %d, want 1 (AP)", len(out.Policies))
+	}
+	// Plan test scenario: ALLOW + no rules → deny_all effect.
+	if out.Policies[0].Effect != "deny_all" {
+		t.Errorf("Policies[0].Effect = %q, want deny_all", out.Policies[0].Effect)
+	}
+}
+
+// TestIstioList_PartialResultOn403 covers the plan's error path: one CRD
+// returns 403 Forbidden; the adapter still returns results for the other CRDs
+// and records the failing kind in Errors.
+func TestIstioList_PartialResultOn403(t *testing.T) {
+	vs := virtualService("shop", "cart-vs", []string{"cart"},
+		[]map[string]any{{"destination": map[string]any{"host": "cart"}}})
+
+	client := newIstioFakeDynClient(vs)
+	// Block listing DestinationRules only.
+	client.PrependReactor("list", "destinationrules",
+		func(_ clienttesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("Forbidden: user cannot list destinationrules")
+		})
+
+	out := ListIstio(context.Background(), client, "")
+
+	if len(out.Routes) != 1 || out.Routes[0].Kind != "VirtualService" {
+		t.Errorf("Routes = %+v, want one VirtualService", out.Routes)
+	}
+	if _, ok := out.Errors["DestinationRule"]; !ok {
+		t.Errorf("Errors = %v, want DestinationRule entry", out.Errors)
+	}
+	// Other kinds still listed (nothing to list, but should not appear in Errors).
+	for _, k := range []string{"VirtualService", "Gateway", "PeerAuthentication", "AuthorizationPolicy"} {
+		if _, bad := out.Errors[k]; bad {
+			t.Errorf("Errors should not include %q, got: %v", k, out.Errors)
+		}
+	}
+}
+
+// TestIstioList_NamespaceScoping covers the plan's integration scenario:
+// namespace="" returns cluster-wide, namespace="foo" returns only foo's items.
+func TestIstioList_NamespaceScoping(t *testing.T) {
+	aFoo := virtualService("foo", "a", []string{"a"}, nil)
+	bBar := virtualService("bar", "b", []string{"b"}, nil)
+
+	client := newIstioFakeDynClient(aFoo, bBar)
+
+	// Cluster-wide: should see both.
+	all := ListIstio(context.Background(), client, "")
+	if len(all.Routes) != 2 {
+		t.Errorf("cluster-wide Routes = %d, want 2", len(all.Routes))
+	}
+
+	// Scoped: should see only foo's.
+	scoped := ListIstio(context.Background(), client, "foo")
+	if len(scoped.Routes) != 1 {
+		t.Fatalf("scoped Routes = %d, want 1", len(scoped.Routes))
+	}
+	if scoped.Routes[0].Namespace != "foo" {
+		t.Errorf("scoped Route namespace = %q, want foo", scoped.Routes[0].Namespace)
+	}
+}

--- a/backend/internal/servicemesh/linkerd.go
+++ b/backend/internal/servicemesh/linkerd.go
@@ -1,0 +1,95 @@
+package servicemesh
+
+import (
+	"context"
+	"sync"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+// linkerdCRD bundles a GVR with the Kind name used for composite IDs and
+// normalizer dispatch. Mirrors istioCRD in istio.go; kept per-mesh to match
+// the plan's "per-mesh adapter isolation" principle.
+type linkerdCRD struct {
+	GVR  schema.GroupVersionResource
+	Kind string
+}
+
+var (
+	// linkerdRouteCRDs are the routing-shaped CRDs normalized into TrafficRoute.
+	// HTTPRoute uses the Linkerd-flavored group (policy.linkerd.io), not the
+	// upstream gateway.networking.k8s.io CRD — the two coexist on some clusters
+	// and the handler must only surface Linkerd's.
+	linkerdRouteCRDs = []linkerdCRD{
+		{LinkerdServiceProfileGVR, "ServiceProfile"},
+		{LinkerdServerGVR, "Server"},
+		{LinkerdHTTPRouteGVR, "HTTPRoute"},
+	}
+
+	// linkerdPolicyCRDs are the security-shaped CRDs normalized into MeshedPolicy.
+	linkerdPolicyCRDs = []linkerdCRD{
+		{LinkerdAuthorizationPolicyGVR, "AuthorizationPolicy"},
+		{LinkerdMeshTLSAuthenticationGVR, "MeshTLSAuthentication"},
+	}
+)
+
+// LinkerdListResult carries partial results from a parallel list across all
+// Linkerd CRDs. Same shape as IstioListResult so the handler treats both
+// meshes symmetrically.
+type LinkerdListResult struct {
+	Routes   []TrafficRoute
+	Policies []MeshedPolicy
+	Errors   map[string]string // Kind → error message
+}
+
+// ListLinkerd fetches every Linkerd route and policy CRD from the given
+// namespace (pass "" for cluster-wide) in parallel. Per-call timeout +
+// item cap + partial-error semantics come from the shared listCRD helper.
+func ListLinkerd(ctx context.Context, dynClient dynamic.Interface, namespace string) LinkerdListResult {
+	result := LinkerdListResult{Errors: map[string]string{}}
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	listOpts := metav1.ListOptions{Limit: meshListCap}
+
+	for _, c := range linkerdRouteCRDs {
+		wg.Add(1)
+		go func(c linkerdCRD) {
+			defer wg.Done()
+			items, err := listCRD(ctx, dynClient, c.GVR, namespace, listOpts)
+
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				result.Errors[c.Kind] = err.Error()
+				return
+			}
+			for i := range items {
+				result.Routes = append(result.Routes, normalizeLinkerdRoute(&items[i], c.Kind))
+			}
+		}(c)
+	}
+
+	for _, c := range linkerdPolicyCRDs {
+		wg.Add(1)
+		go func(c linkerdCRD) {
+			defer wg.Done()
+			items, err := listCRD(ctx, dynClient, c.GVR, namespace, listOpts)
+
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				result.Errors[c.Kind] = err.Error()
+				return
+			}
+			for i := range items {
+				result.Policies = append(result.Policies, normalizeLinkerdPolicy(&items[i], c.Kind))
+			}
+		}(c)
+	}
+
+	wg.Wait()
+	return result
+}

--- a/backend/internal/servicemesh/linkerd_test.go
+++ b/backend/internal/servicemesh/linkerd_test.go
@@ -1,0 +1,311 @@
+package servicemesh
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+// --- fake dynamic client ----------------------------------------------------
+
+// upstreamHTTPRouteGVR is the Gateway-API standard HTTPRoute, distinct from
+// Linkerd's policy.linkerd.io flavor. Kept local to the test file because the
+// production adapter intentionally never lists it.
+var upstreamHTTPRouteGVR = schema.GroupVersionResource{
+	Group: "gateway.networking.k8s.io", Version: "v1", Resource: "httproutes",
+}
+
+func linkerdScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	registrations := []struct {
+		gvr  schema.GroupVersionResource
+		kind string
+	}{
+		{LinkerdServiceProfileGVR, "ServiceProfile"},
+		{LinkerdServerGVR, "Server"},
+		{LinkerdHTTPRouteGVR, "HTTPRoute"},
+		{LinkerdAuthorizationPolicyGVR, "AuthorizationPolicy"},
+		{LinkerdMeshTLSAuthenticationGVR, "MeshTLSAuthentication"},
+		// Register upstream HTTPRoute too so the fake can hold both flavors
+		// and the adapter can prove it only picks up Linkerd's.
+		{upstreamHTTPRouteGVR, "HTTPRoute"},
+	}
+	for _, r := range registrations {
+		gvk := schema.GroupVersionKind{Group: r.gvr.Group, Version: r.gvr.Version, Kind: r.kind}
+		s.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+		s.AddKnownTypeWithName(
+			schema.GroupVersionKind{Group: r.gvr.Group, Version: r.gvr.Version, Kind: r.kind + "List"},
+			&unstructured.UnstructuredList{},
+		)
+	}
+	return s
+}
+
+func newLinkerdFakeDynClient(objects ...runtime.Object) *dynamicfake.FakeDynamicClient {
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		LinkerdServiceProfileGVR:        "ServiceProfileList",
+		LinkerdServerGVR:                "ServerList",
+		LinkerdHTTPRouteGVR:             "HTTPRouteList",
+		LinkerdAuthorizationPolicyGVR:   "AuthorizationPolicyList",
+		LinkerdMeshTLSAuthenticationGVR: "MeshTLSAuthenticationList",
+		upstreamHTTPRouteGVR:            "HTTPRouteList",
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(linkerdScheme(), gvrToListKind, objects...)
+}
+
+// --- fixtures ---------------------------------------------------------------
+
+func serviceProfile(ns, name string, routes []map[string]any) *unstructured.Unstructured {
+	routesAny := make([]any, len(routes))
+	for i, r := range routes {
+		routesAny[i] = r
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "linkerd.io/v1alpha2",
+		"kind":       "ServiceProfile",
+		"metadata":   map[string]any{"name": name, "namespace": ns},
+		"spec":       map[string]any{"routes": routesAny},
+	}}
+}
+
+func linkerdServer(ns, name string, matchLabels map[string]string) *unstructured.Unstructured {
+	labels := make(map[string]any, len(matchLabels))
+	for k, v := range matchLabels {
+		labels[k] = v
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "policy.linkerd.io/v1beta3",
+		"kind":       "Server",
+		"metadata":   map[string]any{"name": name, "namespace": ns},
+		"spec": map[string]any{
+			"podSelector": map[string]any{"matchLabels": labels},
+			"port":        "http",
+		},
+	}}
+}
+
+func linkerdHTTPRoute(ns, name string, parents []string, matches []map[string]any) *unstructured.Unstructured {
+	parentsAny := make([]any, len(parents))
+	for i, p := range parents {
+		parentsAny[i] = map[string]any{"name": p, "kind": "Server", "group": "policy.linkerd.io"}
+	}
+	matchesAny := make([]any, len(matches))
+	for i, m := range matches {
+		matchesAny[i] = m
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "policy.linkerd.io/v1beta1",
+		"kind":       "HTTPRoute",
+		"metadata":   map[string]any{"name": name, "namespace": ns},
+		"spec": map[string]any{
+			"parentRefs": parentsAny,
+			"rules":      []any{map[string]any{"matches": matchesAny}},
+		},
+	}}
+}
+
+func upstreamHTTPRoute(ns, name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "HTTPRoute",
+		"metadata":   map[string]any{"name": name, "namespace": ns},
+		"spec":       map[string]any{},
+	}}
+}
+
+// --- normalizer tests -------------------------------------------------------
+
+func TestLinkerdNormalize_ServiceProfileThreeRoutes(t *testing.T) {
+	sp := serviceProfile("prod", "webapp.prod.svc.cluster.local", []map[string]any{
+		{"name": "GET /", "condition": map[string]any{"method": "GET", "pathRegex": "/"}},
+		{"name": "POST /login", "condition": map[string]any{"method": "POST", "pathRegex": "/login"}},
+		{"name": "default", "condition": map[string]any{"pathRegex": ".*"}},
+	})
+
+	tr := normalizeServiceProfile(sp)
+
+	if tr.Mesh != MeshLinkerd || tr.Kind != "ServiceProfile" {
+		t.Errorf("Mesh/Kind = %q/%q, want linkerd/ServiceProfile", tr.Mesh, tr.Kind)
+	}
+	if tr.ID != "linkerd:prod:sp:webapp.prod.svc.cluster.local" {
+		t.Errorf("ID = %q, unexpected", tr.ID)
+	}
+	if len(tr.Hosts) != 1 || tr.Hosts[0] != "webapp.prod.svc.cluster.local" {
+		t.Errorf("Hosts = %v, want [webapp.prod.svc.cluster.local]", tr.Hosts)
+	}
+	if len(tr.Matchers) != 3 {
+		t.Fatalf("Matchers = %d, want 3", len(tr.Matchers))
+	}
+	wantMatchers := []RouteMatcher{
+		{Name: "GET /", Method: "GET", PathRegex: "/"},
+		{Name: "POST /login", Method: "POST", PathRegex: "/login"},
+		{Name: "default", PathRegex: ".*"},
+	}
+	for i, want := range wantMatchers {
+		if tr.Matchers[i] != want {
+			t.Errorf("Matchers[%d] = %+v, want %+v", i, tr.Matchers[i], want)
+		}
+	}
+}
+
+// TestLinkerdNormalize_ServiceProfileEmptyRoutes covers the plan's edge case:
+// a ServiceProfile with no routes must emit Matchers as an empty slice, not
+// nil, so JSON clients see `matchers: []` and can render an empty state
+// consistently.
+func TestLinkerdNormalize_ServiceProfileEmptyRoutes(t *testing.T) {
+	sp := serviceProfile("prod", "empty.prod", nil)
+
+	tr := normalizeServiceProfile(sp)
+
+	if tr.Matchers == nil {
+		t.Fatal("Matchers is nil; want empty slice for parity with populated case")
+	}
+	if len(tr.Matchers) != 0 {
+		t.Errorf("Matchers = %v, want empty slice", tr.Matchers)
+	}
+}
+
+func TestLinkerdNormalize_ServerLabelSelector(t *testing.T) {
+	srv := linkerdServer("prod", "webapp-server", map[string]string{
+		"app":     "webapp",
+		"version": "v1",
+	})
+
+	tr := normalizeLinkerdServer(srv)
+
+	if tr.Kind != "Server" || tr.Mesh != MeshLinkerd {
+		t.Errorf("Kind/Mesh = %q/%q, want Server/linkerd", tr.Kind, tr.Mesh)
+	}
+	if tr.ID != "linkerd:prod:srv:webapp-server" {
+		t.Errorf("ID = %q, unexpected", tr.ID)
+	}
+	// stringifyMatchLabels sorts keys alphabetically → deterministic string.
+	if tr.Selector != "app=webapp,version=v1" {
+		t.Errorf("Selector = %q, want app=webapp,version=v1", tr.Selector)
+	}
+}
+
+func TestLinkerdNormalize_HTTPRouteMatchers(t *testing.T) {
+	hr := linkerdHTTPRoute("prod", "webapp-routes", []string{"webapp-server"},
+		[]map[string]any{
+			{"method": "GET", "path": map[string]any{"type": "PathPrefix", "value": "/api"}},
+			{"method": "POST", "path": map[string]any{"type": "Exact", "value": "/login"}},
+		})
+
+	tr := normalizeLinkerdHTTPRoute(hr)
+
+	if len(tr.Gateways) != 1 || tr.Gateways[0] != "webapp-server" {
+		t.Errorf("Gateways = %v, want [webapp-server]", tr.Gateways)
+	}
+	if len(tr.Matchers) != 2 {
+		t.Fatalf("Matchers = %d, want 2", len(tr.Matchers))
+	}
+	if tr.Matchers[0].PathPrefix != "/api" || tr.Matchers[0].Method != "GET" {
+		t.Errorf("Matchers[0] = %+v, want {GET PathPrefix=/api}", tr.Matchers[0])
+	}
+	if tr.Matchers[1].PathExact != "/login" || tr.Matchers[1].Method != "POST" {
+		t.Errorf("Matchers[1] = %+v, want {POST PathExact=/login}", tr.Matchers[1])
+	}
+}
+
+func TestLinkerdNormalize_AuthzPolicyTargetRef(t *testing.T) {
+	ap := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "policy.linkerd.io/v1alpha1",
+		"kind":       "AuthorizationPolicy",
+		"metadata":   map[string]any{"name": "allow-prom", "namespace": "prod"},
+		"spec": map[string]any{
+			"targetRef": map[string]any{"kind": "Server", "name": "webapp-server", "group": "policy.linkerd.io"},
+			"requiredAuthenticationRefs": []any{
+				map[string]any{"kind": "MeshTLSAuthentication", "name": "prom-mtls"},
+			},
+		},
+	}}
+
+	p := normalizeLinkerdAuthzPolicy(ap)
+
+	if p.Action != "ALLOW" {
+		t.Errorf("Action = %q, want ALLOW (Linkerd AP is allow-list semantics)", p.Action)
+	}
+	if p.Selector != "Server/webapp-server" {
+		t.Errorf("Selector = %q, want Server/webapp-server", p.Selector)
+	}
+	if p.RuleCount != 1 {
+		t.Errorf("RuleCount = %d, want 1 (one required authn ref)", p.RuleCount)
+	}
+}
+
+func TestLinkerdNormalize_MeshTLSAuthIdentities(t *testing.T) {
+	mtls := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "policy.linkerd.io/v1alpha1",
+		"kind":       "MeshTLSAuthentication",
+		"metadata":   map[string]any{"name": "prom-mtls", "namespace": "prod"},
+		"spec": map[string]any{
+			"identities": []any{
+				"prometheus.linkerd-viz.serviceaccount.identity.linkerd.cluster.local",
+				"grafana.linkerd-viz.serviceaccount.identity.linkerd.cluster.local",
+			},
+		},
+	}}
+
+	p := normalizeLinkerdMeshTLSAuth(mtls)
+
+	if p.Kind != "MeshTLSAuthentication" || p.Mesh != MeshLinkerd {
+		t.Errorf("Kind/Mesh = %q/%q", p.Kind, p.Mesh)
+	}
+	if p.RuleCount != 2 {
+		t.Errorf("RuleCount = %d, want 2 (two identities)", p.RuleCount)
+	}
+}
+
+// --- adapter integration tests ---------------------------------------------
+
+func TestLinkerdList_HappyPathSplitsRoutesAndPolicies(t *testing.T) {
+	sp := serviceProfile("prod", "webapp.prod", []map[string]any{
+		{"name": "GET /", "condition": map[string]any{"method": "GET", "pathRegex": "/"}},
+	})
+	srv := linkerdServer("prod", "webapp-server", map[string]string{"app": "webapp"})
+
+	client := newLinkerdFakeDynClient(sp, srv)
+	out := ListLinkerd(context.Background(), client, "")
+
+	if len(out.Errors) != 0 {
+		t.Errorf("Errors = %v, want empty", out.Errors)
+	}
+	if len(out.Routes) != 2 {
+		t.Errorf("Routes = %d, want 2 (ServiceProfile + Server)", len(out.Routes))
+	}
+	if len(out.Policies) != 0 {
+		t.Errorf("Policies = %d, want 0", len(out.Policies))
+	}
+}
+
+// TestLinkerdList_UpstreamHTTPRouteIgnored covers the plan's edge case: the
+// Linkerd HTTPRoute CRD lives at policy.linkerd.io, and the upstream
+// Gateway-API HTTPRoute at gateway.networking.k8s.io. The adapter must only
+// surface Linkerd's flavor even when both exist on the cluster.
+func TestLinkerdList_UpstreamHTTPRouteIgnored(t *testing.T) {
+	linkerdHR := linkerdHTTPRoute("prod", "linkerd-route", []string{"webapp-server"},
+		[]map[string]any{{"method": "GET", "path": map[string]any{"type": "PathPrefix", "value": "/"}}})
+	upstreamHR := upstreamHTTPRoute("prod", "upstream-route")
+
+	client := newLinkerdFakeDynClient(linkerdHR, upstreamHR)
+	out := ListLinkerd(context.Background(), client, "")
+
+	// Among routes, only one HTTPRoute — and it must be the Linkerd one.
+	var httpRoutes []TrafficRoute
+	for _, r := range out.Routes {
+		if r.Kind == "HTTPRoute" {
+			httpRoutes = append(httpRoutes, r)
+		}
+	}
+	if len(httpRoutes) != 1 {
+		t.Fatalf("HTTPRoutes in result = %d, want 1 (upstream should not appear)", len(httpRoutes))
+	}
+	if httpRoutes[0].Name != "linkerd-route" {
+		t.Errorf("HTTPRoute[0].Name = %q, want linkerd-route", httpRoutes[0].Name)
+	}
+}

--- a/backend/internal/servicemesh/normalize.go
+++ b/backend/internal/servicemesh/normalize.go
@@ -1,0 +1,254 @@
+package servicemesh
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// istioKindCodes maps CRD Kind → short code used in composite IDs. Matches
+// the plan's scheme ("vs", "dr", "gw", "pa", "ap"). Unknown kinds fall back
+// to lowercased Kind — keeps the function total without silent dropping.
+var istioKindCodes = map[string]string{
+	"VirtualService":      "vs",
+	"DestinationRule":     "dr",
+	"Gateway":             "gw",
+	"PeerAuthentication":  "pa",
+	"AuthorizationPolicy": "ap",
+}
+
+func istioCompositeID(kind, namespace, name string) string {
+	code, ok := istioKindCodes[kind]
+	if !ok {
+		code = strings.ToLower(kind)
+	}
+	return fmt.Sprintf("istio:%s:%s:%s", namespace, code, name)
+}
+
+// normalizeIstioRoute dispatches to the per-kind normalizer. The dispatch
+// shape keeps istio.go's list loop simple and makes future kind additions
+// (e.g., ServiceEntry) a one-line change.
+func normalizeIstioRoute(obj *unstructured.Unstructured, kind string) TrafficRoute {
+	switch kind {
+	case "VirtualService":
+		return normalizeIstioVirtualService(obj)
+	case "DestinationRule":
+		return normalizeIstioDestinationRule(obj)
+	case "Gateway":
+		return normalizeIstioGateway(obj)
+	}
+	return TrafficRoute{
+		ID:        istioCompositeID(kind, obj.GetNamespace(), obj.GetName()),
+		Mesh:      MeshIstio,
+		Kind:      kind,
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+		Raw:       obj.Object,
+	}
+}
+
+func normalizeIstioVirtualService(obj *unstructured.Unstructured) TrafficRoute {
+	name, ns := obj.GetName(), obj.GetNamespace()
+	hosts, _, _ := unstructured.NestedStringSlice(obj.Object, "spec", "hosts")
+	gateways, _, _ := unstructured.NestedStringSlice(obj.Object, "spec", "gateways")
+
+	// VirtualService carries destinations under spec.{http,tls,tcp}[*].route[*].destination.
+	// All three protocol branches share the same nested shape, so we walk them uniformly.
+	var destinations []RouteDestination
+	for _, protocol := range []string{"http", "tls", "tcp"} {
+		routes, _, _ := unstructured.NestedSlice(obj.Object, "spec", protocol)
+		for _, r := range routes {
+			rm, ok := r.(map[string]any)
+			if !ok {
+				continue
+			}
+			inner, _, _ := unstructured.NestedSlice(rm, "route")
+			for _, ir := range inner {
+				irMap, ok := ir.(map[string]any)
+				if !ok {
+					continue
+				}
+				host, _, _ := unstructured.NestedString(irMap, "destination", "host")
+				subset, _, _ := unstructured.NestedString(irMap, "destination", "subset")
+				port, _, _ := unstructured.NestedInt64(irMap, "destination", "port", "number")
+				weight, _, _ := unstructured.NestedInt64(irMap, "weight")
+				destinations = append(destinations, RouteDestination{
+					Host:   host,
+					Subset: subset,
+					Port:   port,
+					Weight: weight,
+				})
+			}
+		}
+	}
+
+	return TrafficRoute{
+		ID:           istioCompositeID("VirtualService", ns, name),
+		Mesh:         MeshIstio,
+		Kind:         "VirtualService",
+		Name:         name,
+		Namespace:    ns,
+		Hosts:        hosts,
+		Gateways:     gateways,
+		Destinations: destinations,
+		Raw:          obj.Object,
+	}
+}
+
+func normalizeIstioDestinationRule(obj *unstructured.Unstructured) TrafficRoute {
+	name, ns := obj.GetName(), obj.GetNamespace()
+	host, _, _ := unstructured.NestedString(obj.Object, "spec", "host")
+
+	subsetsRaw, _, _ := unstructured.NestedSlice(obj.Object, "spec", "subsets")
+	var subsets []string
+	for _, s := range subsetsRaw {
+		sm, ok := s.(map[string]any)
+		if !ok {
+			continue
+		}
+		if n, _, _ := unstructured.NestedString(sm, "name"); n != "" {
+			subsets = append(subsets, n)
+		}
+	}
+
+	tr := TrafficRoute{
+		ID:        istioCompositeID("DestinationRule", ns, name),
+		Mesh:      MeshIstio,
+		Kind:      "DestinationRule",
+		Name:      name,
+		Namespace: ns,
+		Subsets:   subsets,
+		Raw:       obj.Object,
+	}
+	if host != "" {
+		tr.Hosts = []string{host}
+	}
+	return tr
+}
+
+func normalizeIstioGateway(obj *unstructured.Unstructured) TrafficRoute {
+	name, ns := obj.GetName(), obj.GetNamespace()
+
+	// A Gateway's spec.servers[*].hosts is a per-listener list; flatten + dedupe
+	// so the UI can render a single host column.
+	hostSet := map[string]struct{}{}
+	serversRaw, _, _ := unstructured.NestedSlice(obj.Object, "spec", "servers")
+	for _, s := range serversRaw {
+		sm, ok := s.(map[string]any)
+		if !ok {
+			continue
+		}
+		hs, _, _ := unstructured.NestedStringSlice(sm, "hosts")
+		for _, h := range hs {
+			hostSet[h] = struct{}{}
+		}
+	}
+	hosts := make([]string, 0, len(hostSet))
+	for h := range hostSet {
+		hosts = append(hosts, h)
+	}
+	sort.Strings(hosts)
+
+	return TrafficRoute{
+		ID:        istioCompositeID("Gateway", ns, name),
+		Mesh:      MeshIstio,
+		Kind:      "Gateway",
+		Name:      name,
+		Namespace: ns,
+		Hosts:     hosts,
+		Raw:       obj.Object,
+	}
+}
+
+func normalizeIstioPolicy(obj *unstructured.Unstructured, kind string) MeshedPolicy {
+	switch kind {
+	case "PeerAuthentication":
+		return normalizeIstioPeerAuth(obj)
+	case "AuthorizationPolicy":
+		return normalizeIstioAuthzPolicy(obj)
+	}
+	return MeshedPolicy{
+		ID:        istioCompositeID(kind, obj.GetNamespace(), obj.GetName()),
+		Mesh:      MeshIstio,
+		Kind:      kind,
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+		Raw:       obj.Object,
+	}
+}
+
+func normalizeIstioPeerAuth(obj *unstructured.Unstructured) MeshedPolicy {
+	name, ns := obj.GetName(), obj.GetNamespace()
+	mode, _, _ := unstructured.NestedString(obj.Object, "spec", "mtls", "mode")
+	if mode == "" {
+		mode = "UNSET"
+	}
+
+	return MeshedPolicy{
+		ID:        istioCompositeID("PeerAuthentication", ns, name),
+		Mesh:      MeshIstio,
+		Kind:      "PeerAuthentication",
+		Name:      name,
+		Namespace: ns,
+		MTLSMode:  mode,
+		Selector:  stringifyMatchLabels(obj.Object, "spec", "selector", "matchLabels"),
+		Raw:       obj.Object,
+	}
+}
+
+func normalizeIstioAuthzPolicy(obj *unstructured.Unstructured) MeshedPolicy {
+	name, ns := obj.GetName(), obj.GetNamespace()
+
+	action, _, _ := unstructured.NestedString(obj.Object, "spec", "action")
+	if action == "" {
+		action = "ALLOW" // Istio default
+	}
+	rulesRaw, _, _ := unstructured.NestedSlice(obj.Object, "spec", "rules")
+
+	// Istio semantics: ALLOW + no rules = allows nothing (deny_all);
+	// DENY + no rules = denies nothing (allow_all). The UI surfaces this
+	// computed effect so operators don't have to infer it from the spec.
+	effect := ""
+	if len(rulesRaw) == 0 {
+		switch action {
+		case "ALLOW":
+			effect = "deny_all"
+		case "DENY":
+			effect = "allow_all"
+		}
+	}
+
+	return MeshedPolicy{
+		ID:        istioCompositeID("AuthorizationPolicy", ns, name),
+		Mesh:      MeshIstio,
+		Kind:      "AuthorizationPolicy",
+		Name:      name,
+		Namespace: ns,
+		Action:    action,
+		Effect:    effect,
+		Selector:  stringifyMatchLabels(obj.Object, "spec", "selector", "matchLabels"),
+		RuleCount: len(rulesRaw),
+		Raw:       obj.Object,
+	}
+}
+
+// stringifyMatchLabels renders a nested matchLabels map as a stable,
+// sorted "k=v,k=v" string for display.
+func stringifyMatchLabels(obj map[string]any, path ...string) string {
+	labels, found, _ := unstructured.NestedStringMap(obj, path...)
+	if !found || len(labels) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(labels))
+	for k := range labels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, k+"="+labels[k])
+	}
+	return strings.Join(parts, ",")
+}

--- a/backend/internal/servicemesh/normalize.go
+++ b/backend/internal/servicemesh/normalize.go
@@ -234,6 +234,221 @@ func normalizeIstioAuthzPolicy(obj *unstructured.Unstructured) MeshedPolicy {
 	}
 }
 
+// linkerdKindCodes maps CRD Kind → short code used in composite IDs.
+// Matches the plan's scheme (ServiceProfile → "sp", Server → "srv", etc.).
+var linkerdKindCodes = map[string]string{
+	"ServiceProfile":        "sp",
+	"Server":                "srv",
+	"HTTPRoute":             "hr",
+	"AuthorizationPolicy":   "ap",
+	"MeshTLSAuthentication": "mtls",
+}
+
+func linkerdCompositeID(kind, namespace, name string) string {
+	code, ok := linkerdKindCodes[kind]
+	if !ok {
+		code = strings.ToLower(kind)
+	}
+	return fmt.Sprintf("linkerd:%s:%s:%s", namespace, code, name)
+}
+
+// normalizeLinkerdRoute dispatches to the per-kind normalizer. Mirrors
+// normalizeIstioRoute for symmetry so the handler in A4 can treat both
+// meshes identically at the call site.
+func normalizeLinkerdRoute(obj *unstructured.Unstructured, kind string) TrafficRoute {
+	switch kind {
+	case "ServiceProfile":
+		return normalizeServiceProfile(obj)
+	case "Server":
+		return normalizeLinkerdServer(obj)
+	case "HTTPRoute":
+		return normalizeLinkerdHTTPRoute(obj)
+	}
+	return TrafficRoute{
+		ID:        linkerdCompositeID(kind, obj.GetNamespace(), obj.GetName()),
+		Mesh:      MeshLinkerd,
+		Kind:      kind,
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+		Raw:       obj.Object,
+	}
+}
+
+// normalizeServiceProfile preserves per-route matchers in Matchers so UI
+// rows can render them without re-parsing Raw. Initializes to an empty
+// (non-nil) slice when no routes exist so the API payload doesn't surface
+// JSON `null` for a list-shaped field.
+func normalizeServiceProfile(obj *unstructured.Unstructured) TrafficRoute {
+	name, ns := obj.GetName(), obj.GetNamespace()
+	routesRaw, _, _ := unstructured.NestedSlice(obj.Object, "spec", "routes")
+
+	matchers := make([]RouteMatcher, 0, len(routesRaw))
+	for _, r := range routesRaw {
+		rm, ok := r.(map[string]any)
+		if !ok {
+			continue
+		}
+		routeName, _, _ := unstructured.NestedString(rm, "name")
+		method, _, _ := unstructured.NestedString(rm, "condition", "method")
+		pathRegex, _, _ := unstructured.NestedString(rm, "condition", "pathRegex")
+		matchers = append(matchers, RouteMatcher{
+			Name:      routeName,
+			Method:    method,
+			PathRegex: pathRegex,
+		})
+	}
+
+	return TrafficRoute{
+		ID:        linkerdCompositeID("ServiceProfile", ns, name),
+		Mesh:      MeshLinkerd,
+		Kind:      "ServiceProfile",
+		Name:      name,
+		Namespace: ns,
+		// Linkerd encodes the FQDN as the resource name — surface it as a host
+		// so the UI can render a "traffic to X" row without reaching into Raw.
+		Hosts:    []string{name},
+		Matchers: matchers,
+		Raw:      obj.Object,
+	}
+}
+
+func normalizeLinkerdServer(obj *unstructured.Unstructured) TrafficRoute {
+	name, ns := obj.GetName(), obj.GetNamespace()
+	return TrafficRoute{
+		ID:        linkerdCompositeID("Server", ns, name),
+		Mesh:      MeshLinkerd,
+		Kind:      "Server",
+		Name:      name,
+		Namespace: ns,
+		Selector:  stringifyMatchLabels(obj.Object, "spec", "podSelector", "matchLabels"),
+		Raw:       obj.Object,
+	}
+}
+
+func normalizeLinkerdHTTPRoute(obj *unstructured.Unstructured) TrafficRoute {
+	name, ns := obj.GetName(), obj.GetNamespace()
+
+	parents, _, _ := unstructured.NestedSlice(obj.Object, "spec", "parentRefs")
+	var gateways []string
+	for _, p := range parents {
+		pm, ok := p.(map[string]any)
+		if !ok {
+			continue
+		}
+		if n, _, _ := unstructured.NestedString(pm, "name"); n != "" {
+			gateways = append(gateways, n)
+		}
+	}
+
+	rules, _, _ := unstructured.NestedSlice(obj.Object, "spec", "rules")
+	var matchers []RouteMatcher
+	for _, r := range rules {
+		rm, ok := r.(map[string]any)
+		if !ok {
+			continue
+		}
+		matches, _, _ := unstructured.NestedSlice(rm, "matches")
+		for _, m := range matches {
+			mm, ok := m.(map[string]any)
+			if !ok {
+				continue
+			}
+			matchers = append(matchers, extractGatewayAPIMatcher(mm))
+		}
+	}
+
+	return TrafficRoute{
+		ID:        linkerdCompositeID("HTTPRoute", ns, name),
+		Mesh:      MeshLinkerd,
+		Kind:      "HTTPRoute",
+		Name:      name,
+		Namespace: ns,
+		Gateways:  gateways,
+		Matchers:  matchers,
+		Raw:       obj.Object,
+	}
+}
+
+// extractGatewayAPIMatcher reads Gateway-API-shaped path+method matchers
+// (used by both Linkerd HTTPRoute and upstream gateway.networking.k8s.io).
+// Extracted so future Gateway-API adapters can reuse it.
+func extractGatewayAPIMatcher(m map[string]any) RouteMatcher {
+	method, _, _ := unstructured.NestedString(m, "method")
+	pathType, _, _ := unstructured.NestedString(m, "path", "type")
+	pathValue, _, _ := unstructured.NestedString(m, "path", "value")
+
+	out := RouteMatcher{Method: method}
+	switch pathType {
+	case "Exact":
+		out.PathExact = pathValue
+	case "PathPrefix":
+		out.PathPrefix = pathValue
+	case "RegularExpression":
+		out.PathRegex = pathValue
+	}
+	return out
+}
+
+// normalizeLinkerdPolicy dispatches Linkerd security CRDs into MeshedPolicy.
+func normalizeLinkerdPolicy(obj *unstructured.Unstructured, kind string) MeshedPolicy {
+	switch kind {
+	case "AuthorizationPolicy":
+		return normalizeLinkerdAuthzPolicy(obj)
+	case "MeshTLSAuthentication":
+		return normalizeLinkerdMeshTLSAuth(obj)
+	}
+	return MeshedPolicy{
+		ID:        linkerdCompositeID(kind, obj.GetNamespace(), obj.GetName()),
+		Mesh:      MeshLinkerd,
+		Kind:      kind,
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+		Raw:       obj.Object,
+	}
+}
+
+func normalizeLinkerdAuthzPolicy(obj *unstructured.Unstructured) MeshedPolicy {
+	name, ns := obj.GetName(), obj.GetNamespace()
+	targetKind, _, _ := unstructured.NestedString(obj.Object, "spec", "targetRef", "kind")
+	targetName, _, _ := unstructured.NestedString(obj.Object, "spec", "targetRef", "name")
+	authns, _, _ := unstructured.NestedSlice(obj.Object, "spec", "requiredAuthenticationRefs")
+
+	// Linkerd AuthorizationPolicies are allow-lists: presence grants access
+	// to the targetRef. The "target" identifier acts as a Selector the UI
+	// can show alongside Istio's label-based selector.
+	var selector string
+	if targetKind != "" && targetName != "" {
+		selector = targetKind + "/" + targetName
+	}
+
+	return MeshedPolicy{
+		ID:        linkerdCompositeID("AuthorizationPolicy", ns, name),
+		Mesh:      MeshLinkerd,
+		Kind:      "AuthorizationPolicy",
+		Name:      name,
+		Namespace: ns,
+		Action:    "ALLOW",
+		Selector:  selector,
+		RuleCount: len(authns),
+		Raw:       obj.Object,
+	}
+}
+
+func normalizeLinkerdMeshTLSAuth(obj *unstructured.Unstructured) MeshedPolicy {
+	name, ns := obj.GetName(), obj.GetNamespace()
+	identities, _, _ := unstructured.NestedStringSlice(obj.Object, "spec", "identities")
+
+	return MeshedPolicy{
+		ID:        linkerdCompositeID("MeshTLSAuthentication", ns, name),
+		Mesh:      MeshLinkerd,
+		Kind:      "MeshTLSAuthentication",
+		Name:      name,
+		Namespace: ns,
+		RuleCount: len(identities),
+		Raw:       obj.Object,
+	}
+}
+
 // stringifyMatchLabels renders a nested matchLabels map as a stable,
 // sorted "k=v,k=v" string for display.
 func stringifyMatchLabels(obj map[string]any, path ...string) string {

--- a/backend/internal/servicemesh/types.go
+++ b/backend/internal/servicemesh/types.go
@@ -91,8 +91,63 @@ type MeshInfo struct {
 // Callers must treat the returned value as read-only: mutating the Istio
 // or Linkerd pointer fields may race with concurrent cache updates.
 type MeshStatus struct {
-	Detected    MeshType   `json:"detected"`
-	Istio       *MeshInfo  `json:"istio,omitempty"`
-	Linkerd     *MeshInfo  `json:"linkerd,omitempty"`
-	LastChecked time.Time  `json:"lastChecked"`
+	Detected    MeshType  `json:"detected"`
+	Istio       *MeshInfo `json:"istio,omitempty"`
+	Linkerd     *MeshInfo `json:"linkerd,omitempty"`
+	LastChecked time.Time `json:"lastChecked"`
+}
+
+// RouteDestination identifies one backend a TrafficRoute forwards to.
+// Fields are optional: meshes differ in what they expose (e.g., Linkerd
+// ServiceProfiles don't carry port or subset).
+type RouteDestination struct {
+	Host   string `json:"host,omitempty"`
+	Subset string `json:"subset,omitempty"`
+	Port   int64  `json:"port,omitempty"`
+	Weight int64  `json:"weight,omitempty"`
+}
+
+// TrafficRoute is the mesh-agnostic shape for routing CRDs (Istio
+// VirtualService / DestinationRule / Gateway, Linkerd ServiceProfile /
+// HTTPRoute / Server). `Mesh` + `Kind` discriminate for typed UI handling.
+// `Raw` preserves the full spec for detail-view rendering and YAML export.
+type TrafficRoute struct {
+	ID           string             `json:"id"` // composite: "{mesh}:{namespace}:{kindCode}:{name}"
+	Mesh         MeshType           `json:"mesh"`
+	Kind         string             `json:"kind"`
+	Name         string             `json:"name"`
+	Namespace    string             `json:"namespace,omitempty"`
+	Hosts        []string           `json:"hosts,omitempty"`
+	Gateways     []string           `json:"gateways,omitempty"`
+	Subsets      []string           `json:"subsets,omitempty"`
+	Destinations []RouteDestination `json:"destinations,omitempty"`
+	Raw          map[string]any     `json:"raw,omitempty"`
+}
+
+// MeshedPolicy is the mesh-agnostic shape for security / authz CRDs
+// (Istio PeerAuthentication / AuthorizationPolicy, Linkerd MeshTLSAuthentication
+// / AuthorizationPolicy). `Effect` captures computed semantics for corner
+// cases (e.g., ALLOW with no rules → "deny_all").
+type MeshedPolicy struct {
+	ID        string         `json:"id"`
+	Mesh      MeshType       `json:"mesh"`
+	Kind      string         `json:"kind"`
+	Name      string         `json:"name"`
+	Namespace string         `json:"namespace,omitempty"`
+	Action    string         `json:"action,omitempty"`   // ALLOW / DENY / AUDIT / CUSTOM / ... (mesh-native)
+	Effect    string         `json:"effect,omitempty"`   // computed: "deny_all" | "allow_all" | ""
+	MTLSMode  string         `json:"mtlsMode,omitempty"` // PeerAuthentication: STRICT / PERMISSIVE / DISABLE / UNSET
+	Selector  string         `json:"selector,omitempty"` // stringified matchLabels: "k=v,k=v"
+	RuleCount int            `json:"ruleCount"`
+	Raw       map[string]any `json:"raw,omitempty"`
+}
+
+// NormalizedMeshMembership reports per-namespace mesh injection status —
+// the signal that drives the coverage summary on the mesh dashboard and
+// the mTLS posture page. Populated in detail in Phase B; the type is
+// surfaced here so downstream packages can already reference it.
+type NormalizedMeshMembership struct {
+	Namespace      string   `json:"namespace"`
+	Mesh           MeshType `json:"mesh,omitempty"` // empty = unmeshed
+	InjectionLabel string   `json:"injectionLabel,omitempty"`
 }

--- a/backend/internal/servicemesh/types.go
+++ b/backend/internal/servicemesh/types.go
@@ -62,7 +62,7 @@ var (
 // by API group.
 var (
 	LinkerdServiceProfileGVR = schema.GroupVersionResource{
-		Group: "linkerd.io", Version: "v1beta1", Resource: "serviceprofiles",
+		Group: "linkerd.io", Version: "v1alpha2", Resource: "serviceprofiles",
 	}
 	LinkerdServerGVR = schema.GroupVersionResource{
 		Group: "policy.linkerd.io", Version: "v1beta3", Resource: "servers",
@@ -107,6 +107,18 @@ type RouteDestination struct {
 	Weight int64  `json:"weight,omitempty"`
 }
 
+// RouteMatcher describes how a route selects requests. Different meshes
+// populate different fields — Linkerd ServiceProfile uses Method + PathRegex,
+// Linkerd HTTPRoute (and Gateway API) uses Method + Path{Exact,Prefix,Regex}.
+// Empty fields mean "no constraint on that axis".
+type RouteMatcher struct {
+	Name       string `json:"name,omitempty"`
+	Method     string `json:"method,omitempty"`
+	PathExact  string `json:"pathExact,omitempty"`
+	PathPrefix string `json:"pathPrefix,omitempty"`
+	PathRegex  string `json:"pathRegex,omitempty"`
+}
+
 // TrafficRoute is the mesh-agnostic shape for routing CRDs (Istio
 // VirtualService / DestinationRule / Gateway, Linkerd ServiceProfile /
 // HTTPRoute / Server). `Mesh` + `Kind` discriminate for typed UI handling.
@@ -120,6 +132,8 @@ type TrafficRoute struct {
 	Hosts        []string           `json:"hosts,omitempty"`
 	Gateways     []string           `json:"gateways,omitempty"`
 	Subsets      []string           `json:"subsets,omitempty"`
+	Selector     string             `json:"selector,omitempty"` // stringified matchLabels for Server-like resources
+	Matchers     []RouteMatcher     `json:"matchers,omitempty"` // request-level matchers (SP routes, HTTPRoute rules)
 	Destinations []RouteDestination `json:"destinations,omitempty"`
 	Raw          map[string]any     `json:"raw,omitempty"`
 }

--- a/backend/internal/servicemesh/types.go
+++ b/backend/internal/servicemesh/types.go
@@ -1,0 +1,98 @@
+// Package servicemesh provides Istio and Linkerd service mesh observability.
+//
+// Phase A surfaces mesh installation status, traffic-routing CRDs (VirtualService,
+// DestinationRule, ServiceProfile, etc.), and RBAC-filtered list/detail views.
+// Phase B adds mTLS posture and golden-signal metrics. Phase C builds the UI.
+// Phase D overlays mesh edges on the existing topology graph.
+//
+// The package mirrors internal/gitops: per-mesh adapter files keep mesh-specific
+// logic isolated, while shared normalized types provide a stable UI contract.
+package servicemesh
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// MeshType identifies which service mesh manages a resource.
+type MeshType string
+
+const (
+	MeshNone    MeshType = ""
+	MeshIstio   MeshType = "istio"
+	MeshLinkerd MeshType = "linkerd"
+	MeshBoth    MeshType = "both"
+)
+
+// MeshMode distinguishes Istio's sidecar and ambient data-plane modes.
+// Linkerd has no equivalent toggle today.
+type MeshMode string
+
+const (
+	MeshModeSidecar MeshMode = "sidecar"
+	MeshModeAmbient MeshMode = "ambient"
+)
+
+// Istio CRD GroupVersionResources (networking.istio.io/v1, security.istio.io/v1).
+var (
+	IstioVirtualServiceGVR = schema.GroupVersionResource{
+		Group: "networking.istio.io", Version: "v1", Resource: "virtualservices",
+	}
+	IstioDestinationRuleGVR = schema.GroupVersionResource{
+		Group: "networking.istio.io", Version: "v1", Resource: "destinationrules",
+	}
+	IstioGatewayGVR = schema.GroupVersionResource{
+		Group: "networking.istio.io", Version: "v1", Resource: "gateways",
+	}
+	IstioServiceEntryGVR = schema.GroupVersionResource{
+		Group: "networking.istio.io", Version: "v1", Resource: "serviceentries",
+	}
+	IstioPeerAuthenticationGVR = schema.GroupVersionResource{
+		Group: "security.istio.io", Version: "v1", Resource: "peerauthentications",
+	}
+	IstioAuthorizationPolicyGVR = schema.GroupVersionResource{
+		Group: "security.istio.io", Version: "v1", Resource: "authorizationpolicies",
+	}
+)
+
+// Linkerd CRD GroupVersionResources.
+// Note: Linkerd's HTTPRoute lives under policy.linkerd.io and is distinct
+// from the upstream gateway.networking.k8s.io HTTPRoute. The handler disambiguates
+// by API group.
+var (
+	LinkerdServiceProfileGVR = schema.GroupVersionResource{
+		Group: "linkerd.io", Version: "v1beta1", Resource: "serviceprofiles",
+	}
+	LinkerdServerGVR = schema.GroupVersionResource{
+		Group: "policy.linkerd.io", Version: "v1beta3", Resource: "servers",
+	}
+	LinkerdAuthorizationPolicyGVR = schema.GroupVersionResource{
+		Group: "policy.linkerd.io", Version: "v1alpha1", Resource: "authorizationpolicies",
+	}
+	LinkerdHTTPRouteGVR = schema.GroupVersionResource{
+		Group: "policy.linkerd.io", Version: "v1beta1", Resource: "httproutes",
+	}
+	LinkerdMeshTLSAuthenticationGVR = schema.GroupVersionResource{
+		Group: "policy.linkerd.io", Version: "v1alpha1", Resource: "meshtlsauthentications",
+	}
+)
+
+// MeshInfo describes a single mesh's installation state.
+type MeshInfo struct {
+	Installed bool     `json:"installed"`
+	Namespace string   `json:"namespace,omitempty"`
+	Version   string   `json:"version,omitempty"`
+	Mode      MeshMode `json:"mode,omitempty"` // Istio only; empty for Linkerd
+}
+
+// MeshStatus is returned by GET /mesh/status.
+//
+// Callers must treat the returned value as read-only: mutating the Istio
+// or Linkerd pointer fields may race with concurrent cache updates.
+type MeshStatus struct {
+	Detected    MeshType   `json:"detected"`
+	Istio       *MeshInfo  `json:"istio,omitempty"`
+	Linkerd     *MeshInfo  `json:"linkerd,omitempty"`
+	LastChecked time.Time  `json:"lastChecked"`
+}

--- a/plans/service-mesh-observability.md
+++ b/plans/service-mesh-observability.md
@@ -296,7 +296,7 @@ Phases deliver independently-shippable PRs. Each phase is reviewed and merged be
 
 ---
 
-- [ ] **Unit A3: Linkerd adapter**
+- [x] **Unit A3: Linkerd adapter**
 
 **Goal:** Linkerd adapter for ServiceProfile, AuthorizationPolicy, Server, HTTPRoute, MeshTLSAuthentication.
 

--- a/plans/service-mesh-observability.md
+++ b/plans/service-mesh-observability.md
@@ -1,0 +1,699 @@
+---
+title: feat — Service Mesh Observability (Istio + Linkerd)
+type: feat
+status: active
+date: 2026-04-16
+roadmap: "#6"
+---
+
+# feat: Service Mesh Observability (Istio + Linkerd)
+
+## Overview
+
+Deliver vCenter-level visibility into Istio and Linkerd service meshes: auto-detect the installed mesh(es), surface traffic routing config, expose mTLS posture per workload, visualize mesh edges on the existing topology graph, and pull golden-signal metrics (RPS, p95 latency, error rate) from Prometheus. Read-only in v1 — write/wizard support deferred to a follow-up phase once the inventory surface is stable.
+
+Dual-mesh v1 scope is deliberate: the dual-tool precedents in this repo (`internal/policy/` for Kyverno+Gatekeeper, `internal/gitops/` for Argo+Flux) have shown that adding the second tool later is painful. The cost of designing for two meshes up front is modest because the per-mesh adapters stay isolated; the pain is amortized across four shippable PRs.
+
+Closes roadmap item **#6**.
+
+## Problem Frame
+
+Kubernetes operators running a service mesh today have no unified view inside k8sCenter:
+- Mesh install state, sidecar-injection coverage per namespace, and control-plane health live in disparate CLIs (`istioctl`, `linkerd check`).
+- Traffic-shifting config (VirtualService, DestinationRule, ServiceProfile) requires `kubectl get … -o yaml` to inspect.
+- mTLS posture is opaque: it is unclear which workloads use mTLS, which have it disabled via a PeerAuthentication exception, and which are unmeshed entirely.
+- The existing topology graph (Phase 7B) shows owner/selector/mount edges but no mesh-aware traffic edges.
+- Mesh-specific Prometheus metrics (`istio_*`, `linkerd_*`) are reachable through the existing Prometheus proxy but not surfaced as first-class golden signals.
+
+The gap matches the pattern that motivated the cert-manager observatory (Phase 11A) and the policy dashboard (Phase 8A): the CRDs and metrics already exist, but operators lack a GUI that aggregates and RBAC-filters them.
+
+## Requirements Trace
+
+- **R1. Detect mesh installation** — Report Istio and/or Linkerd presence, control-plane namespace, and version. Graceful empty state when neither is installed.
+- **R2. List mesh-managed resources** — Enumerate VirtualService, DestinationRule, Gateway, PeerAuthentication, AuthorizationPolicy (Istio) and ServiceProfile, Server, HTTPRoute, AuthorizationPolicy, MeshTLSAuthentication (Linkerd) with RBAC filtering.
+- **R3. Detail views** — Per-CRD detail with normalized status, raw YAML fallback, and cross-links to owned/referenced resources.
+- **R4. mTLS posture dashboard** — Per-workload mTLS status (Istio PeerAuthentication mode + connection_security_policy metric; Linkerd default-on + edge security observation).
+- **R5. Mesh-aware topology** — Mesh traffic edges overlaid on existing `/observability/topology` view with a toggle. Edges emitted from VirtualService destinations and Linkerd edges output.
+- **R6. Golden signals** — Per-service RPS, p50/p95/p99 latency, and error rate surfaced on the service detail view when mesh metrics are available.
+- **R7. RBAC-aware** — Every mesh list and detail endpoint filters through `AccessChecker.CanAccessGroupResource` using the CRD's real API group (`networking.istio.io`, `policy.linkerd.io`, etc.), matching Phase 11A precedent.
+- **R8. Multi-cluster correct** — Informers for local cluster reads; dynamic-client calls for remote clusters, matching the project's standing rule. No informer watches on remote clusters.
+- **R9. Non-functional** — `go vet`, `go test ./...`, `deno lint`, `deno fmt --check`, `deno task build` all pass. Zero hardcoded Tailwind color classes (Phase 6C compliance). Theme tokens only.
+
+## Scope Boundaries
+
+- **Read-only in v1.** No mesh config wizards, no apply/delete from the UI. Users who need to edit VirtualServices or AuthorizationPolicies use the existing YAML editor (`/yaml`).
+- **No Istio Ambient Mode-specific features.** Ambient mode (ztunnel, waypoint proxies) is detected but treated as "Istio installed" — dedicated ambient views deferred.
+- **No Kiali replacement.** Kiali has deep Istio-only features (distributed tracing overlay, live traffic animation) that are out of scope.
+- **No service mesh installer.** Detecting an installed mesh is in scope; installing one is not.
+- **No cross-mesh traffic.** Multi-mesh federation (Istio multi-primary, Linkerd multi-cluster) is detected-as-version but not visualized.
+- **No Open Service Mesh (OSM) or Consul Connect.** Istio and Linkerd only in v1.
+
+### Deferred to Separate Tasks
+
+- **Mesh configuration wizards** — VirtualService / DestinationRule / PeerAuthentication / ServiceProfile creation via the wizard pipeline. Separate plan after v1 lands and the inventory surface is battle-tested on the homelab.
+- **Distributed tracing integration** — Tempo/Jaeger client + span viewer. Tracked separately as it is orthogonal to mesh-specific CRDs and metrics.
+- **Mesh-aware SLO scoring** — Once golden signals land, SLO burn-rate alerting on top of them is a natural follow-up.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+Precedent packages to mirror (dual-tool CRD pattern):
+
+- **GitOps** (`backend/internal/gitops/`) — Closest analog. Dual-tool adapters (`argocd.go`, `flux.go`), normalized types with `Tool` + `Kind` discriminators, singleflight + 30s cache, per-user RBAC filter, user impersonation on writes. See handler at `backend/internal/gitops/handler.go`, discoverer at `backend/internal/gitops/discovery.go`.
+- **Policy** (`backend/internal/policy/`) — Similar dual-tool shape. Use for the compliance-score angle if a "mesh coverage score" (% workloads in mesh) is added. See `backend/internal/policy/handler.go`.
+- **Cert-Manager** (`backend/internal/certmanager/`) — Most recent single-tool CRD observatory. Poller pattern (`poller.go`) is the reference if we add a mesh-health poller in v2.
+
+Shared infrastructure to consume:
+
+- `AccessChecker.CanAccessGroupResource(ctx, username, groups, verb, apiGroup, resource, namespace)` at `backend/internal/auth/access.go` — used by all three precedents.
+- `PrometheusClient.Query` / `QueryRange` at `backend/internal/monitoring/` — direct Go-side PromQL for golden signals (not the HTTP proxy).
+- `topology.ResourceLister` at `backend/internal/topology/builder.go` — graph builder decoupled from data source. Extend with new lister methods for mesh data rather than forking the builder.
+- `InformerManager` — extend with per-mesh CRD listers (local cluster only). Remote clusters use `dynamic.Interface` directly.
+
+Frontend patterns:
+
+- `frontend/islands/PolicyDashboard.tsx` — detected-engine banner + empty-state installation link is the exact shell for the mesh status page.
+- `frontend/islands/NamespaceTopology.tsx` — edge renderer supports extensible `type` values (`owner`, `selector`, `mount`, `ingress`). Adding `mesh_vs` / `mesh_edge` is additive, not a rewrite.
+- `frontend/components/SubNav.tsx` — tab count pattern via `/resources/counts?namespace=` already batches counts; extend `RESOURCE_API_KINDS` with mesh CRDs.
+- Nav section placement: `frontend/lib/constants.ts` has a Networking section (for Cilium/Hubble). Mesh observability primary views fit there; topology overlay sits on the existing Observability topology page.
+
+### External References
+
+- Istio CRD reference: https://istio.io/latest/docs/reference/config/networking/ and https://istio.io/latest/docs/reference/config/security/
+- Istio standard metrics: https://istio.io/latest/docs/reference/config/metrics/ — key counter `istio_requests_total`, histogram `istio_request_duration_milliseconds`, label `connection_security_policy=mutual_tls` is the signal for active mTLS.
+- Linkerd CRDs: https://linkerd.io/2-edge/reference/ — ServiceProfile (`linkerd.io/v1beta1`), policy resources (`policy.linkerd.io/v1alpha1`/`v1beta1`/`v1beta3`).
+- Linkerd proxy metrics: https://linkerd.io/2-edge/reference/proxy-metrics/ — `request_total`, `response_latency_ms` with `direction=inbound|outbound`.
+- Linkerd mTLS: https://linkerd.io/2-edge/features/automatic-mtls/ — default-on, no STRICT/PERMISSIVE modes. Observable signal is the `secure_channel` tag on edges.
+
+### Institutional Learnings
+
+- **`docs/solutions/` applicability:** Phase 11A's lesson on CRD discovery caching (5min stale, lazy re-probe) should carry over. Phase 8A's lesson on "service account fetches cluster-wide data, then filter per-user via `CanAccessGroupResource`" is the canonical RBAC shape.
+- **Informer vs. dynamic-client split:** Remote clusters (Phase 2 multi-cluster) always use dynamic clients — do not add informer watches that cover remote clusters. This rule is enforced in every existing resource handler; mesh CRDs must respect it.
+- **Rate-limit and cap reads:** Policy handler uses a 5-wide semaphore + 5s timeout + 100-item cap when enumerating Gatekeeper constraints. Mesh CRDs in large clusters (1000+ VirtualServices) need the same protection.
+
+## Key Technical Decisions
+
+- **Dual-tool adapter pattern mirrors `gitops/`, not `policy/`.** GitOps keeps per-tool adapter files (`argocd.go`, `flux.go`) with a slim shared handler; Policy over-unified types. Mesh metric shapes (Istio's destination-centric labels vs. Linkerd's direction+authority) are too different to share a single metrics type — per-mesh adapters stay separate.
+- **Normalized shared types only where semantics align.** `MeshStatus`, `MeshMembership` (per-namespace injection status), and the outer `MeshedWorkload` wrapper are shared. `IstioTrafficRoute` and `LinkerdTrafficRoute` remain mesh-specific under a common `TrafficRoute` interface with a `Mesh` discriminator field. Frontend TypeScript mirrors this with a tagged union.
+- **mTLS posture computed server-side, not inferred client-side.** The handler combines PeerAuthentication mode (Istio) or default-on (Linkerd) with the `connection_security_policy` Prometheus label to produce a three-state result: `active` / `inactive` / `mixed`. Clients do not see the raw data.
+- **Golden signals on-demand, not cached.** PromQL queries execute at request time against the existing Prometheus client (templated queries with label substitution — validated via the existing `QueryTemplate.Render` path). No separate cache; Prometheus already caches.
+- **Topology overlay is additive.** Extend `ResourceLister` with two new methods (`ListVirtualServices`, `ListMeshEdges`) and add mesh-edge emission to the graph builder behind a flag. The existing per-namespace topology response format gains optional fields; no breaking change.
+- **Local cluster informers for CRD lists; remote uses dynamic-client.** Identical to the policy/gitops/cert-manager pattern. Informer startup is gated on mesh CRD presence (detected by discoverer) to avoid listing non-existent resources.
+- **Rate-limit + 2000-node cap on topology overlay endpoint.** Large meshes (1000+ services) would generate thousands of edges; cap at 2000 and return a truncation warning field, matching the Phase 7B topology endpoint.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Q: Shared types or per-mesh types?** — Resolved: hybrid. Shared outer types (`MeshStatus`, `MeshMembership`, `MeshedWorkload`). Per-mesh types for routing config and policies. Golden signals normalized to `{ rps, p50_ms, p95_ms, p99_ms, error_rate }` since both meshes export compatible-enough quantiles.
+- **Q: Where do mesh views live in navigation?** — Resolved: primary views under `/networking/mesh/*` (Networking section, adjacent to Cilium/Hubble); topology overlay is a toggle on the existing `/observability/topology` page. Rationale: mesh is data-plane networking; putting it next to CNI policy is the least-surprising placement.
+- **Q: Read-only in v1?** — Confirmed. Apply goes through the existing `/yaml/apply` endpoint (SSA). No mesh wizards in v1.
+- **Q: Should mTLS status be a standalone page or a column?** — Resolved: both. Per-workload mTLS column on the workload list, standalone `/networking/mesh/mtls` page with namespace-level aggregation + red/yellow/green posture cards.
+
+### Deferred to Implementation
+
+- **Exact label sets for golden-signal PromQL templates.** Validated during Phase C implementation against real Istio/Linkerd Prometheus scrapes — label cardinality varies by mesh version (v1.22 vs v1.24 Istio have different default labels).
+- **Istio Ambient Mode detection details.** The `ambient.istio.io/redirection` namespace label and absence of sidecar annotations together signal ambient. Exact detection logic resolved when an ambient cluster is available for testing.
+- **Rate-limit threshold for topology overlay at scale.** Starting value 10 req/min; tune after homelab validation.
+
+## Output Structure
+
+```
+backend/internal/servicemesh/
+├── discovery.go          # MeshDiscoverer — Istio + Linkerd CRD detection, control-plane ns, version
+├── types.go              # MeshStatus, MeshMembership, MeshedWorkload, TrafficRoute interface
+├── normalize.go          # normalizeIstioVS, normalizeLinkerdSP, mTLS posture computation
+├── handler.go            # HTTP handlers, singleflight + 30s cache, RBAC filter
+├── istio.go              # Istio adapter — CRD listers, mTLS from PeerAuthentication
+├── linkerd.go            # Linkerd adapter — CRD listers, default-on mTLS + edge observation
+├── metrics.go            # Prometheus golden-signal queries (templates per mesh)
+├── discovery_test.go     # CRD presence table tests
+├── normalize_test.go     # Status + mTLS posture unit tests
+├── istio_test.go         # Adapter tests with fake dynamic client
+├── linkerd_test.go       # Adapter tests with fake dynamic client
+└── metrics_test.go       # PromQL template rendering + label substitution
+
+frontend/islands/
+├── MeshDashboard.tsx             # Status banner + mesh coverage summary
+├── MeshRoutingList.tsx           # Unified list of VirtualServices / ServiceProfiles / etc.
+├── MeshRouteDetail.tsx           # Per-route detail with raw YAML fallback
+├── MTLSPosture.tsx               # Per-namespace mTLS posture cards + drill-down table
+└── MeshTopologyOverlay.tsx       # Toggle + renderer for mesh edges on topology page
+
+frontend/routes/networking/mesh/
+├── index.tsx                     # Redirect to /networking/mesh/dashboard
+├── dashboard.tsx                 # MeshDashboard island
+├── routing.tsx                   # MeshRoutingList island
+├── routing/[id].tsx              # MeshRouteDetail island (composite id: "mesh:ns:kind:name")
+└── mtls.tsx                      # MTLSPosture island
+
+frontend/lib/
+├── mesh-types.ts                 # TS mirror of backend types (tagged unions)
+└── mesh-api.ts                   # Typed API client wrappers for /mesh/* endpoints
+```
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+**Backend request flow:**
+
+```
+GET /api/v1/mesh/status
+    ↓
+Handler.HandleStatus
+    ↓
+MeshDiscoverer.Status()  ← 5min cached
+    ↓
+returns { istio: {installed, namespace, version}, linkerd: {installed, namespace, version} }
+
+GET /api/v1/mesh/routing?namespace=foo
+    ↓
+Handler.HandleListRoutes
+    ↓
+singleflight.Do("routing:foo", 30s cache)
+    ↓
+parallel: istio.ListRoutes(ns)  +  linkerd.ListRoutes(ns)
+    ↓
+filterByRBAC(user, routes)  ← CanAccessGroupResource per CRD group
+    ↓
+returns { routes: [NormalizedRoute{Mesh, Kind, Name, Namespace, RawRef, ...}] }
+
+GET /api/v1/mesh/mtls?namespace=foo
+    ↓
+Handler.HandleMTLSPosture
+    ↓
+istio:   read PeerAuthentication (namespace + mesh-level) → compute effective mode per workload
+         optionally query `sum by (destination_workload)(rate(istio_requests_total{connection_security_policy="mutual_tls"}[5m]))`
+linkerd: default-on → observed via presence of linkerd-proxy sidecar; optionally tap metrics
+    ↓
+returns { workloads: [{name, mesh, mtls: "active"|"inactive"|"mixed", source: "policy"|"metric"|"default"}] }
+
+GET /api/v1/mesh/metrics?service=bar&namespace=foo
+    ↓
+Handler.HandleGoldenSignals
+    ↓
+detect which mesh covers this service (via MeshMembership)
+    ↓
+mesh-specific QueryTemplate.Render({ns, svc}) → PromQL queries in parallel
+    ↓
+returns { rps, p50_ms, p95_ms, p99_ms, error_rate, mesh: "istio"|"linkerd" }
+```
+
+**Topology overlay (Phase D):**
+
+```
+GET /api/v1/topology/{ns}?overlay=mesh
+    ↓
+existing builder builds node/edge graph from ResourceLister
+    ↓
+if overlay=mesh AND mesh installed:
+    ListVirtualServices(ns) → emit edges from vs.spec.hosts → destination.host
+    (Linkerd) walk ServiceProfile → infer routes OR query `linkerd viz edges` PromQL equivalent
+    ↓
+additive: graph.edges += mesh_edges  (edge.type = "mesh_vs" | "mesh_destination")
+    ↓
+2000-edge cap enforced; truncation flag in response
+```
+
+## Implementation Units
+
+Phases deliver independently-shippable PRs. Each phase is reviewed and merged before the next starts (per CLAUDE.md "PHASED EXECUTION" rule).
+
+### Phase A — Backend foundation + routing inventory (PR 1)
+
+- [x] **Unit A1: Package skeleton + MeshDiscoverer**
+
+**Goal:** New `internal/servicemesh/` package with CRD-based discovery for Istio and Linkerd, returning a stable `MeshStatus` response.
+
+**Requirements:** R1, R7
+
+**Dependencies:** None.
+
+**Files:**
+- Create: `backend/internal/servicemesh/discovery.go`
+- Create: `backend/internal/servicemesh/types.go`
+- Create: `backend/internal/servicemesh/discovery_test.go`
+
+**Approach:**
+- `MeshDiscoverer` struct mirrors `gitops.GitOpsDiscoverer` — same 5min `recheckInterval`, same lazy re-probe on `Status()`.
+- Istio detection: probe `networking.istio.io/v1` for `virtualservices`; cross-check by listing deployments labelled `app=istiod` in any namespace.
+- Linkerd detection: probe `policy.linkerd.io/v1beta3` for `servers`; cross-check by listing deployments labelled `linkerd.io/control-plane-component=identity`.
+- Version detection from the control-plane deployment's image tag (same heuristic as cert-manager `discovery.go`).
+- `types.go` defines: `MeshType` enum (Istio / Linkerd), `MeshInfo { Type, Installed, Namespace, Version }`, `MeshStatus { Istio *MeshInfo, Linkerd *MeshInfo }`.
+
+**Patterns to follow:**
+- `backend/internal/gitops/discovery.go` for CRD probe loop
+- `backend/internal/certmanager/discovery.go` for version extraction from deployment image
+
+**Test scenarios:**
+- Happy path: both meshes installed → Status returns both present with versions.
+- Happy path: only Istio installed → Linkerd field is `nil` (or `Installed: false`).
+- Edge case: Istio CRDs present but control-plane deployment missing → `Installed: true, Version: "unknown"` (CRDs imply install, even if istiod crashed).
+- Edge case: discovery server returns `ErrGroupDiscoveryFailed` → discoverer returns cached `Status` + logs warning, does not fail the request.
+- Edge case: stale cache (past `recheckInterval`) → lazy re-probe fires on next `Status()` call.
+
+**Verification:**
+- `go test ./internal/servicemesh/... -run TestDiscoverer` passes.
+- Smoke: hit `GET /api/v1/mesh/status` on homelab with Istio installed and confirm the response shape.
+
+---
+
+- [ ] **Unit A2: Normalized types + Istio adapter**
+
+**Goal:** Istio adapter lists VirtualService, DestinationRule, Gateway, PeerAuthentication, AuthorizationPolicy and normalizes them into the shared `TrafficRoute` / `NormalizedPolicy` shapes.
+
+**Requirements:** R2, R3, R7
+
+**Dependencies:** Unit A1.
+
+**Files:**
+- Create: `backend/internal/servicemesh/istio.go`
+- Create: `backend/internal/servicemesh/normalize.go`
+- Create: `backend/internal/servicemesh/istio_test.go`
+- Modify: `backend/internal/servicemesh/types.go` (add `TrafficRoute`, `MeshedPolicy`, `NormalizedMeshMembership`)
+
+**Approach:**
+- `istio.go`: Uses `dynamic.Interface` for all reads (works against informer cache on local cluster via the typed wrapper, and direct API on remote).
+- Composite ID scheme: `"istio:{namespace}:{kind}:{name}"` where kind is `vs`/`dr`/`gw`/`pa`/`ap`. Matches gitops' `"argo:ns:name"` shape.
+- `normalize.go` exports `normalizeIstioVirtualService(u *unstructured.Unstructured) TrafficRoute`, etc. Keeps raw `map[string]any` as a fallback field for the detail view.
+- Rate-limit list calls: 5s timeout, 2000-item cap per CRD type.
+
+**Patterns to follow:**
+- `backend/internal/gitops/argocd.go` for dynamic-client adapter shape
+- `backend/internal/policy/kyverno.go` for semaphore+timeout+cap guards
+
+**Test scenarios:**
+- Happy path: unstructured VirtualService with two destinations → normalized with correct host list and destinations.
+- Happy path: DestinationRule with subset weights → normalized with subsets array preserved.
+- Edge case: AuthorizationPolicy with no rules (deny-all effect) → normalized with empty `rules` and a computed `effect: "deny_all"`.
+- Error path: dynamic client returns `403 Forbidden` for a specific CRD → adapter returns partial result (other CRDs listed) with an error annotation.
+- Integration: list with namespace="" hits cluster-scope; with namespace=specified hits one namespace only.
+
+**Verification:**
+- `go test ./internal/servicemesh/... -run TestIstio` passes with fake dynamic client fixtures.
+
+---
+
+- [ ] **Unit A3: Linkerd adapter**
+
+**Goal:** Linkerd adapter for ServiceProfile, AuthorizationPolicy, Server, HTTPRoute, MeshTLSAuthentication.
+
+**Requirements:** R2, R3, R7
+
+**Dependencies:** Unit A1, Unit A2 (shares normalize.go infrastructure).
+
+**Files:**
+- Create: `backend/internal/servicemesh/linkerd.go`
+- Create: `backend/internal/servicemesh/linkerd_test.go`
+- Modify: `backend/internal/servicemesh/normalize.go` (add Linkerd normalizers)
+
+**Approach:**
+- Same composite ID shape: `"linkerd:{namespace}:{kind}:{name}"`.
+- Normalizers per CRD: `normalizeServiceProfile`, `normalizeLinkerdAuthzPolicy`, `normalizeLinkerdServer`, `normalizeLinkerdHTTPRoute`.
+- HTTPRoute uses the Linkerd-flavored Gateway API CRD (`policy.linkerd.io/v1beta1 HTTPRoute`), not the upstream `gateway.networking.k8s.io/v1 HTTPRoute` — these are distinct. Handler disambiguates via API group.
+
+**Patterns to follow:** Unit A2's normalizer layout.
+
+**Test scenarios:**
+- Happy path: ServiceProfile with three routes → normalized with route matchers preserved.
+- Happy path: Linkerd Server selecting pods by label → normalized with the label selector emitted as a string.
+- Edge case: HTTPRoute from Linkerd group vs upstream group → only Linkerd group is picked up.
+- Edge case: empty ServiceProfile (no routes) → normalized with empty routes array, not nil.
+
+**Verification:** `go test ./internal/servicemesh/... -run TestLinkerd` passes.
+
+---
+
+- [ ] **Unit A4: Handler + routes + RBAC filtering**
+
+**Goal:** HTTP handlers for `GET /mesh/{status,routing,policies,routing/{id}}` with singleflight + 30s cache and per-user RBAC filtering.
+
+**Requirements:** R1, R2, R3, R7, R8
+
+**Dependencies:** A1–A3.
+
+**Files:**
+- Create: `backend/internal/servicemesh/handler.go`
+- Modify: `backend/internal/server/routes.go` (mount `/mesh/*` routes)
+- Create: `backend/internal/servicemesh/handler_test.go`
+
+**Approach:**
+- `Handler` struct carries `Discoverer`, `AccessChecker`, `DynamicClient`, `Logger`, `Cache` fields — mirrors gitops `Handler` exactly.
+- `filterByRBAC[T]` generic helper factored into `types.go`, signature `filterByRBAC[T Resource](ctx, checker, user, items) []T`. Reused from Phase 11A (already a proven shape).
+- Route layout:
+  - `GET /api/v1/mesh/status` → HandleStatus
+  - `GET /api/v1/mesh/routing?namespace=` → HandleListRoutes
+  - `GET /api/v1/mesh/routing/{id}` → HandleGetRoute (composite id URL-encoded)
+  - `GET /api/v1/mesh/policies?namespace=` → HandleListPolicies
+- All routes require auth; writes reserved for v2.
+
+**Patterns to follow:**
+- `backend/internal/gitops/handler.go` for composite-ID parsing and per-handler cache
+- `backend/internal/policy/handler.go` for `filterByRBAC` pattern
+
+**Test scenarios:**
+- Happy path: authenticated user with cluster-wide access → gets all routes.
+- RBAC: user with access only to namespace "foo" → sees only foo's routes, no 403 on mixed data.
+- Cache: two concurrent requests coalesce via singleflight; verify with a counter in the adapter mock.
+- Error path: composite ID malformed → 400 with structured error message.
+- Error path: no mesh installed → routing list returns `{routes: []}` with `status.installed = false`, not 500.
+
+**Verification:**
+- Unit tests pass.
+- E2E smoke: `curl /api/v1/mesh/status` on homelab with Istio installed returns expected shape.
+
+### Phase B — mTLS posture + golden signals (PR 2)
+
+- [ ] **Unit B1: mTLS posture computation**
+
+**Goal:** Compute per-workload mTLS status for both meshes with a unified three-state result (`active` / `inactive` / `mixed`).
+
+**Requirements:** R4
+
+**Dependencies:** Phase A.
+
+**Files:**
+- Create: `backend/internal/servicemesh/mtls.go`
+- Modify: `backend/internal/servicemesh/handler.go` (add `HandleMTLSPosture`)
+- Create: `backend/internal/servicemesh/mtls_test.go`
+- Modify: `backend/internal/server/routes.go` (add `GET /mesh/mtls`)
+
+**Approach:**
+- Istio: list PeerAuthentications at mesh level (root-of-mesh namespace), namespace level, workload level. Apply the precedence rule (workload > namespace > mesh) per workload. Output `IstioMTLSState { Mode: STRICT|PERMISSIVE|DISABLE, Source: mesh|namespace|workload }`.
+- Linkerd: mTLS is default-on for meshed workloads. Output is `active` if the pod carries `linkerd.io/proxy-version` annotation, else `inactive` (unmeshed). No PERMISSIVE equivalent.
+- Optional metric cross-check (Istio only): query `sum by (destination_workload, destination_workload_namespace)(rate(istio_requests_total{connection_security_policy="mutual_tls"}[5m]))` vs. total — if ratio < 1, posture is `mixed` regardless of policy.
+
+**Patterns to follow:** Policy evaluation precedence mirrors Kyverno's cluster-vs-namespace pattern in `backend/internal/policy/kyverno.go`.
+
+**Test scenarios:**
+- Happy path: Istio mesh-level STRICT, no namespace or workload overrides → all workloads `active`.
+- Happy path: namespace-level PERMISSIVE override → workloads in that namespace `inactive-or-mixed`.
+- Edge case: workload-level DISABLE overrides namespace STRICT → that workload `inactive`.
+- Edge case: Linkerd meshed pod in unmeshed namespace → `active` (annotation wins).
+- Integration: metric says 90% mTLS but policy says STRICT → posture is `mixed`, `source: "metric"`.
+- Error path: Prometheus unavailable → fall back to policy-only evaluation; `source: "policy"`.
+
+**Verification:** unit tests cover all precedence permutations; homelab smoke confirms real cluster output.
+
+---
+
+- [ ] **Unit B2: Golden-signals Prometheus queries**
+
+**Goal:** Per-service RPS, latency percentiles, and error rate pulled from Prometheus via templated queries.
+
+**Requirements:** R6
+
+**Dependencies:** Phase A; requires existing `monitoring.PrometheusClient`.
+
+**Files:**
+- Create: `backend/internal/servicemesh/metrics.go`
+- Modify: `backend/internal/servicemesh/handler.go` (add `HandleGoldenSignals`)
+- Create: `backend/internal/servicemesh/metrics_test.go`
+- Modify: `backend/internal/server/routes.go` (add `GET /mesh/metrics`)
+
+**Approach:**
+- Use the existing `monitoring.QueryTemplate.Render` path for safe label substitution (already validated at the existing template layer — do not bypass it).
+- Istio templates (per service):
+  - RPS: `sum(rate(istio_requests_total{destination_service_name="{{.svc}}",destination_service_namespace="{{.ns}}"}[2m]))`
+  - Error rate: `sum(rate(istio_requests_total{destination_service_name="{{.svc}}",destination_service_namespace="{{.ns}}",response_code=~"5.."}[2m])) / sum(rate(istio_requests_total{destination_service_name="{{.svc}}",destination_service_namespace="{{.ns}}"}[2m]))`
+  - p95 latency: `histogram_quantile(0.95, sum by (le)(rate(istio_request_duration_milliseconds_bucket{destination_service_name="{{.svc}}",destination_service_namespace="{{.ns}}"}[2m])))`
+- Linkerd templates use `request_total` and `response_latency_ms` with `direction="inbound"` and `dst_service="{{.svc}}"`. Different label names; parallel template set.
+- Handler auto-selects template set based on `MeshMembership` for the target workload (determined by sidecar annotation).
+- All queries have `PromQLTimeout = 2s`. Never block the UI.
+
+**Patterns to follow:** `backend/internal/monitoring/utilization.go` for the QueryTemplate render path.
+
+**Test scenarios:**
+- Happy path (Istio): template renders with correct labels; mocked Prometheus returns single-vector result; golden signals populated.
+- Happy path (Linkerd): different template set, same output shape.
+- Edge case: Prometheus returns empty vector (no traffic in 2m window) → golden signals all zero, not error.
+- Error path: Prometheus timeout → handler returns 200 with `metrics: null, error: "metrics_unavailable"` (non-blocking degraded mode).
+- Error path: label-substitution rejects a namespace with `"` in it → 400, template never sent to Prometheus (validated via existing template validator).
+
+**Verification:** unit tests; homelab smoke against real Istio + real Prometheus.
+
+### Phase C — Frontend (PR 3)
+
+- [ ] **Unit C1: Type mirrors + API client**
+
+**Goal:** TypeScript types + typed API client wrappers for all Phase A+B endpoints.
+
+**Requirements:** R1–R6 (consumption)
+
+**Dependencies:** Phases A and B merged.
+
+**Files:**
+- Create: `frontend/lib/mesh-types.ts`
+- Create: `frontend/lib/mesh-api.ts`
+
+**Approach:** Tagged union pattern — `type TrafficRoute = IstioRoute | LinkerdRoute` with `mesh` discriminator. API functions use existing `apiGet<T>` helper from `frontend/lib/api.ts`.
+
+**Patterns to follow:** `frontend/lib/gitops-types.ts`, `frontend/lib/gitops-api.ts` (if exists) — or `frontend/lib/policy-types.ts`.
+
+**Test scenarios:**
+- Test expectation: none — type definitions and thin wrappers; no behavior beyond network plumbing. Covered indirectly by C2–C4 tests.
+
+**Verification:** `deno check` clean; `deno lint` clean.
+
+---
+
+- [ ] **Unit C2: Mesh dashboard island**
+
+**Goal:** Status banner (detected mesh + version + control-plane namespace) with namespace-level injection coverage summary.
+
+**Requirements:** R1
+
+**Dependencies:** C1.
+
+**Files:**
+- Create: `frontend/islands/MeshDashboard.tsx`
+- Create: `frontend/routes/networking/mesh/index.tsx`
+- Create: `frontend/routes/networking/mesh/dashboard.tsx`
+- Modify: `frontend/lib/constants.ts` (add Mesh SubNav tabs under Networking section)
+
+**Approach:** Mirror `PolicyDashboard.tsx`. Empty state prompts install if no mesh detected. Coverage card: "24 of 31 namespaces have sidecar injection enabled" with drill-down.
+
+**Patterns to follow:** `frontend/islands/PolicyDashboard.tsx` for the banner + empty state.
+
+**Test scenarios:**
+- Happy path: mesh installed → banner shows mesh + version.
+- Empty state: no mesh → empty state with "Install Istio" / "Install Linkerd" external links.
+- Both meshes installed → both banners render.
+- Theme: renders in all 7 themes without color regressions (visual Playwright smoke).
+
+**Verification:** component renders in all themes; Playwright smoke: `/networking/mesh/dashboard` shows banner.
+
+---
+
+- [ ] **Unit C3: Routing list + detail islands**
+
+**Goal:** Unified list of traffic routing resources (VirtualService, DestinationRule, ServiceProfile, etc.) with detail view.
+
+**Requirements:** R2, R3
+
+**Dependencies:** C1.
+
+**Files:**
+- Create: `frontend/islands/MeshRoutingList.tsx`
+- Create: `frontend/islands/MeshRouteDetail.tsx`
+- Create: `frontend/routes/networking/mesh/routing.tsx`
+- Create: `frontend/routes/networking/mesh/routing/[id].tsx`
+
+**Approach:** Filterable table with mesh + kind badges (e.g., `Istio / VirtualService`, `Linkerd / ServiceProfile`). Detail view shows normalized fields above a collapsed raw-YAML block (Monaco, read-only). URL-encode composite IDs.
+
+**Patterns to follow:** `frontend/islands/GitOpsApplications.tsx` for the filterable list; `frontend/islands/GitOpsAppDetail.tsx` for the detail.
+
+**Test scenarios:**
+- Happy path: list shows routes from both meshes with correct badges.
+- Filter: filter by mesh → only that mesh's routes shown.
+- Filter: filter by namespace → only that namespace's routes shown.
+- Empty state: no routes in the selected namespace → shows empty state, not a broken table.
+- Detail: composite ID with `%3A` URL-encoding decodes correctly and loads the right resource.
+- Detail: 404 composite ID → empty state with back link, not a crash.
+
+**Verification:** Playwright smoke clicks through list → detail → back; visual no-regression in dark themes.
+
+---
+
+- [ ] **Unit C4: mTLS posture page**
+
+**Goal:** Per-namespace mTLS posture cards + drill-down table.
+
+**Requirements:** R4
+
+**Dependencies:** C1.
+
+**Files:**
+- Create: `frontend/islands/MTLSPosture.tsx`
+- Create: `frontend/routes/networking/mesh/mtls.tsx`
+
+**Approach:** Cards (per namespace): "X of Y workloads have mTLS active" with a colored posture indicator. Drill-down expands to a per-workload table with `mtls: active|inactive|mixed` column + source (`policy`/`metric`/`default`).
+
+**Patterns to follow:** `frontend/islands/ComplianceDashboard.tsx` (GaugeRing + severity bars layout).
+
+**Test scenarios:**
+- Happy path: all workloads active → green cards across the board.
+- Edge case: mixed namespace (some active, some inactive) → yellow card with drill-down expandable.
+- Edge case: unmeshed namespace → separate "Not in mesh" section, not a red card (distinguishes "opted-out" from "broken").
+- Theme: accent colors use `var(--success)` / `var(--warning)` / `var(--error)`, no hardcoded Tailwind colors.
+
+**Verification:** Playwright smoke + manual theme check.
+
+### Phase D — Topology overlay + golden signals display (PR 4)
+
+- [ ] **Unit D1: Topology ResourceLister extension + mesh edges**
+
+**Goal:** Add mesh-edge emission to the topology builder behind an `?overlay=mesh` query param.
+
+**Requirements:** R5
+
+**Dependencies:** Phase A (provides normalized route data).
+
+**Files:**
+- Modify: `backend/internal/topology/builder.go` (extend `ResourceLister` interface with `ListVirtualServices`, `ListServiceProfiles`)
+- Modify: `backend/internal/topology/informer_lister.go` (implement new methods against informer cache)
+- Modify: `backend/internal/topology/handler.go` (accept `overlay=mesh`, call new emitters)
+- Create: `backend/internal/topology/mesh_edges.go` (emitter: converts normalized routes to topo edges)
+- Create: `backend/internal/topology/mesh_edges_test.go`
+
+**Approach:**
+- Edge types added: `mesh_vs` (Istio VirtualService route target), `mesh_dest` (DestinationRule subset), `mesh_sp` (Linkerd ServiceProfile route).
+- Overlay is opt-in via query param — default topology remains unchanged.
+- 2000-edge cap reused from existing topology handler.
+- Informer watch added only if mesh installed; otherwise the lister returns empty (no-op).
+
+**Patterns to follow:** existing `topology/builder.go` edge emission; `backend/internal/k8s/informer_manager.go` for adding watch types.
+
+**Test scenarios:**
+- Happy path: two services with a VirtualService routing → mesh_vs edges emitted from VS to each destination.
+- Edge case: VS with no matching destination services → no edges emitted (not an error).
+- Edge case: overlay=mesh requested but mesh not installed → base topology returned, overlay silently no-op, response includes `overlay: "unavailable"`.
+- Cap: 2500 edges → truncated at 2000 with `truncated: true` flag.
+- Integration: overlay + RBAC — user without access to VS CRD sees base topology only (no partial mesh edges).
+
+**Verification:** unit tests; homelab smoke shows mesh edges on `/observability/topology?overlay=mesh`.
+
+---
+
+- [ ] **Unit D2: Frontend topology overlay toggle**
+
+**Goal:** "Show mesh traffic" toggle on `/observability/topology` renders mesh edges with a distinct style.
+
+**Requirements:** R5
+
+**Dependencies:** D1 backend merged, Phase C.
+
+**Files:**
+- Modify: `frontend/islands/NamespaceTopology.tsx` (add overlay toggle + edge style for new types)
+
+**Approach:** Toggle sends `?overlay=mesh` to the topology endpoint. Mesh edges render in the theme's accent color, distinct from owner/selector edges. Legend updated.
+
+**Patterns to follow:** existing edge styles in `NamespaceTopology.tsx` (`EDGE_STYLES` map).
+
+**Test scenarios:**
+- Happy path: toggle on → mesh edges appear; toggle off → only base edges.
+- Edge case: overlay unavailable (no mesh) → toggle is disabled with tooltip "no mesh detected".
+- Theme: mesh edge color is themed (no hardcoded hex).
+
+**Verification:** Playwright smoke on homelab with mesh installed.
+
+---
+
+- [ ] **Unit D3: Golden signals on service detail**
+
+**Goal:** Surface RPS, p50/p95/p99 latency, and error rate on the existing Service detail page when the service is meshed.
+
+**Requirements:** R6
+
+**Dependencies:** Phase B.
+
+**Files:**
+- Modify: `frontend/components/k8s/ServiceOverview.tsx` (or equivalent service detail panel — locate via current repo structure)
+- Create: `frontend/components/mesh/GoldenSignals.tsx` (small embedded card)
+
+**Approach:** Lazy-load golden signals when the Service detail page mounts. Card renders only when mesh membership detected; no empty state for unmeshed services (silently absent).
+
+**Patterns to follow:** existing monitoring cards on `/monitoring` dashboard.
+
+**Test scenarios:**
+- Happy path: meshed service → RPS/latency/error card renders with live values.
+- Edge case: unmeshed service → card does not render at all.
+- Edge case: Prometheus unavailable → card renders with `Metrics unavailable` sub-message, not an error toast.
+- Refresh: values re-query every 30s while the page is open (matches other monitoring cards).
+
+**Verification:** Playwright + homelab smoke against a meshed service with live traffic.
+
+---
+
+- [ ] **Unit D4: Helm chart + docs**
+
+**Goal:** Helm chart updates + smoke documentation.
+
+**Requirements:** R9
+
+**Dependencies:** Phases A–D merged.
+
+**Files:**
+- Modify: `helm/kubecenter/templates/*` (add RBAC rules for mesh CRD read — impersonation still carries user creds, but service account needs some baseline for discovery)
+- Modify: `README.md` / `CLAUDE.md` — mark item #6 complete, append Phase 12 entry to Build Progress
+
+**Approach:** Service account needs `list`/`get` on the mesh CRD groups for discovery (discoverer runs as SA, impersonates only on user-scoped list calls). Keep the grant minimal — explicitly listed resources, not `*`.
+
+**Patterns to follow:** `helm/kubecenter/templates/clusterrole.yaml` — add mesh CRD groups to existing baseline.
+
+**Test scenarios:**
+- Test expectation: none — chart change; covered by `make helm-lint`, `make helm-template`, and a homelab reinstall smoke.
+
+**Verification:** `make helm-lint`, `make helm-template` pass; homelab smoke install → mesh features work without permission errors in logs.
+
+## System-Wide Impact
+
+- **Interaction graph:** New handlers added to `routes.go`; existing AccessChecker used; existing PrometheusClient used; topology builder gains optional path. No middleware changes.
+- **Error propagation:** Failures in discovery or metrics degrade gracefully to an empty state with an inline message. No mesh-related error should break the base topology page, the Networking section, or the dashboard.
+- **State lifecycle risks:** CRD discovery cache (5min) + handler cache (30s). Stale cache windows are bounded and match existing precedents. No write state to manage.
+- **API surface parity:** `/mesh/*` endpoints follow the `/gitops/*` response-shape convention precisely — the frontend client can reuse `apiGet<T>` patterns without adaptation.
+- **Integration coverage:** (a) Istio + Linkerd co-installed on the same cluster, (b) Istio ambient mode, (c) remote cluster reads (dynamic client only, no informer), (d) RBAC denial on a specific CRD group — each needs an integration test scenario.
+- **Unchanged invariants:** `/observability/topology` default response (no `overlay` param) is byte-identical to before. Cert-manager, policy, and gitops endpoints are untouched. No change to the authentication or session flow.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|---|---|
+| **Mesh CRD API-group drift** (Istio promoted `v1beta1` → `v1` across versions) | Discovery probes `v1` preferred, falls back to `v1beta1` on `ErrGroupDiscoveryNotFound`. Unit test fixtures cover both shapes. |
+| **Istio Ambient Mode differs from sidecar model** | v1 detects ambient but does not differentiate features. `MeshInfo` gains an optional `Mode: "sidecar"\|"ambient"` field; frontend displays the mode as a badge but does not branch behavior. |
+| **Prometheus golden-signal queries are expensive on large clusters** | All mesh PromQL has a 2s timeout; failures degrade silently. Hard cap: 10 PromQL queries per request (parallel). |
+| **Informer watch for mesh CRDs adds memory pressure on large clusters** | Informer watches gated on discovery result — not started unless the mesh is installed. Lazy-start avoids the cost for mesh-less clusters. |
+| **Remote-cluster correctness** (no informer, dynamic client only) | E2E test with a registered remote cluster. Any accidental informer usage on remote clusters is a regression flagged by the existing remote-cluster test suite. |
+| **Dual-mesh co-installation causes double-counting** (a service owned by both meshes) | Normalize mesh membership to prefer the sidecar annotation's stated mesh; log a warning if both meshes claim a pod. |
+| **CLAUDE.md Rule 5 (Sub-agent swarming for >5 files)** | Phase C (5 frontend islands) stays within one PR's scope because the files are small and follow a proven precedent; no sub-agent needed. Phase A (5 backend files) is the threshold — if scope creeps during implementation, split A2 off into its own commit. |
+
+## Documentation / Operational Notes
+
+- **CLAUDE.md roadmap update:** mark item #6 complete on merge of Phase D; append a Phase 12 entry under Build Progress.
+- **README architecture diagram:** add the servicemesh package to the architecture diagram alongside certmanager, policy, and gitops.
+- **Homelab smoke:** per CLAUDE.md pre-merge rule, each phase must smoke-test on homelab (Istio + Linkerd should be installed there before Phase A merges).
+- **Security review:** Phase B introduces new PromQL queries — security review should confirm label substitution uses the existing validated template path and not string concatenation. Note explicitly in the PR description for each phase.
+- **Grafana dashboard:** optional follow-up — add a dedicated mesh Grafana dashboard. Out of v1 scope; tracked as sibling.
+
+## Sources & References
+
+- **Origin document:** `plans/service-mesh-observability.md` (this plan — no prior brainstorm document)
+- **Closest precedent:** `backend/internal/gitops/` (dual-tool adapter pattern) — `handler.go`, `discovery.go`, `types.go`, `argocd.go`, `flux.go`
+- **Supporting precedents:**
+  - `backend/internal/policy/` — RBAC filter generic, compliance scoring
+  - `backend/internal/certmanager/` — CRD discovery, version extraction, singleflight cache
+  - `backend/internal/topology/` — builder + ResourceLister interface extension
+- **Frontend references:**
+  - `frontend/islands/PolicyDashboard.tsx` — status banner + empty state
+  - `frontend/islands/GitOpsApplications.tsx` / `GitOpsAppDetail.tsx` — list + detail with composite IDs
+  - `frontend/islands/NamespaceTopology.tsx` — edge renderer, overlay extension point
+  - `frontend/islands/ComplianceDashboard.tsx` — posture-card layout for mTLS page
+- **External docs:**
+  - Istio CRDs: https://istio.io/latest/docs/reference/config/networking/ and https://istio.io/latest/docs/reference/config/security/
+  - Istio metrics: https://istio.io/latest/docs/reference/config/metrics/
+  - Linkerd CRDs: https://linkerd.io/2-edge/reference/
+  - Linkerd proxy metrics: https://linkerd.io/2-edge/reference/proxy-metrics/
+  - Linkerd automatic mTLS: https://linkerd.io/2-edge/features/automatic-mtls/
+- **Roadmap:** item #6 in `CLAUDE.md` Future Features list

--- a/plans/service-mesh-observability.md
+++ b/plans/service-mesh-observability.md
@@ -326,7 +326,7 @@ Phases deliver independently-shippable PRs. Each phase is reviewed and merged be
 
 ---
 
-- [ ] **Unit A4: Handler + routes + RBAC filtering**
+- [x] **Unit A4: Handler + routes + RBAC filtering**
 
 **Goal:** HTTP handlers for `GET /mesh/{status,routing,policies,routing/{id}}` with singleflight + 30s cache and per-user RBAC filtering.
 

--- a/plans/service-mesh-observability.md
+++ b/plans/service-mesh-observability.md
@@ -364,6 +364,9 @@ Phases deliver independently-shippable PRs. Each phase is reviewed and merged be
 - Unit tests pass.
 - E2E smoke: `curl /api/v1/mesh/status` on homelab with Istio installed returns expected shape.
 
+**Notes carried in from A3 (2026-04-19):**
+- `ListIstio` and `ListLinkerd` are structurally near-identical — both fan out a goroutine per CRD, share `listCRD` for timeout/cap, and return a `{Routes, Policies, Errors map[string]string}` bundle. After A4 is wired up and the handler call-sites are visible, decide whether a generic helper (e.g., `listMeshCRDs[T](...)`) pays its way. Defer for now; the plan's "per-mesh adapter isolation" principle is the tiebreaker while the handler side is still unwritten.
+
 ### Phase B — mTLS posture + golden signals (PR 2)
 
 - [ ] **Unit B1: mTLS posture computation**

--- a/plans/service-mesh-observability.md
+++ b/plans/service-mesh-observability.md
@@ -260,7 +260,7 @@ Phases deliver independently-shippable PRs. Each phase is reviewed and merged be
 
 ---
 
-- [ ] **Unit A2: Normalized types + Istio adapter**
+- [x] **Unit A2: Normalized types + Istio adapter**
 
 **Goal:** Istio adapter lists VirtualService, DestinationRule, Gateway, PeerAuthentication, AuthorizationPolicy and normalizes them into the shared `TrafficRoute` / `NormalizedPolicy` shapes.
 


### PR DESCRIPTION
## Summary

Phase A of the service mesh observability roadmap (item #6): auto-detect Istio and Linkerd, list their routing and security CRDs with normalized types, and serve them through four RBAC-filtered HTTP endpoints. Read-only; mTLS posture (Phase B), frontend (Phase C), and topology overlay (Phase D) land separately.

Commits (A1–A4):
- **A1** `MeshDiscoverer` with CRD + control-plane detection, 5min lazy recheck
- **A2** Istio adapter + normalized `TrafficRoute` / `MeshedPolicy` types
- **A3** Linkerd adapter sharing the normalizer infrastructure
- **A4** `Handler` + `/api/v1/mesh/*` routes with singleflight cache + RBAC

Endpoints:
- `GET /api/v1/mesh/status` — detected meshes, version, mode
- `GET /api/v1/mesh/routing` — VirtualService / DestinationRule / Gateway / ServiceProfile / Server / HTTPRoute
- `GET /api/v1/mesh/routing/{id}` — single route, user-impersonated
- `GET /api/v1/mesh/policies` — PeerAuthentication / AuthorizationPolicy / MeshTLSAuthentication

Composite ID format is ``{mesh}:{namespace}:{kindCode}:{name}``, URL-encoded on the wire. A static dispatch map translates `(mesh, kindCode)` into the CRD's API group + resource + GVR, so unknown kinds fail closed with 400 rather than bypassing the access check.

The generic `filterByRBAC[T namespacedResource]` helper (Phase 11A shape) caches per-`(apiGroup+resource, namespace)` decisions within a request and treats cluster-scoped items (empty namespace) as admin-only. No-mesh installs return an empty response with `status.detected = "none"` — never 500.

## Test plan

- [x] ``go vet ./...``, ``go test ./...``, ``go build ./...`` clean
- [x] Unit tests cover normalizers, adapters (fake dynamic client), handler (parse, dispatch, RBAC deny, singleflight coalescing, no-mesh empty)
- [ ] Smoke test on homelab with Istio installed
- [ ] Smoke test on homelab with Linkerd installed
- [ ] Smoke test with both meshes co-installed
- [ ] Confirm non-admin user sees stripped status (no control-plane namespace)

## Scope boundaries

Read-only in v1. Wizards and writes are explicitly deferred. No Kiali-style traffic animation or distributed tracing. No OSM/Consul support. See ``plans/service-mesh-observability.md`` for the full scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)