### PR TITLE
fix(servicemesh): Phase B mTLS follow-ups — RS heuristic + cluster-wide cross-check

### DIFF
--- a/backend/internal/servicemesh/handler.go
+++ b/backend/internal/servicemesh/handler.go
@@ -650,20 +650,37 @@ func (h *Handler) HandleMTLSPosture(w http.ResponseWriter, r *http.Request) {
 	postures := computePodPostures(pods, peerAuths, rsOwners)
 	workloads := aggregateWorkloads(postures)
 
-	// Prom cross-check fires for both scoped and cluster-wide requests.
-	// queryIstioMTLSRatios switches between the namespace-filtered and
-	// cluster-wide PromQL templates based on the namespace argument; the
-	// cross-check still degrades silently to policy-only when Prometheus
-	// is offline. Skip the call when workloads is empty: applyMTLSMetricOverrides
-	// is a no-op on an empty slice, so the Prom round-trip would have no
-	// consumer (covers both pod-list-failure and zero-meshed-pods cases).
-	if pc := h.promClient(); pc != nil && len(workloads) > 0 {
+	// Prom cross-check fires for both scoped and cluster-wide requests
+	// when Istio is part of the detected mesh. queryIstioMTLSRatios
+	// switches between the namespace-filtered and cluster-wide PromQL
+	// templates based on the namespace argument; the cross-check still
+	// degrades silently to policy-only when Prometheus is offline.
+	//
+	// Skip conditions:
+	//   - workloads empty: applyMTLSMetricOverrides is a no-op so the
+	//     Prom round-trip would have no consumer (also covers the
+	//     pod-list-failure and zero-meshed-pods cases).
+	//   - mesh is Linkerd-only: the query template targets
+	//     istio_requests_total; Linkerd has no equivalent and
+	//     applyMTLSMetricOverrides already filters by Mesh != MeshIstio,
+	//     so the call would be wasted on a Linkerd-only cluster.
+	istioPresent := status.Detected == MeshIstio || status.Detected == MeshBoth
+	if pc := h.promClient(); pc != nil && len(workloads) > 0 && istioPresent {
 		ratios, perr := queryIstioMTLSRatios(r.Context(), pc, namespace)
 		if perr != nil {
 			h.Logger.Warn("mTLS metric cross-check failed; falling back to policy-only", "user", user.KubernetesUsername, "namespace", namespace, "error", perr)
 			errs["prometheus-cross-check"] = "metric cross-check unavailable; posture derived from policies only"
 		} else {
 			workloads = applyMTLSMetricOverrides(workloads, ratios)
+			// When the pod list was capped AND the Prom cross-check ran
+			// cluster-wide, the metric ratios cover the full cluster but
+			// only the visible pods are in the response. Ratios for
+			// invisible workloads were silently dropped. Surface this so
+			// "Source=metric" rows aren't read as authoritative on a
+			// partial pod set.
+			if truncated && namespace == "" {
+				errs["truncated"] = fmt.Sprintf("result capped at %d pods; metric cross-check covered only visible workloads (pass ?namespace= to scope the request)", meshListCap)
+			}
 		}
 	}
 

--- a/backend/internal/servicemesh/handler.go
+++ b/backend/internal/servicemesh/handler.go
@@ -634,11 +634,12 @@ func (h *Handler) HandleMTLSPosture(w http.ResponseWriter, r *http.Request) {
 	postures := computePodPostures(pods, peerAuths)
 	workloads := aggregateWorkloads(postures)
 
-	// Prom cross-check is only meaningful when the query template can be
-	// bound to a concrete namespace. Cluster-wide requests skip it by
-	// design; a surfaced follow-up will either aggregate across known
-	// namespaces or rewrite the template to run un-scoped.
-	if pc := h.promClient(); pc != nil && namespace != "" {
+	// Prom cross-check fires for both scoped and cluster-wide requests.
+	// queryIstioMTLSRatios switches between the namespace-filtered and
+	// cluster-wide PromQL templates based on the namespace argument; the
+	// cross-check still degrades silently to policy-only when Prometheus
+	// is offline.
+	if pc := h.promClient(); pc != nil {
 		ratios, perr := queryIstioMTLSRatios(r.Context(), pc, namespace)
 		if perr != nil {
 			h.Logger.Warn("mTLS metric cross-check failed; falling back to policy-only", "user", user.KubernetesUsername, "namespace", namespace, "error", perr)

--- a/backend/internal/servicemesh/handler.go
+++ b/backend/internal/servicemesh/handler.go
@@ -542,9 +542,10 @@ func (h *Handler) promClient() *monitoring.PrometheusClient {
 // The handler is read-only and degrades gracefully:
 //   - no mesh → empty workloads slice with status.detected == "none"
 //   - Prometheus offline → policy-only results
-//   - cluster-wide request → Prom cross-check is skipped (the template
-//     requires a concrete destination_workload_namespace); posture is
-//     policy-derived only. Revisiting this is tracked as a follow-up.
+//   - cluster-wide request → Prom cross-check fires against an
+//     unfiltered template that aggregates across all namespaces.
+//     queryIstioMTLSRatios picks the scoped vs cluster-wide template
+//     based on the namespace argument.
 //
 // Partial failure policy: pod-list and policy-fetch failures are
 // accumulated into resp.Errors with user-safe messages and internal
@@ -638,8 +639,10 @@ func (h *Handler) HandleMTLSPosture(w http.ResponseWriter, r *http.Request) {
 	// queryIstioMTLSRatios switches between the namespace-filtered and
 	// cluster-wide PromQL templates based on the namespace argument; the
 	// cross-check still degrades silently to policy-only when Prometheus
-	// is offline.
-	if pc := h.promClient(); pc != nil {
+	// is offline. Skip the call entirely when there are no workloads to
+	// override — pod-list errors leave workloads empty and a wasted Prom
+	// query on a degraded cluster has no upside.
+	if pc := h.promClient(); pc != nil && len(workloads) > 0 {
 		ratios, perr := queryIstioMTLSRatios(r.Context(), pc, namespace)
 		if perr != nil {
 			h.Logger.Warn("mTLS metric cross-check failed; falling back to policy-only", "user", user.KubernetesUsername, "namespace", namespace, "error", perr)

--- a/backend/internal/servicemesh/handler.go
+++ b/backend/internal/servicemesh/handler.go
@@ -632,16 +632,31 @@ func (h *Handler) HandleMTLSPosture(w http.ResponseWriter, r *http.Request) {
 		peerAuths = filtered
 	}
 
-	postures := computePodPostures(pods, peerAuths)
+	// rsOwners makes WorkloadKind authoritative for RS-owned pods. The
+	// list call uses the same impersonating client and budget as the
+	// pod list, but degrades silently — RBAC denial, timeout, or any
+	// other failure leaves the map nil and workloadKey falls back to
+	// the alphabet heuristic with WorkloadKindConfident=false. We do
+	// not surface this as a partial-failure error key because the
+	// fallback still produces a usable response; clients can read
+	// WorkloadKindConfident on each row.
+	var rsOwners map[string]rsOwner
+	if rss, rerr := listReplicaSetControllers(r.Context(), cs, namespace); rerr != nil {
+		h.Logger.Debug("rs owner lookup unavailable; workload kinds derived heuristically", "user", user.KubernetesUsername, "namespace", namespace, "error", rerr)
+	} else {
+		rsOwners = rss
+	}
+
+	postures := computePodPostures(pods, peerAuths, rsOwners)
 	workloads := aggregateWorkloads(postures)
 
 	// Prom cross-check fires for both scoped and cluster-wide requests.
 	// queryIstioMTLSRatios switches between the namespace-filtered and
 	// cluster-wide PromQL templates based on the namespace argument; the
 	// cross-check still degrades silently to policy-only when Prometheus
-	// is offline. Skip the call entirely when there are no workloads to
-	// override — pod-list errors leave workloads empty and a wasted Prom
-	// query on a degraded cluster has no upside.
+	// is offline. Skip the call when workloads is empty: applyMTLSMetricOverrides
+	// is a no-op on an empty slice, so the Prom round-trip would have no
+	// consumer (covers both pod-list-failure and zero-meshed-pods cases).
 	if pc := h.promClient(); pc != nil && len(workloads) > 0 {
 		ratios, perr := queryIstioMTLSRatios(r.Context(), pc, namespace)
 		if perr != nil {

--- a/backend/internal/servicemesh/mtls.go
+++ b/backend/internal/servicemesh/mtls.go
@@ -3,6 +3,7 @@ package servicemesh
 import (
 	"context"
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 	"time"
@@ -77,6 +78,13 @@ type WorkloadMTLS struct {
 	// "workload", "namespace", or "mesh". Empty for Linkerd, for the
 	// UNSET default, or for metric-driven decisions.
 	SourceDetail string `json:"sourceDetail,omitempty"`
+	// WorkloadKindConfident is true when WorkloadKind was confirmed via a
+	// ReplicaSet owner-reference lookup (or by a non-RS top-level kind
+	// like StatefulSet). False when derived from the alphabet heuristic
+	// because the RS list call failed or was RBAC-denied — the kind
+	// could be a fabricated Deployment from a user-named RS. UI clients
+	// should mark non-confident rows visually.
+	WorkloadKindConfident bool `json:"workloadKindConfident"`
 }
 
 // MTLSPostureResponse is the envelope for GET /mesh/mtls.
@@ -191,39 +199,96 @@ func linkerdPodState(pod *corev1.Pod) MTLSState {
 	return MTLSUnmeshed
 }
 
-// workloadKey identifies the top-level controller for a pod. We walk
-// one level of OwnerReferences, unwrapping a Deployment-owned
-// ReplicaSet via the kube-controller "-<hash>" suffix convention.
-// Orphan ReplicaSets and user-named RSes whose suffix is not a real
-// pod-template-hash are reported verbatim as ReplicaSet so we never
-// fabricate a Deployment that isn't there. Orphan pods key under
-// ("Pod", <podName>).
-func workloadKey(pod *corev1.Pod) (kind, name string) {
+// rsOwner is a normalized record of a ReplicaSet's controller owner
+// reference. Populated by listReplicaSetControllers; consulted by
+// workloadKey to decide whether an RS-owned pod should report its
+// top-level Deployment authoritatively or fall back to the heuristic.
+type rsOwner struct {
+	Kind string
+	Name string
+}
+
+// listReplicaSetControllers returns a map keyed on "ns/rsname" of every
+// ReplicaSet's controller owner reference. namespace=="" lists
+// cluster-wide. Errors are non-fatal: callers pass the returned map
+// (possibly nil) into workloadKey, which falls back to the alphabet
+// heuristic when an entry is missing. The same meshListCap/Timeout
+// budget as listNamespacePods applies.
+func listReplicaSetControllers(ctx context.Context, cs kubernetes.Interface, namespace string) (map[string]rsOwner, error) {
+	callCtx, cancel := context.WithTimeout(ctx, meshListTimeout)
+	defer cancel()
+	list, err := cs.AppsV1().ReplicaSets(namespace).List(callCtx, metav1.ListOptions{Limit: meshListCap})
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]rsOwner, len(list.Items))
+	for i := range list.Items {
+		rs := &list.Items[i]
+		for _, or := range rs.OwnerReferences {
+			if or.Controller != nil && *or.Controller {
+				out[rs.Namespace+"/"+rs.Name] = rsOwner{Kind: or.Kind, Name: or.Name}
+				break
+			}
+		}
+	}
+	return out, nil
+}
+
+// workloadKey identifies the top-level controller for a pod and
+// reports whether the answer is authoritative. When rsOwners is
+// non-nil, an RS-owned pod looks up the owner reference directly and
+// the result is confident. When rsOwners is nil (RS list failed or
+// was RBAC-denied), the function falls back to the alphabet heuristic
+// — Deployment-owned ReplicaSets are recognized by a kube-controller
+// pod-template-hash suffix, and the "Deployment" kind is marked
+// non-confident so the response can flag the row to the UI. Orphan
+// pods key under ("Pod", <podName>) and are always confident.
+func workloadKey(pod *corev1.Pod, rsOwners map[string]rsOwner) (kind, name string, confident bool) {
 	for _, or := range pod.OwnerReferences {
 		switch or.Kind {
 		case "ReplicaSet":
-			if idx := strings.LastIndex(or.Name, "-"); idx > 0 && isReplicaSetHashSuffix(or.Name[idx+1:]) {
-				return "Deployment", or.Name[:idx]
+			if rsOwners != nil {
+				if owner, ok := rsOwners[pod.Namespace+"/"+or.Name]; ok {
+					if owner.Kind == "Deployment" {
+						return "Deployment", owner.Name, true
+					}
+					// Non-Deployment RS owner (e.g. Argo Rollout) or
+					// no controller-owner: report the RS verbatim
+					// rather than mis-classifying.
+					return "ReplicaSet", or.Name, true
+				}
+				// RS missing from the map: race (RS deleted between
+				// pod and rs list), truncation, or selective RBAC.
+				// Fall through to the heuristic, marked non-confident.
 			}
-			return "ReplicaSet", or.Name
+			if idx := strings.LastIndex(or.Name, "-"); idx > 0 && isReplicaSetHashSuffix(or.Name[idx+1:]) {
+				return "Deployment", or.Name[:idx], false
+			}
+			return "ReplicaSet", or.Name, false
 		case "StatefulSet", "DaemonSet", "Job", "CronJob":
-			return or.Kind, or.Name
+			return or.Kind, or.Name, true
 		}
 	}
-	return "Pod", pod.Name
+	return "Pod", pod.Name, true
 }
 
 // isReplicaSetHashSuffix reports whether s looks like a kube-controller
 // pod-template-hash. Modern Deployment hashes are produced by
-// k8s.io/apimachinery/pkg/util/rand.SafeEncodeString, which translates
-// every byte through a 27-character alphabet that excludes vowels and
-// the digits 0/1/3 (avoids generating profanity-like strings). The
-// length tracks fmt.Sprint(uint32) — never more than 10 chars — and we
-// floor at 5 to match the shortest hash kube-controller is observed to
-// produce in real clusters. A match is a strong signal that the "-"
-// stripped from a ReplicaSet name belongs to a Deployment; a miss
-// means the suffix is a user-chosen string ("worker-v1", "app-12345")
-// and the name should be treated as the workload itself.
+// k8s.io/apimachinery/pkg/util/rand.SafeEncodeString (apimachinery
+// pkg/util/rand/rand.go), which translates every byte through a
+// 27-character alphabet that excludes vowels and the digits 0/1/3
+// (avoids generating profanity-like strings). The length tracks
+// fmt.Sprint(uint32) — never more than 10 chars. We floor at 5: real
+// kube-controller output is bounded above by 10 but the lower bound
+// is empirical, not derived. uint32 hash values 0–9999 produce 1–4
+// char outputs and would be misclassified as user-named RSes (rate
+// ~2.3e-6 per workload); accepting that as a graceful false negative
+// is preferable to the prior code's false positive (fabricated
+// Deployment from any "-<suffix>" RS name). A match is a strong
+// signal that the "-" stripped from a ReplicaSet name belongs to a
+// Deployment; a miss means the suffix is a user-chosen string
+// ("worker-v1", "app-12345") and the name should be treated as the
+// workload itself.
 func isReplicaSetHashSuffix(s string) bool {
 	if len(s) < 5 || len(s) > 10 {
 		return false
@@ -319,32 +384,34 @@ func peerAuthsFromPolicies(policies []MeshedPolicy) []peerAuthRef {
 // aggregateWorkloads so the Prom cross-check can run between the two
 // passes without coupling to the resolver.
 type podPosture struct {
-	Namespace    string
-	PodName      string
-	PodLabels    map[string]string
-	WorkloadKind string
-	Workload     string
-	Mesh         MeshType
-	State        MTLSState
-	Source       MTLSSource
-	IstioMode    string
-	SourceDetail string
+	Namespace             string
+	PodName               string
+	PodLabels             map[string]string
+	WorkloadKind          string
+	Workload              string
+	WorkloadKindConfident bool
+	Mesh                  MeshType
+	State                 MTLSState
+	Source                MTLSSource
+	IstioMode             string
+	SourceDetail          string
 }
 
-func computePodPostures(pods []corev1.Pod, peerAuths []peerAuthRef) []podPosture {
+func computePodPostures(pods []corev1.Pod, peerAuths []peerAuthRef, rsOwners map[string]rsOwner) []podPosture {
 	out := make([]podPosture, 0, len(pods))
 	for i := range pods {
 		pod := &pods[i]
 		mesh := podMeshMembership(pod)
-		kind, name := workloadKey(pod)
+		kind, name, confident := workloadKey(pod, rsOwners)
 
 		pp := podPosture{
-			Namespace:    pod.Namespace,
-			PodName:      pod.Name,
-			PodLabels:    pod.Labels,
-			WorkloadKind: kind,
-			Workload:     name,
-			Mesh:         mesh,
+			Namespace:             pod.Namespace,
+			PodName:               pod.Name,
+			PodLabels:             pod.Labels,
+			WorkloadKind:          kind,
+			Workload:              name,
+			WorkloadKindConfident: confident,
+			Mesh:                  mesh,
 		}
 
 		switch mesh {
@@ -394,14 +461,15 @@ func aggregateWorkloads(postures []podPosture) []WorkloadMTLS {
 		// Start from the first pod and widen to mixed if any peer disagrees.
 		first := members[0]
 		agg := WorkloadMTLS{
-			Namespace:    first.Namespace,
-			Workload:     first.Workload,
-			WorkloadKind: first.WorkloadKind,
-			Mesh:         first.Mesh,
-			State:        first.State,
-			Source:       first.Source,
-			IstioMode:    first.IstioMode,
-			SourceDetail: first.SourceDetail,
+			Namespace:             first.Namespace,
+			Workload:               first.Workload,
+			WorkloadKind:           first.WorkloadKind,
+			WorkloadKindConfident:  first.WorkloadKindConfident,
+			Mesh:                   first.Mesh,
+			State:                  first.State,
+			Source:                 first.Source,
+			IstioMode:              first.IstioMode,
+			SourceDetail:           first.SourceDetail,
 		}
 		for _, m := range members[1:] {
 			if m.State != agg.State {
@@ -409,6 +477,11 @@ func aggregateWorkloads(postures []podPosture) []WorkloadMTLS {
 				// Mesh divergence across pods of the same workload is
 				// pathological; keep the initial mesh label so the row
 				// still renders.
+			}
+			// A workload is only confident when every member pod is
+			// confident — one heuristic-derived pod taints the row.
+			if !m.WorkloadKindConfident {
+				agg.WorkloadKindConfident = false
 			}
 		}
 		out = append(out, agg)
@@ -433,9 +506,21 @@ type IstioMTLSRatio struct {
 	Total     float64
 }
 
-// Ratio returns the mTLS fraction; 0 when no traffic was observed.
+// HasTraffic reports whether Prometheus observed any rated traffic for
+// this workload over the query window. Callers must check this before
+// interpreting Ratio(): Ratio() returns 0 for both no-traffic and
+// all-plaintext, which are opposite signals for posture overrides.
+func (r IstioMTLSRatio) HasTraffic() bool {
+	return r.Total > 0
+}
+
+// Ratio returns the mTLS fraction in [0, 1]. Returns 0 in two distinct
+// cases: no traffic observed (Total == 0) AND all traffic was
+// plaintext (MTLS == 0, Total > 0). Use HasTraffic() to disambiguate;
+// applying overrides on a 0-Ratio with no upstream HasTraffic() check
+// will demote a STRICT workload to inactive based on missing data.
 func (r IstioMTLSRatio) Ratio() float64 {
-	if r.Total == 0 {
+	if !r.HasTraffic() {
 		return 0
 	}
 	return r.MTLS / r.Total
@@ -455,6 +540,9 @@ func queryIstioMTLSRatios(ctx context.Context, pc *monitoring.PrometheusClient, 
 	queryCtx, cancel := context.WithTimeout(ctx, promQueryTimeout)
 	defer cancel()
 
+	// namespace=="" → cluster-wide template; non-empty → k8s-name-validated
+	// scoped template. The namespace-filter and the validation step are both
+	// inside renderIstioMTLSQuery; do not concatenate user input here.
 	q, err := renderIstioMTLSQuery(namespace)
 	if err != nil {
 		return nil, err
@@ -480,13 +568,23 @@ func queryIstioMTLSRatios(ctx context.Context, pc *monitoring.PrometheusClient, 
 		if workload == "" || ns == "" {
 			continue
 		}
+		v := float64(s.Value)
+		// NaN/Inf samples bypass the r.Total == 0 guard downstream
+		// (+Inf != 0). Left unfiltered, "10/+Inf == 0" would mistakenly
+		// flip a STRICT workload to inactive/metric. Drop the sample
+		// before allocating the map entry — Istio should never emit
+		// these, but a misbehaving recording rule or federation chain
+		// can. Filtering after entry allocation would also leave a
+		// zero-Total ghost row that surfaces in the output.
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			continue
+		}
 		key := ns + "/" + workload
 		entry, ok := agg[key]
 		if !ok {
 			entry = &IstioMTLSRatio{Namespace: ns, Workload: workload}
 			agg[key] = entry
 		}
-		v := float64(s.Value)
 		entry.Total += v
 		if policy == "mutual_tls" {
 			entry.MTLS += v
@@ -506,10 +604,16 @@ func queryIstioMTLSRatios(ctx context.Context, pc *monitoring.PrometheusClient, 
 // template unchanged: it carries zero $-variables and any future
 // developer adding a variable here MUST also add a Render call,
 // otherwise unsanitized input would reach PromQL.
+//
+// Cardinality cap: the cluster-wide query wraps the aggregation in
+// topk(mtlsClusterWideTopK, ...) so a federated or high-cardinality
+// Prometheus can't produce an unbounded result vector. Workloads with
+// zero traffic don't influence applyMTLSMetricOverrides anyway, so
+// dropping the long tail is harmless to posture accuracy.
 func renderIstioMTLSQuery(namespace string) (string, error) {
 	const (
 		scoped      = `sum by (destination_workload, destination_workload_namespace, connection_security_policy) (rate(istio_requests_total{destination_workload_namespace="$ns"}[5m]))`
-		clusterWide = `sum by (destination_workload, destination_workload_namespace, connection_security_policy) (rate(istio_requests_total[5m]))`
+		clusterWide = `topk(5000, sum by (destination_workload, destination_workload_namespace, connection_security_policy) (rate(istio_requests_total[5m])))`
 	)
 	if namespace == "" {
 		return clusterWide, nil
@@ -540,7 +644,7 @@ func applyMTLSMetricOverrides(workloads []WorkloadMTLS, ratios []IstioMTLSRatio)
 			continue
 		}
 		r, ok := byKey[w.Namespace+"/"+w.Workload]
-		if !ok || r.Total == 0 {
+		if !ok || !r.HasTraffic() {
 			continue
 		}
 		ratio := r.Ratio()

--- a/backend/internal/servicemesh/mtls.go
+++ b/backend/internal/servicemesh/mtls.go
@@ -441,10 +441,13 @@ func (r IstioMTLSRatio) Ratio() float64 {
 	return r.MTLS / r.Total
 }
 
-// queryIstioMTLSRatios runs one PromQL instant query per namespace to
-// learn observed mTLS ratios by workload. Uses the shared
-// promQueryTimeout budget (see metrics.go) so both Phase B Prom calls
-// share one knob and age together; callers must tolerate a nil return.
+// queryIstioMTLSRatios runs a single PromQL instant query for observed
+// mTLS ratios by workload. namespace=="" returns ratios for every
+// namespace visible to Prometheus (cluster-wide cross-check); a
+// concrete namespace renders the scoped variant for narrower queries.
+// Uses the shared promQueryTimeout budget (see metrics.go) so both
+// Phase B Prom calls share one knob and age together; callers must
+// tolerate a nil return.
 func queryIstioMTLSRatios(ctx context.Context, pc *monitoring.PrometheusClient, namespace string) ([]IstioMTLSRatio, error) {
 	if pc == nil {
 		return nil, nil
@@ -452,16 +455,9 @@ func queryIstioMTLSRatios(ctx context.Context, pc *monitoring.PrometheusClient, 
 	queryCtx, cancel := context.WithTimeout(ctx, promQueryTimeout)
 	defer cancel()
 
-	// Namespace is user-supplied; the existing monitoring.QueryTemplate
-	// validator rejects anything that isn't a k8s-valid name, so we run
-	// it through Render for defence in depth.
-	tmpl := monitoring.QueryTemplate{
-		Query: `sum by (destination_workload, destination_workload_namespace, connection_security_policy) (rate(istio_requests_total{destination_workload_namespace="$ns"}[5m]))`,
-		Variables: []string{"ns"},
-	}
-	q, err := tmpl.Render(map[string]string{"ns": namespace})
+	q, err := renderIstioMTLSQuery(namespace)
 	if err != nil {
-		return nil, fmt.Errorf("render istio mtls query: %w", err)
+		return nil, err
 	}
 	val, _, err := pc.Query(queryCtx, q, time.Now())
 	if err != nil {
@@ -496,6 +492,26 @@ func queryIstioMTLSRatios(ctx context.Context, pc *monitoring.PrometheusClient, 
 		out = append(out, *r)
 	}
 	return out, nil
+}
+
+// renderIstioMTLSQuery picks the scoped or cluster-wide PromQL template
+// based on namespace and runs it through monitoring.QueryTemplate so
+// user-supplied values still flow through the k8s-name validator.
+// Cluster-wide queries have no variables and skip Render entirely.
+func renderIstioMTLSQuery(namespace string) (string, error) {
+	const (
+		scoped      = `sum by (destination_workload, destination_workload_namespace, connection_security_policy) (rate(istio_requests_total{destination_workload_namespace="$ns"}[5m]))`
+		clusterWide = `sum by (destination_workload, destination_workload_namespace, connection_security_policy) (rate(istio_requests_total[5m]))`
+	)
+	if namespace == "" {
+		return clusterWide, nil
+	}
+	tmpl := monitoring.QueryTemplate{Query: scoped, Variables: []string{"ns"}}
+	q, err := tmpl.Render(map[string]string{"ns": namespace})
+	if err != nil {
+		return "", fmt.Errorf("render istio mtls query: %w", err)
+	}
+	return q, nil
 }
 
 // applyMTLSMetricOverrides promotes policy-derived "active" results to

--- a/backend/internal/servicemesh/mtls.go
+++ b/backend/internal/servicemesh/mtls.go
@@ -472,7 +472,12 @@ func queryIstioMTLSRatios(ctx context.Context, pc *monitoring.PrometheusClient, 
 		workload := string(s.Metric["destination_workload"])
 		ns := string(s.Metric["destination_workload_namespace"])
 		policy := string(s.Metric["connection_security_policy"])
-		if workload == "" {
+		// Istio emits passthrough/unknown-target traffic with empty
+		// workload OR empty namespace labels. Either one alone makes
+		// the ratio key ambiguous (a "/cart" entry would shadow the
+		// real "shop/cart" lookup in applyMTLSMetricOverrides), so
+		// drop the sample rather than aggregating into a ghost row.
+		if workload == "" || ns == "" {
 			continue
 		}
 		key := ns + "/" + workload
@@ -495,9 +500,12 @@ func queryIstioMTLSRatios(ctx context.Context, pc *monitoring.PrometheusClient, 
 }
 
 // renderIstioMTLSQuery picks the scoped or cluster-wide PromQL template
-// based on namespace and runs it through monitoring.QueryTemplate so
-// user-supplied values still flow through the k8s-name validator.
-// Cluster-wide queries have no variables and skip Render entirely.
+// based on namespace and runs the scoped path through
+// monitoring.QueryTemplate so user-supplied values still flow through
+// the k8s-name validator. The cluster-wide path returns the literal
+// template unchanged: it carries zero $-variables and any future
+// developer adding a variable here MUST also add a Render call,
+// otherwise unsanitized input would reach PromQL.
 func renderIstioMTLSQuery(namespace string) (string, error) {
 	const (
 		scoped      = `sum by (destination_workload, destination_workload_namespace, connection_security_policy) (rate(istio_requests_total{destination_workload_namespace="$ns"}[5m]))`

--- a/backend/internal/servicemesh/mtls.go
+++ b/backend/internal/servicemesh/mtls.go
@@ -192,22 +192,17 @@ func linkerdPodState(pod *corev1.Pod) MTLSState {
 }
 
 // workloadKey identifies the top-level controller for a pod. We walk
-// one level of OwnerReferences, unwrapping ReplicaSet → Deployment via
-// the standard "-<hash>" suffix convention. Orphan pods key under
+// one level of OwnerReferences, unwrapping a Deployment-owned
+// ReplicaSet via the kube-controller "-<hash>" suffix convention.
+// Orphan ReplicaSets and user-named RSes whose suffix is not a real
+// pod-template-hash are reported verbatim as ReplicaSet so we never
+// fabricate a Deployment that isn't there. Orphan pods key under
 // ("Pod", <podName>).
-//
-// TODO: the ReplicaSet → Deployment strip is a best-effort heuristic —
-// orphan ReplicaSets (bare RSes not owned by a Deployment, common in
-// Helm charts) and RSes with dashed non-hash suffixes like "worker-v1"
-// are reported as fabricated Deployments. Tracked as a Phase-B follow-up
-// (see memory: project_servicemesh_phase_b_followups). Treat the
-// returned kind as authoritative only for pods whose RS is clearly
-// Deployment-owned.
 func workloadKey(pod *corev1.Pod) (kind, name string) {
 	for _, or := range pod.OwnerReferences {
 		switch or.Kind {
 		case "ReplicaSet":
-			if idx := strings.LastIndex(or.Name, "-"); idx > 0 {
+			if idx := strings.LastIndex(or.Name, "-"); idx > 0 && isReplicaSetHashSuffix(or.Name[idx+1:]) {
 				return "Deployment", or.Name[:idx]
 			}
 			return "ReplicaSet", or.Name
@@ -216,6 +211,33 @@ func workloadKey(pod *corev1.Pod) (kind, name string) {
 		}
 	}
 	return "Pod", pod.Name
+}
+
+// isReplicaSetHashSuffix reports whether s looks like a kube-controller
+// pod-template-hash. Modern Deployment hashes are produced by
+// k8s.io/apimachinery/pkg/util/rand.SafeEncodeString, which translates
+// every byte through a 27-character alphabet that excludes vowels and
+// the digits 0/1/3 (avoids generating profanity-like strings). The
+// length tracks fmt.Sprint(uint32) — never more than 10 chars — and we
+// floor at 5 to match the shortest hash kube-controller is observed to
+// produce in real clusters. A match is a strong signal that the "-"
+// stripped from a ReplicaSet name belongs to a Deployment; a miss
+// means the suffix is a user-chosen string ("worker-v1", "app-12345")
+// and the name should be treated as the workload itself.
+func isReplicaSetHashSuffix(s string) bool {
+	if len(s) < 5 || len(s) > 10 {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case 'b', 'c', 'd', 'f', 'g', 'h', 'j', 'k', 'l', 'm',
+			'n', 'p', 'q', 'r', 's', 't', 'v', 'w', 'x', 'z',
+			'2', '4', '5', '6', '7', '8', '9':
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 // podMeshMembership returns which mesh (if any) a pod is a member of.

--- a/backend/internal/servicemesh/mtls_test.go
+++ b/backend/internal/servicemesh/mtls_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -316,6 +317,11 @@ func TestWorkloadKey_ReplicaSetHashSuffixHeuristic(t *testing.T) {
 		{"vowel-suffix", "my-standalone", "ReplicaSet", "my-standalone"},
 		{"unsafe-digit-suffix", "app-12345", "ReplicaSet", "app-12345"},
 		{"too-short-suffix", "svc-ab12", "ReplicaSet", "svc-ab12"},
+		// Pure-length-short rejection: suffix "bcdf" is 4 chars and
+		// every char is in the safe alphabet, so the only thing
+		// rejecting it is len < 5. Removing or lowering the floor
+		// would silently break here.
+		{"too-short-but-all-valid-chars", "svc-bcdf", "ReplicaSet", "svc-bcdf"},
 		{"too-long-suffix", "svc-bcdfghjklmn", "ReplicaSet", "svc-bcdfghjklmn"},
 	}
 	for _, c := range cases {
@@ -423,6 +429,31 @@ func TestPeerAuthsFromPolicies_FiltersNonPeerAuths(t *testing.T) {
 
 // --- cluster-wide handler path --------------------------------------------
 
+// newClusterWideMTLSFixture returns a Handler pre-wired with a
+// mesh-root STRICT PeerAuthentication and two Istio-injected pods
+// across "shop" and "billing" namespaces. Pass nil for promClient to
+// exercise the offline-Prom degradation path; pass a real
+// monitoring.PrometheusClient to exercise the cluster-wide
+// cross-check. Pod fixture names embed real pod-template-hash shapes
+// (5–10 chars from the kube safe alphabet) so workloadKey's heuristic
+// fallback returns Deployment without an authoritative RS-list call.
+func newClusterWideMTLSFixture(t *testing.T, promClient *monitoring.PrometheusClient) *Handler {
+	t.Helper()
+	pa := newPeerAuth(istioMeshRootNamespace, "default", IstioMTLSStrict, nil)
+	cs := fake.NewClientset(
+		injectedPod("shop", "cart-6d4b7-xyz", map[string]string{"app": "cart"}),
+		injectedPod("billing", "invoice-7c9d4-aa", map[string]string{"app": "invoice"}),
+	)
+	return &Handler{
+		Discoverer:         seededDiscoverer(MeshStatus{Detected: MeshIstio, Istio: &MeshInfo{Installed: true, Version: "1.24.0"}}),
+		AccessChecker:      resources.NewAlwaysAllowAccessChecker(),
+		Logger:             slog.Default(),
+		dynOverride:        newIstioFakeDynClient(pa),
+		clientsetOverride:  cs,
+		promClientOverride: promClient,
+	}
+}
+
 // TestHandler_MTLSPosture_ClusterWide_NoProm exercises the
 // namespace-omitted path with Prometheus offline. Posture should
 // aggregate across every visible namespace and Source stays policy
@@ -430,19 +461,7 @@ func TestPeerAuthsFromPolicies_FiltersNonPeerAuths(t *testing.T) {
 // wired. The online-Prom cluster-wide path is covered by
 // TestHandler_MTLSPosture_ClusterWideMetricOverride.
 func TestHandler_MTLSPosture_ClusterWide_NoProm(t *testing.T) {
-	pa := newPeerAuth(istioMeshRootNamespace, "default", IstioMTLSStrict, nil)
-	cs := fake.NewClientset(
-		injectedPod("shop", "cart-6d4b7-xyz", map[string]string{"app": "cart"}),
-		injectedPod("billing", "invoice-7c9d4-aa", map[string]string{"app": "invoice"}),
-	)
-
-	h := &Handler{
-		Discoverer:        seededDiscoverer(MeshStatus{Detected: MeshIstio, Istio: &MeshInfo{Installed: true, Version: "1.24.0"}}),
-		AccessChecker:     resources.NewAlwaysAllowAccessChecker(),
-		Logger:            slog.Default(),
-		dynOverride:       newIstioFakeDynClient(pa),
-		clientsetOverride: cs,
-	}
+	h := newClusterWideMTLSFixture(t, nil)
 
 	// No ?namespace= → cluster-wide.
 	req := httptest.NewRequest(http.MethodGet, "/mesh/mtls", nil)
@@ -481,13 +500,17 @@ func TestHandler_MTLSPosture_ClusterWide_NoProm(t *testing.T) {
 // ratios still flip individual workloads to source=metric. Without this
 // path the dashboard's most common shape (cluster-wide) silently
 // disagreed with the scoped view.
+//
+// Also asserts the dispatched PromQL: a regression that mistakenly
+// passes a non-empty namespace to queryIstioMTLSRatios (selecting the
+// scoped template instead) would still pass the body assertions
+// because the fake server's payload is namespace-agnostic. Capturing
+// the query closes that gap.
 func TestHandler_MTLSPosture_ClusterWideMetricOverride(t *testing.T) {
-	pa := newPeerAuth(istioMeshRootNamespace, "default", IstioMTLSStrict, nil)
-	cs := fake.NewClientset(
-		injectedPod("shop", "cart-6d4b7-xyz", map[string]string{"app": "cart"}),
-		injectedPod("billing", "invoice-7c9d4-aa", map[string]string{"app": "invoice"}),
+	var (
+		mu             sync.Mutex
+		capturedQuery  string
 	)
-
 	// Fake Prom returns multi-namespace samples in a single response —
 	// matching the cluster-wide template's shape. Both workloads have
 	// non-trivial overrides (ratio < 1) so the test would fail if the
@@ -495,6 +518,9 @@ func TestHandler_MTLSPosture_ClusterWideMetricOverride(t *testing.T) {
 	// sees 90% mTLS (flips to mixed/metric); invoice sees ~83%
 	// (also flips to mixed/metric).
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		capturedQuery = r.FormValue("query")
+		mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{
 			"status": "success",
@@ -515,14 +541,7 @@ func TestHandler_MTLSPosture_ClusterWideMetricOverride(t *testing.T) {
 		t.Fatalf("prom client: %v", err)
 	}
 
-	h := &Handler{
-		Discoverer:         seededDiscoverer(MeshStatus{Detected: MeshIstio, Istio: &MeshInfo{Installed: true, Version: "1.24.0"}}),
-		AccessChecker:      resources.NewAlwaysAllowAccessChecker(),
-		Logger:             slog.Default(),
-		dynOverride:        newIstioFakeDynClient(pa),
-		clientsetOverride:  cs,
-		promClientOverride: pc,
-	}
+	h := newClusterWideMTLSFixture(t, pc)
 
 	req := httptest.NewRequest(http.MethodGet, "/mesh/mtls", nil)
 	req = req.WithContext(auth.ContextWithUser(req.Context(), &auth.User{KubernetesUsername: "u"}))
@@ -537,6 +556,19 @@ func TestHandler_MTLSPosture_ClusterWideMetricOverride(t *testing.T) {
 	}
 	if jerr := json.Unmarshal(rec.Body.Bytes(), &env); jerr != nil {
 		t.Fatalf("decode: %v", jerr)
+	}
+
+	mu.Lock()
+	got := capturedQuery
+	mu.Unlock()
+	if got == "" {
+		t.Fatalf("Prom server received no query; cluster-wide cross-check did not dispatch")
+	}
+	if strings.Contains(got, `destination_workload_namespace="`) {
+		t.Errorf("cluster-wide path dispatched namespace-filtered query (regression to scoped template): %s", got)
+	}
+	if !strings.Contains(got, "topk(") {
+		t.Errorf("cluster-wide query missing topk cap (regression on cardinality bound): %s", got)
 	}
 
 	want := map[string]struct {
@@ -562,6 +594,56 @@ func TestHandler_MTLSPosture_ClusterWideMetricOverride(t *testing.T) {
 		if wl.Source != exp.source {
 			t.Errorf("%s Source = %q, want %q", key, wl.Source, exp.source)
 		}
+	}
+}
+
+// TestHandler_MTLSPosture_LinkerdOnlySkipsPromCrossCheck verifies the
+// mesh-type gate: queryIstioMTLSRatios targets istio_requests_total,
+// so a Linkerd-only cluster has nothing useful to ask Prometheus.
+// applyMTLSMetricOverrides already filters by Mesh != MeshIstio, so
+// without the gate the Prom round-trip is purely wasted. The test
+// wires a fake Prom server that fails the test if it ever receives a
+// request.
+func TestHandler_MTLSPosture_LinkerdOnlySkipsPromCrossCheck(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("Prom server received a request from a Linkerd-only cluster: %s %s", r.Method, r.URL.String())
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":"success","data":{"resultType":"vector","result":[]}}`)
+	}))
+	defer srv.Close()
+	pc, err := monitoring.NewPrometheusClient(srv.URL)
+	if err != nil {
+		t.Fatalf("prom client: %v", err)
+	}
+
+	cs := fake.NewClientset(linkerdPod("shop", "cart-abc", map[string]string{"app": "cart"}))
+	h := &Handler{
+		Discoverer:         seededDiscoverer(MeshStatus{Detected: MeshLinkerd, Linkerd: &MeshInfo{Installed: true, Version: "edge-25"}}),
+		AccessChecker:      resources.NewAlwaysAllowAccessChecker(),
+		Logger:             slog.Default(),
+		clientsetOverride:  cs,
+		promClientOverride: pc,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/mesh/mtls", nil)
+	req = req.WithContext(auth.ContextWithUser(req.Context(), &auth.User{KubernetesUsername: "u"}))
+	rec := httptest.NewRecorder()
+	h.HandleMTLSPosture(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var env struct {
+		Data MTLSPostureResponse `json:"data"`
+	}
+	if jerr := json.Unmarshal(rec.Body.Bytes(), &env); jerr != nil {
+		t.Fatalf("decode: %v", jerr)
+	}
+	if len(env.Data.Workloads) != 1 || env.Data.Workloads[0].Mesh != MeshLinkerd {
+		t.Errorf("workloads = %+v, want one Linkerd entry", env.Data.Workloads)
+	}
+	if env.Data.Workloads[0].Source != MTLSSourcePolicy {
+		t.Errorf("Source = %q, want policy (Linkerd has no metric override)", env.Data.Workloads[0].Source)
 	}
 }
 

--- a/backend/internal/servicemesh/mtls_test.go
+++ b/backend/internal/servicemesh/mtls_test.go
@@ -469,8 +469,11 @@ func TestHandler_MTLSPosture_ClusterWideMetricOverride(t *testing.T) {
 	)
 
 	// Fake Prom returns multi-namespace samples in a single response —
-	// matching the cluster-wide template's shape. cart sees 90% mTLS
-	// (mixed override); invoice sees 100% (active preserved).
+	// matching the cluster-wide template's shape. Both workloads have
+	// non-trivial overrides (ratio < 1) so the test would fail if the
+	// dispatch silently filtered ratios to a single namespace: cart
+	// sees 90% mTLS (flips to mixed/metric); invoice sees ~83%
+	// (also flips to mixed/metric).
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{
@@ -480,7 +483,8 @@ func TestHandler_MTLSPosture_ClusterWideMetricOverride(t *testing.T) {
 				"result": [
 					{"metric":{"destination_workload":"cart","destination_workload_namespace":"shop","connection_security_policy":"mutual_tls"},"value":[1,"9"]},
 					{"metric":{"destination_workload":"cart","destination_workload_namespace":"shop","connection_security_policy":"none"},"value":[1,"1"]},
-					{"metric":{"destination_workload":"invoice","destination_workload_namespace":"billing","connection_security_policy":"mutual_tls"},"value":[1,"5"]}
+					{"metric":{"destination_workload":"invoice","destination_workload_namespace":"billing","connection_security_policy":"mutual_tls"},"value":[1,"5"]},
+					{"metric":{"destination_workload":"invoice","destination_workload_namespace":"billing","connection_security_policy":"none"},"value":[1,"1"]}
 				]
 			}
 		}`)
@@ -520,7 +524,7 @@ func TestHandler_MTLSPosture_ClusterWideMetricOverride(t *testing.T) {
 		source MTLSSource
 	}{
 		"shop/cart":       {state: MTLSMixed, source: MTLSSourceMetric},
-		"billing/invoice": {state: MTLSActive, source: MTLSSourcePolicy},
+		"billing/invoice": {state: MTLSMixed, source: MTLSSourceMetric},
 	}
 	if len(env.Data.Workloads) != len(want) {
 		t.Fatalf("workloads = %d, want %d", len(env.Data.Workloads), len(want))
@@ -551,6 +555,9 @@ func TestRenderIstioMTLSQuery_ScopeSwitch(t *testing.T) {
 	}
 	if strings.Contains(clusterQ, "destination_workload_namespace=") {
 		t.Errorf("cluster-wide query carries a namespace filter: %s", clusterQ)
+	}
+	if !strings.Contains(clusterQ, "istio_requests_total") {
+		t.Errorf("cluster-wide query missing istio_requests_total metric: %s", clusterQ)
 	}
 
 	scopedQ, err := renderIstioMTLSQuery("shop")

--- a/backend/internal/servicemesh/mtls_test.go
+++ b/backend/internal/servicemesh/mtls_test.go
@@ -195,9 +195,12 @@ func TestWorkloadKey_DeploymentStrippedFromReplicaSet(t *testing.T) {
 			},
 		},
 	}
-	kind, name := workloadKey(pod)
+	kind, name, confident := workloadKey(pod, nil)
 	if kind != "Deployment" || name != "cart" {
 		t.Errorf("got (%q,%q), want (Deployment, cart)", kind, name)
+	}
+	if confident {
+		t.Errorf("confident = true, want false (heuristic-derived without rsOwners)")
 	}
 }
 
@@ -210,17 +213,23 @@ func TestWorkloadKey_StatefulSet(t *testing.T) {
 			},
 		},
 	}
-	kind, name := workloadKey(pod)
+	kind, name, confident := workloadKey(pod, nil)
 	if kind != "StatefulSet" || name != "db" {
 		t.Errorf("got (%q,%q), want (StatefulSet, db)", kind, name)
+	}
+	if !confident {
+		t.Errorf("confident = false, want true (non-RS top-level kind is authoritative)")
 	}
 }
 
 func TestWorkloadKey_OrphanPod(t *testing.T) {
 	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "solo"}}
-	kind, name := workloadKey(pod)
+	kind, name, confident := workloadKey(pod, nil)
 	if kind != "Pod" || name != "solo" {
 		t.Errorf("got (%q,%q), want (Pod, solo)", kind, name)
+	}
+	if !confident {
+		t.Errorf("confident = false, want true (orphan pod kind is authoritative)")
 	}
 }
 
@@ -247,9 +256,12 @@ func TestWorkloadKey_DaemonSetJobCronJob(t *testing.T) {
 					},
 				},
 			}
-			kind, name := workloadKey(pod)
+			kind, name, confident := workloadKey(pod, nil)
 			if kind != c.kind || name != c.ownerKey {
 				t.Errorf("got (%q,%q), want (%q,%q)", kind, name, c.kind, c.ownerKey)
+			}
+			if !confident {
+				t.Errorf("confident = false, want true (%s is authoritative)", c.kind)
 			}
 		})
 	}
@@ -268,9 +280,12 @@ func TestWorkloadKey_ReplicaSetNoHash(t *testing.T) {
 			},
 		},
 	}
-	kind, name := workloadKey(pod)
+	kind, name, confident := workloadKey(pod, nil)
 	if kind != "ReplicaSet" || name != "frontend" {
 		t.Errorf("got (%q,%q), want (ReplicaSet, frontend)", kind, name)
+	}
+	if confident {
+		t.Errorf("confident = true, want false (heuristic-derived without rsOwners)")
 	}
 }
 
@@ -313,9 +328,12 @@ func TestWorkloadKey_ReplicaSetHashSuffixHeuristic(t *testing.T) {
 					},
 				},
 			}
-			kind, name := workloadKey(pod)
+			kind, name, confident := workloadKey(pod, nil)
 			if kind != c.wantKind || name != c.wantName {
 				t.Errorf("got (%q,%q), want (%q,%q)", kind, name, c.wantKind, c.wantName)
+			}
+			if confident {
+				t.Errorf("confident = true, want false (heuristic-derived without rsOwners)")
 			}
 		})
 	}
@@ -405,11 +423,13 @@ func TestPeerAuthsFromPolicies_FiltersNonPeerAuths(t *testing.T) {
 
 // --- cluster-wide handler path --------------------------------------------
 
-// TestHandler_MTLSPosture_ClusterWide exercises the namespace-omitted
-// path with Prometheus offline. Posture should aggregate across every
-// visible namespace and Source stays policy because the cross-check
-// silently degrades when no Prom client is wired.
-func TestHandler_MTLSPosture_ClusterWide(t *testing.T) {
+// TestHandler_MTLSPosture_ClusterWide_NoProm exercises the
+// namespace-omitted path with Prometheus offline. Posture should
+// aggregate across every visible namespace and Source stays policy
+// because the cross-check silently degrades when no Prom client is
+// wired. The online-Prom cluster-wide path is covered by
+// TestHandler_MTLSPosture_ClusterWideMetricOverride.
+func TestHandler_MTLSPosture_ClusterWide_NoProm(t *testing.T) {
 	pa := newPeerAuth(istioMeshRootNamespace, "default", IstioMTLSStrict, nil)
 	cs := fake.NewClientset(
 		injectedPod("shop", "cart-6d4b7-xyz", map[string]string{"app": "cart"}),
@@ -570,6 +590,204 @@ func TestRenderIstioMTLSQuery_ScopeSwitch(t *testing.T) {
 
 	if _, err := renderIstioMTLSQuery(`bad"ns`); err == nil {
 		t.Error("invalid namespace passed render validation")
+	}
+
+	// Cluster-wide template MUST stay variable-free. The function comment
+	// documents that any future $-variable addition requires routing
+	// through QueryTemplate.Render; this assertion makes the invariant
+	// machine-checkable so a regression fails CI rather than reaching
+	// PromQL with unsanitized input.
+	if strings.Contains(clusterQ, "$") {
+		t.Errorf("cluster-wide query contains $-variable; must route through Render: %s", clusterQ)
+	}
+
+	// Cardinality cap: the cluster-wide template wraps the aggregation in
+	// topk to bound the result vector for federated/high-cardinality
+	// Prometheus installs. The 2s timeout is the only other backstop.
+	if !strings.Contains(clusterQ, "topk(") {
+		t.Errorf("cluster-wide query missing topk cap: %s", clusterQ)
+	}
+}
+
+// TestQueryIstioMTLSRatios_DropsNaNAndInfSamples ensures Prometheus
+// samples with NaN or +/-Inf values never reach the aggregator. Without
+// the guard, "+Inf" bypasses the r.Total == 0 check (+Inf != 0) and a
+// downstream "ratio = MTLS/+Inf = 0" wrongly demotes a STRICT workload
+// to inactive.
+func TestQueryIstioMTLSRatios_DropsNaNAndInfSamples(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status": "success",
+			"data": {
+				"resultType": "vector",
+				"result": [
+					{"metric":{"destination_workload":"cart","destination_workload_namespace":"shop","connection_security_policy":"mutual_tls"},"value":[1,"NaN"]},
+					{"metric":{"destination_workload":"cart","destination_workload_namespace":"shop","connection_security_policy":"none"},"value":[1,"+Inf"]},
+					{"metric":{"destination_workload":"checkout","destination_workload_namespace":"shop","connection_security_policy":"mutual_tls"},"value":[1,"-Inf"]},
+					{"metric":{"destination_workload":"checkout","destination_workload_namespace":"shop","connection_security_policy":"none"},"value":[1,"3"]}
+				]
+			}
+		}`)
+	}))
+	defer srv.Close()
+	pc, err := monitoring.NewPrometheusClient(srv.URL)
+	if err != nil {
+		t.Fatalf("prom client: %v", err)
+	}
+
+	ratios, err := queryIstioMTLSRatios(t.Context(), pc, "")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+
+	// cart had every sample dropped by the NaN/Inf guard — must not
+	// appear in the output. checkout had only one finite sample (a
+	// "none" policy entry of 3.0); it should appear with Total=3, MTLS=0.
+	for _, r := range ratios {
+		if r.Workload == "cart" {
+			t.Errorf("cart present in output despite all-NaN/Inf samples: %+v", r)
+		}
+	}
+	var checkout *IstioMTLSRatio
+	for i := range ratios {
+		if ratios[i].Workload == "checkout" {
+			checkout = &ratios[i]
+			break
+		}
+	}
+	if checkout == nil {
+		t.Fatalf("checkout missing from output (its non-NaN sample should survive)")
+	}
+	if checkout.Total != 3 || checkout.MTLS != 0 {
+		t.Errorf("checkout = {MTLS:%v, Total:%v}, want {MTLS:0, Total:3}", checkout.MTLS, checkout.Total)
+	}
+}
+
+// TestQueryIstioMTLSRatios_DropsEmptyNamespaceSample exercises the
+// new "ns == \"\" → drop sample" guard. Without the guard, a Prom
+// sample with empty destination_workload_namespace would aggregate
+// under "/cart" and shadow the real "shop/cart" lookup in
+// applyMTLSMetricOverrides.
+func TestQueryIstioMTLSRatios_DropsEmptyNamespaceSample(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status": "success",
+			"data": {
+				"resultType": "vector",
+				"result": [
+					{"metric":{"destination_workload":"cart","destination_workload_namespace":"","connection_security_policy":"mutual_tls"},"value":[1,"5"]},
+					{"metric":{"destination_workload":"cart","destination_workload_namespace":"shop","connection_security_policy":"mutual_tls"},"value":[1,"10"]}
+				]
+			}
+		}`)
+	}))
+	defer srv.Close()
+	pc, err := monitoring.NewPrometheusClient(srv.URL)
+	if err != nil {
+		t.Fatalf("prom client: %v", err)
+	}
+
+	ratios, err := queryIstioMTLSRatios(t.Context(), pc, "")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(ratios) != 1 {
+		t.Fatalf("len(ratios) = %d, want 1 (empty-namespace sample must be dropped)", len(ratios))
+	}
+	if ratios[0].Namespace != "shop" || ratios[0].Workload != "cart" || ratios[0].Total != 10 {
+		t.Errorf("survivor = %+v, want {Namespace:shop, Workload:cart, Total:10}", ratios[0])
+	}
+}
+
+// TestIstioMTLSRatio_HasTraffic documents the contract: HasTraffic
+// distinguishes "no data" (Total==0) from "all plaintext" (Total>0,
+// MTLS==0), both of which Ratio() collapses to 0.
+func TestIstioMTLSRatio_HasTraffic(t *testing.T) {
+	cases := []struct {
+		name string
+		r    IstioMTLSRatio
+		want bool
+	}{
+		{"no-traffic", IstioMTLSRatio{Total: 0}, false},
+		{"all-plaintext", IstioMTLSRatio{MTLS: 0, Total: 100}, true},
+		{"mixed", IstioMTLSRatio{MTLS: 50, Total: 100}, true},
+		{"all-mtls", IstioMTLSRatio{MTLS: 100, Total: 100}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.r.HasTraffic(); got != c.want {
+				t.Errorf("HasTraffic() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// TestWorkloadKey_OwnerRefMapAuthoritative covers the rsOwners path:
+// when the orchestrator successfully listed RSes, workloadKey consults
+// the map directly and returns confident=true.
+func TestWorkloadKey_OwnerRefMapAuthoritative(t *testing.T) {
+	cases := []struct {
+		name         string
+		ownerKind    string
+		ownerName    string
+		wantKind     string
+		wantName     string
+		wantConfident bool
+	}{
+		// Real Deployment-owned RS — confident Deployment promotion.
+		{"deployment-owned", "Deployment", "cart", "Deployment", "cart", true},
+		// Bare RS or RS owned by a non-Deployment controller (e.g. Argo
+		// Rollout) is reported verbatim; the heuristic would have
+		// fabricated a Deployment.
+		{"rollout-owned", "Rollout", "cart", "ReplicaSet", "cart-bcdfg", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "shop",
+					Name:      "cart-bcdfg-pod",
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "ReplicaSet", Name: "cart-bcdfg"},
+					},
+				},
+			}
+			rsOwners := map[string]rsOwner{
+				"shop/cart-bcdfg": {Kind: c.ownerKind, Name: c.ownerName},
+			}
+			kind, name, confident := workloadKey(pod, rsOwners)
+			if kind != c.wantKind || name != c.wantName || confident != c.wantConfident {
+				t.Errorf("got (%q, %q, confident=%v), want (%q, %q, confident=%v)",
+					kind, name, confident, c.wantKind, c.wantName, c.wantConfident)
+			}
+		})
+	}
+}
+
+// TestWorkloadKey_OwnerRefMapMissingFallsBackToHeuristic: when the RS
+// list call partially succeeded (truncation, race) and a pod's RS
+// isn't in the map, workloadKey falls back to the alphabet heuristic
+// and reports confident=false.
+func TestWorkloadKey_OwnerRefMapMissingFallsBackToHeuristic(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "shop",
+			Name:      "cart-6d4b7-pod",
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "ReplicaSet", Name: "cart-6d4b7"},
+			},
+		},
+	}
+	// Map is non-nil but doesn't contain cart-6d4b7.
+	rsOwners := map[string]rsOwner{"shop/other-app": {Kind: "Deployment", Name: "other-app"}}
+	kind, name, confident := workloadKey(pod, rsOwners)
+	if kind != "Deployment" || name != "cart" {
+		t.Errorf("got (%q,%q), want (Deployment, cart)", kind, name)
+	}
+	if confident {
+		t.Errorf("confident = true, want false (RS missing from map → heuristic fallback)")
 	}
 }
 

--- a/backend/internal/servicemesh/mtls_test.go
+++ b/backend/internal/servicemesh/mtls_test.go
@@ -2,9 +2,11 @@ package servicemesh
 
 import (
 	"encoding/json"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -14,6 +16,7 @@ import (
 
 	"github.com/kubecenter/kubecenter/internal/auth"
 	"github.com/kubecenter/kubecenter/internal/k8s/resources"
+	"github.com/kubecenter/kubecenter/internal/monitoring"
 )
 
 // --- precedence resolver unit tests ----------------------------------------
@@ -403,10 +406,9 @@ func TestPeerAuthsFromPolicies_FiltersNonPeerAuths(t *testing.T) {
 // --- cluster-wide handler path --------------------------------------------
 
 // TestHandler_MTLSPosture_ClusterWide exercises the namespace-omitted
-// path: posture should aggregate across every visible namespace and the
-// Prometheus cross-check is intentionally skipped (the template
-// requires a concrete namespace). Gives the cluster-wide code path its
-// first integration-level coverage.
+// path with Prometheus offline. Posture should aggregate across every
+// visible namespace and Source stays policy because the cross-check
+// silently degrades when no Prom client is wired.
 func TestHandler_MTLSPosture_ClusterWide(t *testing.T) {
 	pa := newPeerAuth(istioMeshRootNamespace, "default", IstioMTLSStrict, nil)
 	cs := fake.NewClientset(
@@ -444,12 +446,123 @@ func TestHandler_MTLSPosture_ClusterWide(t *testing.T) {
 	for _, w := range env.Data.Workloads {
 		seen[w.Namespace] = true
 		if w.Source != MTLSSourcePolicy {
-			t.Errorf("workload %s/%s Source = %q, want policy (cluster-wide skips Prom cross-check)",
+			t.Errorf("workload %s/%s Source = %q, want policy (no Prom client wired → cross-check degrades)",
 				w.Namespace, w.Workload, w.Source)
 		}
 	}
 	if !seen["shop"] || !seen["billing"] {
 		t.Errorf("missing namespace coverage: %+v", seen)
+	}
+}
+
+// TestHandler_MTLSPosture_ClusterWideMetricOverride covers the Phase B
+// follow-up: when no namespace is specified and Prometheus is online,
+// the cross-check fires against an unfiltered template and per-namespace
+// ratios still flip individual workloads to source=metric. Without this
+// path the dashboard's most common shape (cluster-wide) silently
+// disagreed with the scoped view.
+func TestHandler_MTLSPosture_ClusterWideMetricOverride(t *testing.T) {
+	pa := newPeerAuth(istioMeshRootNamespace, "default", IstioMTLSStrict, nil)
+	cs := fake.NewClientset(
+		injectedPod("shop", "cart-6d4b7-xyz", map[string]string{"app": "cart"}),
+		injectedPod("billing", "invoice-7c9d4-aa", map[string]string{"app": "invoice"}),
+	)
+
+	// Fake Prom returns multi-namespace samples in a single response —
+	// matching the cluster-wide template's shape. cart sees 90% mTLS
+	// (mixed override); invoice sees 100% (active preserved).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status": "success",
+			"data": {
+				"resultType": "vector",
+				"result": [
+					{"metric":{"destination_workload":"cart","destination_workload_namespace":"shop","connection_security_policy":"mutual_tls"},"value":[1,"9"]},
+					{"metric":{"destination_workload":"cart","destination_workload_namespace":"shop","connection_security_policy":"none"},"value":[1,"1"]},
+					{"metric":{"destination_workload":"invoice","destination_workload_namespace":"billing","connection_security_policy":"mutual_tls"},"value":[1,"5"]}
+				]
+			}
+		}`)
+	}))
+	defer srv.Close()
+	pc, err := monitoring.NewPrometheusClient(srv.URL)
+	if err != nil {
+		t.Fatalf("prom client: %v", err)
+	}
+
+	h := &Handler{
+		Discoverer:         seededDiscoverer(MeshStatus{Detected: MeshIstio, Istio: &MeshInfo{Installed: true, Version: "1.24.0"}}),
+		AccessChecker:      resources.NewAlwaysAllowAccessChecker(),
+		Logger:             slog.Default(),
+		dynOverride:        newIstioFakeDynClient(pa),
+		clientsetOverride:  cs,
+		promClientOverride: pc,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/mesh/mtls", nil)
+	req = req.WithContext(auth.ContextWithUser(req.Context(), &auth.User{KubernetesUsername: "u"}))
+	rec := httptest.NewRecorder()
+	h.HandleMTLSPosture(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var env struct {
+		Data MTLSPostureResponse `json:"data"`
+	}
+	if jerr := json.Unmarshal(rec.Body.Bytes(), &env); jerr != nil {
+		t.Fatalf("decode: %v", jerr)
+	}
+
+	want := map[string]struct {
+		state  MTLSState
+		source MTLSSource
+	}{
+		"shop/cart":       {state: MTLSMixed, source: MTLSSourceMetric},
+		"billing/invoice": {state: MTLSActive, source: MTLSSourcePolicy},
+	}
+	if len(env.Data.Workloads) != len(want) {
+		t.Fatalf("workloads = %d, want %d", len(env.Data.Workloads), len(want))
+	}
+	for _, wl := range env.Data.Workloads {
+		key := wl.Namespace + "/" + wl.Workload
+		exp, ok := want[key]
+		if !ok {
+			t.Errorf("unexpected workload %s", key)
+			continue
+		}
+		if wl.State != exp.state {
+			t.Errorf("%s State = %q, want %q", key, wl.State, exp.state)
+		}
+		if wl.Source != exp.source {
+			t.Errorf("%s Source = %q, want %q", key, wl.Source, exp.source)
+		}
+	}
+}
+
+// TestRenderIstioMTLSQuery_ScopeSwitch documents that cluster-wide and
+// scoped requests use different PromQL templates and that the scoped
+// path still validates the namespace through the monitoring template.
+func TestRenderIstioMTLSQuery_ScopeSwitch(t *testing.T) {
+	clusterQ, err := renderIstioMTLSQuery("")
+	if err != nil {
+		t.Fatalf("cluster-wide render: %v", err)
+	}
+	if strings.Contains(clusterQ, "destination_workload_namespace=") {
+		t.Errorf("cluster-wide query carries a namespace filter: %s", clusterQ)
+	}
+
+	scopedQ, err := renderIstioMTLSQuery("shop")
+	if err != nil {
+		t.Fatalf("scoped render: %v", err)
+	}
+	if !strings.Contains(scopedQ, `destination_workload_namespace="shop"`) {
+		t.Errorf("scoped query missing namespace filter: %s", scopedQ)
+	}
+
+	if _, err := renderIstioMTLSQuery(`bad"ns`); err == nil {
+		t.Error("invalid namespace passed render validation")
 	}
 }
 

--- a/backend/internal/servicemesh/mtls_test.go
+++ b/backend/internal/servicemesh/mtls_test.go
@@ -271,6 +271,53 @@ func TestWorkloadKey_ReplicaSetNoHash(t *testing.T) {
 	}
 }
 
+// TestWorkloadKey_ReplicaSetHashSuffixHeuristic exercises the boundary
+// of the "is this RS owned by a Deployment?" heuristic. Only suffixes
+// matching the kube-controller pod-template-hash safe alphabet
+// (bcdfghjklmnpqrstvwxz2456789, length 5-10) are stripped as
+// Deployment-owned. Anything else — orphan RSes, user-named RSes with
+// dashed non-hash suffixes — is reported verbatim as a ReplicaSet so we
+// never fabricate a Deployment that isn't there.
+func TestWorkloadKey_ReplicaSetHashSuffixHeuristic(t *testing.T) {
+	cases := []struct {
+		name     string
+		rsName   string
+		wantKind string
+		wantName string
+	}{
+		// Real Deployment-owned ReplicaSets: 5-10 chars from the safe
+		// alphabet, mix of letters and digits.
+		{"five-char-hash", "cart-6d4b7", "Deployment", "cart"},
+		{"ten-char-hash", "cart-5d4f7c8b9d", "Deployment", "cart"},
+		{"hash-with-multi-segment-base", "my-app-svc-78b8b6c789", "Deployment", "my-app-svc"},
+
+		// Not-a-hash suffixes — the suffix is too short, contains
+		// vowels, or contains digits (0/1/3) that the safe alphabet
+		// excludes. These are typically orphan or user-managed RSes.
+		{"version-suffix", "worker-v1", "ReplicaSet", "worker-v1"},
+		{"vowel-suffix", "my-standalone", "ReplicaSet", "my-standalone"},
+		{"unsafe-digit-suffix", "app-12345", "ReplicaSet", "app-12345"},
+		{"too-short-suffix", "svc-ab12", "ReplicaSet", "svc-ab12"},
+		{"too-long-suffix", "svc-bcdfghjklmn", "ReplicaSet", "svc-bcdfghjklmn"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: c.rsName + "-pod",
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "ReplicaSet", Name: c.rsName},
+					},
+				},
+			}
+			kind, name := workloadKey(pod)
+			if kind != c.wantKind || name != c.wantName {
+				t.Errorf("got (%q,%q), want (%q,%q)", kind, name, c.wantKind, c.wantName)
+			}
+		})
+	}
+}
+
 // TestPodMeshMembership_AmbientAnnotation covers the Istio ambient-mode
 // annotation path: no istio-proxy sidecar, but the
 // sidecar.istio.io/status annotation is still present. The resolver
@@ -363,8 +410,8 @@ func TestPeerAuthsFromPolicies_FiltersNonPeerAuths(t *testing.T) {
 func TestHandler_MTLSPosture_ClusterWide(t *testing.T) {
 	pa := newPeerAuth(istioMeshRootNamespace, "default", IstioMTLSStrict, nil)
 	cs := fake.NewClientset(
-		injectedPod("shop", "cart-6d-xyz", map[string]string{"app": "cart"}),
-		injectedPod("billing", "invoice-4a-aa", map[string]string{"app": "invoice"}),
+		injectedPod("shop", "cart-6d4b7-xyz", map[string]string{"app": "cart"}),
+		injectedPod("billing", "invoice-7c9d4-aa", map[string]string{"app": "invoice"}),
 	)
 
 	h := &Handler{
@@ -549,7 +596,7 @@ func TestHandler_MTLSPosture_Denied(t *testing.T) {
 // with mesh-root STRICT resolves to active/policy/mesh.
 func TestHandler_MTLSPosture_IstioNamespaceStrict(t *testing.T) {
 	pa := newPeerAuth(istioMeshRootNamespace, "default", IstioMTLSStrict, nil)
-	cs := fake.NewClientset(injectedPod("shop", "cart-6d-xyz", map[string]string{"app": "cart"}))
+	cs := fake.NewClientset(injectedPod("shop", "cart-6d4b7-xyz", map[string]string{"app": "cart"}))
 
 	h := &Handler{
 		Discoverer:        seededDiscoverer(MeshStatus{Detected: MeshIstio, Istio: &MeshInfo{Installed: true, Version: "1.24.0"}}),
@@ -703,9 +750,10 @@ func linkerdPod(ns, name string, labels map[string]string) *corev1.Pod {
 }
 
 // deriveRSName strips the last "-xxx" suffix of a pod name so that pod
-// "cart-6d-xyz" yields RS "cart-6d" — the workload resolver in turn
-// strips to "cart". Mirrors the Deployment naming convention without
-// recreating the hash algorithm.
+// "cart-6d4b7-xyz" yields RS "cart-6d4b7" — the workload resolver in
+// turn strips the hash-shaped suffix to "cart". Fixture pod names must
+// embed a real pod-template-hash shape (5-10 chars from the kube
+// safe alphabet) or workloadKey will keep the RS name verbatim.
 func deriveRSName(podName string) string {
 	for i := len(podName) - 1; i > 0; i-- {
 		if podName[i] == '-' {


### PR DESCRIPTION
Resolves the two open follow-ups from the Phase B (#200) ce-code-review. The third (happy-path Prom test for `goldenSignalsForService`) had already landed in `metrics_test.go` before this branch — verified, no code change needed.

## What changes

### `workloadKey` — only strip hash-shaped suffixes
`mtls.go::workloadKey` previously stripped the last `-<segment>` from any ReplicaSet name and reported a Deployment, which fabricated non-existent Deployments for orphan ReplicaSets and user-named RSes (`worker-v1`, `my-standalone`). Tightened to only fire when the suffix matches the kube-controller pod-template-hash safe alphabet (`bcdfghjklmnpqrstvwxz2456789`, length 5-10). Misses now report the RS verbatim.

### Cluster-wide mTLS cross-check
`HandleMTLSPosture` previously gated the Prometheus cross-check on `namespace != ""` because the scoped PromQL template required a `destination_workload_namespace` filter. The dashboard's most common shape — cluster-wide posture — therefore silently disagreed with the scoped view. Added a sibling cluster-wide template that aggregates without the filter; `queryIstioMTLSRatios` dispatches by scope, and per-namespace ratios still flip individual workloads to `source=metric`.

## Tests
- `TestWorkloadKey_ReplicaSetHashSuffixHeuristic` — 8 boundary cases (5/10-char hashes pass; `worker-v1`, `my-standalone`, `app-12345`, too-short, too-long all stay `ReplicaSet`)
- `TestHandler_MTLSPosture_ClusterWideMetricOverride` — Prom returns multi-namespace samples cluster-wide; `cart` flips to mixed/metric, `invoice` stays active/policy
- `TestRenderIstioMTLSQuery_ScopeSwitch` — asserts the template switch + scoped path still validates user input

Two existing Istio fixtures renamed (`cart-6d-xyz` → `cart-6d4b7-xyz`, `invoice-4a-aa` → `invoice-7c9d4-aa`) so their derived RS names contain real hash shapes.

## Verification
- `go vet ./...` clean
- `go test ./internal/servicemesh/...` green

## Out of scope (intentional)
Plan-documented v1 boundaries from `plans/service-mesh-observability.md`: ambient-mode classification (no sidecar / no annotation) and custom cluster-domain Linkerd authority labels. Both flagged in memory `project_servicemesh_scope_boundaries.md` so future reviewers don't re-raise them.