### PR TITLE
feat(servicemesh): Phase B — mTLS posture + golden signals

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,7 @@ All endpoints prefixed with `/api/v1`. Full list derivable from `backend/interna
 - Policy: `GET /policy/{status,policies,violations,compliance}` (Kyverno + Gatekeeper, RBAC-filtered)
 - Limits: `GET /limits/{status,namespaces,namespaces/:namespace}` (ResourceQuota + LimitRange dashboard, RBAC-filtered)
 - Certificates: `GET /certificates/{status,certificates,certificates/:ns/:name,issuers,clusterissuers,expiring}`, `POST /certificates/certificates/:ns/:name/{renew,reissue}` (cert-manager, RBAC-filtered)
+- Service mesh: `GET /mesh/{status,routing,routing/:id,policies,mtls,golden-signals}` (Istio + Linkerd, RBAC-filtered; mtls and golden-signals require ?namespace=; golden-signals also needs ?service= and optional ?mesh=istio|linkerd; Prometheus cross-check is best-effort, endpoint degrades to policy-only when Prom is offline)
 - Dashboard: `GET /cluster/dashboard-summary` (aggregated counts + utilization, RBAC-filtered)
 - Counts: `GET /resources/counts[?namespace=]` (batch resource counts from informer cache, RBAC-filtered)
 - Multi-cluster: `GET/POST/DELETE /clusters`
@@ -317,6 +318,13 @@ make check-dashboards                             # Verify Grafana JSON sync
   - 3 frontend islands: CertificatesList, CertificateDetail (with Renew/Re-issue actions), IssuersList
   - 4 routes under `/security/certificates/*` with SubNav tab and command palette quick actions
   - Theme-compliant: Tailwind semantic token classes for all colors
+- **Phase 11B (Cert-Manager Wizards):** COMPLETE
+  - Three wizards in `internal/wizard/`: `certificate.go`, `issuer.go`, `cert_helpers.go` with full table-driven validation tests
+  - 3 HTTP endpoints: `POST /wizards/{certificate,issuer,cluster-issuer}/preview`
+  - 2 frontend islands: `CertificateWizard.tsx`, `IssuerWizard.tsx` (Issuer/ClusterIssuer share one island via `scope` prop)
+  - Routes: `/security/certificates/{new,issuers/new,cluster-issuers/new}` plus entry buttons on list pages and command palette quick actions
+  - v1 ACME scope: SelfSigned + HTTP01 ingress only (CA/Vault/DNS01 deferred to YAML editor)
+  - Ships via PR #180 with cleanup follow-ups in #181, #182, #183
 
 ## Future Features (Roadmap)
 
@@ -329,7 +337,8 @@ Priority order from 2026-04-09 brainstorm. Check off each item as its PR merges 
 - [x] **5. Backup & Restore (Velero)** — schedule backups, browse snapshots, one-click restore
 - [ ] **6. Service Mesh Observability (Istio/Linkerd)** — traffic routing visualization, mTLS status, circuit breaker config
 - [x] **7. Cert-Manager integration** — certificate inventory, expiry warnings, issuers management (Phase 11A)
-- [ ] **7b. Cert-Manager wizards (Phase 11B)** — Certificate/Issuer/ClusterIssuer creation wizards, configurable expiry thresholds
+- [x] **7b. Cert-Manager wizards (Phase 11B)** — Certificate/Issuer/ClusterIssuer creation wizards (PR #180, follow-ups #181–#183)
+- [ ] **7c. Cert-Manager configurable expiry thresholds** — per-cert/per-issuer warn/critical thresholds via annotation
 - [ ] **8. External Secrets Operator integration** — view synced secrets, source status, rotation schedule
 - [ ] **9. Saved Views & Custom Dashboards** — pin favorite resources, save filter presets, arrange dashboard widgets
 

--- a/backend/cmd/kubecenter/main.go
+++ b/backend/cmd/kubecenter/main.go
@@ -676,10 +676,11 @@ func main() {
 	// Service Mesh integration (Istio + Linkerd)
 	meshDisc := servicemesh.NewDiscoverer(k8sClient, logger)
 	meshHandler := &servicemesh.Handler{
-		K8sClient:     k8sClient,
-		Discoverer:    meshDisc,
-		AccessChecker: accessChecker,
-		Logger:        logger,
+		K8sClient:      k8sClient,
+		Discoverer:     meshDisc,
+		AccessChecker:  accessChecker,
+		Logger:         logger,
+		MonitoringDisc: monDiscoverer,
 	}
 
 	// Ready state: true after informer sync, false during shutdown

--- a/backend/internal/server/routes.go
+++ b/backend/internal/server/routes.go
@@ -652,7 +652,7 @@ func (s *Server) registerServiceMeshRoutes(ar chi.Router) {
 		mr.Get("/routing/{id}", h.HandleGetRoute)
 		mr.Get("/policies", h.HandleListPolicies)
 		mr.Get("/mtls", h.HandleMTLSPosture)
-		mr.Get("/metrics", h.HandleGoldenSignals)
+		mr.Get("/golden-signals", h.HandleGoldenSignals)
 	})
 }
 

--- a/backend/internal/server/routes.go
+++ b/backend/internal/server/routes.go
@@ -652,6 +652,7 @@ func (s *Server) registerServiceMeshRoutes(ar chi.Router) {
 		mr.Get("/routing/{id}", h.HandleGetRoute)
 		mr.Get("/policies", h.HandleListPolicies)
 		mr.Get("/mtls", h.HandleMTLSPosture)
+		mr.Get("/metrics", h.HandleGoldenSignals)
 	})
 }
 

--- a/backend/internal/server/routes.go
+++ b/backend/internal/server/routes.go
@@ -651,6 +651,7 @@ func (s *Server) registerServiceMeshRoutes(ar chi.Router) {
 		mr.Get("/routing", h.HandleListRoutes)
 		mr.Get("/routing/{id}", h.HandleGetRoute)
 		mr.Get("/policies", h.HandleListPolicies)
+		mr.Get("/mtls", h.HandleMTLSPosture)
 	})
 }
 

--- a/backend/internal/servicemesh/handler.go
+++ b/backend/internal/servicemesh/handler.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net/http"
 	"net/url"
 	"slices"
@@ -20,11 +21,13 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/kubecenter/kubecenter/internal/auth"
 	"github.com/kubecenter/kubecenter/internal/httputil"
 	"github.com/kubecenter/kubecenter/internal/k8s"
 	"github.com/kubecenter/kubecenter/internal/k8s/resources"
+	"github.com/kubecenter/kubecenter/internal/monitoring"
 )
 
 const meshCacheTTL = 30 * time.Second
@@ -40,6 +43,12 @@ type Handler struct {
 	AccessChecker *resources.AccessChecker
 	Logger        *slog.Logger
 
+	// MonitoringDisc is optional; when set, Phase-B endpoints use it to
+	// query Prometheus for metric-backed cross-checks (mTLS posture) and
+	// golden-signal metrics. Nil is a supported configuration — the
+	// handler degrades to policy-only results.
+	MonitoringDisc *monitoring.Discoverer
+
 	fetchGroup singleflight.Group
 	cacheMu    sync.RWMutex
 	cache      *cachedMeshData
@@ -48,6 +57,14 @@ type Handler struct {
 	// dynOverride, when non-nil, replaces K8sClient.BaseDynamicClient() for
 	// cache-population reads. Exposed only to tests in this package.
 	dynOverride dynamic.Interface
+
+	// clientsetOverride is the typed-clientset test seam mirroring
+	// dynOverride; used by HandleMTLSPosture when listing pods in tests.
+	clientsetOverride kubernetes.Interface
+
+	// promClientOverride lets tests inject a PrometheusClient without
+	// standing up a monitoring.Discoverer.
+	promClientOverride *monitoring.PrometheusClient
 }
 
 type cachedMeshData struct {
@@ -477,6 +494,122 @@ func normalizeRouteByMesh(mesh MeshType, kind string, obj *unstructured.Unstruct
 		Namespace: obj.GetNamespace(),
 		Raw:       obj.Object,
 	}
+}
+
+// clientset returns the typed Kubernetes clientset, respecting any test
+// override. Returns nil when neither K8sClient nor an override is set.
+func (h *Handler) clientset() kubernetes.Interface {
+	if h.clientsetOverride != nil {
+		return h.clientsetOverride
+	}
+	if h.K8sClient == nil {
+		return nil
+	}
+	return h.K8sClient.BaseClientset()
+}
+
+// promClient returns the Prometheus client if monitoring is configured.
+// Nil is a supported state — handlers degrade gracefully without it.
+func (h *Handler) promClient() *monitoring.PrometheusClient {
+	if h.promClientOverride != nil {
+		return h.promClientOverride
+	}
+	if h.MonitoringDisc == nil {
+		return nil
+	}
+	return h.MonitoringDisc.PrometheusClient()
+}
+
+// HandleMTLSPosture returns per-workload mTLS posture. Optional
+// ?namespace= query param scopes to a single namespace; omitted means
+// cluster-wide (RBAC-filtered).
+//
+// The handler is read-only and degrades gracefully: no mesh → empty
+// workloads slice with status.detected == "none"; Prometheus offline →
+// policy-only results.
+func (h *Handler) HandleMTLSPosture(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	status := h.Discoverer.Status(r.Context())
+	resp := MTLSPostureResponse{Status: status, Workloads: []WorkloadMTLS{}, Errors: map[string]string{}}
+
+	if status.Detected == MeshNone {
+		httputil.WriteData(w, resp)
+		return
+	}
+
+	namespace := r.URL.Query().Get("namespace")
+
+	// Pre-filter: only list pods in namespaces the user can read. An empty
+	// namespace request is cluster-wide — we let the API server's RBAC filter
+	// push back via 403, then drop the rows at aggregation time. Checking
+	// before touching the clientset keeps denied users from noisy error
+	// responses when the binary is built without a real k8s client.
+	can, err := h.AccessChecker.CanAccessGroupResource(r.Context(), user.KubernetesUsername, user.KubernetesGroups, "list", "", "pods", namespace)
+	if err != nil || !can {
+		httputil.WriteData(w, resp)
+		return
+	}
+
+	cs := h.clientset()
+	if cs == nil {
+		h.Logger.Error("mTLS posture requested but no clientset available")
+		httputil.WriteError(w, http.StatusInternalServerError, "kubernetes client unavailable", "")
+		return
+	}
+
+	pods, err := listNamespacePods(r.Context(), cs, namespace)
+	if err != nil {
+		h.Logger.Error("failed to list pods for mTLS posture", "namespace", namespace, "error", err)
+		resp.Errors["pods"] = err.Error()
+		httputil.WriteData(w, resp)
+		return
+	}
+
+	data, err := h.fetchData(r.Context())
+	if err != nil {
+		h.Logger.Error("failed to fetch mesh policies", "error", err)
+		resp.Errors["policies"] = err.Error()
+		httputil.WriteData(w, resp)
+		return
+	}
+
+	peerAuths := peerAuthsFromPolicies(data.policies)
+
+	// Scope PAs to the mesh root (always in scope) plus the requested
+	// namespace when a filter is applied — keeps precedence resolution
+	// correct for a namespace-scoped request.
+	if namespace != "" {
+		filtered := peerAuths[:0]
+		for _, pa := range peerAuths {
+			if pa.Namespace == namespace || pa.Namespace == istioMeshRootNamespace {
+				filtered = append(filtered, pa)
+			}
+		}
+		peerAuths = filtered
+	}
+
+	postures := computePodPostures(pods, peerAuths)
+	workloads := aggregateWorkloads(postures)
+
+	if pc := h.promClient(); pc != nil && namespace != "" {
+		ratios, perr := queryIstioMTLSRatios(r.Context(), pc, namespace)
+		if perr != nil {
+			h.Logger.Warn("mTLS metric cross-check failed; falling back to policy-only", "namespace", namespace, "error", perr)
+		} else {
+			workloads = applyMTLSMetricOverrides(workloads, ratios)
+		}
+	}
+
+	maps.Copy(resp.Errors, data.errors)
+	if len(resp.Errors) == 0 {
+		resp.Errors = nil
+	}
+	resp.Workloads = workloads
+	httputil.WriteData(w, resp)
 }
 
 // parseMeshCompositeID splits "{mesh}:{namespace}:{kindCode}:{name}" into

--- a/backend/internal/servicemesh/handler.go
+++ b/backend/internal/servicemesh/handler.go
@@ -612,6 +612,97 @@ func (h *Handler) HandleMTLSPosture(w http.ResponseWriter, r *http.Request) {
 	httputil.WriteData(w, resp)
 }
 
+// goldenSignalsResponse envelopes GoldenSignals with the common
+// MeshStatus so clients can disambiguate "no mesh installed" from
+// "service not meshed" without a separate probe.
+type goldenSignalsResponse struct {
+	Status  MeshStatus    `json:"status"`
+	Signals GoldenSignals `json:"signals"`
+}
+
+// HandleGoldenSignals returns RPS, error rate, and p50/p95/p99 latency
+// for a single mesh-managed service.
+//
+// Required query params: namespace, service, mesh=istio|linkerd. The
+// mesh param is explicit in v1; auto-detection based on sidecar
+// annotations is deferred to Phase D when the frontend can pass
+// workload context. Input values are re-validated through the existing
+// monitoring.QueryTemplate render path — the handler never concatenates
+// user input into PromQL.
+func (h *Handler) HandleGoldenSignals(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	status := h.Discoverer.Status(r.Context())
+	namespace := r.URL.Query().Get("namespace")
+	service := r.URL.Query().Get("service")
+	meshParam := r.URL.Query().Get("mesh")
+
+	if namespace == "" || service == "" {
+		httputil.WriteError(w, http.StatusBadRequest, "namespace and service are required", "")
+		return
+	}
+
+	mesh, merr := resolveMeshParam(meshParam, status)
+	if merr != nil {
+		httputil.WriteError(w, http.StatusBadRequest, merr.Error(), "")
+		return
+	}
+
+	// RBAC: require pod-list in the target namespace. Golden signals name
+	// the service, but the underlying workload lives in the namespace; if
+	// the user can't read pods there, the metric breakdown would leak
+	// workload names they shouldn't see.
+	can, aerr := h.AccessChecker.CanAccessGroupResource(r.Context(), user.KubernetesUsername, user.KubernetesGroups, "list", "", "pods", namespace)
+	if aerr != nil || !can {
+		httputil.WriteError(w, http.StatusForbidden, "you do not have permission to view metrics for this namespace", "")
+		return
+	}
+
+	pc := h.promClient()
+	signals, gerr := goldenSignalsForService(r.Context(), pc, mesh, namespace, service)
+	if gerr != nil {
+		// Validation errors (render failures) are 400; the plan's error
+		// scenario for "label-substitution rejects a namespace with quotes".
+		httputil.WriteError(w, http.StatusBadRequest, gerr.Error(), "")
+		return
+	}
+
+	httputil.WriteData(w, goldenSignalsResponse{Status: status, Signals: signals})
+}
+
+// resolveMeshParam validates the `?mesh=` query parameter against the
+// discovered mesh installation. Empty param + exactly one mesh installed
+// → that mesh. Empty param + none or both installed → error (ambiguous
+// or impossible). Explicit param must match an installed mesh.
+func resolveMeshParam(param string, status MeshStatus) (MeshType, error) {
+	switch param {
+	case string(MeshIstio):
+		if status.Istio == nil || !status.Istio.Installed {
+			return MeshNone, errors.New("mesh=istio requested but istio is not installed")
+		}
+		return MeshIstio, nil
+	case string(MeshLinkerd):
+		if status.Linkerd == nil || !status.Linkerd.Installed {
+			return MeshNone, errors.New("mesh=linkerd requested but linkerd is not installed")
+		}
+		return MeshLinkerd, nil
+	case "":
+		switch status.Detected {
+		case MeshIstio:
+			return MeshIstio, nil
+		case MeshLinkerd:
+			return MeshLinkerd, nil
+		case MeshBoth:
+			return MeshNone, errors.New("both meshes installed — pass ?mesh=istio or ?mesh=linkerd")
+		}
+		return MeshNone, errors.New("no service mesh detected")
+	}
+	return MeshNone, fmt.Errorf("unsupported mesh %q", param)
+}
+
 // parseMeshCompositeID splits "{mesh}:{namespace}:{kindCode}:{name}" into
 // its four parts. The id may arrive URL-encoded from chi.URLParam.
 func parseMeshCompositeID(id string) (mesh, namespace, code, name string, err error) {

--- a/backend/internal/servicemesh/handler.go
+++ b/backend/internal/servicemesh/handler.go
@@ -288,6 +288,15 @@ func filterByRBAC[T namespacedResource](ctx context.Context, h *Handler, user *a
 	return out
 }
 
+// MeshStatusResponse wraps MeshStatus under a `status` key so all
+// /mesh/* endpoints share one envelope shape. Without this wrapper,
+// /mesh/status returned MeshStatus flat while the routing, policies,
+// mtls, and golden-signals endpoints all embed it under `status` —
+// forcing clients to special-case the one endpoint.
+type MeshStatusResponse struct {
+	Status MeshStatus `json:"status"`
+}
+
 // HandleStatus returns detected mesh installations. Non-admin users see a
 // stripped view without control-plane namespace details, matching the
 // gitops/policy precedent.
@@ -312,7 +321,7 @@ func (h *Handler) HandleStatus(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	httputil.WriteData(w, status)
+	httputil.WriteData(w, MeshStatusResponse{Status: status})
 }
 
 // routingResponse is the envelope for GET /mesh/routing. When no mesh is
@@ -496,16 +505,22 @@ func normalizeRouteByMesh(mesh MeshType, kind string, obj *unstructured.Unstruct
 	}
 }
 
-// clientset returns the typed Kubernetes clientset, respecting any test
-// override. Returns nil when neither K8sClient nor an override is set.
-func (h *Handler) clientset() kubernetes.Interface {
+// userClient returns an impersonating Kubernetes clientset scoped to the
+// authenticated user. All request-time read paths in this handler MUST
+// go through this helper — using BaseClientset() (the service account's
+// own credentials) would violate the impersonation rule in CLAUDE.md
+// and mis-attribute the call in the Kubernetes audit log.
+//
+// The clientsetOverride test seam is preserved for unit tests; fake
+// clientsets stand in for a real impersonating client in table tests.
+func (h *Handler) userClient(user *auth.User) (kubernetes.Interface, error) {
 	if h.clientsetOverride != nil {
-		return h.clientsetOverride
+		return h.clientsetOverride, nil
 	}
 	if h.K8sClient == nil {
-		return nil
+		return nil, errors.New("no kubernetes client configured")
 	}
-	return h.K8sClient.BaseClientset()
+	return h.K8sClient.ClientForUser(user.KubernetesUsername, user.KubernetesGroups)
 }
 
 // promClient returns the Prometheus client if monitoring is configured.
@@ -524,9 +539,18 @@ func (h *Handler) promClient() *monitoring.PrometheusClient {
 // ?namespace= query param scopes to a single namespace; omitted means
 // cluster-wide (RBAC-filtered).
 //
-// The handler is read-only and degrades gracefully: no mesh → empty
-// workloads slice with status.detected == "none"; Prometheus offline →
-// policy-only results.
+// The handler is read-only and degrades gracefully:
+//   - no mesh → empty workloads slice with status.detected == "none"
+//   - Prometheus offline → policy-only results
+//   - cluster-wide request → Prom cross-check is skipped (the template
+//     requires a concrete destination_workload_namespace); posture is
+//     policy-derived only. Revisiting this is tracked as a follow-up.
+//
+// Partial failure policy: pod-list and policy-fetch failures are
+// accumulated into resp.Errors with user-safe messages and internal
+// details in the log; the handler continues with whatever data it has
+// rather than failing the request. System errors (RBAC check failed,
+// impersonation failed) are 5xx; RBAC denial is 403.
 func (h *Handler) HandleMTLSPosture(w http.ResponseWriter, r *http.Request) {
 	user, ok := httputil.RequireUser(w, r)
 	if !ok {
@@ -534,7 +558,7 @@ func (h *Handler) HandleMTLSPosture(w http.ResponseWriter, r *http.Request) {
 	}
 
 	status := h.Discoverer.Status(r.Context())
-	resp := MTLSPostureResponse{Status: status, Workloads: []WorkloadMTLS{}, Errors: map[string]string{}}
+	resp := MTLSPostureResponse{Status: status, Workloads: []WorkloadMTLS{}}
 
 	if status.Detected == MeshNone {
 		httputil.WriteData(w, resp)
@@ -542,48 +566,63 @@ func (h *Handler) HandleMTLSPosture(w http.ResponseWriter, r *http.Request) {
 	}
 
 	namespace := r.URL.Query().Get("namespace")
+	errs := map[string]string{}
 
-	// Pre-filter: only list pods in namespaces the user can read. An empty
-	// namespace request is cluster-wide — we let the API server's RBAC filter
-	// push back via 403, then drop the rows at aggregation time. Checking
-	// before touching the clientset keeps denied users from noisy error
-	// responses when the binary is built without a real k8s client.
-	can, err := h.AccessChecker.CanAccessGroupResource(r.Context(), user.KubernetesUsername, user.KubernetesGroups, "list", "", "pods", namespace)
-	if err != nil || !can {
-		httputil.WriteData(w, resp)
+	// RBAC: a checker error is a system fault (500); a plain "no" is 403.
+	// Conflating the two would mask infrastructure outages as access
+	// denials.
+	can, aerr := h.AccessChecker.CanAccessGroupResource(r.Context(), user.KubernetesUsername, user.KubernetesGroups, "list", "", "pods", namespace)
+	if aerr != nil {
+		h.Logger.Error("mTLS posture RBAC check failed", "user", user.KubernetesUsername, "namespace", namespace, "error", aerr)
+		httputil.WriteError(w, http.StatusInternalServerError, "permission check failed", "")
+		return
+	}
+	if !can {
+		httputil.WriteError(w, http.StatusForbidden, "you do not have permission to view mTLS posture for this scope", "")
 		return
 	}
 
-	cs := h.clientset()
-	if cs == nil {
-		h.Logger.Error("mTLS posture requested but no clientset available")
+	cs, cerr := h.userClient(user)
+	if cerr != nil {
+		h.Logger.Error("mTLS posture: impersonating client unavailable", "user", user.KubernetesUsername, "error", cerr)
 		httputil.WriteError(w, http.StatusInternalServerError, "kubernetes client unavailable", "")
 		return
 	}
 
-	pods, err := listNamespacePods(r.Context(), cs, namespace)
-	if err != nil {
-		h.Logger.Error("failed to list pods for mTLS posture", "namespace", namespace, "error", err)
-		resp.Errors["pods"] = err.Error()
-		httputil.WriteData(w, resp)
-		return
+	pods, truncated, listErr := listNamespacePods(r.Context(), cs, namespace)
+	if listErr != nil {
+		h.Logger.Error("failed to list pods for mTLS posture", "user", user.KubernetesUsername, "namespace", namespace, "error", listErr)
+		errs["pods"] = "failed to list pods"
+		pods = nil
+	} else if truncated {
+		// Surface the silent-truncation hazard called out in the Phase B
+		// review: a namespace (or cluster-wide request) with more than
+		// meshListCap pods returns a partial posture table with no
+		// Continue handling. Make the partial nature visible instead of
+		// pretending the result is complete.
+		if namespace == "" {
+			errs["truncated"] = fmt.Sprintf("result capped at %d pods; pass ?namespace= to scope the request", meshListCap)
+		} else {
+			errs["truncated"] = fmt.Sprintf("result capped at %d pods in namespace %q", meshListCap, namespace)
+		}
 	}
 
-	data, err := h.fetchData(r.Context())
-	if err != nil {
-		h.Logger.Error("failed to fetch mesh policies", "error", err)
-		resp.Errors["policies"] = err.Error()
-		httputil.WriteData(w, resp)
-		return
+	var peerAuths []peerAuthRef
+	data, derr := h.fetchData(r.Context())
+	if derr != nil {
+		h.Logger.Error("failed to fetch mesh policies for mTLS posture", "user", user.KubernetesUsername, "error", derr)
+		errs["policies"] = "failed to fetch mesh policies"
+	} else {
+		peerAuths = peerAuthsFromPolicies(data.policies)
 	}
-
-	peerAuths := peerAuthsFromPolicies(data.policies)
 
 	// Scope PAs to the mesh root (always in scope) plus the requested
-	// namespace when a filter is applied — keeps precedence resolution
-	// correct for a namespace-scoped request.
-	if namespace != "" {
-		filtered := peerAuths[:0]
+	// namespace when a filter is applied. Full-slice expression
+	// (peerAuths[:0:0]) prevents the filter from aliasing into a
+	// cache-backed backing array if peerAuthsFromPolicies ever returns a
+	// view instead of a copy.
+	if namespace != "" && len(peerAuths) > 0 {
+		filtered := peerAuths[:0:0]
 		for _, pa := range peerAuths {
 			if pa.Namespace == namespace || pa.Namespace == istioMeshRootNamespace {
 				filtered = append(filtered, pa)
@@ -595,27 +634,36 @@ func (h *Handler) HandleMTLSPosture(w http.ResponseWriter, r *http.Request) {
 	postures := computePodPostures(pods, peerAuths)
 	workloads := aggregateWorkloads(postures)
 
+	// Prom cross-check is only meaningful when the query template can be
+	// bound to a concrete namespace. Cluster-wide requests skip it by
+	// design; a surfaced follow-up will either aggregate across known
+	// namespaces or rewrite the template to run un-scoped.
 	if pc := h.promClient(); pc != nil && namespace != "" {
 		ratios, perr := queryIstioMTLSRatios(r.Context(), pc, namespace)
 		if perr != nil {
-			h.Logger.Warn("mTLS metric cross-check failed; falling back to policy-only", "namespace", namespace, "error", perr)
+			h.Logger.Warn("mTLS metric cross-check failed; falling back to policy-only", "user", user.KubernetesUsername, "namespace", namespace, "error", perr)
+			errs["prometheus-cross-check"] = "metric cross-check unavailable; posture derived from policies only"
 		} else {
 			workloads = applyMTLSMetricOverrides(workloads, ratios)
 		}
 	}
 
-	maps.Copy(resp.Errors, data.errors)
-	if len(resp.Errors) == 0 {
-		resp.Errors = nil
+	if data != nil {
+		maps.Copy(errs, data.errors)
+	}
+	if len(errs) > 0 {
+		resp.Errors = errs
 	}
 	resp.Workloads = workloads
 	httputil.WriteData(w, resp)
 }
 
-// goldenSignalsResponse envelopes GoldenSignals with the common
+// GoldenSignalsResponse envelopes GoldenSignals with the common
 // MeshStatus so clients can disambiguate "no mesh installed" from
-// "service not meshed" without a separate probe.
-type goldenSignalsResponse struct {
+// "service not meshed" without a separate probe. Exported so external
+// consumers get a compile-time signal on wire-shape changes, mirroring
+// MTLSPostureResponse.
+type GoldenSignalsResponse struct {
 	Status  MeshStatus    `json:"status"`
 	Signals GoldenSignals `json:"signals"`
 }
@@ -629,6 +677,11 @@ type goldenSignalsResponse struct {
 // workload context. Input values are re-validated through the existing
 // monitoring.QueryTemplate render path — the handler never concatenates
 // user input into PromQL.
+//
+// Error semantics mirror HandleMTLSPosture: RBAC checker failure is a
+// 500 (system fault), RBAC denial is a 403, invalid param is a 400 with
+// a user-safe message. Internal render errors are logged in full but
+// never echoed to the response body.
 func (h *Handler) HandleGoldenSignals(w http.ResponseWriter, r *http.Request) {
 	user, ok := httputil.RequireUser(w, r)
 	if !ok {
@@ -656,7 +709,12 @@ func (h *Handler) HandleGoldenSignals(w http.ResponseWriter, r *http.Request) {
 	// the user can't read pods there, the metric breakdown would leak
 	// workload names they shouldn't see.
 	can, aerr := h.AccessChecker.CanAccessGroupResource(r.Context(), user.KubernetesUsername, user.KubernetesGroups, "list", "", "pods", namespace)
-	if aerr != nil || !can {
+	if aerr != nil {
+		h.Logger.Error("golden signals RBAC check failed", "user", user.KubernetesUsername, "namespace", namespace, "error", aerr)
+		httputil.WriteError(w, http.StatusInternalServerError, "permission check failed", "")
+		return
+	}
+	if !can {
 		httputil.WriteError(w, http.StatusForbidden, "you do not have permission to view metrics for this namespace", "")
 		return
 	}
@@ -664,13 +722,15 @@ func (h *Handler) HandleGoldenSignals(w http.ResponseWriter, r *http.Request) {
 	pc := h.promClient()
 	signals, gerr := goldenSignalsForService(r.Context(), pc, mesh, namespace, service)
 	if gerr != nil {
-		// Validation errors (render failures) are 400; the plan's error
-		// scenario for "label-substitution rejects a namespace with quotes".
-		httputil.WriteError(w, http.StatusBadRequest, gerr.Error(), "")
+		// Validation errors come from the monitoring package's k8s-name
+		// guard inside QueryTemplate.Render. The full cause goes to the
+		// log; the response says only what the caller needs to retry.
+		h.Logger.Warn("golden signals render failed", "user", user.KubernetesUsername, "namespace", namespace, "service", service, "mesh", mesh, "error", gerr)
+		httputil.WriteError(w, http.StatusBadRequest, "invalid namespace or service name", "")
 		return
 	}
 
-	httputil.WriteData(w, goldenSignalsResponse{Status: status, Signals: signals})
+	httputil.WriteData(w, GoldenSignalsResponse{Status: status, Signals: signals})
 }
 
 // resolveMeshParam validates the `?mesh=` query parameter against the

--- a/backend/internal/servicemesh/metrics.go
+++ b/backend/internal/servicemesh/metrics.go
@@ -1,0 +1,264 @@
+package servicemesh
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/prometheus/common/model"
+
+	"github.com/kubecenter/kubecenter/internal/monitoring"
+)
+
+// goldenSignalsTimeout bounds every PromQL query originating from
+// HandleGoldenSignals. The plan explicitly forbids blocking the UI on
+// Prometheus, so we degrade to "unavailable" on timeout.
+const goldenSignalsTimeout = 2 * time.Second
+
+// GoldenSignals carries RPS + latency quantiles + error rate for a
+// single service. All values are zero when no traffic was observed —
+// Available stays true so the UI can distinguish "silent service" from
+// "metrics subsystem offline".
+type GoldenSignals struct {
+	Mesh      MeshType `json:"mesh"`
+	Namespace string   `json:"namespace"`
+	Service   string   `json:"service"`
+
+	Available bool   `json:"available"`
+	Reason    string `json:"reason,omitempty"` // populated only when Available=false
+
+	RPS       float64 `json:"rps"`
+	ErrorRate float64 `json:"errorRate"` // fraction 0..1
+	P50Ms     float64 `json:"p50Ms"`
+	P95Ms     float64 `json:"p95Ms"`
+	P99Ms     float64 `json:"p99Ms"`
+}
+
+// goldenSignalsTemplates are the six PromQL templates needed per mesh.
+// They are declared per-mesh because Istio's destination-centric labels
+// (destination_service_name) and Linkerd's inbound-authority labels
+// (authority=...) are incompatible shapes — no shared template set.
+type goldenSignalsTemplates struct {
+	rps       monitoring.QueryTemplate
+	errorNum  monitoring.QueryTemplate
+	errorDen  monitoring.QueryTemplate
+	latencyP  func(q string) monitoring.QueryTemplate
+}
+
+// istioTemplates use the v1.18+ Istio standard metric names. Labels
+// follow the "destination_service_*" convention documented in Istio's
+// metrics reference and the plan's Phase B approach section.
+var istioTemplates = goldenSignalsTemplates{
+	rps: monitoring.QueryTemplate{
+		Query:     `sum(rate(istio_requests_total{destination_service_name="$svc",destination_service_namespace="$ns"}[2m]))`,
+		Variables: []string{"svc", "ns"},
+	},
+	errorNum: monitoring.QueryTemplate{
+		Query:     `sum(rate(istio_requests_total{destination_service_name="$svc",destination_service_namespace="$ns",response_code=~"5.."}[2m]))`,
+		Variables: []string{"svc", "ns"},
+	},
+	errorDen: monitoring.QueryTemplate{
+		Query:     `sum(rate(istio_requests_total{destination_service_name="$svc",destination_service_namespace="$ns"}[2m]))`,
+		Variables: []string{"svc", "ns"},
+	},
+	latencyP: func(quantile string) monitoring.QueryTemplate {
+		return monitoring.QueryTemplate{
+			Query:     fmt.Sprintf(`histogram_quantile(%s, sum by (le) (rate(istio_request_duration_milliseconds_bucket{destination_service_name="$svc",destination_service_namespace="$ns"}[2m])))`, quantile),
+			Variables: []string{"svc", "ns"},
+		}
+	},
+}
+
+// linkerdTemplates use the linkerd-proxy metric names with
+// direction=inbound so we count traffic terminated by the destination
+// workload, not egress from peers. `authority` is the Host header and
+// matches the default <svc>.<ns>.svc.cluster.local form.
+var linkerdTemplates = goldenSignalsTemplates{
+	rps: monitoring.QueryTemplate{
+		Query:     `sum(rate(request_total{direction="inbound",authority="$svc.$ns.svc.cluster.local"}[2m]))`,
+		Variables: []string{"svc", "ns"},
+	},
+	errorNum: monitoring.QueryTemplate{
+		Query:     `sum(rate(response_total{direction="inbound",authority="$svc.$ns.svc.cluster.local",classification="failure"}[2m]))`,
+		Variables: []string{"svc", "ns"},
+	},
+	errorDen: monitoring.QueryTemplate{
+		Query:     `sum(rate(response_total{direction="inbound",authority="$svc.$ns.svc.cluster.local"}[2m]))`,
+		Variables: []string{"svc", "ns"},
+	},
+	latencyP: func(quantile string) monitoring.QueryTemplate {
+		return monitoring.QueryTemplate{
+			Query:     fmt.Sprintf(`histogram_quantile(%s, sum by (le) (rate(response_latency_ms_bucket{direction="inbound",authority="$svc.$ns.svc.cluster.local"}[2m])))`, quantile),
+			Variables: []string{"svc", "ns"},
+		}
+	},
+}
+
+// templatesForMesh selects the mesh-specific template set. Callers must
+// pre-validate that the mesh is one we support; returning an error here
+// keeps the handler path narrow.
+func templatesForMesh(mesh MeshType) (goldenSignalsTemplates, error) {
+	switch mesh {
+	case MeshIstio:
+		return istioTemplates, nil
+	case MeshLinkerd:
+		return linkerdTemplates, nil
+	}
+	return goldenSignalsTemplates{}, fmt.Errorf("unsupported mesh %q", mesh)
+}
+
+// goldenSignalsForService runs the six queries in parallel, derives
+// the ErrorRate ratio from its two components, and returns a populated
+// GoldenSignals. Context-deadline breaches produce a degraded result
+// with Available=false rather than an error — this matches the plan's
+// "never block the UI" contract.
+func goldenSignalsForService(ctx context.Context, pc *monitoring.PrometheusClient, mesh MeshType, namespace, service string) (GoldenSignals, error) {
+	result := GoldenSignals{Mesh: mesh, Namespace: namespace, Service: service}
+
+	// Validate mesh first so unsupported values surface as a hard error —
+	// a nil Prometheus client with a bogus mesh should not silently
+	// "succeed" with an unavailable response.
+	templates, err := templatesForMesh(mesh)
+	if err != nil {
+		return result, err
+	}
+
+	if pc == nil {
+		result.Available = false
+		result.Reason = "metrics_unavailable"
+		return result, nil
+	}
+
+	vars := map[string]string{"svc": service, "ns": namespace}
+
+	// Render all queries up front. Any render failure is a validation
+	// error — the injected values failed the monitoring package's k8s-name
+	// check — and should surface to the caller as a 400.
+	queries := map[string]monitoring.QueryTemplate{
+		"rps":      templates.rps,
+		"errorNum": templates.errorNum,
+		"errorDen": templates.errorDen,
+		"p50":      templates.latencyP("0.50"),
+		"p95":      templates.latencyP("0.95"),
+		"p99":      templates.latencyP("0.99"),
+	}
+
+	rendered := make(map[string]string, len(queries))
+	for name, q := range queries {
+		rq, rerr := q.Render(vars)
+		if rerr != nil {
+			return result, fmt.Errorf("render %s: %w", name, rerr)
+		}
+		rendered[name] = rq
+	}
+
+	queryCtx, cancel := context.WithTimeout(ctx, goldenSignalsTimeout)
+	defer cancel()
+
+	results := make(map[string]float64, len(rendered))
+	var resultsMu sync.Mutex
+	var firstErr onceBox[error]
+	var wg sync.WaitGroup
+	now := time.Now()
+
+	for name, q := range rendered {
+		wg.Add(1)
+		go func(name, q string) {
+			defer wg.Done()
+			val, _, qerr := pc.Query(queryCtx, q, now)
+			if qerr != nil {
+				firstErr.storeOnce(qerr)
+				return
+			}
+			scalar, ok := firstScalarValue(val)
+			if !ok {
+				return
+			}
+			resultsMu.Lock()
+			results[name] = scalar
+			resultsMu.Unlock()
+		}(name, q)
+	}
+	wg.Wait()
+
+	if err := firstErr.load(); err != nil {
+		result.Available = false
+		if errors.Is(err, context.DeadlineExceeded) {
+			result.Reason = "metrics_unavailable"
+			return result, nil
+		}
+		result.Reason = "metrics_unavailable"
+		return result, nil
+	}
+
+	result.Available = true
+	result.RPS = results["rps"]
+	den := results["errorDen"]
+	if den > 0 {
+		result.ErrorRate = results["errorNum"] / den
+	}
+	result.P50Ms = nanToZero(results["p50"])
+	result.P95Ms = nanToZero(results["p95"])
+	result.P99Ms = nanToZero(results["p99"])
+
+	return result, nil
+}
+
+// nanToZero collapses NaN values from histogram_quantile (which can
+// return NaN when there is no traffic) to a clean 0 so the JSON
+// payload never carries a NaN.
+func nanToZero(v float64) float64 {
+	if math.IsNaN(v) || math.IsInf(v, 0) {
+		return 0
+	}
+	return v
+}
+
+// firstScalarValue pulls a single numeric value from a Prometheus
+// result. Empty vectors (no traffic in the window) cleanly return
+// (0, true) rather than an error — "silent service" is normal state.
+func firstScalarValue(v model.Value) (float64, bool) {
+	switch val := v.(type) {
+	case *model.Scalar:
+		return float64(val.Value), true
+	case model.Vector:
+		if len(val) == 0 {
+			return 0, true
+		}
+		return float64(val[0].Value), true
+	case model.Matrix:
+		if len(val) == 0 || len(val[0].Values) == 0 {
+			return 0, true
+		}
+		last := val[0].Values[len(val[0].Values)-1]
+		return float64(last.Value), true
+	}
+	return 0, false
+}
+
+// onceBox[T] is a minimal generic cell used for first-error capture in
+// the parallel fan-out. storeOnce keeps the first non-nil error; the
+// rest are dropped — the handler surfaces only one cause anyway.
+type onceBox[T any] struct {
+	mu  sync.Mutex
+	set bool
+	v   T
+}
+
+func (a *onceBox[T]) storeOnce(v T) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if !a.set {
+		a.v = v
+		a.set = true
+	}
+}
+
+func (a *onceBox[T]) load() T {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.v
+}

--- a/backend/internal/servicemesh/metrics.go
+++ b/backend/internal/servicemesh/metrics.go
@@ -2,10 +2,8 @@ package servicemesh
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math"
-	"sync"
 	"time"
 
 	"github.com/prometheus/common/model"
@@ -13,10 +11,17 @@ import (
 	"github.com/kubecenter/kubecenter/internal/monitoring"
 )
 
-// goldenSignalsTimeout bounds every PromQL query originating from
-// HandleGoldenSignals. The plan explicitly forbids blocking the UI on
+// promQueryTimeout bounds every PromQL query originating from this
+// package's handlers. The plan explicitly forbids blocking the UI on
 // Prometheus, so we degrade to "unavailable" on timeout.
-const goldenSignalsTimeout = 2 * time.Second
+//
+// The underlying monitoring.PrometheusClient.Query wraps the caller's
+// context with its own 10s WithTimeout. context.WithTimeout selects the
+// earlier deadline, so this 2s budget is authoritative regardless of the
+// client's internal value. Callers in this package rely on that
+// ordering — do not raise this above 10s without also reviewing the
+// client.
+const promQueryTimeout = 2 * time.Second
 
 // GoldenSignals carries RPS + latency quantiles + error rate for a
 // single service. All values are zero when no traffic was observed —
@@ -115,6 +120,14 @@ func templatesForMesh(mesh MeshType) (goldenSignalsTemplates, error) {
 // GoldenSignals. Context-deadline breaches produce a degraded result
 // with Available=false rather than an error — this matches the plan's
 // "never block the UI" contract.
+//
+// Partial-failure policy: if any subset of queries succeeds, those
+// results are used and Available is true. p99 histogram_quantile is
+// reliably the slowest query — under load it is the most likely to
+// time out. Discarding RPS and error-rate because p99 didn't return
+// would hide the signals operators need most in that moment. Missing
+// signals are zero-valued (matching the "silent service" convention);
+// only a full fan-out failure flips Available to false.
 func goldenSignalsForService(ctx context.Context, pc *monitoring.PrometheusClient, mesh MeshType, namespace, service string) (GoldenSignals, error) {
 	result := GoldenSignals{Mesh: mesh, Namespace: namespace, Service: service}
 
@@ -155,41 +168,44 @@ func goldenSignalsForService(ctx context.Context, pc *monitoring.PrometheusClien
 		rendered[name] = rq
 	}
 
-	queryCtx, cancel := context.WithTimeout(ctx, goldenSignalsTimeout)
+	queryCtx, cancel := context.WithTimeout(ctx, promQueryTimeout)
 	defer cancel()
 
-	results := make(map[string]float64, len(rendered))
-	var resultsMu sync.Mutex
-	var firstErr onceBox[error]
-	var wg sync.WaitGroup
+	type outcome struct {
+		name  string
+		value float64
+		ok    bool
+		err   error
+	}
+	outcomes := make(chan outcome, len(rendered))
 	now := time.Now()
 
 	for name, q := range rendered {
-		wg.Add(1)
 		go func(name, q string) {
-			defer wg.Done()
 			val, _, qerr := pc.Query(queryCtx, q, now)
 			if qerr != nil {
-				firstErr.storeOnce(qerr)
+				outcomes <- outcome{name: name, err: qerr}
 				return
 			}
 			scalar, ok := firstScalarValue(val)
-			if !ok {
-				return
-			}
-			resultsMu.Lock()
-			results[name] = scalar
-			resultsMu.Unlock()
+			outcomes <- outcome{name: name, value: scalar, ok: ok}
 		}(name, q)
 	}
-	wg.Wait()
 
-	if err := firstErr.load(); err != nil {
-		result.Available = false
-		if errors.Is(err, context.DeadlineExceeded) {
-			result.Reason = "metrics_unavailable"
-			return result, nil
+	results := make(map[string]float64, len(rendered))
+	for i := 0; i < len(rendered); i++ {
+		o := <-outcomes
+		if o.err != nil || !o.ok {
+			continue
 		}
+		results[o.name] = o.value
+	}
+
+	// Full fan-out failure is the only state where Available flips false.
+	// Any partial success still counts — operators would rather see RPS
+	// and error-rate without latency than a blank panel.
+	if len(results) == 0 {
+		result.Available = false
 		result.Reason = "metrics_unavailable"
 		return result, nil
 	}
@@ -218,8 +234,15 @@ func nanToZero(v float64) float64 {
 }
 
 // firstScalarValue pulls a single numeric value from a Prometheus
-// result. Empty vectors (no traffic in the window) cleanly return
-// (0, true) rather than an error — "silent service" is normal state.
+// instant-query result. Empty vectors (no traffic in the window)
+// cleanly return (0, true) — "silent service" is normal state.
+//
+// pc.Query is an instant query; its result is always Scalar or Vector.
+// We do not handle Matrix here because a Matrix response would indicate
+// the client was swapped with QueryRange — a mismatch the caller should
+// fix at the call site, not paper over by taking the last sample.
+// Unknown types return (0, false) so the caller treats the query as
+// having no usable value.
 func firstScalarValue(v model.Value) (float64, bool) {
 	switch val := v.(type) {
 	case *model.Scalar:
@@ -229,36 +252,6 @@ func firstScalarValue(v model.Value) (float64, bool) {
 			return 0, true
 		}
 		return float64(val[0].Value), true
-	case model.Matrix:
-		if len(val) == 0 || len(val[0].Values) == 0 {
-			return 0, true
-		}
-		last := val[0].Values[len(val[0].Values)-1]
-		return float64(last.Value), true
 	}
 	return 0, false
-}
-
-// onceBox[T] is a minimal generic cell used for first-error capture in
-// the parallel fan-out. storeOnce keeps the first non-nil error; the
-// rest are dropped — the handler surfaces only one cause anyway.
-type onceBox[T any] struct {
-	mu  sync.Mutex
-	set bool
-	v   T
-}
-
-func (a *onceBox[T]) storeOnce(v T) {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	if !a.set {
-		a.v = v
-		a.set = true
-	}
-}
-
-func (a *onceBox[T]) load() T {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	return a.v
 }

--- a/backend/internal/servicemesh/metrics_test.go
+++ b/backend/internal/servicemesh/metrics_test.go
@@ -3,6 +3,7 @@ package servicemesh
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"math"
 	"net/http"
@@ -282,7 +283,7 @@ func TestHandler_GoldenSignals_PrometheusOffline(t *testing.T) {
 		t.Fatalf("status = %d, want 200", w.Code)
 	}
 	var env struct {
-		Data goldenSignalsResponse `json:"data"`
+		Data GoldenSignalsResponse `json:"data"`
 	}
 	if err := json.Unmarshal(w.Body.Bytes(), &env); err != nil {
 		t.Fatalf("decode: %v", err)
@@ -295,11 +296,197 @@ func TestHandler_GoldenSignals_PrometheusOffline(t *testing.T) {
 	}
 }
 
+// --- fan-out coverage -----------------------------------------------------
+
+// TestGoldenSignalsForService_HappyPath exercises the six-query fan-out
+// end-to-end with a fake Prometheus HTTP server. It asserts that every
+// result lands in the right bucket (RPS, errorRate, P50/P95/P99), which
+// is the regression coverage the Phase B review flagged as the largest
+// testing gap: a mis-keying of "rps" vs "errorNum" would compile and
+// pass every existing test.
+func TestGoldenSignalsForService_HappyPath(t *testing.T) {
+	srv := newFakePromServer(t, map[string]float64{
+		// Order matters: more-specific fragments first so errorNum
+		// (which contains response_code) doesn't collide with the
+		// plain RPS template.
+		`response_code=~"5.."`:             2.5,  // errorNum
+		"istio_requests_total":             100,  // rps + errorDen
+		"histogram_quantile(0.50":          11.0, // p50
+		"histogram_quantile(0.95":          55.0, // p95
+		"histogram_quantile(0.99":          99.0, // p99
+	})
+	defer srv.Close()
+	pc, err := monitoring.NewPrometheusClient(srv.URL)
+	if err != nil {
+		t.Fatalf("prom client: %v", err)
+	}
+
+	got, gerr := goldenSignalsForService(context.Background(), pc, MeshIstio, "shop", "cart")
+	if gerr != nil {
+		t.Fatalf("unexpected error: %v", gerr)
+	}
+	if !got.Available {
+		t.Fatalf("Available = false, want true")
+	}
+	if got.RPS != 100 {
+		t.Errorf("RPS = %v, want 100", got.RPS)
+	}
+	if wantRate := 2.5 / 100.0; got.ErrorRate != wantRate {
+		t.Errorf("ErrorRate = %v, want %v", got.ErrorRate, wantRate)
+	}
+	if got.P50Ms != 11 || got.P95Ms != 55 || got.P99Ms != 99 {
+		t.Errorf("latencies = (%v, %v, %v), want (11, 55, 99)", got.P50Ms, got.P95Ms, got.P99Ms)
+	}
+}
+
+// TestGoldenSignalsForService_PartialFailure drops one of the six
+// queries and asserts the rest still populate the response. The Phase B
+// review flagged this as a UX regression: p99 histogram_quantile is
+// reliably the slowest query under load, and discarding RPS +
+// error-rate because p99 errored out would blank exactly the signals
+// operators need most during an incident.
+func TestGoldenSignalsForService_PartialFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query := r.FormValue("query")
+		if strings.Contains(query, "histogram_quantile(0.99") {
+			// Simulate a backend failure for p99 only.
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"status":"error","errorType":"timeout","error":"query timed out"}`))
+			return
+		}
+		var value float64
+		switch {
+		case strings.Contains(query, `response_code=~"5.."`):
+			value = 1
+		case strings.Contains(query, "istio_requests_total"):
+			value = 50
+		case strings.Contains(query, "histogram_quantile(0.50"):
+			value = 7
+		case strings.Contains(query, "histogram_quantile(0.95"):
+			value = 23
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w,
+			`{"status":"success","data":{"resultType":"vector","result":[{"metric":{},"value":[1,"%g"]}]}}`, value)
+	}))
+	defer srv.Close()
+	pc, err := monitoring.NewPrometheusClient(srv.URL)
+	if err != nil {
+		t.Fatalf("prom client: %v", err)
+	}
+
+	got, gerr := goldenSignalsForService(context.Background(), pc, MeshIstio, "shop", "cart")
+	if gerr != nil {
+		t.Fatalf("unexpected error: %v", gerr)
+	}
+	if !got.Available {
+		t.Fatalf("Available = false, want true (partial results should still count)")
+	}
+	if got.RPS != 50 {
+		t.Errorf("RPS = %v, want 50", got.RPS)
+	}
+	if got.P50Ms != 7 || got.P95Ms != 23 {
+		t.Errorf("P50/P95 = (%v, %v), want (7, 23)", got.P50Ms, got.P95Ms)
+	}
+	if got.P99Ms != 0 {
+		t.Errorf("P99 = %v, want 0 (query failed so no value)", got.P99Ms)
+	}
+}
+
+// TestGoldenSignalsForService_AllQueriesFailReportsUnavailable asserts
+// the whole-fan-out-failure path still flips Available=false. Without
+// this, a blanket Prometheus outage would incorrectly look like a
+// meshed service reporting zero traffic.
+func TestGoldenSignalsForService_AllQueriesFailReportsUnavailable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	pc, err := monitoring.NewPrometheusClient(srv.URL)
+	if err != nil {
+		t.Fatalf("prom client: %v", err)
+	}
+
+	got, gerr := goldenSignalsForService(context.Background(), pc, MeshIstio, "shop", "cart")
+	if gerr != nil {
+		t.Fatalf("unexpected error: %v", gerr)
+	}
+	if got.Available {
+		t.Error("Available = true, want false when every query fails")
+	}
+	if got.Reason != "metrics_unavailable" {
+		t.Errorf("Reason = %q, want metrics_unavailable", got.Reason)
+	}
+}
+
+// TestHandler_GoldenSignals_RenderFailureSurfacesAs400 covers the
+// handler's mapping of a monitoring.QueryTemplate render error onto an
+// HTTP 400 with a user-safe message. Internal render-key text ("render
+// rps:" etc.) must not leak into the body.
+func TestHandler_GoldenSignals_RenderFailureSurfacesAs400(t *testing.T) {
+	// promClientOverride bypasses the nil-client early-exit, ensuring
+	// the render path is the one that fails.
+	srv := newFakePromServer(t, map[string]float64{"istio_requests_total": 1})
+	defer srv.Close()
+	pc, err := monitoring.NewPrometheusClient(srv.URL)
+	if err != nil {
+		t.Fatalf("prom client: %v", err)
+	}
+
+	h := &Handler{
+		Discoverer:         seededDiscoverer(MeshStatus{Detected: MeshIstio, Istio: &MeshInfo{Installed: true}}),
+		AccessChecker:      resources.NewAlwaysAllowAccessChecker(),
+		Logger:             slog.Default(),
+		promClientOverride: pc,
+	}
+	// Namespace with embedded double-quote — the monitoring package's
+	// k8s-name guard rejects this.
+	w := doGoldenSignals(t, h, url.Values{"namespace": {`bad"ns`}, "service": {"cart"}})
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+	body := w.Body.String()
+	if strings.Contains(body, "render") {
+		t.Errorf("body leaks internal render-key prefix: %q", body)
+	}
+}
+
 // --- helpers ---------------------------------------------------------------
+
+// newFakePromServer returns an httptest.Server that impersonates a
+// Prometheus v1 /api/v1/query endpoint. The values map is keyed by a
+// substring of the PromQL query; whichever entry matches first wins, so
+// callers must order the map with the most-specific fragments first.
+// Queries that match no entry produce an empty vector (valid, zero).
+func newFakePromServer(t *testing.T, values map[string]float64) *httptest.Server {
+	t.Helper()
+	// Preserve insertion order so callers control match precedence.
+	keys := make([]string, 0, len(values))
+	for k := range values {
+		keys = append(keys, k)
+	}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/query" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		query := r.FormValue("query")
+		w.Header().Set("Content-Type", "application/json")
+		for _, frag := range keys {
+			if strings.Contains(query, frag) {
+				_, _ = fmt.Fprintf(w,
+					`{"status":"success","data":{"resultType":"vector","result":[{"metric":{},"value":[1,"%g"]}]}}`,
+					values[frag])
+				return
+			}
+		}
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[]}}`))
+	}))
+}
 
 func doGoldenSignals(t *testing.T, h *Handler, q url.Values) *httptest.ResponseRecorder {
 	t.Helper()
-	req := httptest.NewRequest(http.MethodGet, "/mesh/metrics?"+q.Encode(), nil)
+	req := httptest.NewRequest(http.MethodGet, "/mesh/golden-signals?"+q.Encode(), nil)
 	req = req.WithContext(auth.ContextWithUser(req.Context(), &auth.User{KubernetesUsername: "u"}))
 	w := httptest.NewRecorder()
 	h.HandleGoldenSignals(w, req)

--- a/backend/internal/servicemesh/metrics_test.go
+++ b/backend/internal/servicemesh/metrics_test.go
@@ -1,0 +1,308 @@
+package servicemesh
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/kubecenter/kubecenter/internal/auth"
+	"github.com/kubecenter/kubecenter/internal/k8s/resources"
+	"github.com/kubecenter/kubecenter/internal/monitoring"
+)
+
+// --- template render tests -------------------------------------------------
+
+// TestIstioTemplates_RenderLabels confirms the Istio templates resolve
+// to queries with the expected labels and no unsubstituted $ tokens.
+func TestIstioTemplates_RenderLabels(t *testing.T) {
+	vars := map[string]string{"svc": "cart", "ns": "shop"}
+	rps, err := istioTemplates.rps.Render(vars)
+	if err != nil {
+		t.Fatalf("render rps: %v", err)
+	}
+	if strings.Contains(rps, "$") {
+		t.Errorf("rps has unsubstituted variable: %q", rps)
+	}
+	if !strings.Contains(rps, `destination_service_name="cart"`) {
+		t.Errorf("rps missing destination_service_name: %q", rps)
+	}
+	if !strings.Contains(rps, `destination_service_namespace="shop"`) {
+		t.Errorf("rps missing destination_service_namespace: %q", rps)
+	}
+
+	errNum, err := istioTemplates.errorNum.Render(vars)
+	if err != nil {
+		t.Fatalf("render errorNum: %v", err)
+	}
+	if !strings.Contains(errNum, `response_code=~"5.."`) {
+		t.Errorf("errorNum should filter 5xx responses: %q", errNum)
+	}
+
+	p95, err := istioTemplates.latencyP("0.95").Render(vars)
+	if err != nil {
+		t.Fatalf("render p95: %v", err)
+	}
+	if !strings.Contains(p95, "histogram_quantile(0.95") {
+		t.Errorf("p95 should use histogram_quantile(0.95): %q", p95)
+	}
+	if !strings.Contains(p95, "istio_request_duration_milliseconds_bucket") {
+		t.Errorf("p95 should use the bucket histogram: %q", p95)
+	}
+}
+
+// TestLinkerdTemplates_RenderLabels confirms the Linkerd templates use
+// direction=inbound and the authority-shaped selector.
+func TestLinkerdTemplates_RenderLabels(t *testing.T) {
+	vars := map[string]string{"svc": "cart", "ns": "shop"}
+	rps, err := linkerdTemplates.rps.Render(vars)
+	if err != nil {
+		t.Fatalf("render rps: %v", err)
+	}
+	if !strings.Contains(rps, `direction="inbound"`) {
+		t.Errorf("rps should filter inbound traffic: %q", rps)
+	}
+	if !strings.Contains(rps, `authority="cart.shop.svc.cluster.local"`) {
+		t.Errorf("rps should build authority from svc+ns: %q", rps)
+	}
+	errNum, err := linkerdTemplates.errorNum.Render(vars)
+	if err != nil {
+		t.Fatalf("render errorNum: %v", err)
+	}
+	if !strings.Contains(errNum, `classification="failure"`) {
+		t.Errorf("errorNum should filter classification=failure: %q", errNum)
+	}
+}
+
+// TestTemplateRejectsInjection: the monitoring.QueryTemplate validator
+// refuses values containing quotes, spaces, or PromQL operators. This
+// is the plan's "label-substitution rejects a namespace with \" in it"
+// scenario — the injection attempt surfaces as an error upstream.
+func TestTemplateRejectsInjection(t *testing.T) {
+	vars := map[string]string{"svc": "cart", "ns": `shop"}) or vector(1) #`}
+	if _, err := istioTemplates.rps.Render(vars); err == nil {
+		t.Error("render accepted an invalid namespace with embedded quotes")
+	}
+}
+
+// --- nanToZero -------------------------------------------------------------
+
+func TestNanToZero(t *testing.T) {
+	if got := nanToZero(0); got != 0 {
+		t.Errorf("nanToZero(0) = %v", got)
+	}
+	if got := nanToZero(1.5); got != 1.5 {
+		t.Errorf("nanToZero(1.5) = %v", got)
+	}
+	if got := nanToZero(math.NaN()); got != 0 {
+		t.Errorf("nanToZero(NaN) = %v, want 0", got)
+	}
+	if got := nanToZero(math.Inf(1)); got != 0 {
+		t.Errorf("nanToZero(+Inf) = %v, want 0", got)
+	}
+	if got := nanToZero(math.Inf(-1)); got != 0 {
+		t.Errorf("nanToZero(-Inf) = %v, want 0", got)
+	}
+}
+
+// --- goldenSignalsForService (nil PromQL client) ---------------------------
+
+// TestGoldenSignalsForService_NilClientReportsUnavailable covers the
+// plan's edge case: Prometheus offline → Available=false, Reason
+// populated, zero values. Never returns an error to the caller.
+func TestGoldenSignalsForService_NilClientReportsUnavailable(t *testing.T) {
+	got, err := goldenSignalsForService(context.Background(), nil, MeshIstio, "shop", "cart")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Available {
+		t.Error("Available should be false when client is nil")
+	}
+	if got.Reason != "metrics_unavailable" {
+		t.Errorf("Reason = %q, want metrics_unavailable", got.Reason)
+	}
+}
+
+// TestGoldenSignalsForService_UnsupportedMesh rejects unknown meshes
+// before issuing any Prometheus work.
+func TestGoldenSignalsForService_UnsupportedMesh(t *testing.T) {
+	_, err := goldenSignalsForService(context.Background(), nil, MeshType("kuma"), "shop", "cart")
+	if err == nil {
+		t.Fatal("expected error for unsupported mesh")
+	}
+	if !strings.Contains(err.Error(), "unsupported mesh") {
+		t.Errorf("error = %v, want unsupported mesh", err)
+	}
+}
+
+// TestGoldenSignalsForService_RenderFailureSurfacesError: invalid
+// namespace (embedded quotes) surfaces as a render-layer error so the
+// handler can emit 400. We build a Prometheus client against an unreachable
+// address — Render fires before Query would ever touch the network.
+func TestGoldenSignalsForService_RenderFailureSurfacesError(t *testing.T) {
+	pc, err := monitoring.NewPrometheusClient("http://127.0.0.1:1")
+	if err != nil {
+		t.Fatalf("prom client: %v", err)
+	}
+	_, err = goldenSignalsForService(context.Background(), pc, MeshIstio, `bad"ns`, "cart")
+	if err == nil {
+		t.Fatal("expected render error for namespace with quotes")
+	}
+	if !strings.Contains(err.Error(), "render") {
+		t.Errorf("error = %v, want render wrapping", err)
+	}
+}
+
+// --- resolveMeshParam ------------------------------------------------------
+
+func TestResolveMeshParam(t *testing.T) {
+	istioOnly := MeshStatus{Detected: MeshIstio, Istio: &MeshInfo{Installed: true}}
+	linkerdOnly := MeshStatus{Detected: MeshLinkerd, Linkerd: &MeshInfo{Installed: true}}
+	both := MeshStatus{Detected: MeshBoth, Istio: &MeshInfo{Installed: true}, Linkerd: &MeshInfo{Installed: true}}
+	none := MeshStatus{Detected: MeshNone}
+
+	cases := []struct {
+		name    string
+		param   string
+		status  MeshStatus
+		want    MeshType
+		wantErr bool
+	}{
+		{"empty + istio only → istio", "", istioOnly, MeshIstio, false},
+		{"empty + linkerd only → linkerd", "", linkerdOnly, MeshLinkerd, false},
+		{"empty + none → error", "", none, MeshNone, true},
+		{"empty + both → error (ambiguous)", "", both, MeshNone, true},
+		{"explicit istio + istio installed", "istio", istioOnly, MeshIstio, false},
+		{"explicit istio + not installed → error", "istio", linkerdOnly, MeshNone, true},
+		{"explicit linkerd + linkerd installed", "linkerd", linkerdOnly, MeshLinkerd, false},
+		{"explicit linkerd + not installed → error", "linkerd", istioOnly, MeshNone, true},
+		{"bogus param → error", "osm", istioOnly, MeshNone, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := resolveMeshParam(c.param, c.status)
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got mesh=%q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != c.want {
+				t.Errorf("got %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+// --- handler tests ---------------------------------------------------------
+
+// TestHandler_GoldenSignals_BadRequestMissingParams covers the plan's
+// validation scenario — missing service / namespace → 400.
+func TestHandler_GoldenSignals_BadRequestMissingParams(t *testing.T) {
+	h := &Handler{
+		Discoverer:    seededDiscoverer(MeshStatus{Detected: MeshIstio, Istio: &MeshInfo{Installed: true}}),
+		AccessChecker: resources.NewAlwaysAllowAccessChecker(),
+		Logger:        slog.Default(),
+	}
+	w := doGoldenSignals(t, h, url.Values{})
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+// TestHandler_GoldenSignals_NoMeshDetected returns 400 with a guidance
+// message so the frontend can surface a helpful empty state.
+func TestHandler_GoldenSignals_NoMeshDetected(t *testing.T) {
+	h := &Handler{
+		Discoverer:    seededDiscoverer(MeshStatus{Detected: MeshNone}),
+		AccessChecker: resources.NewAlwaysAllowAccessChecker(),
+		Logger:        slog.Default(),
+	}
+	w := doGoldenSignals(t, h, url.Values{"namespace": {"shop"}, "service": {"cart"}})
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+// TestHandler_GoldenSignals_AmbiguousDualMesh: both meshes installed
+// and no explicit ?mesh= → 400 with ambiguity message.
+func TestHandler_GoldenSignals_AmbiguousDualMesh(t *testing.T) {
+	h := &Handler{
+		Discoverer: seededDiscoverer(MeshStatus{
+			Detected: MeshBoth,
+			Istio:    &MeshInfo{Installed: true},
+			Linkerd:  &MeshInfo{Installed: true},
+		}),
+		AccessChecker: resources.NewAlwaysAllowAccessChecker(),
+		Logger:        slog.Default(),
+	}
+	w := doGoldenSignals(t, h, url.Values{"namespace": {"shop"}, "service": {"cart"}})
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "both meshes") {
+		t.Errorf("body should mention ambiguity: %q", w.Body.String())
+	}
+}
+
+// TestHandler_GoldenSignals_Denied: user cannot list pods in namespace
+// → 403. This diverges from the mTLS handler's silent empty-state
+// because single-service metrics have no meaningful partial shape.
+func TestHandler_GoldenSignals_Denied(t *testing.T) {
+	h := &Handler{
+		Discoverer:    seededDiscoverer(MeshStatus{Detected: MeshIstio, Istio: &MeshInfo{Installed: true}}),
+		AccessChecker: resources.NewAlwaysDenyAccessChecker(),
+		Logger:        slog.Default(),
+	}
+	w := doGoldenSignals(t, h, url.Values{"namespace": {"shop"}, "service": {"cart"}})
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", w.Code)
+	}
+}
+
+// TestHandler_GoldenSignals_PrometheusOffline is the plan's graceful-
+// degradation path: no Prometheus client → 200 with
+// Signals.Available=false, Reason="metrics_unavailable".
+func TestHandler_GoldenSignals_PrometheusOffline(t *testing.T) {
+	h := &Handler{
+		Discoverer:    seededDiscoverer(MeshStatus{Detected: MeshIstio, Istio: &MeshInfo{Installed: true}}),
+		AccessChecker: resources.NewAlwaysAllowAccessChecker(),
+		Logger:        slog.Default(),
+	}
+	w := doGoldenSignals(t, h, url.Values{"namespace": {"shop"}, "service": {"cart"}})
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var env struct {
+		Data goldenSignalsResponse `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if env.Data.Signals.Available {
+		t.Error("Available should be false when Prometheus is offline")
+	}
+	if env.Data.Signals.Reason != "metrics_unavailable" {
+		t.Errorf("Reason = %q, want metrics_unavailable", env.Data.Signals.Reason)
+	}
+}
+
+// --- helpers ---------------------------------------------------------------
+
+func doGoldenSignals(t *testing.T, h *Handler, q url.Values) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/mesh/metrics?"+q.Encode(), nil)
+	req = req.WithContext(auth.ContextWithUser(req.Context(), &auth.User{KubernetesUsername: "u"}))
+	w := httptest.NewRecorder()
+	h.HandleGoldenSignals(w, req)
+	return w
+}
+

--- a/backend/internal/servicemesh/metrics_test.go
+++ b/backend/internal/servicemesh/metrics_test.go
@@ -305,15 +305,15 @@ func TestHandler_GoldenSignals_PrometheusOffline(t *testing.T) {
 // testing gap: a mis-keying of "rps" vs "errorNum" would compile and
 // pass every existing test.
 func TestGoldenSignalsForService_HappyPath(t *testing.T) {
-	srv := newFakePromServer(t, map[string]float64{
+	srv := newFakePromServer(t, []promStub{
 		// Order matters: more-specific fragments first so errorNum
-		// (which contains response_code) doesn't collide with the
-		// plain RPS template.
-		`response_code=~"5.."`:             2.5,  // errorNum
-		"istio_requests_total":             100,  // rps + errorDen
-		"histogram_quantile(0.50":          11.0, // p50
-		"histogram_quantile(0.95":          55.0, // p95
-		"histogram_quantile(0.99":          99.0, // p99
+		// (which contains istio_requests_total) doesn't collide with
+		// the plain RPS template.
+		{`response_code=~"5.."`, 2.5},     // errorNum
+		{"istio_requests_total", 100},     // rps + errorDen
+		{"histogram_quantile(0.50", 11.0}, // p50
+		{"histogram_quantile(0.95", 55.0}, // p95
+		{"histogram_quantile(0.99", 99.0}, // p99
 	})
 	defer srv.Close()
 	pc, err := monitoring.NewPrometheusClient(srv.URL)
@@ -426,7 +426,7 @@ func TestGoldenSignalsForService_AllQueriesFailReportsUnavailable(t *testing.T) 
 func TestHandler_GoldenSignals_RenderFailureSurfacesAs400(t *testing.T) {
 	// promClientOverride bypasses the nil-client early-exit, ensuring
 	// the render path is the one that fails.
-	srv := newFakePromServer(t, map[string]float64{"istio_requests_total": 1})
+	srv := newFakePromServer(t, []promStub{{"istio_requests_total", 1}})
 	defer srv.Close()
 	pc, err := monitoring.NewPrometheusClient(srv.URL)
 	if err != nil {
@@ -453,18 +453,24 @@ func TestHandler_GoldenSignals_RenderFailureSurfacesAs400(t *testing.T) {
 
 // --- helpers ---------------------------------------------------------------
 
+// promStub pairs a query-fragment with the scalar value the fake
+// Prometheus server should return when the PromQL query contains that
+// fragment. Callers pass an ordered slice so match precedence is
+// deterministic — a Go map would randomize iteration and silently
+// cross-wire queries whose templates share a common substring (e.g.
+// errorNum embeds istio_requests_total).
+type promStub struct {
+	frag  string
+	value float64
+}
+
 // newFakePromServer returns an httptest.Server that impersonates a
-// Prometheus v1 /api/v1/query endpoint. The values map is keyed by a
-// substring of the PromQL query; whichever entry matches first wins, so
-// callers must order the map with the most-specific fragments first.
-// Queries that match no entry produce an empty vector (valid, zero).
-func newFakePromServer(t *testing.T, values map[string]float64) *httptest.Server {
+// Prometheus v1 /api/v1/query endpoint. Stubs are checked in slice
+// order; the first fragment contained in the query wins. Callers must
+// list the most-specific fragments first. Queries that match no stub
+// produce an empty vector (valid, zero).
+func newFakePromServer(t *testing.T, stubs []promStub) *httptest.Server {
 	t.Helper()
-	// Preserve insertion order so callers control match precedence.
-	keys := make([]string, 0, len(values))
-	for k := range values {
-		keys = append(keys, k)
-	}
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v1/query" {
 			w.WriteHeader(http.StatusNotFound)
@@ -472,11 +478,11 @@ func newFakePromServer(t *testing.T, values map[string]float64) *httptest.Server
 		}
 		query := r.FormValue("query")
 		w.Header().Set("Content-Type", "application/json")
-		for _, frag := range keys {
-			if strings.Contains(query, frag) {
+		for _, s := range stubs {
+			if strings.Contains(query, s.frag) {
 				_, _ = fmt.Fprintf(w,
 					`{"status":"success","data":{"resultType":"vector","result":[{"metric":{},"value":[1,"%g"]}]}}`,
-					values[frag])
+					s.value)
 				return
 			}
 		}

--- a/backend/internal/servicemesh/mtls.go
+++ b/backend/internal/servicemesh/mtls.go
@@ -87,8 +87,9 @@ type MTLSPostureResponse struct {
 }
 
 // peerAuthRef is the precedence-resolver-friendly shape extracted from
-// a PeerAuthentication. Keep labels as map[string]string (not Selector)
-// so the resolver can compare cheaply against pod labels.
+// a PeerAuthentication. We keep the raw Selector map (for equality and
+// tests) plus a compiled labels.Selector so selectorMatches avoids
+// reallocating one per (pod, PA) pair inside computePodPostures.
 type peerAuthRef struct {
 	Namespace string
 	Name      string
@@ -97,6 +98,10 @@ type peerAuthRef struct {
 	// PA applies to the whole namespace (or whole mesh when Namespace is
 	// the mesh-root namespace).
 	Selector map[string]string
+	// compiled caches labels.SelectorFromSet(Selector). Populated by
+	// peerAuthsFromPolicies; nil in tests that construct peerAuthRef
+	// directly (selectorMatches falls back to just-in-time compilation).
+	compiled labels.Selector
 }
 
 // resolveIstioMTLSMode applies Istio's three-level precedence:
@@ -115,7 +120,7 @@ func resolveIstioMTLSMode(podLabels map[string]string, podNS, meshRootNS string,
 		pa := peerAuths[i]
 		switch {
 		case pa.Namespace == podNS && len(pa.Selector) > 0:
-			if selectorMatches(pa.Selector, podLabels) {
+			if peerAuths[i].matches(podLabels) {
 				return pa.Mode, "workload"
 			}
 		case pa.Namespace == podNS && len(pa.Selector) == 0:
@@ -144,6 +149,21 @@ func selectorMatches(selector, podLabels map[string]string) bool {
 		return false
 	}
 	return labels.SelectorFromSet(selector).Matches(labels.Set(podLabels))
+}
+
+// matches is the peerAuthRef-scoped selector check. It prefers the
+// pre-compiled selector when peerAuthsFromPolicies populated one;
+// otherwise it falls back to the allocating helper. Production code
+// paths always hit the compiled branch — the fallback exists so tests
+// constructing peerAuthRef literals stay legible.
+func (p *peerAuthRef) matches(podLabels map[string]string) bool {
+	if len(p.Selector) == 0 {
+		return false
+	}
+	if p.compiled != nil {
+		return p.compiled.Matches(labels.Set(podLabels))
+	}
+	return selectorMatches(p.Selector, podLabels)
 }
 
 // modeToState collapses a resolved PeerAuthentication mode to the
@@ -175,6 +195,14 @@ func linkerdPodState(pod *corev1.Pod) MTLSState {
 // one level of OwnerReferences, unwrapping ReplicaSet → Deployment via
 // the standard "-<hash>" suffix convention. Orphan pods key under
 // ("Pod", <podName>).
+//
+// TODO: the ReplicaSet → Deployment strip is a best-effort heuristic —
+// orphan ReplicaSets (bare RSes not owned by a Deployment, common in
+// Helm charts) and RSes with dashed non-hash suffixes like "worker-v1"
+// are reported as fabricated Deployments. Tracked as a Phase-B follow-up
+// (see memory: project_servicemesh_phase_b_followups). Treat the
+// returned kind as authoritative only for pods whose RS is clearly
+// Deployment-owned.
 func workloadKey(pod *corev1.Pod) (kind, name string) {
 	for _, or := range pod.OwnerReferences {
 		switch or.Kind {
@@ -193,6 +221,16 @@ func workloadKey(pod *corev1.Pod) (kind, name string) {
 // podMeshMembership returns which mesh (if any) a pod is a member of.
 // Sidecar-container name is the authoritative signal; annotations are
 // checked as a fallback so ambient Istio pods (no sidecar) still count.
+//
+// Known v1 scope limits (tracked in the plan's scope-boundaries section):
+//   - Istio Ambient-mode pods that have neither the istio-proxy sidecar
+//     nor the sidecar.istio.io/status annotation are classified as
+//     unmeshed. ztunnel handles L4 mTLS out-of-band, so a dedicated
+//     ambient-aware view is deferred beyond Phase B.
+//   - Linkerd workloads do not have a Prometheus cross-check equivalent
+//     to Istio's queryIstioMTLSRatios. A crashed linkerd-proxy will
+//     continue to report MTLSActive with Source=policy until the pod is
+//     restarted. Surfacing proxy-crash state is Phase D work.
 func podMeshMembership(pod *corev1.Pod) MeshType {
 	for _, c := range pod.Spec.Containers {
 		switch c.Name {
@@ -226,12 +264,16 @@ func peerAuthsFromPolicies(policies []MeshedPolicy) []peerAuthRef {
 			mode = IstioMTLSUnset
 		}
 		selector, _, _ := unstructured.NestedStringMap(p.Raw, "spec", "selector", "matchLabels")
-		out = append(out, peerAuthRef{
+		ref := peerAuthRef{
 			Namespace: p.Namespace,
 			Name:      p.Name,
 			Mode:      mode,
 			Selector:  selector,
-		})
+		}
+		if len(selector) > 0 {
+			ref.compiled = labels.SelectorFromSet(selector)
+		}
+		out = append(out, ref)
 	}
 	// Deterministic ordering: workload-scoped first within each namespace
 	// (so a workload PA beats a namespace PA when both match via the
@@ -378,13 +420,14 @@ func (r IstioMTLSRatio) Ratio() float64 {
 }
 
 // queryIstioMTLSRatios runs one PromQL instant query per namespace to
-// learn observed mTLS ratios by workload. A short 2s timeout matches the
-// plan's "never block the UI" rule; callers must tolerate a nil return.
+// learn observed mTLS ratios by workload. Uses the shared
+// promQueryTimeout budget (see metrics.go) so both Phase B Prom calls
+// share one knob and age together; callers must tolerate a nil return.
 func queryIstioMTLSRatios(ctx context.Context, pc *monitoring.PrometheusClient, namespace string) ([]IstioMTLSRatio, error) {
 	if pc == nil {
 		return nil, nil
 	}
-	queryCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	queryCtx, cancel := context.WithTimeout(ctx, promQueryTimeout)
 	defer cancel()
 
 	// Namespace is user-supplied; the existing monitoring.QueryTemplate
@@ -466,15 +509,23 @@ func applyMTLSMetricOverrides(workloads []WorkloadMTLS, ratios []IstioMTLSRatio)
 	return workloads
 }
 
-// listNamespacePods lists pods visible to the service account clientset,
-// optionally scoped to a namespace ("" means cluster-wide). RBAC filtering
-// is the caller's responsibility.
-func listNamespacePods(ctx context.Context, cs kubernetes.Interface, namespace string) ([]corev1.Pod, error) {
+// listNamespacePods lists pods visible to the caller-supplied clientset,
+// optionally scoped to a namespace ("" means cluster-wide). The caller
+// is expected to pass an impersonating client; RBAC filtering is the
+// Kubernetes API server's responsibility from that point on.
+//
+// The List call caps at meshListCap items per request and does not
+// continue. The truncated return flag tells the handler to surface a
+// response-level warning so users reading mTLS posture on very large
+// namespaces (or cluster-wide) know the result is partial rather than
+// authoritative.
+func listNamespacePods(ctx context.Context, cs kubernetes.Interface, namespace string) (pods []corev1.Pod, truncated bool, err error) {
 	callCtx, cancel := context.WithTimeout(ctx, meshListTimeout)
 	defer cancel()
-	list, err := cs.CoreV1().Pods(namespace).List(callCtx, metav1.ListOptions{Limit: meshListCap})
-	if err != nil {
-		return nil, err
+	list, lerr := cs.CoreV1().Pods(namespace).List(callCtx, metav1.ListOptions{Limit: meshListCap})
+	if lerr != nil {
+		return nil, false, lerr
 	}
-	return list.Items, nil
+	truncated = list.Continue != "" || int64(len(list.Items)) == meshListCap
+	return list.Items, truncated, nil
 }

--- a/backend/internal/servicemesh/mtls.go
+++ b/backend/internal/servicemesh/mtls.go
@@ -1,0 +1,480 @@
+package servicemesh
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/prometheus/common/model"
+
+	"github.com/kubecenter/kubecenter/internal/monitoring"
+)
+
+// MTLSState is the three-state posture surfaced to the UI. "unmeshed" is
+// a fourth value so the UI can distinguish "opted out" from "broken" —
+// the plan's explicit guidance for Unit C4.
+type MTLSState string
+
+const (
+	MTLSActive   MTLSState = "active"
+	MTLSInactive MTLSState = "inactive"
+	MTLSMixed    MTLSState = "mixed"
+	MTLSUnmeshed MTLSState = "unmeshed"
+)
+
+// MTLSSource explains where the posture decision came from. When a metric
+// cross-check overrides a policy-derived decision, Source flips to "metric".
+type MTLSSource string
+
+const (
+	MTLSSourcePolicy  MTLSSource = "policy"
+	MTLSSourceMetric  MTLSSource = "metric"
+	MTLSSourceDefault MTLSSource = "default"
+)
+
+// Istio PeerAuthentication modes. The spec field value is a string; we
+// keep a typed set so the precedence resolver can switch exhaustively.
+const (
+	IstioMTLSStrict     = "STRICT"
+	IstioMTLSPermissive = "PERMISSIVE"
+	IstioMTLSDisable    = "DISABLE"
+	// IstioMTLSUnset is the sentinel when no PeerAuthentication applies.
+	// Istio's published default is PERMISSIVE in that case, so the resolver
+	// treats UNSET as PERMISSIVE semantically but keeps the token for source
+	// disambiguation on the wire.
+	IstioMTLSUnset = "UNSET"
+)
+
+// linkerdProxyAnnotation marks a pod as meshed by Linkerd. Presence is
+// the canonical "this pod is in the mesh" signal.
+const linkerdProxyAnnotation = "linkerd.io/proxy-version"
+
+// istioMeshRootNamespace is the namespace whose empty-selector
+// PeerAuthentication acts as the mesh-wide default. Matches Istio's
+// install default; the plan explicitly limits v1 scope to this convention.
+const istioMeshRootNamespace = "istio-system"
+
+// WorkloadMTLS is a single workload's posture entry.
+type WorkloadMTLS struct {
+	Namespace    string     `json:"namespace"`
+	Workload     string     `json:"workload"`
+	WorkloadKind string     `json:"workloadKind,omitempty"`
+	Mesh         MeshType   `json:"mesh"`
+	State        MTLSState  `json:"state"`
+	Source       MTLSSource `json:"source"`
+	// IstioMode is the resolved PeerAuthentication mode
+	// (STRICT/PERMISSIVE/DISABLE/UNSET). Empty for Linkerd.
+	IstioMode string `json:"istioMode,omitempty"`
+	// SourceDetail names the scope of the winning PeerAuthentication:
+	// "workload", "namespace", or "mesh". Empty for Linkerd, for the
+	// UNSET default, or for metric-driven decisions.
+	SourceDetail string `json:"sourceDetail,omitempty"`
+}
+
+// MTLSPostureResponse is the envelope for GET /mesh/mtls.
+type MTLSPostureResponse struct {
+	Status    MeshStatus        `json:"status"`
+	Workloads []WorkloadMTLS    `json:"workloads"`
+	Errors    map[string]string `json:"errors,omitempty"`
+}
+
+// peerAuthRef is the precedence-resolver-friendly shape extracted from
+// a PeerAuthentication. Keep labels as map[string]string (not Selector)
+// so the resolver can compare cheaply against pod labels.
+type peerAuthRef struct {
+	Namespace string
+	Name      string
+	Mode      string
+	// Selector is the PA's spec.selector.matchLabels. Nil/empty means the
+	// PA applies to the whole namespace (or whole mesh when Namespace is
+	// the mesh-root namespace).
+	Selector map[string]string
+}
+
+// resolveIstioMTLSMode applies Istio's three-level precedence:
+//
+//	workload (matching selector in pod NS) > namespace (empty selector in pod NS) > mesh (empty selector in mesh root).
+//
+// Returns the winning mode and a sourceDetail string for the response.
+// When no PA applies, returns (IstioMTLSUnset, "") so the caller can
+// classify the pod as PERMISSIVE-by-default.
+func resolveIstioMTLSMode(podLabels map[string]string, podNS, meshRootNS string, peerAuths []peerAuthRef) (mode, sourceDetail string) {
+	var namespacePA, meshPA *peerAuthRef
+	// Workload-level PAs can fan out; the precedence within the same
+	// scope is implementation-defined, so pick the first match in a
+	// stable iteration (caller pre-sorts) to keep results deterministic.
+	for i := range peerAuths {
+		pa := peerAuths[i]
+		switch {
+		case pa.Namespace == podNS && len(pa.Selector) > 0:
+			if selectorMatches(pa.Selector, podLabels) {
+				return pa.Mode, "workload"
+			}
+		case pa.Namespace == podNS && len(pa.Selector) == 0:
+			if namespacePA == nil {
+				namespacePA = &peerAuths[i]
+			}
+		case pa.Namespace == meshRootNS && len(pa.Selector) == 0:
+			if meshPA == nil {
+				meshPA = &peerAuths[i]
+			}
+		}
+	}
+	if namespacePA != nil {
+		return namespacePA.Mode, "namespace"
+	}
+	if meshPA != nil {
+		return meshPA.Mode, "mesh"
+	}
+	return IstioMTLSUnset, ""
+}
+
+// selectorMatches returns true when every label in selector is present
+// in podLabels with the same value. Istio PA matchLabels are AND-ed.
+func selectorMatches(selector, podLabels map[string]string) bool {
+	if len(selector) == 0 {
+		return false
+	}
+	return labels.SelectorFromSet(selector).Matches(labels.Set(podLabels))
+}
+
+// modeToState collapses a resolved PeerAuthentication mode to the
+// unified three-state MTLSState. UNSET (no PA) and PERMISSIVE both
+// resolve to inactive: Istio's published default is PERMISSIVE.
+func modeToState(mode string) MTLSState {
+	switch mode {
+	case IstioMTLSStrict:
+		return MTLSActive
+	case IstioMTLSPermissive, IstioMTLSDisable, IstioMTLSUnset, "":
+		return MTLSInactive
+	}
+	// Unknown future mode: fail closed so the UI surfaces an explicit
+	// inactive rather than silently promoting to active.
+	return MTLSInactive
+}
+
+// linkerdPodState returns active when the pod carries the Linkerd proxy
+// annotation, unmeshed otherwise. Linkerd has no PERMISSIVE/DISABLE
+// equivalents — mTLS is default-on whenever the sidecar is injected.
+func linkerdPodState(pod *corev1.Pod) MTLSState {
+	if _, ok := pod.Annotations[linkerdProxyAnnotation]; ok {
+		return MTLSActive
+	}
+	return MTLSUnmeshed
+}
+
+// workloadKey identifies the top-level controller for a pod. We walk
+// one level of OwnerReferences, unwrapping ReplicaSet → Deployment via
+// the standard "-<hash>" suffix convention. Orphan pods key under
+// ("Pod", <podName>).
+func workloadKey(pod *corev1.Pod) (kind, name string) {
+	for _, or := range pod.OwnerReferences {
+		switch or.Kind {
+		case "ReplicaSet":
+			if idx := strings.LastIndex(or.Name, "-"); idx > 0 {
+				return "Deployment", or.Name[:idx]
+			}
+			return "ReplicaSet", or.Name
+		case "StatefulSet", "DaemonSet", "Job", "CronJob":
+			return or.Kind, or.Name
+		}
+	}
+	return "Pod", pod.Name
+}
+
+// podMeshMembership returns which mesh (if any) a pod is a member of.
+// Sidecar-container name is the authoritative signal; annotations are
+// checked as a fallback so ambient Istio pods (no sidecar) still count.
+func podMeshMembership(pod *corev1.Pod) MeshType {
+	for _, c := range pod.Spec.Containers {
+		switch c.Name {
+		case "istio-proxy":
+			return MeshIstio
+		case "linkerd-proxy":
+			return MeshLinkerd
+		}
+	}
+	if _, ok := pod.Annotations[linkerdProxyAnnotation]; ok {
+		return MeshLinkerd
+	}
+	if v, ok := pod.Annotations["sidecar.istio.io/status"]; ok && v != "" {
+		return MeshIstio
+	}
+	return MeshNone
+}
+
+// peerAuthsFromPolicies filters normalized MeshedPolicy entries down to
+// Istio PeerAuthentications and projects them into peerAuthRef. We
+// re-read the selector from Raw since MeshedPolicy.Selector is a
+// stringified form that discards the original map.
+func peerAuthsFromPolicies(policies []MeshedPolicy) []peerAuthRef {
+	out := make([]peerAuthRef, 0)
+	for _, p := range policies {
+		if p.Mesh != MeshIstio || p.Kind != "PeerAuthentication" {
+			continue
+		}
+		mode := p.MTLSMode
+		if mode == "" {
+			mode = IstioMTLSUnset
+		}
+		selector, _, _ := unstructured.NestedStringMap(p.Raw, "spec", "selector", "matchLabels")
+		out = append(out, peerAuthRef{
+			Namespace: p.Namespace,
+			Name:      p.Name,
+			Mode:      mode,
+			Selector:  selector,
+		})
+	}
+	// Deterministic ordering: workload-scoped first within each namespace
+	// (so a workload PA beats a namespace PA when both match via the
+	// precedence resolver's selector check), then by name.
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Namespace != out[j].Namespace {
+			return out[i].Namespace < out[j].Namespace
+		}
+		iw := len(out[i].Selector) > 0
+		jw := len(out[j].Selector) > 0
+		if iw != jw {
+			return iw
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+
+// computePodPostures runs the precedence resolver per pod and produces a
+// per-pod intermediate result. Workload aggregation happens in
+// aggregateWorkloads so the Prom cross-check can run between the two
+// passes without coupling to the resolver.
+type podPosture struct {
+	Namespace    string
+	PodName      string
+	PodLabels    map[string]string
+	WorkloadKind string
+	Workload     string
+	Mesh         MeshType
+	State        MTLSState
+	Source       MTLSSource
+	IstioMode    string
+	SourceDetail string
+}
+
+func computePodPostures(pods []corev1.Pod, peerAuths []peerAuthRef) []podPosture {
+	out := make([]podPosture, 0, len(pods))
+	for i := range pods {
+		pod := &pods[i]
+		mesh := podMeshMembership(pod)
+		kind, name := workloadKey(pod)
+
+		pp := podPosture{
+			Namespace:    pod.Namespace,
+			PodName:      pod.Name,
+			PodLabels:    pod.Labels,
+			WorkloadKind: kind,
+			Workload:     name,
+			Mesh:         mesh,
+		}
+
+		switch mesh {
+		case MeshIstio:
+			mode, detail := resolveIstioMTLSMode(pod.Labels, pod.Namespace, istioMeshRootNamespace, peerAuths)
+			pp.State = modeToState(mode)
+			pp.IstioMode = mode
+			pp.SourceDetail = detail
+			if detail == "" {
+				pp.Source = MTLSSourceDefault
+			} else {
+				pp.Source = MTLSSourcePolicy
+			}
+		case MeshLinkerd:
+			pp.State = linkerdPodState(pod)
+			pp.Source = MTLSSourcePolicy
+		default:
+			pp.State = MTLSUnmeshed
+			pp.Source = MTLSSourceDefault
+		}
+
+		out = append(out, pp)
+	}
+	return out
+}
+
+// aggregateWorkloads groups pod postures by (namespace, workloadKind,
+// workload) and resolves a single state per workload. Mixed membership
+// (some active, some inactive) collapses to MTLSMixed.
+func aggregateWorkloads(postures []podPosture) []WorkloadMTLS {
+	type key struct {
+		ns, kind, name string
+	}
+	groups := map[key][]podPosture{}
+	order := []key{}
+	for _, pp := range postures {
+		k := key{pp.Namespace, pp.WorkloadKind, pp.Workload}
+		if _, seen := groups[k]; !seen {
+			order = append(order, k)
+		}
+		groups[k] = append(groups[k], pp)
+	}
+
+	out := make([]WorkloadMTLS, 0, len(groups))
+	for _, k := range order {
+		members := groups[k]
+		// Start from the first pod and widen to mixed if any peer disagrees.
+		first := members[0]
+		agg := WorkloadMTLS{
+			Namespace:    first.Namespace,
+			Workload:     first.Workload,
+			WorkloadKind: first.WorkloadKind,
+			Mesh:         first.Mesh,
+			State:        first.State,
+			Source:       first.Source,
+			IstioMode:    first.IstioMode,
+			SourceDetail: first.SourceDetail,
+		}
+		for _, m := range members[1:] {
+			if m.State != agg.State {
+				agg.State = MTLSMixed
+				// Mesh divergence across pods of the same workload is
+				// pathological; keep the initial mesh label so the row
+				// still renders.
+			}
+		}
+		out = append(out, agg)
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Namespace != out[j].Namespace {
+			return out[i].Namespace < out[j].Namespace
+		}
+		return out[i].Workload < out[j].Workload
+	})
+	return out
+}
+
+// IstioMTLSRatio is the per-workload mTLS fraction reported by Prometheus.
+// Total is rps across all connection_security_policy values; MTLS is just
+// the mutual_tls subset. Ratio = MTLS/Total, 0 when Total == 0.
+type IstioMTLSRatio struct {
+	Namespace string
+	Workload  string
+	MTLS      float64
+	Total     float64
+}
+
+// Ratio returns the mTLS fraction; 0 when no traffic was observed.
+func (r IstioMTLSRatio) Ratio() float64 {
+	if r.Total == 0 {
+		return 0
+	}
+	return r.MTLS / r.Total
+}
+
+// queryIstioMTLSRatios runs one PromQL instant query per namespace to
+// learn observed mTLS ratios by workload. A short 2s timeout matches the
+// plan's "never block the UI" rule; callers must tolerate a nil return.
+func queryIstioMTLSRatios(ctx context.Context, pc *monitoring.PrometheusClient, namespace string) ([]IstioMTLSRatio, error) {
+	if pc == nil {
+		return nil, nil
+	}
+	queryCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	// Namespace is user-supplied; the existing monitoring.QueryTemplate
+	// validator rejects anything that isn't a k8s-valid name, so we run
+	// it through Render for defence in depth.
+	tmpl := monitoring.QueryTemplate{
+		Query: `sum by (destination_workload, destination_workload_namespace, connection_security_policy) (rate(istio_requests_total{destination_workload_namespace="$ns"}[5m]))`,
+		Variables: []string{"ns"},
+	}
+	q, err := tmpl.Render(map[string]string{"ns": namespace})
+	if err != nil {
+		return nil, fmt.Errorf("render istio mtls query: %w", err)
+	}
+	val, _, err := pc.Query(queryCtx, q, time.Now())
+	if err != nil {
+		return nil, err
+	}
+	vec, ok := val.(model.Vector)
+	if !ok {
+		return nil, fmt.Errorf("unexpected prometheus result type %T", val)
+	}
+	agg := map[string]*IstioMTLSRatio{}
+	for _, s := range vec {
+		workload := string(s.Metric["destination_workload"])
+		ns := string(s.Metric["destination_workload_namespace"])
+		policy := string(s.Metric["connection_security_policy"])
+		if workload == "" {
+			continue
+		}
+		key := ns + "/" + workload
+		entry, ok := agg[key]
+		if !ok {
+			entry = &IstioMTLSRatio{Namespace: ns, Workload: workload}
+			agg[key] = entry
+		}
+		v := float64(s.Value)
+		entry.Total += v
+		if policy == "mutual_tls" {
+			entry.MTLS += v
+		}
+	}
+	out := make([]IstioMTLSRatio, 0, len(agg))
+	for _, r := range agg {
+		out = append(out, *r)
+	}
+	return out, nil
+}
+
+// applyMTLSMetricOverrides promotes policy-derived "active" results to
+// "mixed" when observed traffic shows a fraction of non-mTLS requests.
+// Zero-traffic workloads keep their policy state — a silent service
+// isn't evidence against STRICT.
+func applyMTLSMetricOverrides(workloads []WorkloadMTLS, ratios []IstioMTLSRatio) []WorkloadMTLS {
+	if len(ratios) == 0 {
+		return workloads
+	}
+	byKey := map[string]IstioMTLSRatio{}
+	for _, r := range ratios {
+		byKey[r.Namespace+"/"+r.Workload] = r
+	}
+	for i := range workloads {
+		w := &workloads[i]
+		if w.Mesh != MeshIstio {
+			continue
+		}
+		r, ok := byKey[w.Namespace+"/"+w.Workload]
+		if !ok || r.Total == 0 {
+			continue
+		}
+		ratio := r.Ratio()
+		if ratio < 1.0 && ratio > 0 {
+			w.State = MTLSMixed
+			w.Source = MTLSSourceMetric
+		} else if ratio == 0 && w.State == MTLSActive {
+			w.State = MTLSInactive
+			w.Source = MTLSSourceMetric
+		}
+	}
+	return workloads
+}
+
+// listNamespacePods lists pods visible to the service account clientset,
+// optionally scoped to a namespace ("" means cluster-wide). RBAC filtering
+// is the caller's responsibility.
+func listNamespacePods(ctx context.Context, cs kubernetes.Interface, namespace string) ([]corev1.Pod, error) {
+	callCtx, cancel := context.WithTimeout(ctx, meshListTimeout)
+	defer cancel()
+	list, err := cs.CoreV1().Pods(namespace).List(callCtx, metav1.ListOptions{Limit: meshListCap})
+	if err != nil {
+		return nil, err
+	}
+	return list.Items, nil
+}

--- a/backend/internal/servicemesh/mtls_test.go
+++ b/backend/internal/servicemesh/mtls_test.go
@@ -221,6 +221,191 @@ func TestWorkloadKey_OrphanPod(t *testing.T) {
 	}
 }
 
+// TestWorkloadKey_DaemonSetJobCronJob covers the StatefulSet-adjacent
+// owner kinds that previously had no test coverage. The resolver must
+// return (OwnerKind, OwnerName) verbatim for these — no "-<hash>"
+// strip.
+func TestWorkloadKey_DaemonSetJobCronJob(t *testing.T) {
+	cases := []struct {
+		kind     string
+		ownerKey string
+	}{
+		{"DaemonSet", "fluentd"},
+		{"Job", "migrate-db"},
+		{"CronJob", "nightly-report"},
+	}
+	for _, c := range cases {
+		t.Run(c.kind, func(t *testing.T) {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod-x",
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: c.kind, Name: c.ownerKey},
+					},
+				},
+			}
+			kind, name := workloadKey(pod)
+			if kind != c.kind || name != c.ownerKey {
+				t.Errorf("got (%q,%q), want (%q,%q)", kind, name, c.kind, c.ownerKey)
+			}
+		})
+	}
+}
+
+// TestWorkloadKey_ReplicaSetNoHash: a ReplicaSet name with no hyphen
+// (e.g. a user-created RS named "frontend") falls through to the
+// (ReplicaSet, name) branch rather than attempting a Deployment strip.
+// Documents the intentional fallback.
+func TestWorkloadKey_ReplicaSetNoHash(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "frontend-0",
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "ReplicaSet", Name: "frontend"},
+			},
+		},
+	}
+	kind, name := workloadKey(pod)
+	if kind != "ReplicaSet" || name != "frontend" {
+		t.Errorf("got (%q,%q), want (ReplicaSet, frontend)", kind, name)
+	}
+}
+
+// TestPodMeshMembership_AmbientAnnotation covers the Istio ambient-mode
+// annotation path: no istio-proxy sidecar, but the
+// sidecar.istio.io/status annotation is still present. The resolver
+// classifies this as MeshIstio so ambient pods don't fall off the
+// posture table.
+func TestPodMeshMembership_AmbientAnnotation(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"sidecar.istio.io/status": `{"initContainers":[],"containers":[]}`,
+			},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "app"}}},
+	}
+	if got := podMeshMembership(pod); got != MeshIstio {
+		t.Errorf("ambient-annotated pod: mesh = %q, want %q", got, MeshIstio)
+	}
+}
+
+// --- peerAuthsFromPolicies ordering ---------------------------------------
+
+// TestPeerAuthsFromPolicies_WorkloadBeatsNamespaceInSort asserts the
+// load-bearing sort that makes the precedence resolver correct:
+// workload-scoped PAs must sort before namespace-scoped PAs within the
+// same namespace. A regression here would silently flip every
+// workload-vs-namespace decision in the cluster.
+func TestPeerAuthsFromPolicies_WorkloadBeatsNamespaceInSort(t *testing.T) {
+	policies := []MeshedPolicy{
+		{
+			Mesh: MeshIstio, Kind: "PeerAuthentication",
+			Namespace: "shop", Name: "namespace-wide",
+			MTLSMode: IstioMTLSPermissive,
+			Raw: map[string]any{
+				"spec": map[string]any{"mtls": map[string]any{"mode": IstioMTLSPermissive}},
+			},
+		},
+		{
+			Mesh: MeshIstio, Kind: "PeerAuthentication",
+			Namespace: "shop", Name: "cart-strict",
+			MTLSMode: IstioMTLSStrict,
+			Raw: map[string]any{
+				"spec": map[string]any{
+					"selector": map[string]any{
+						"matchLabels": map[string]any{"app": "cart"},
+					},
+					"mtls": map[string]any{"mode": IstioMTLSStrict},
+				},
+			},
+		},
+	}
+	out := peerAuthsFromPolicies(policies)
+	if len(out) != 2 {
+		t.Fatalf("len = %d, want 2", len(out))
+	}
+	if out[0].Name != "cart-strict" {
+		t.Errorf("first = %q, want cart-strict (workload-scoped must sort first)", out[0].Name)
+	}
+	if out[0].compiled == nil {
+		t.Error("workload-scoped PA should have a pre-compiled selector")
+	}
+	if len(out[1].Selector) != 0 {
+		t.Errorf("second = %+v, want namespace-wide (empty selector)", out[1])
+	}
+}
+
+// TestPeerAuthsFromPolicies_FiltersNonPeerAuths confirms the filter
+// drops non-PA policies and normalizes empty Mode to UNSET.
+func TestPeerAuthsFromPolicies_FiltersNonPeerAuths(t *testing.T) {
+	policies := []MeshedPolicy{
+		{Mesh: MeshIstio, Kind: "PeerAuthentication", Namespace: "shop", Name: "pa1", MTLSMode: ""},
+		{Mesh: MeshIstio, Kind: "AuthorizationPolicy", Namespace: "shop", Name: "ap"},
+		{Mesh: MeshLinkerd, Kind: "Server", Namespace: "shop", Name: "srv"},
+	}
+	out := peerAuthsFromPolicies(policies)
+	if len(out) != 1 {
+		t.Fatalf("len = %d, want 1 (only the PA)", len(out))
+	}
+	if out[0].Mode != IstioMTLSUnset {
+		t.Errorf("Mode = %q, want %q (empty normalizes to UNSET)", out[0].Mode, IstioMTLSUnset)
+	}
+}
+
+// --- cluster-wide handler path --------------------------------------------
+
+// TestHandler_MTLSPosture_ClusterWide exercises the namespace-omitted
+// path: posture should aggregate across every visible namespace and the
+// Prometheus cross-check is intentionally skipped (the template
+// requires a concrete namespace). Gives the cluster-wide code path its
+// first integration-level coverage.
+func TestHandler_MTLSPosture_ClusterWide(t *testing.T) {
+	pa := newPeerAuth(istioMeshRootNamespace, "default", IstioMTLSStrict, nil)
+	cs := fake.NewClientset(
+		injectedPod("shop", "cart-6d-xyz", map[string]string{"app": "cart"}),
+		injectedPod("billing", "invoice-4a-aa", map[string]string{"app": "invoice"}),
+	)
+
+	h := &Handler{
+		Discoverer:        seededDiscoverer(MeshStatus{Detected: MeshIstio, Istio: &MeshInfo{Installed: true, Version: "1.24.0"}}),
+		AccessChecker:     resources.NewAlwaysAllowAccessChecker(),
+		Logger:            slog.Default(),
+		dynOverride:       newIstioFakeDynClient(pa),
+		clientsetOverride: cs,
+	}
+
+	// No ?namespace= → cluster-wide.
+	req := httptest.NewRequest(http.MethodGet, "/mesh/mtls", nil)
+	req = req.WithContext(auth.ContextWithUser(req.Context(), &auth.User{KubernetesUsername: "u"}))
+	w := httptest.NewRecorder()
+	h.HandleMTLSPosture(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var env struct {
+		Data MTLSPostureResponse `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(env.Data.Workloads) != 2 {
+		t.Fatalf("workloads = %d, want 2 (one per namespace)", len(env.Data.Workloads))
+	}
+	seen := map[string]bool{}
+	for _, w := range env.Data.Workloads {
+		seen[w.Namespace] = true
+		if w.Source != MTLSSourcePolicy {
+			t.Errorf("workload %s/%s Source = %q, want policy (cluster-wide skips Prom cross-check)",
+				w.Namespace, w.Workload, w.Source)
+		}
+	}
+	if !seen["shop"] || !seen["billing"] {
+		t.Errorf("missing namespace coverage: %+v", seen)
+	}
+}
+
 // --- metric overrides ------------------------------------------------------
 
 // TestApplyMTLSMetricOverrides_MixedFromRatio: policy says STRICT, but
@@ -337,8 +522,11 @@ func TestHandler_MTLSPosture_NoMesh(t *testing.T) {
 	}
 }
 
-// TestHandler_MTLSPosture_Denied: user can't list pods → empty workloads,
-// not 403. Mirrors HandleListRoutes' precedent.
+// TestHandler_MTLSPosture_Denied: user can't list pods → 403 with a
+// user-safe message. An earlier revision returned 200 empty to match
+// HandleListRoutes' precedent, but mTLS posture is not a pure list
+// endpoint — silent denial would mask a misconfigured RBAC as
+// "no workloads in this scope" and hide real infrastructure problems.
 func TestHandler_MTLSPosture_Denied(t *testing.T) {
 	h := &Handler{
 		Discoverer:    seededDiscoverer(MeshStatus{Detected: MeshIstio, Istio: &MeshInfo{Installed: true, Version: "1.24.0"}}),
@@ -351,17 +539,8 @@ func TestHandler_MTLSPosture_Denied(t *testing.T) {
 	w := httptest.NewRecorder()
 	h.HandleMTLSPosture(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200 (denial yields empty list)", w.Code)
-	}
-	var env struct {
-		Data MTLSPostureResponse `json:"data"`
-	}
-	if err := json.Unmarshal(w.Body.Bytes(), &env); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	if len(env.Data.Workloads) != 0 {
-		t.Errorf("workloads = %d, want 0", len(env.Data.Workloads))
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", w.Code)
 	}
 }
 

--- a/backend/internal/servicemesh/mtls_test.go
+++ b/backend/internal/servicemesh/mtls_test.go
@@ -1,0 +1,538 @@
+package servicemesh
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/kubecenter/kubecenter/internal/auth"
+	"github.com/kubecenter/kubecenter/internal/k8s/resources"
+)
+
+// --- precedence resolver unit tests ----------------------------------------
+
+// TestResolveIstioMTLSMode_MeshStrict_NoOverrides is the canonical happy
+// path: a single mesh-root PeerAuthentication with STRICT applies to every
+// workload in every namespace.
+func TestResolveIstioMTLSMode_MeshStrict_NoOverrides(t *testing.T) {
+	pas := []peerAuthRef{
+		{Namespace: istioMeshRootNamespace, Name: "default", Mode: IstioMTLSStrict},
+	}
+	mode, detail := resolveIstioMTLSMode(map[string]string{"app": "cart"}, "shop", istioMeshRootNamespace, pas)
+	if mode != IstioMTLSStrict {
+		t.Errorf("mode = %q, want %q", mode, IstioMTLSStrict)
+	}
+	if detail != "mesh" {
+		t.Errorf("detail = %q, want \"mesh\"", detail)
+	}
+}
+
+// TestResolveIstioMTLSMode_NamespaceOverridesMesh: the plan scenario where
+// namespace PERMISSIVE overrides mesh STRICT.
+func TestResolveIstioMTLSMode_NamespaceOverridesMesh(t *testing.T) {
+	pas := []peerAuthRef{
+		{Namespace: istioMeshRootNamespace, Name: "default", Mode: IstioMTLSStrict},
+		{Namespace: "shop", Name: "ns-default", Mode: IstioMTLSPermissive},
+	}
+	mode, detail := resolveIstioMTLSMode(map[string]string{"app": "cart"}, "shop", istioMeshRootNamespace, pas)
+	if mode != IstioMTLSPermissive {
+		t.Errorf("mode = %q, want %q", mode, IstioMTLSPermissive)
+	}
+	if detail != "namespace" {
+		t.Errorf("detail = %q, want \"namespace\"", detail)
+	}
+}
+
+// TestResolveIstioMTLSMode_WorkloadOverridesNamespace: selector-matched
+// workload PA wins over a namespace-wide PA.
+func TestResolveIstioMTLSMode_WorkloadOverridesNamespace(t *testing.T) {
+	pas := []peerAuthRef{
+		{Namespace: "shop", Name: "cart-strict", Mode: IstioMTLSStrict, Selector: map[string]string{"app": "cart"}},
+		{Namespace: "shop", Name: "ns-default", Mode: IstioMTLSDisable},
+	}
+	mode, detail := resolveIstioMTLSMode(map[string]string{"app": "cart"}, "shop", istioMeshRootNamespace, pas)
+	if mode != IstioMTLSStrict {
+		t.Errorf("mode = %q, want %q", mode, IstioMTLSStrict)
+	}
+	if detail != "workload" {
+		t.Errorf("detail = %q, want \"workload\"", detail)
+	}
+}
+
+// TestResolveIstioMTLSMode_WorkloadDisableOverridesStrict: the edge case
+// from the plan — workload DISABLE wins over mesh/namespace STRICT.
+func TestResolveIstioMTLSMode_WorkloadDisableOverridesStrict(t *testing.T) {
+	pas := []peerAuthRef{
+		{Namespace: istioMeshRootNamespace, Name: "default", Mode: IstioMTLSStrict},
+		{Namespace: "shop", Name: "ns-default", Mode: IstioMTLSStrict},
+		{Namespace: "shop", Name: "legacy-disable", Mode: IstioMTLSDisable, Selector: map[string]string{"app": "legacy"}},
+	}
+	mode, detail := resolveIstioMTLSMode(map[string]string{"app": "legacy"}, "shop", istioMeshRootNamespace, pas)
+	if mode != IstioMTLSDisable {
+		t.Errorf("mode = %q, want %q", mode, IstioMTLSDisable)
+	}
+	if detail != "workload" {
+		t.Errorf("detail = %q, want \"workload\"", detail)
+	}
+}
+
+// TestResolveIstioMTLSMode_WorkloadSelectorMisses: a workload PA whose
+// selector does not match falls through to namespace scope.
+func TestResolveIstioMTLSMode_WorkloadSelectorMisses(t *testing.T) {
+	pas := []peerAuthRef{
+		{Namespace: "shop", Name: "cart-strict", Mode: IstioMTLSStrict, Selector: map[string]string{"app": "cart"}},
+		{Namespace: "shop", Name: "ns-default", Mode: IstioMTLSPermissive},
+	}
+	// checkout pod — does not carry app=cart.
+	mode, detail := resolveIstioMTLSMode(map[string]string{"app": "checkout"}, "shop", istioMeshRootNamespace, pas)
+	if mode != IstioMTLSPermissive {
+		t.Errorf("mode = %q, want %q", mode, IstioMTLSPermissive)
+	}
+	if detail != "namespace" {
+		t.Errorf("detail = %q, want \"namespace\"", detail)
+	}
+}
+
+// TestResolveIstioMTLSMode_NoApplicablePA: no PA in any scope falls back
+// to UNSET, which the caller classifies as PERMISSIVE per Istio's default.
+func TestResolveIstioMTLSMode_NoApplicablePA(t *testing.T) {
+	mode, detail := resolveIstioMTLSMode(map[string]string{"app": "cart"}, "shop", istioMeshRootNamespace, nil)
+	if mode != IstioMTLSUnset {
+		t.Errorf("mode = %q, want %q", mode, IstioMTLSUnset)
+	}
+	if detail != "" {
+		t.Errorf("detail = %q, want \"\"", detail)
+	}
+}
+
+// --- modeToState -----------------------------------------------------------
+
+func TestModeToState(t *testing.T) {
+	cases := map[string]MTLSState{
+		IstioMTLSStrict:     MTLSActive,
+		IstioMTLSPermissive: MTLSInactive,
+		IstioMTLSDisable:    MTLSInactive,
+		IstioMTLSUnset:      MTLSInactive,
+		"":                  MTLSInactive,
+		"MYSTERY":           MTLSInactive, // unknown future mode fails closed
+	}
+	for mode, want := range cases {
+		if got := modeToState(mode); got != want {
+			t.Errorf("modeToState(%q) = %q, want %q", mode, got, want)
+		}
+	}
+}
+
+// --- Linkerd ---------------------------------------------------------------
+
+// TestLinkerdPodState_Meshed covers the plan's edge case: a Linkerd pod in
+// an unmeshed namespace is still active because the proxy annotation wins.
+func TestLinkerdPodState_Meshed(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "web-abc",
+			Namespace:   "default", // namespace has no injection label
+			Annotations: map[string]string{linkerdProxyAnnotation: "edge-25.1.1"},
+		},
+	}
+	if got := linkerdPodState(pod); got != MTLSActive {
+		t.Errorf("state = %q, want %q", got, MTLSActive)
+	}
+}
+
+func TestLinkerdPodState_Unmeshed(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "raw"}}
+	if got := linkerdPodState(pod); got != MTLSUnmeshed {
+		t.Errorf("state = %q, want %q", got, MTLSUnmeshed)
+	}
+}
+
+// --- mesh membership -------------------------------------------------------
+
+func TestPodMeshMembership(t *testing.T) {
+	sidecar := func(name string) *corev1.Pod {
+		return &corev1.Pod{
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "app"}, {Name: name}}},
+		}
+	}
+	if got := podMeshMembership(sidecar("istio-proxy")); got != MeshIstio {
+		t.Errorf("istio-proxy sidecar: mesh = %q, want %q", got, MeshIstio)
+	}
+	if got := podMeshMembership(sidecar("linkerd-proxy")); got != MeshLinkerd {
+		t.Errorf("linkerd-proxy sidecar: mesh = %q, want %q", got, MeshLinkerd)
+	}
+	annotated := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{linkerdProxyAnnotation: "x"}},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "app"}}},
+	}
+	if got := podMeshMembership(annotated); got != MeshLinkerd {
+		t.Errorf("linkerd-annotated: mesh = %q, want %q", got, MeshLinkerd)
+	}
+	bare := &corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "app"}}}}
+	if got := podMeshMembership(bare); got != MeshNone {
+		t.Errorf("bare pod: mesh = %q, want %q", got, MeshNone)
+	}
+}
+
+// --- workloadKey -----------------------------------------------------------
+
+func TestWorkloadKey_DeploymentStrippedFromReplicaSet(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cart-6d4b7-xyz",
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "ReplicaSet", Name: "cart-6d4b7"},
+			},
+		},
+	}
+	kind, name := workloadKey(pod)
+	if kind != "Deployment" || name != "cart" {
+		t.Errorf("got (%q,%q), want (Deployment, cart)", kind, name)
+	}
+}
+
+func TestWorkloadKey_StatefulSet(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "db-0",
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "StatefulSet", Name: "db"},
+			},
+		},
+	}
+	kind, name := workloadKey(pod)
+	if kind != "StatefulSet" || name != "db" {
+		t.Errorf("got (%q,%q), want (StatefulSet, db)", kind, name)
+	}
+}
+
+func TestWorkloadKey_OrphanPod(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "solo"}}
+	kind, name := workloadKey(pod)
+	if kind != "Pod" || name != "solo" {
+		t.Errorf("got (%q,%q), want (Pod, solo)", kind, name)
+	}
+}
+
+// --- metric overrides ------------------------------------------------------
+
+// TestApplyMTLSMetricOverrides_MixedFromRatio: policy says STRICT, but
+// the metric cross-check observed 90% mTLS → posture becomes mixed.
+func TestApplyMTLSMetricOverrides_MixedFromRatio(t *testing.T) {
+	wl := []WorkloadMTLS{
+		{Namespace: "shop", Workload: "cart", Mesh: MeshIstio, State: MTLSActive, Source: MTLSSourcePolicy, IstioMode: IstioMTLSStrict},
+	}
+	ratios := []IstioMTLSRatio{
+		{Namespace: "shop", Workload: "cart", MTLS: 90, Total: 100},
+	}
+	out := applyMTLSMetricOverrides(wl, ratios)
+	if out[0].State != MTLSMixed {
+		t.Errorf("state = %q, want %q", out[0].State, MTLSMixed)
+	}
+	if out[0].Source != MTLSSourceMetric {
+		t.Errorf("source = %q, want %q", out[0].Source, MTLSSourceMetric)
+	}
+}
+
+// TestApplyMTLSMetricOverrides_ZeroTrafficLeavesPolicyAlone is the
+// no-traffic edge case: a silent service keeps its policy-derived state.
+func TestApplyMTLSMetricOverrides_ZeroTrafficLeavesPolicyAlone(t *testing.T) {
+	wl := []WorkloadMTLS{
+		{Namespace: "shop", Workload: "cart", Mesh: MeshIstio, State: MTLSActive, Source: MTLSSourcePolicy},
+	}
+	ratios := []IstioMTLSRatio{
+		{Namespace: "shop", Workload: "cart", MTLS: 0, Total: 0},
+	}
+	out := applyMTLSMetricOverrides(wl, ratios)
+	if out[0].State != MTLSActive || out[0].Source != MTLSSourcePolicy {
+		t.Errorf("got (%q,%q), want (active, policy)", out[0].State, out[0].Source)
+	}
+}
+
+// TestApplyMTLSMetricOverrides_AllMTLSPreservesActive: 100% mTLS means
+// policy and metric agree — no override.
+func TestApplyMTLSMetricOverrides_AllMTLSPreservesActive(t *testing.T) {
+	wl := []WorkloadMTLS{
+		{Namespace: "shop", Workload: "cart", Mesh: MeshIstio, State: MTLSActive, Source: MTLSSourcePolicy},
+	}
+	ratios := []IstioMTLSRatio{
+		{Namespace: "shop", Workload: "cart", MTLS: 100, Total: 100},
+	}
+	out := applyMTLSMetricOverrides(wl, ratios)
+	if out[0].State != MTLSActive || out[0].Source != MTLSSourcePolicy {
+		t.Errorf("got (%q,%q), want (active, policy)", out[0].State, out[0].Source)
+	}
+}
+
+// TestApplyMTLSMetricOverrides_AllPlaintextFlipsToInactive: metric says
+// zero mTLS on an "active" policy → demote to inactive with source=metric.
+func TestApplyMTLSMetricOverrides_AllPlaintextFlipsToInactive(t *testing.T) {
+	wl := []WorkloadMTLS{
+		{Namespace: "shop", Workload: "cart", Mesh: MeshIstio, State: MTLSActive, Source: MTLSSourcePolicy},
+	}
+	ratios := []IstioMTLSRatio{
+		{Namespace: "shop", Workload: "cart", MTLS: 0, Total: 100},
+	}
+	out := applyMTLSMetricOverrides(wl, ratios)
+	if out[0].State != MTLSInactive || out[0].Source != MTLSSourceMetric {
+		t.Errorf("got (%q,%q), want (inactive, metric)", out[0].State, out[0].Source)
+	}
+}
+
+// --- aggregation -----------------------------------------------------------
+
+// TestAggregateWorkloads_MixedPodsCollapseToMixed: two pods of the same
+// deployment with different states roll up to MTLSMixed.
+func TestAggregateWorkloads_MixedPodsCollapseToMixed(t *testing.T) {
+	postures := []podPosture{
+		{Namespace: "shop", Workload: "cart", WorkloadKind: "Deployment", Mesh: MeshIstio, State: MTLSActive},
+		{Namespace: "shop", Workload: "cart", WorkloadKind: "Deployment", Mesh: MeshIstio, State: MTLSInactive},
+	}
+	out := aggregateWorkloads(postures)
+	if len(out) != 1 {
+		t.Fatalf("len = %d, want 1", len(out))
+	}
+	if out[0].State != MTLSMixed {
+		t.Errorf("state = %q, want %q", out[0].State, MTLSMixed)
+	}
+}
+
+// --- handler integration ---------------------------------------------------
+
+// TestHandler_MTLSPosture_NoMesh: plan scenario — no mesh installed
+// returns an empty workloads slice (never nil) with detected="none".
+func TestHandler_MTLSPosture_NoMesh(t *testing.T) {
+	h := &Handler{
+		Discoverer:    seededDiscoverer(MeshStatus{Detected: MeshNone}),
+		AccessChecker: resources.NewAlwaysAllowAccessChecker(),
+		Logger:        slog.Default(),
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/mesh/mtls", nil)
+	req = req.WithContext(auth.ContextWithUser(req.Context(), &auth.User{KubernetesUsername: "u"}))
+	w := httptest.NewRecorder()
+	h.HandleMTLSPosture(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var env struct {
+		Data MTLSPostureResponse `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if env.Data.Status.Detected != MeshNone {
+		t.Errorf("detected = %q, want %q", env.Data.Status.Detected, MeshNone)
+	}
+	if env.Data.Workloads == nil {
+		t.Error("Workloads is nil; frontend treats null as error — want empty slice")
+	}
+}
+
+// TestHandler_MTLSPosture_Denied: user can't list pods → empty workloads,
+// not 403. Mirrors HandleListRoutes' precedent.
+func TestHandler_MTLSPosture_Denied(t *testing.T) {
+	h := &Handler{
+		Discoverer:    seededDiscoverer(MeshStatus{Detected: MeshIstio, Istio: &MeshInfo{Installed: true, Version: "1.24.0"}}),
+		AccessChecker: resources.NewAlwaysDenyAccessChecker(),
+		Logger:        slog.Default(),
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/mesh/mtls", nil)
+	req = req.WithContext(auth.ContextWithUser(req.Context(), &auth.User{KubernetesUsername: "u"}))
+	w := httptest.NewRecorder()
+	h.HandleMTLSPosture(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (denial yields empty list)", w.Code)
+	}
+	var env struct {
+		Data MTLSPostureResponse `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(env.Data.Workloads) != 0 {
+		t.Errorf("workloads = %d, want 0", len(env.Data.Workloads))
+	}
+}
+
+// TestHandler_MTLSPosture_IstioNamespaceStrict: end-to-end integration
+// with a real fake clientset. A single Istio-injected pod in a namespace
+// with mesh-root STRICT resolves to active/policy/mesh.
+func TestHandler_MTLSPosture_IstioNamespaceStrict(t *testing.T) {
+	pa := newPeerAuth(istioMeshRootNamespace, "default", IstioMTLSStrict, nil)
+	cs := fake.NewClientset(injectedPod("shop", "cart-6d-xyz", map[string]string{"app": "cart"}))
+
+	h := &Handler{
+		Discoverer:        seededDiscoverer(MeshStatus{Detected: MeshIstio, Istio: &MeshInfo{Installed: true, Version: "1.24.0"}}),
+		AccessChecker:     resources.NewAlwaysAllowAccessChecker(),
+		Logger:            slog.Default(),
+		dynOverride:       newIstioFakeDynClient(pa),
+		clientsetOverride: cs,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/mesh/mtls?namespace=shop", nil)
+	q := req.URL.Query()
+	q.Set("namespace", "shop")
+	req.URL.RawQuery = q.Encode()
+	req = req.WithContext(auth.ContextWithUser(req.Context(), &auth.User{KubernetesUsername: "u"}))
+	w := httptest.NewRecorder()
+	h.HandleMTLSPosture(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var env struct {
+		Data MTLSPostureResponse `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(env.Data.Workloads) != 1 {
+		t.Fatalf("workloads = %d, want 1", len(env.Data.Workloads))
+	}
+	got := env.Data.Workloads[0]
+	if got.Workload != "cart" {
+		t.Errorf("Workload = %q, want cart", got.Workload)
+	}
+	if got.State != MTLSActive {
+		t.Errorf("State = %q, want %q", got.State, MTLSActive)
+	}
+	if got.Source != MTLSSourcePolicy {
+		t.Errorf("Source = %q, want %q", got.Source, MTLSSourcePolicy)
+	}
+	if got.SourceDetail != "mesh" {
+		t.Errorf("SourceDetail = %q, want mesh", got.SourceDetail)
+	}
+	if got.IstioMode != IstioMTLSStrict {
+		t.Errorf("IstioMode = %q, want %q", got.IstioMode, IstioMTLSStrict)
+	}
+}
+
+// TestHandler_MTLSPosture_LinkerdMeshed: a Linkerd-injected pod with the
+// proxy annotation resolves to active/policy/empty-detail.
+func TestHandler_MTLSPosture_LinkerdMeshed(t *testing.T) {
+	cs := fake.NewClientset(linkerdPod("shop", "web-abc", map[string]string{"app": "web"}))
+
+	h := &Handler{
+		Discoverer:        seededDiscoverer(MeshStatus{Detected: MeshLinkerd, Linkerd: &MeshInfo{Installed: true, Version: "edge-25"}}),
+		AccessChecker:     resources.NewAlwaysAllowAccessChecker(),
+		Logger:            slog.Default(),
+		dynOverride:       newLinkerdFakeDynClient(),
+		clientsetOverride: cs,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/mesh/mtls?namespace=shop", nil)
+	req = req.WithContext(auth.ContextWithUser(req.Context(), &auth.User{KubernetesUsername: "u"}))
+	w := httptest.NewRecorder()
+	h.HandleMTLSPosture(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var env struct {
+		Data MTLSPostureResponse `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(env.Data.Workloads) != 1 {
+		t.Fatalf("workloads = %d, want 1", len(env.Data.Workloads))
+	}
+	got := env.Data.Workloads[0]
+	if got.Mesh != MeshLinkerd || got.State != MTLSActive {
+		t.Errorf("got (mesh=%q state=%q), want (linkerd, active)", got.Mesh, got.State)
+	}
+}
+
+// --- helpers ---------------------------------------------------------------
+
+// newPeerAuth returns an unstructured PeerAuthentication for fake client
+// seeding. selector nil means namespace/mesh-level (no spec.selector).
+func newPeerAuth(ns, name, mode string, selector map[string]string) *unstructured.Unstructured {
+	spec := map[string]any{
+		"mtls": map[string]any{"mode": mode},
+	}
+	if len(selector) > 0 {
+		sel := map[string]any{}
+		for k, v := range selector {
+			sel[k] = v
+		}
+		spec["selector"] = map[string]any{"matchLabels": sel}
+	}
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "security.istio.io/v1",
+			"kind":       "PeerAuthentication",
+			"metadata":   map[string]any{"name": name, "namespace": ns},
+			"spec":       spec,
+		},
+	}
+}
+
+// injectedPod returns a pod with the istio-proxy sidecar container and
+// the standard Deployment → ReplicaSet → Pod ownership chain.
+func injectedPod(ns, name string, labels map[string]string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Labels:    labels,
+			Annotations: map[string]string{
+				"sidecar.istio.io/status": `{"initContainers":["istio-init"],"containers":["istio-proxy"]}`,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "ReplicaSet", Name: deriveRSName(name)},
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "app", Image: "cart:1"},
+				{Name: "istio-proxy", Image: "istio/proxyv2:1.24"},
+			},
+		},
+	}
+}
+
+func linkerdPod(ns, name string, labels map[string]string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   ns,
+			Labels:      labels,
+			Annotations: map[string]string{linkerdProxyAnnotation: "edge-25.1.1"},
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "ReplicaSet", Name: deriveRSName(name)},
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "app", Image: "web:1"},
+				{Name: "linkerd-proxy", Image: "cr.l5d.io/proxy:edge-25"},
+			},
+		},
+	}
+}
+
+// deriveRSName strips the last "-xxx" suffix of a pod name so that pod
+// "cart-6d-xyz" yields RS "cart-6d" — the workload resolver in turn
+// strips to "cart". Mirrors the Deployment naming convention without
+// recreating the hash algorithm.
+func deriveRSName(podName string) string {
+	for i := len(podName) - 1; i > 0; i-- {
+		if podName[i] == '-' {
+			return podName[:i]
+		}
+	}
+	return podName
+}
+


### PR DESCRIPTION
## Summary

Phase B of the service mesh observability feature, adding two read-only endpoints on top of the Phase A inventory/discovery layer:

- **`GET /mesh/mtls?namespace=<ns>`** — per-workload mTLS posture. Istio PeerAuthentication precedence (workload → namespace → mesh default) with a Prometheus cross-check when available; endpoint degrades gracefully to policy-only when Prom is offline.
- **`GET /mesh/golden-signals?namespace=<ns>&service=<svc>[&mesh=istio|linkerd]`** — RPS, error rate, and P50/P95/P99 latency via per-mesh PromQL templates. Six-query fan-out runs in parallel; partial failures surface what's available rather than blanking the whole response.

Both endpoints are RBAC-filtered via `CanAccessGroupResource`, use user impersonation (not the service account's client), and route through the same singleflight + 30s cache pattern as the Phase A status endpoint. Golden-signals is whitelisted in `SanitizeError` so render-stage validation errors map to HTTP 400 with user-safe messages (no internal render-key prefixes leak into bodies).

Phase B review remediation (commit 7c469bd) addressed three findings from `/ce:review`:
- `HandleMTLSPosture` now uses the user-impersonating client instead of the service-account clientset.
- Partial-failure accumulation in the six-query fan-out no longer discards RPS + error rate when the slowest query (typically P99) errors out.
- Response envelope is consistent across success, degraded, and error paths.

Scope boundaries (documented in `plans/service-mesh-observability.md`): Istio Ambient mode and custom cluster-domain handling are deferred to a later phase; mTLS posture assumes `cluster.local`.

## Changes

- `backend/internal/servicemesh/mtls.go` (+531) — mTLS posture engine with PeerAuthentication precedence + Prom cross-check
- `backend/internal/servicemesh/metrics.go` (+257) — golden-signals fan-out with per-mesh PromQL templates
- `backend/internal/servicemesh/handler.go` — `HandleMTLSPosture` + `HandleGoldenSignals` wired in
- `backend/internal/server/routes.go`, `backend/cmd/kubecenter/main.go` — endpoint wiring
- `backend/internal/servicemesh/{mtls,metrics}_test.go` (+1212) — covers precedence, partial-failure fan-out, render-error surfacing, and RBAC. A map-order bug in the fake Prom server (commit 5d34f43) was fixed so `TestGoldenSignalsForService_HappyPath` is deterministic across runs.
- `CLAUDE.md` — documents the two new endpoints in the mesh section

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/servicemesh/...` passes 3× consecutively (verifying the fake-Prom ordering fix)
- [ ] CI green on this PR
- [ ] Homelab smoke test against a live Istio namespace before merge: hit `/mesh/mtls?namespace=...` and `/mesh/golden-signals?namespace=...&service=...`

## Follow-ups (deferred, tracked in memory)

- Prometheus integration test against a real Prom fixture (not just the fake server)
- `workloadKey` heuristic hardening for edge-case workload names
- Cluster-wide mTLS cross-check (current endpoint is namespace-scoped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)