### PR TITLE
feat(servicemesh): Phase D — topology mesh overlay + golden signals

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -324,6 +324,11 @@ make check-dashboards                             # Verify Grafana JSON sync
   - Routes: `/security/certificates/{new,issuers/new,cluster-issuers/new}` plus entry buttons on list pages and command palette quick actions
   - v1 ACME scope: SelfSigned + HTTP01 ingress only (CA/Vault/DNS01 deferred to YAML editor)
   - Ships via PR #180 with cleanup follow-ups in #181, #182, #183
+- **Phase 12 (Service Mesh Observability):** COMPLETE — 4 sub-phases (A–D)
+  - **Phase A (Inventory):** New `internal/servicemesh/` package — CRD-based auto-detection of Istio + Linkerd with 5min discovery cache, dynamic-client reads via singleflight + 30s cache, per-user RBAC filtering via `CanAccessGroupResource`. Endpoints: `GET /mesh/{status,routing,policies,routing/:id}`. Composite-ID scheme `mesh:namespace:kindCode:name`. Mesh CRDs covered: Istio VirtualService/DestinationRule/Gateway/PeerAuthentication/AuthorizationPolicy, Linkerd ServiceProfile/Server/HTTPRoute/AuthorizationPolicy/MeshTLSAuthentication. Ships via PR #199.
+  - **Phase B (mTLS posture + golden signals):** Per-workload mTLS state (`active`/`inactive`/`mixed`/`unmeshed`) with policy + Prometheus metric cross-check, three-source attribution (`policy`/`metric`/`default`). Per-service golden signals (RPS, error rate, p50/p95/p99 latency) via templated PromQL with `monitoring.QueryTemplate.Render` k8s-name guard. Endpoints: `GET /mesh/{mtls,golden-signals}`. Partial-failure surface via response `errors` map; ReplicaSet pod-template-hash heuristic for workload-kind attribution with `workloadKindConfident` flag. Ships via PR #200; follow-ups #203 (RS heuristic + cluster-wide PromQL cross-check).
+  - **Phase C (Frontend dashboard / routing / mTLS):** 3 islands — `MeshDashboard`, `RoutingTable`, `MTLSPosture` — under `/networking/mesh/*`. `lib/mesh-types.ts` mirrors backend types; `lib/mesh-api.ts` typed client. Theme tokens only. Ships via PR #204.
+  - **Phase D (Topology overlay + golden signals on Service detail):** Backend (D1) extends topology builder with `?overlay=mesh`: new `MeshRouteProvider` interface, pure `buildMeshEdges` emitter (mesh_vs / mesh_sp service-to-service edges with name/namespaced/FQDN host resolution + `(source, target, type)` dedup + 2000-edge cap), per-CRD-group RBAC fail-closed via `CanAccessGroupResource`, `Graph.Overlay` field omitempty so default response is byte-identical. Frontend (D2) adds toolbar toggle on `/observability/topology` with themed mesh edges (`var(--accent)` for Istio, `var(--accent-secondary)` for Linkerd) and disabled state when backend reports `overlay: "unavailable"`. Frontend (D3) adds inline `MeshGoldenSignals` card on Service detail — silently absent for unmeshed services or zero-traffic baselines, renders "Metrics unavailable" when Prometheus is offline, refreshes every 30s. Helm (D4) declares explicit ClusterRole grants for mesh CRD groups (Istio + Linkerd) so the discoverer + cache layer doesn't depend on the Extensions Hub catch-all `*/*` wildcard.
 
 ## Future Features (Roadmap)
 
@@ -334,7 +339,7 @@ Priority order from 2026-04-09 brainstorm. Check off each item as its PR merges 
 - [x] **3. Diff view** — compare manifests between GitOps revisions (PR #156)
 - [x] **4. Resource Quota & LimitRange Management** — namespace quota wizards, utilization vs. quota visualization, overage warnings (PR #164)
 - [x] **5. Backup & Restore (Velero)** — schedule backups, browse snapshots, one-click restore
-- [ ] **6. Service Mesh Observability (Istio/Linkerd)** — traffic routing visualization, mTLS status, circuit breaker config
+- [x] **6. Service Mesh Observability (Istio/Linkerd)** — traffic routing visualization, mTLS posture, golden signals, topology overlay (Phase 12)
 - [x] **7. Cert-Manager integration** — certificate inventory, expiry warnings, issuers management (Phase 11A)
 - [x] **7b. Cert-Manager wizards (Phase 11B)** — Certificate/Issuer/ClusterIssuer creation wizards (PR #180, follow-ups #181–#183)
 - [ ] **7c. Cert-Manager configurable expiry thresholds** — per-cert/per-issuer warn/critical thresholds via annotation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,7 @@ All endpoints prefixed with `/api/v1`. Full list derivable from `backend/interna
 - YAML tools: `POST /yaml/{validate,apply,diff,export}`
 - Monitoring: `GET /monitoring/{status,query,query_range,dashboards}`, `GET /monitoring/grafana/proxy/*`
 - Logs (Loki): `GET /logs/{status,query,labels,labels/:name/values,volume}` (RBAC namespace-scoped)
-- Topology: `GET /topology/{namespace}` (RBAC-gated resource dependency graph with health)
+- Topology: `GET /topology/{namespace}[?overlay=mesh]` (RBAC-gated resource dependency graph with health; `?overlay=mesh` adds service-to-service `mesh_vs` (Istio VirtualService) and `mesh_sp` (Linkerd ServiceProfile) edges. Response gains `overlay` (`""` omitted when not requested, `"mesh"` when applied, `"unavailable"` when no mesh installed / provider unwired / fetch errored), `edgesTruncated` flagged separately from `truncated` (node cap), and `errors` for per-stage warnings)
 - Diagnostics: `GET /diagnostics/{ns}/{kind}/{name}`, `GET /diagnostics/{ns}/summary` (automated checks + blast radius)
 - Policy: `GET /policy/{status,policies,violations,compliance}` (Kyverno + Gatekeeper, RBAC-filtered)
 - Limits: `GET /limits/{status,namespaces,namespaces/:namespace}` (ResourceQuota + LimitRange dashboard, RBAC-filtered)

--- a/backend/cmd/kubecenter/main.go
+++ b/backend/cmd/kubecenter/main.go
@@ -275,13 +275,22 @@ func main() {
 		Logger:         logger,
 		MonitoringDisc: monDiscoverer,
 	}
+	// On a mesh-detection transition (install / uninstall), drop the
+	// 30s route cache so the next overlay/list request returns the new
+	// shape without waiting out the TTL. Mirrors the gitops/policy
+	// invalidation pattern.
+	meshDisc.SetOnChange(func(prev, current servicemesh.MeshType) {
+		logger.Info("service mesh detection changed; invalidating cache", "prev", prev, "current", current)
+		meshHandler.InvalidateCache()
+	})
+	go meshDisc.RunDiscoveryLoop(ctx)
 
 	// Initialize topology graph builder. The mesh handler doubles as the
 	// MeshRouteProvider for the ?overlay=mesh path; passing a nil here
 	// would degrade the overlay to "unavailable" without affecting the
 	// base graph.
 	topoLister := topology.NewInformerLister(informerMgr)
-	topoBuilder := topology.NewBuilderWithMesh(topoLister, meshHandler, logger)
+	topoBuilder := topology.NewBuilder(topoLister, meshHandler, logger)
 	topoHandler := &topology.Handler{
 		Builder:       topoBuilder,
 		AccessChecker: accessChecker,

--- a/backend/cmd/kubecenter/main.go
+++ b/backend/cmd/kubecenter/main.go
@@ -265,9 +265,23 @@ func main() {
 	logQueryLimiter := middleware.NewRateLimiterWithRate(30, time.Minute)
 	logQueryLimiter.StartCleanup(ctx)
 
-	// Initialize topology graph builder
+	// Service Mesh integration (Istio + Linkerd) — hoisted above topology so
+	// the topology builder's mesh-overlay path has a route provider wired in.
+	meshDisc := servicemesh.NewDiscoverer(k8sClient, logger)
+	meshHandler := &servicemesh.Handler{
+		K8sClient:      k8sClient,
+		Discoverer:     meshDisc,
+		AccessChecker:  accessChecker,
+		Logger:         logger,
+		MonitoringDisc: monDiscoverer,
+	}
+
+	// Initialize topology graph builder. The mesh handler doubles as the
+	// MeshRouteProvider for the ?overlay=mesh path; passing a nil here
+	// would degrade the overlay to "unavailable" without affecting the
+	// base graph.
 	topoLister := topology.NewInformerLister(informerMgr)
-	topoBuilder := topology.NewBuilder(topoLister, logger)
+	topoBuilder := topology.NewBuilderWithMesh(topoLister, meshHandler, logger)
 	topoHandler := &topology.Handler{
 		Builder:       topoBuilder,
 		AccessChecker: accessChecker,
@@ -672,16 +686,6 @@ func main() {
 	// Gateway API integration
 	gwDisc := gateway.NewDiscoverer(k8sClient, logger)
 	gwHandler := gateway.NewHandler(k8sClient, gwDisc, accessChecker, logger)
-
-	// Service Mesh integration (Istio + Linkerd)
-	meshDisc := servicemesh.NewDiscoverer(k8sClient, logger)
-	meshHandler := &servicemesh.Handler{
-		K8sClient:      k8sClient,
-		Discoverer:     meshDisc,
-		AccessChecker:  accessChecker,
-		Logger:         logger,
-		MonitoringDisc: monDiscoverer,
-	}
 
 	// Ready state: true after informer sync, false during shutdown
 	var ready atomic.Bool

--- a/backend/internal/k8s/resources/access.go
+++ b/backend/internal/k8s/resources/access.go
@@ -32,14 +32,20 @@ type accessCacheEntry struct {
 // AccessChecker provides per-request RBAC filtering for informer cache reads.
 // It uses SelfSubjectAccessReview to verify individual verb+resource+namespace
 // permissions, cached for 60 seconds per user.
+// AccessPredicate decides whether a user should be granted a specific
+// (verb, apiGroup, resource, namespace) tuple. Used only by the
+// predicate test fake — production never sets it.
+type AccessPredicate func(verb, apiGroup, resource, namespace string) bool
+
 type AccessChecker struct {
 	clientFactory interface {
 		ClientForUser(username string, groups []string) (*kubernetes.Clientset, error)
 	}
 	cache       sync.Map // map[accessCacheKey]accessCacheEntry
 	logger      *slog.Logger
-	alwaysAllow bool // for testing only
-	alwaysDeny  bool // for testing only
+	alwaysAllow bool            // for testing only
+	alwaysDeny  bool            // for testing only
+	predicate   AccessPredicate // for testing only
 }
 
 // NewAccessChecker creates an AccessChecker that verifies user permissions.
@@ -63,6 +69,13 @@ func (ac *AccessChecker) CanAccess(ctx context.Context, username string, groups 
 	}
 	if ac.alwaysDeny {
 		return false, nil
+	}
+	// In predicate-fake mode, CanAccess short-circuits to allow so tests
+	// targeting CanAccessGroupResource (the CRD path) aren't forced to
+	// supply rules for every core resource the base graph touches. The
+	// predicate is consulted directly by CanAccessGroupResource.
+	if ac.predicate != nil {
+		return true, nil
 	}
 	key := accessCacheKey{
 		username:  username,
@@ -138,6 +151,9 @@ func (ac *AccessChecker) CanAccessGroupResource(ctx context.Context, username st
 	if ac.alwaysDeny {
 		return false, nil
 	}
+	if ac.predicate != nil {
+		return ac.predicate(verb, apiGroup, resource, namespace), nil
+	}
 
 	key := accessCacheKey{
 		username:  username,
@@ -211,6 +227,19 @@ func NewAlwaysDenyAccessChecker() *AccessChecker {
 		clientFactory: nil,
 		logger:        slog.Default(),
 		alwaysDeny:    true,
+	}
+}
+
+// NewPredicateAccessChecker returns an AccessChecker that consults the
+// supplied predicate for every CanAccessGroupResource call. Intended for
+// tests covering partial-RBAC scenarios (e.g., "user can list one CRD
+// group but not another"). The predicate isn't consulted by the basic
+// CanAccess method because no current test scenario needs it.
+func NewPredicateAccessChecker(fn AccessPredicate) *AccessChecker {
+	return &AccessChecker{
+		clientFactory: nil,
+		logger:        slog.Default(),
+		predicate:     fn,
 	}
 }
 

--- a/backend/internal/servicemesh/discovery.go
+++ b/backend/internal/servicemesh/discovery.go
@@ -19,12 +19,18 @@ import (
 
 const (
 	staleDuration    = 5 * time.Minute
+	recheckInterval  = 60 * time.Second
 	istioSystemNS    = "istio-system"
 	linkerdControlNS = "linkerd"
 	istioDeployLabel = "app=istiod"
 	linkerdDeployLbl = "linkerd.io/control-plane-component=identity"
 	versionUnknown   = "unknown"
 )
+
+// DiscoveryChangeCallback fires when Probe detects a change in the mesh
+// detection state (e.g., MeshNone → MeshIstio after install). Wired by
+// main() to invalidate cross-package caches that depend on mesh data.
+type DiscoveryChangeCallback func(prev, current MeshType)
 
 // Discoverer probes the cluster for Istio and Linkerd control planes
 // and maintains cached mesh-status state with a lazy re-probe on stale reads.
@@ -33,8 +39,9 @@ type Discoverer struct {
 	disco  discovery.DiscoveryInterface
 	logger *slog.Logger
 
-	mu     sync.RWMutex
-	status MeshStatus
+	mu       sync.RWMutex
+	status   MeshStatus
+	onChange DiscoveryChangeCallback
 }
 
 // NewDiscoverer creates a new service-mesh discoverer. Passing a nil
@@ -83,6 +90,35 @@ func (d *Discoverer) IsInstalled(ctx context.Context) bool {
 	return s.Istio != nil || s.Linkerd != nil
 }
 
+// SetOnChange registers a callback invoked when Probe detects a change
+// in mesh detection state. Use this from main() to invalidate downstream
+// caches (e.g., the handler's 30s route cache, the topology overlay) so
+// a fresh install doesn't lag behind the discovery cycle.
+func (d *Discoverer) SetOnChange(cb DiscoveryChangeCallback) {
+	d.mu.Lock()
+	d.onChange = cb
+	d.mu.Unlock()
+}
+
+// RunDiscoveryLoop probes immediately, then every recheckInterval. The
+// loop exits cleanly when ctx is canceled. Without this loop the
+// Discoverer is purely lazy (probe-on-stale-read), which means a
+// post-startup mesh install isn't noticed until the next user request.
+func (d *Discoverer) RunDiscoveryLoop(ctx context.Context) {
+	d.Probe(ctx)
+	ticker := time.NewTicker(recheckInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			d.Probe(ctx)
+		}
+	}
+}
+
 // Probe runs CRD discovery + control-plane deployment probes and refreshes
 // the cached status. Callers may invoke Probe directly to force a refresh.
 //
@@ -93,16 +129,16 @@ func (d *Discoverer) Probe(ctx context.Context) MeshStatus {
 	// Short-circuit for the test constructor with nil client.
 	if d.disco == nil {
 		d.mu.Lock()
-		defer d.mu.Unlock()
 		d.status = MeshStatus{LastChecked: time.Now().UTC()}
-		return d.status
+		s := d.status
+		d.mu.Unlock()
+		return s
 	}
 
 	istioInfo, istioErr := d.probeIstio(ctx)
 	linkerdInfo, linkerdErr := d.probeLinkerd(ctx)
 
 	d.mu.Lock()
-	defer d.mu.Unlock()
 
 	prev := d.status
 	status := MeshStatus{LastChecked: time.Now().UTC()}
@@ -122,11 +158,22 @@ func (d *Discoverer) Probe(ctx context.Context) MeshStatus {
 	status.Detected = detectionFrom(status.Istio, status.Linkerd)
 
 	d.status = status
+	cb := d.onChange
+	prevDetected := prev.Detected
+	d.mu.Unlock()
+
 	d.logger.Info("service mesh discovery completed",
 		"detected", status.Detected,
 		"istioInstalled", status.Istio != nil && status.Istio.Installed,
 		"linkerdInstalled", status.Linkerd != nil && status.Linkerd.Installed,
 	)
+
+	// Fire the change callback OUTSIDE the lock so callbacks (typically
+	// cache invalidations on the handler) don't block subsequent probes.
+	// Only fire on a real transition; a steady state keeps caches warm.
+	if cb != nil && prevDetected != status.Detected {
+		cb(prevDetected, status.Detected)
+	}
 	return status
 }
 

--- a/backend/internal/servicemesh/handler.go
+++ b/backend/internal/servicemesh/handler.go
@@ -228,6 +228,22 @@ func (h *Handler) doFetch(ctx context.Context) (*cachedMeshData, error) {
 	return data, nil
 }
 
+// Routes returns the cached, cluster-wide TrafficRoute slice without RBAC
+// filtering. Callers are responsible for applying their own RBAC scope before
+// surfacing routes to a user — this accessor exists for cross-package
+// consumers (e.g., the topology overlay) that already have a user in context
+// and need to apply CanAccessGroupResource per-CRD-group.
+//
+// The returned slice may be a view into the cache; callers must treat it as
+// read-only and copy any data they intend to mutate.
+func (h *Handler) Routes(ctx context.Context) ([]TrafficRoute, error) {
+	data, err := h.fetchData(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return data.routes, nil
+}
+
 // InvalidateCache clears the cache so the next call re-fetches. Exported for
 // CRD event handlers to hook into, mirroring gitops/policy.
 func (h *Handler) InvalidateCache() {

--- a/backend/internal/servicemesh/handler.go
+++ b/backend/internal/servicemesh/handler.go
@@ -229,19 +229,51 @@ func (h *Handler) doFetch(ctx context.Context) (*cachedMeshData, error) {
 }
 
 // Routes returns the cached, cluster-wide TrafficRoute slice without RBAC
-// filtering. Callers are responsible for applying their own RBAC scope before
-// surfacing routes to a user — this accessor exists for cross-package
-// consumers (e.g., the topology overlay) that already have a user in context
-// and need to apply CanAccessGroupResource per-CRD-group.
+// filtering. Callers are responsible for applying their own RBAC scope
+// before surfacing routes to a user — this accessor exists for cross-
+// package consumers (the topology overlay) that already have a user in
+// context and need to apply CanAccessGroupResource per-CRD-group.
 //
-// The returned slice may be a view into the cache; callers must treat it as
-// read-only and copy any data they intend to mutate.
+// The returned slice is a defensive copy of the cache header so callers
+// can't extend it via append into the cache's spare capacity. The
+// underlying TrafficRoute elements (and TrafficRoute.Raw maps) are
+// shared; treat them as read-only.
 func (h *Handler) Routes(ctx context.Context) ([]TrafficRoute, error) {
 	data, err := h.fetchData(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return data.routes, nil
+	if len(data.routes) == 0 {
+		return nil, nil
+	}
+	out := make([]TrafficRoute, len(data.routes))
+	copy(out, data.routes)
+	return out, nil
+}
+
+// MeshDetected reports whether at least one supported service mesh is
+// installed in the cluster. The topology overlay calls this to choose
+// between OverlayMesh ("we asked, here's what's visible") and
+// OverlayUnavailable ("no mesh installed, the question is meaningless")
+// without paying for a full Routes() fetch.
+func (h *Handler) MeshDetected(ctx context.Context) bool {
+	status := h.Discoverer.Status(ctx)
+	return status.Detected != MeshNone
+}
+
+// MeshKindForRoute returns the (apiGroup, resource) pair the topology
+// overlay needs to RBAC-check a route's source CRD. The mapping lives in
+// servicemesh's meshKindDispatch table; exposing it through one helper
+// keeps topology and servicemesh in sync without re-encoding the (mesh,
+// kind) → (group, resource) translation in two places.
+//
+// Returns ("", "") when the route's (mesh, kind) isn't a known mesh CRD.
+func MeshKindForRoute(r TrafficRoute) (apiGroup, resource string) {
+	entry, ok := meshKindDispatch[string(r.Mesh)+"/"+r.Kind]
+	if !ok {
+		return "", ""
+	}
+	return entry.APIGroup, entry.Resource
 }
 
 // InvalidateCache clears the cache so the next call re-fetches. Exported for

--- a/backend/internal/servicemesh/handler_test.go
+++ b/backend/internal/servicemesh/handler_test.go
@@ -297,6 +297,52 @@ func TestHandler_SingleflightCoalesces(t *testing.T) {
 	}
 }
 
+// TestHandler_Routes_ReturnsCachedSliceUnfiltered covers the Phase D1
+// invariant: Handler.Routes returns the cluster-wide cached slice without
+// applying RBAC. Cross-package consumers (the topology overlay) need this
+// raw view so they can apply CanAccessGroupResource per-CRD-group at the
+// scope of the namespace they're rendering.
+func TestHandler_Routes_ReturnsCachedSliceUnfiltered(t *testing.T) {
+	vsFoo := virtualService("foo", "a", []string{"a.foo"}, nil)
+	vsBar := virtualService("bar", "b", []string{"b.bar"}, nil)
+
+	h := &Handler{
+		Discoverer:    seededDiscoverer(MeshStatus{Detected: MeshIstio, Istio: &MeshInfo{Installed: true, Version: "1.24.0"}}),
+		AccessChecker: resources.NewAlwaysDenyAccessChecker(), // RBAC denies everything
+		Logger:        slog.Default(),
+		dynOverride:   newIstioFakeDynClient(vsFoo, vsBar),
+	}
+
+	routes, err := h.Routes(context.Background())
+	if err != nil {
+		t.Fatalf("Routes: %v", err)
+	}
+	// Two VS routes seeded; deny-all RBAC must NOT be applied at this layer.
+	if got := len(routes); got != 2 {
+		t.Errorf("Routes len = %d, want 2 (Routes is unfiltered; RBAC is the caller's job)", got)
+	}
+}
+
+// TestHandler_Routes_NilDynClient covers the degraded-cluster path: when no
+// dynamic client is wired, Routes returns an empty slice and no error so
+// callers can render an empty overlay rather than 5xx.
+func TestHandler_Routes_NilDynClient(t *testing.T) {
+	h := &Handler{
+		Discoverer:    seededDiscoverer(MeshStatus{Detected: MeshIstio, Istio: &MeshInfo{Installed: true, Version: "1.24.0"}}),
+		AccessChecker: resources.NewAlwaysAllowAccessChecker(),
+		Logger:        slog.Default(),
+		// no dynOverride and no K8sClient -> dynClient() returns nil
+	}
+
+	routes, err := h.Routes(context.Background())
+	if err != nil {
+		t.Fatalf("Routes: %v", err)
+	}
+	if len(routes) != 0 {
+		t.Errorf("Routes len = %d, want 0 when no dynamic client is wired", len(routes))
+	}
+}
+
 // --- helpers ---------------------------------------------------------------
 
 func doGet(t *testing.T, handler http.HandlerFunc, user *auth.User) *httptest.ResponseRecorder {

--- a/backend/internal/topology/builder.go
+++ b/backend/internal/topology/builder.go
@@ -15,11 +15,26 @@ import (
 
 	"github.com/kubecenter/kubecenter/internal/auth"
 	"github.com/kubecenter/kubecenter/internal/k8s/resources"
+	"github.com/kubecenter/kubecenter/internal/servicemesh"
 )
 
 // maxNodes caps the total number of nodes in a graph to prevent
 // oversized responses for very large namespaces.
 const maxNodes = 2000
+
+// maxMeshEdges caps mesh-overlay edges separately from maxNodes.
+// A single VirtualService can fan out to dozens of destinations; in a
+// 1000-service mesh this is the realistic blow-up vector. Reuses the
+// existing Graph.Truncated flag to surface the cap to the client.
+const maxMeshEdges = 2000
+
+// MeshRouteProvider returns cached, cluster-wide mesh traffic routes.
+// Implemented by *servicemesh.Handler. The returned slice is not
+// RBAC-filtered — Builder applies per-CRD-group access checks before
+// emitting edges. A nil provider disables the mesh overlay path.
+type MeshRouteProvider interface {
+	Routes(ctx context.Context) ([]servicemesh.TrafficRoute, error)
+}
 
 // ResourceLister abstracts resource listing for the graph builder.
 // Implemented by InformerLister (wraps InformerManager) and test fakes.
@@ -39,14 +54,25 @@ type ResourceLister interface {
 }
 
 // Builder constructs resource dependency graphs from a ResourceLister.
+// meshProvider is optional; when nil, the mesh overlay path returns
+// Overlay = "unavailable" and the base graph.
 type Builder struct {
-	lister ResourceLister
-	logger *slog.Logger
+	lister       ResourceLister
+	meshProvider MeshRouteProvider
+	logger       *slog.Logger
 }
 
-// NewBuilder creates a new topology graph builder.
+// NewBuilder creates a new topology graph builder without mesh-overlay support.
+// Callers that want the mesh overlay should use NewBuilderWithMesh.
 func NewBuilder(lister ResourceLister, logger *slog.Logger) *Builder {
 	return &Builder{lister: lister, logger: logger}
+}
+
+// NewBuilderWithMesh creates a topology graph builder that can emit
+// mesh-overlay edges when callers request ?overlay=mesh. Pass a nil
+// meshProvider to behave identically to NewBuilder.
+func NewBuilderWithMesh(lister ResourceLister, meshProvider MeshRouteProvider, logger *slog.Logger) *Builder {
+	return &Builder{lister: lister, meshProvider: meshProvider, logger: logger}
 }
 
 // resourceMeta is a normalized representation of a k8s resource for generic node building.
@@ -67,8 +93,23 @@ func canAccess(ctx context.Context, user *auth.User, checker *resources.AccessCh
 	return allowed
 }
 
-// BuildNamespaceGraph builds a full resource dependency graph for a namespace.
+// BuildNamespaceGraph builds a full resource dependency graph for a namespace
+// without any optional overlay. Equivalent to calling
+// BuildNamespaceGraphWithOverlay with an empty overlay string.
 func (b *Builder) BuildNamespaceGraph(ctx context.Context, namespace string, user *auth.User, checker *resources.AccessChecker) (*Graph, error) {
+	return b.BuildNamespaceGraphWithOverlay(ctx, namespace, user, checker, "")
+}
+
+// BuildNamespaceGraphWithOverlay builds the namespace graph and optionally
+// layers an additional set of edges on top.
+//
+// Supported overlay values:
+//   - ""      — no overlay (response is byte-identical to the no-overlay path)
+//   - "mesh"  — emit mesh-overlay edges between Service nodes when the
+//     caller has list permission on the underlying CRD groups
+//
+// Unknown overlay values return an error so the handler can emit a 400.
+func (b *Builder) BuildNamespaceGraphWithOverlay(ctx context.Context, namespace string, user *auth.User, checker *resources.AccessChecker, overlay string) (*Graph, error) {
 	graph := NewGraph()
 	nameIndex := make(map[string]string) // "Kind/Name" -> UID
 
@@ -287,7 +328,140 @@ func (b *Builder) BuildNamespaceGraph(ctx context.Context, namespace string, use
 	// Propagate health
 	propagateHealth(nodeMap, graph.Edges)
 
+	// Apply optional overlay last so health propagation is unaffected by
+	// mesh edges. Overlay errors are logged and downgraded to "unavailable"
+	// — never fail the base graph because the overlay couldn't load.
+	if err := b.applyOverlay(ctx, graph, namespace, user, checker, overlay, nameIndex); err != nil {
+		return nil, err
+	}
+
 	return graph, nil
+}
+
+// applyOverlay layers optional edges on top of an already-built graph.
+// Returns an error only for invalid overlay values (handler emits 400);
+// runtime failures degrade gracefully via Graph.Overlay = "unavailable".
+func (b *Builder) applyOverlay(
+	ctx context.Context,
+	graph *Graph,
+	namespace string,
+	user *auth.User,
+	checker *resources.AccessChecker,
+	overlay string,
+	nameIndex map[string]string,
+) error {
+	switch overlay {
+	case "":
+		return nil
+	case "mesh":
+		b.applyMeshOverlay(ctx, graph, namespace, user, checker, nameIndex)
+		return nil
+	default:
+		return fmt.Errorf("unsupported overlay %q", overlay)
+	}
+}
+
+// applyMeshOverlay fetches mesh routes via the configured provider, filters
+// them by the caller's RBAC on each CRD group, and appends the resulting
+// edges to graph.Edges. The base graph is never mutated except for adding
+// edges and toggling Truncated; if anything goes wrong, the overlay falls
+// back to "unavailable" and the function returns silently.
+func (b *Builder) applyMeshOverlay(
+	ctx context.Context,
+	graph *Graph,
+	namespace string,
+	user *auth.User,
+	checker *resources.AccessChecker,
+	nameIndex map[string]string,
+) {
+	if b.meshProvider == nil {
+		graph.Overlay = "unavailable"
+		return
+	}
+
+	routes, err := b.meshProvider.Routes(ctx)
+	if err != nil {
+		b.logger.Warn("mesh overlay: route fetch failed", "namespace", namespace, "error", err)
+		graph.Overlay = "unavailable"
+		return
+	}
+
+	// From this point on, the overlay is "mesh" — even if every route is
+	// dropped by RBAC or no mesh is installed. "unavailable" is reserved
+	// for "we couldn't try". This distinguishes "no mesh data to show" from
+	// "we don't have a way to ask".
+	graph.Overlay = "mesh"
+
+	// Filter to the requested namespace before the RBAC fan-out so we make
+	// at most one SSAR per (CRD group, namespace) pair.
+	scoped := routes[:0:0]
+	for _, r := range routes {
+		if r.Namespace == namespace {
+			scoped = append(scoped, r)
+		}
+	}
+	if len(scoped) == 0 {
+		return
+	}
+
+	// Cache RBAC decisions per (apiGroup, resource) for this namespace. The
+	// number of unique CRD groups across both meshes is small (≤ 2), so a
+	// plain map is fine. A checker error fail-closes that CRD group: we drop
+	// its routes rather than emit edges the user might not be allowed to see.
+	type accessKey struct{ apiGroup, resource string }
+	access := map[accessKey]bool{}
+	allowed := func(apiGroup, resource string) bool {
+		key := accessKey{apiGroup, resource}
+		if v, ok := access[key]; ok {
+			return v
+		}
+		can, err := checker.CanAccessGroupResource(ctx, user.KubernetesUsername, user.KubernetesGroups, "list", apiGroup, resource, namespace)
+		if err != nil {
+			b.logger.Warn("mesh overlay: RBAC check failed", "namespace", namespace, "apiGroup", apiGroup, "resource", resource, "error", err)
+			access[key] = false
+			return false
+		}
+		access[key] = can
+		return can
+	}
+
+	visible := scoped[:0]
+	for _, r := range scoped {
+		apiGroup, resource := meshCRDForRoute(r)
+		if apiGroup == "" {
+			continue
+		}
+		if !allowed(apiGroup, resource) {
+			continue
+		}
+		visible = append(visible, r)
+	}
+	if len(visible) == 0 {
+		return
+	}
+
+	meshEdges, truncated := buildMeshEdges(visible, namespace, nameIndex, maxMeshEdges)
+	if truncated {
+		graph.Truncated = true
+	}
+	graph.Edges = append(graph.Edges, meshEdges...)
+}
+
+// meshCRDForRoute returns the (apiGroup, resource) pair used to RBAC-check a
+// route's source CRD. Mesh+kind combinations not handled by D1's edge emitter
+// return empty strings and are filtered out upstream.
+func meshCRDForRoute(r servicemesh.TrafficRoute) (apiGroup, resource string) {
+	switch r.Mesh {
+	case servicemesh.MeshIstio:
+		if r.Kind == "VirtualService" {
+			return "networking.istio.io", "virtualservices"
+		}
+	case servicemesh.MeshLinkerd:
+		if r.Kind == "ServiceProfile" {
+			return "linkerd.io", "serviceprofiles"
+		}
+	}
+	return "", ""
 }
 
 // addResourceNodes adds nodes for a list of resources, respecting the node cap.

--- a/backend/internal/topology/builder.go
+++ b/backend/internal/topology/builder.go
@@ -2,6 +2,7 @@ package topology
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -18,22 +19,36 @@ import (
 	"github.com/kubecenter/kubecenter/internal/servicemesh"
 )
 
+// ErrUnsupportedOverlay is returned by BuildNamespaceGraphWithOverlay when
+// the caller passes an overlay value the builder doesn't recognize. The
+// HTTP handler maps this (via errors.Is) to a 400. Wrapping the sentinel
+// keeps the wire status code stable across error-message tweaks.
+var ErrUnsupportedOverlay = errors.New("unsupported overlay")
+
 // maxNodes caps the total number of nodes in a graph to prevent
 // oversized responses for very large namespaces.
 const maxNodes = 2000
 
 // maxMeshEdges caps mesh-overlay edges separately from maxNodes.
 // A single VirtualService can fan out to dozens of destinations; in a
-// 1000-service mesh this is the realistic blow-up vector. Reuses the
-// existing Graph.Truncated flag to surface the cap to the client.
+// 1000-service mesh this is the realistic blow-up vector. Surfaces via
+// Graph.EdgesTruncated, distinct from Graph.Truncated which signals
+// node-cap truncation.
 const maxMeshEdges = 2000
 
-// MeshRouteProvider returns cached, cluster-wide mesh traffic routes.
-// Implemented by *servicemesh.Handler. The returned slice is not
-// RBAC-filtered — Builder applies per-CRD-group access checks before
-// emitting edges. A nil provider disables the mesh overlay path.
+// MeshRouteProvider returns cached, cluster-wide mesh traffic routes
+// and a coarse "is a mesh installed" signal. Implemented by
+// *servicemesh.Handler. The returned routes slice is not RBAC-filtered —
+// Builder applies per-CRD-group access checks before emitting edges.
+// A nil provider disables the mesh overlay path.
+//
+// MeshDetected is required so the overlay path can distinguish
+// "no mesh installed in this cluster" (return OverlayUnavailable, the
+// honest answer) from "mesh installed but the user has no visible
+// routes" (return OverlayMesh with zero edges).
 type MeshRouteProvider interface {
 	Routes(ctx context.Context) ([]servicemesh.TrafficRoute, error)
+	MeshDetected(ctx context.Context) bool
 }
 
 // ResourceLister abstracts resource listing for the graph builder.
@@ -54,24 +69,18 @@ type ResourceLister interface {
 }
 
 // Builder constructs resource dependency graphs from a ResourceLister.
-// meshProvider is optional; when nil, the mesh overlay path returns
-// Overlay = "unavailable" and the base graph.
+// meshProvider is optional; pass nil to disable the mesh-overlay path
+// (the overlay then resolves to OverlayUnavailable).
 type Builder struct {
 	lister       ResourceLister
 	meshProvider MeshRouteProvider
 	logger       *slog.Logger
 }
 
-// NewBuilder creates a new topology graph builder without mesh-overlay support.
-// Callers that want the mesh overlay should use NewBuilderWithMesh.
-func NewBuilder(lister ResourceLister, logger *slog.Logger) *Builder {
-	return &Builder{lister: lister, logger: logger}
-}
-
-// NewBuilderWithMesh creates a topology graph builder that can emit
-// mesh-overlay edges when callers request ?overlay=mesh. Pass a nil
-// meshProvider to behave identically to NewBuilder.
-func NewBuilderWithMesh(lister ResourceLister, meshProvider MeshRouteProvider, logger *slog.Logger) *Builder {
+// NewBuilder creates a topology graph builder. meshProvider may be nil;
+// callers without mesh-overlay needs (e.g. diagnostics blast-radius) pass
+// nil here without affecting any other behavior.
+func NewBuilder(lister ResourceLister, meshProvider MeshRouteProvider, logger *slog.Logger) *Builder {
 	return &Builder{lister: lister, meshProvider: meshProvider, logger: logger}
 }
 
@@ -339,8 +348,10 @@ func (b *Builder) BuildNamespaceGraphWithOverlay(ctx context.Context, namespace 
 }
 
 // applyOverlay layers optional edges on top of an already-built graph.
-// Returns an error only for invalid overlay values (handler emits 400);
-// runtime failures degrade gracefully via Graph.Overlay = "unavailable".
+// Returns ErrUnsupportedOverlay (wrappable, matchable via errors.Is) for
+// unknown overlay values so the handler can map cleanly to a 400.
+// Runtime failures (provider unwired, fetch errored, no mesh installed)
+// degrade gracefully via Graph.Overlay = OverlayUnavailable.
 func (b *Builder) applyOverlay(
 	ctx context.Context,
 	graph *Graph,
@@ -353,19 +364,24 @@ func (b *Builder) applyOverlay(
 	switch overlay {
 	case "":
 		return nil
-	case "mesh":
+	case string(OverlayMesh):
 		b.applyMeshOverlay(ctx, graph, namespace, user, checker, nameIndex)
 		return nil
 	default:
-		return fmt.Errorf("unsupported overlay %q", overlay)
+		return fmt.Errorf("%w: %q", ErrUnsupportedOverlay, overlay)
 	}
 }
 
-// applyMeshOverlay fetches mesh routes via the configured provider, filters
-// them by the caller's RBAC on each CRD group, and appends the resulting
-// edges to graph.Edges. The base graph is never mutated except for adding
-// edges and toggling Truncated; if anything goes wrong, the overlay falls
-// back to "unavailable" and the function returns silently.
+// applyMeshOverlay fetches mesh routes via the configured provider,
+// filters them by the caller's RBAC on each CRD group, and appends the
+// resulting edges to graph.Edges. The base graph is only mutated by
+// appending edges and toggling EdgesTruncated; if anything goes wrong
+// the overlay falls back to OverlayUnavailable and the function returns
+// silently.
+//
+// Unresolved-host counts are surfaced via Graph.Errors so a custom
+// cluster-domain or all-external-hosts namespace doesn't return a silent
+// empty graph.
 func (b *Builder) applyMeshOverlay(
 	ctx context.Context,
 	graph *Graph,
@@ -375,25 +391,33 @@ func (b *Builder) applyMeshOverlay(
 	nameIndex map[string]string,
 ) {
 	if b.meshProvider == nil {
-		graph.Overlay = "unavailable"
+		graph.Overlay = OverlayUnavailable
+		return
+	}
+
+	// MeshDetected lets us reserve OverlayMesh for "we asked a real
+	// mesh"; clusters with no mesh installed yield OverlayUnavailable so
+	// the frontend's disabled-toggle path activates. Cheap call: backed
+	// by the discoverer's 5min cache.
+	if !b.meshProvider.MeshDetected(ctx) {
+		graph.Overlay = OverlayUnavailable
 		return
 	}
 
 	routes, err := b.meshProvider.Routes(ctx)
 	if err != nil {
 		b.logger.Warn("mesh overlay: route fetch failed", "namespace", namespace, "error", err)
-		graph.Overlay = "unavailable"
+		graph.Overlay = OverlayUnavailable
 		return
 	}
 
-	// From this point on, the overlay is "mesh" — even if every route is
-	// dropped by RBAC or no mesh is installed. "unavailable" is reserved
-	// for "we couldn't try". This distinguishes "no mesh data to show" from
-	// "we don't have a way to ask".
-	graph.Overlay = "mesh"
+	// From this point on the overlay is OverlayMesh — even if every
+	// route is dropped by RBAC. OverlayUnavailable is reserved for "we
+	// couldn't try" (provider unwired, fetch errored, no mesh installed).
+	graph.Overlay = OverlayMesh
 
-	// Filter to the requested namespace before the RBAC fan-out so we make
-	// at most one SSAR per (CRD group, namespace) pair.
+	// Filter to the requested namespace before the RBAC fan-out so we
+	// make at most one SSAR per (CRD group, namespace) pair.
 	scoped := routes[:0:0]
 	for _, r := range routes {
 		if r.Namespace == namespace {
@@ -404,10 +428,11 @@ func (b *Builder) applyMeshOverlay(
 		return
 	}
 
-	// Cache RBAC decisions per (apiGroup, resource) for this namespace. The
-	// number of unique CRD groups across both meshes is small (≤ 2), so a
-	// plain map is fine. A checker error fail-closes that CRD group: we drop
-	// its routes rather than emit edges the user might not be allowed to see.
+	// Cache RBAC decisions per (apiGroup, resource) for this namespace.
+	// The number of unique CRD groups across both meshes is small (≤ 2),
+	// so a plain map is fine. A checker error fail-closes that CRD
+	// group — we drop its routes rather than emit edges the user might
+	// not be allowed to see.
 	type accessKey struct{ apiGroup, resource string }
 	access := map[accessKey]bool{}
 	allowed := func(apiGroup, resource string) bool {
@@ -427,8 +452,18 @@ func (b *Builder) applyMeshOverlay(
 
 	visible := scoped[:0]
 	for _, r := range scoped {
-		apiGroup, resource := meshCRDForRoute(r)
+		// Single canonical (mesh, kind) → (group, resource) source —
+		// see servicemesh.MeshKindForRoute. Routes for kinds the
+		// overlay doesn't emit (DestinationRule, Gateway, etc.) return
+		// empty strings here and are filtered upstream of buildMeshEdges.
+		apiGroup, resource := servicemesh.MeshKindForRoute(r)
 		if apiGroup == "" {
+			continue
+		}
+		// In the overlay path we only emit edges for VS and SP, so
+		// short-circuit kinds the emitter wouldn't touch even if the
+		// dispatch table lists them (e.g., PeerAuthentication).
+		if !overlayEmitsEdgesFor(r) {
 			continue
 		}
 		if !allowed(apiGroup, resource) {
@@ -440,28 +475,34 @@ func (b *Builder) applyMeshOverlay(
 		return
 	}
 
-	meshEdges, truncated := buildMeshEdges(visible, namespace, nameIndex, maxMeshEdges)
-	if truncated {
-		graph.Truncated = true
+	meshEdges, stats := buildMeshEdges(visible, namespace, nameIndex, maxMeshEdges)
+	if stats.Truncated {
+		graph.EdgesTruncated = true
+	}
+	if stats.UnresolvedSources > 0 || stats.UnresolvedDests > 0 {
+		if graph.Errors == nil {
+			graph.Errors = map[string]string{}
+		}
+		graph.Errors["mesh.unresolvedHosts"] = fmt.Sprintf(
+			"%d route(s) had unresolved source hosts and %d destination hosts didn't match any Service in this namespace; check for cross-namespace targets, external hosts, or a custom cluster domain",
+			stats.UnresolvedSources, stats.UnresolvedDests,
+		)
 	}
 	graph.Edges = append(graph.Edges, meshEdges...)
 }
 
-// meshCRDForRoute returns the (apiGroup, resource) pair used to RBAC-check a
-// route's source CRD. Mesh+kind combinations not handled by D1's edge emitter
-// return empty strings and are filtered out upstream.
-func meshCRDForRoute(r servicemesh.TrafficRoute) (apiGroup, resource string) {
+// overlayEmitsEdgesFor reports whether the mesh-edge emitter has a
+// service-to-service edge type for this route. Keeping the predicate
+// next to applyMeshOverlay (rather than inside buildMeshEdges) lets
+// the RBAC fan-out skip CRD groups the overlay would never use.
+func overlayEmitsEdgesFor(r servicemesh.TrafficRoute) bool {
 	switch r.Mesh {
 	case servicemesh.MeshIstio:
-		if r.Kind == "VirtualService" {
-			return "networking.istio.io", "virtualservices"
-		}
+		return r.Kind == "VirtualService"
 	case servicemesh.MeshLinkerd:
-		if r.Kind == "ServiceProfile" {
-			return "linkerd.io", "serviceprofiles"
-		}
+		return r.Kind == "ServiceProfile"
 	}
-	return "", ""
+	return false
 }
 
 // addResourceNodes adds nodes for a list of resources, respecting the node cap.

--- a/backend/internal/topology/builder_test.go
+++ b/backend/internal/topology/builder_test.go
@@ -1,0 +1,372 @@
+package topology
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/kubecenter/kubecenter/internal/auth"
+	"github.com/kubecenter/kubecenter/internal/k8s/resources"
+	"github.com/kubecenter/kubecenter/internal/servicemesh"
+)
+
+// fakeLister returns a fixed set of services in a namespace and empties for
+// every other resource kind. Enough for D1's overlay path which only needs
+// Service nodes in the nameIndex.
+type fakeLister struct {
+	services []*corev1.Service
+}
+
+func (f *fakeLister) ListPods(_ context.Context, _ string) ([]*corev1.Pod, error) {
+	return nil, nil
+}
+func (f *fakeLister) ListServices(_ context.Context, namespace string) ([]*corev1.Service, error) {
+	out := make([]*corev1.Service, 0, len(f.services))
+	for _, s := range f.services {
+		if s.Namespace == namespace {
+			out = append(out, s)
+		}
+	}
+	return out, nil
+}
+func (f *fakeLister) ListDeployments(_ context.Context, _ string) ([]*appsv1.Deployment, error) {
+	return nil, nil
+}
+func (f *fakeLister) ListReplicaSets(_ context.Context, _ string) ([]*appsv1.ReplicaSet, error) {
+	return nil, nil
+}
+func (f *fakeLister) ListStatefulSets(_ context.Context, _ string) ([]*appsv1.StatefulSet, error) {
+	return nil, nil
+}
+func (f *fakeLister) ListDaemonSets(_ context.Context, _ string) ([]*appsv1.DaemonSet, error) {
+	return nil, nil
+}
+func (f *fakeLister) ListJobs(_ context.Context, _ string) ([]*batchv1.Job, error) {
+	return nil, nil
+}
+func (f *fakeLister) ListCronJobs(_ context.Context, _ string) ([]*batchv1.CronJob, error) {
+	return nil, nil
+}
+func (f *fakeLister) ListIngresses(_ context.Context, _ string) ([]*networkingv1.Ingress, error) {
+	return nil, nil
+}
+func (f *fakeLister) ListConfigMaps(_ context.Context, _ string) ([]*corev1.ConfigMap, error) {
+	return nil, nil
+}
+func (f *fakeLister) ListPVCs(_ context.Context, _ string) ([]*corev1.PersistentVolumeClaim, error) {
+	return nil, nil
+}
+func (f *fakeLister) ListHPAs(_ context.Context, _ string) ([]*autoscalingv2.HorizontalPodAutoscaler, error) {
+	return nil, nil
+}
+
+// fakeMeshProvider returns canned routes (or an error) so we can drive the
+// overlay path deterministically.
+type fakeMeshProvider struct {
+	routes []servicemesh.TrafficRoute
+	err    error
+}
+
+func (p *fakeMeshProvider) Routes(_ context.Context) ([]servicemesh.TrafficRoute, error) {
+	return p.routes, p.err
+}
+
+func svc(namespace, name, uid string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name, UID: types.UID(uid)},
+		Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeClusterIP},
+	}
+}
+
+func testUser() *auth.User {
+	return &auth.User{KubernetesUsername: "u", KubernetesGroups: []string{"g"}}
+}
+
+func newTestBuilder(provider MeshRouteProvider, services ...*corev1.Service) *Builder {
+	return NewBuilderWithMesh(&fakeLister{services: services}, provider, slog.Default())
+}
+
+// TestBuilder_DefaultPath_NoOverlayField confirms the byte-level invariant
+// that pre-D1 callers must observe: without ?overlay=, the response carries
+// no Overlay value, no mesh edges, and Phase 7B clients see zero behavioral
+// change.
+func TestBuilder_DefaultPath_NoOverlayField(t *testing.T) {
+	b := newTestBuilder(&fakeMeshProvider{
+		routes: []servicemesh.TrafficRoute{
+			{Mesh: servicemesh.MeshIstio, Kind: "VirtualService", Namespace: "foo", Hosts: []string{"a"}, Destinations: []servicemesh.RouteDestination{{Host: "b"}}},
+		},
+	}, svc("foo", "a", "uid-a"), svc("foo", "b", "uid-b"))
+
+	graph, err := b.BuildNamespaceGraph(context.Background(), "foo", testUser(), resources.NewAlwaysAllowAccessChecker())
+	if err != nil {
+		t.Fatalf("BuildNamespaceGraph: %v", err)
+	}
+	if graph.Overlay != "" {
+		t.Errorf("Overlay = %q, want empty string (no-overlay path must not set Overlay)", graph.Overlay)
+	}
+	for _, e := range graph.Edges {
+		if e.Type == EdgeMeshVS || e.Type == EdgeMeshSP {
+			t.Errorf("found mesh edge %+v on no-overlay path; default response must be byte-identical", e)
+		}
+	}
+}
+
+func TestBuilder_OverlayMesh_HappyPath(t *testing.T) {
+	b := newTestBuilder(&fakeMeshProvider{
+		routes: []servicemesh.TrafficRoute{
+			{Mesh: servicemesh.MeshIstio, Kind: "VirtualService", Namespace: "foo", Name: "vs", Hosts: []string{"a"}, Destinations: []servicemesh.RouteDestination{{Host: "b"}}},
+		},
+	}, svc("foo", "a", "uid-a"), svc("foo", "b", "uid-b"))
+
+	graph, err := b.BuildNamespaceGraphWithOverlay(context.Background(), "foo", testUser(), resources.NewAlwaysAllowAccessChecker(), "mesh")
+	if err != nil {
+		t.Fatalf("BuildNamespaceGraphWithOverlay: %v", err)
+	}
+	if graph.Overlay != "mesh" {
+		t.Errorf("Overlay = %q, want %q", graph.Overlay, "mesh")
+	}
+	if !findEdge(graph.Edges, "uid-a", "uid-b", EdgeMeshVS) {
+		t.Errorf("missing mesh_vs edge a->b in graph edges %+v", graph.Edges)
+	}
+}
+
+func TestBuilder_OverlayMesh_NilProviderUnavailable(t *testing.T) {
+	b := NewBuilder(&fakeLister{services: []*corev1.Service{svc("foo", "a", "uid-a")}}, slog.Default())
+
+	graph, err := b.BuildNamespaceGraphWithOverlay(context.Background(), "foo", testUser(), resources.NewAlwaysAllowAccessChecker(), "mesh")
+	if err != nil {
+		t.Fatalf("BuildNamespaceGraphWithOverlay: %v", err)
+	}
+	if graph.Overlay != "unavailable" {
+		t.Errorf("Overlay = %q, want %q (nil provider must degrade)", graph.Overlay, "unavailable")
+	}
+	for _, e := range graph.Edges {
+		if e.Type == EdgeMeshVS || e.Type == EdgeMeshSP {
+			t.Errorf("unexpected mesh edge %+v with nil provider", e)
+		}
+	}
+}
+
+func TestBuilder_OverlayMesh_ProviderErrorUnavailable(t *testing.T) {
+	b := newTestBuilder(&fakeMeshProvider{err: errors.New("transient")},
+		svc("foo", "a", "uid-a"), svc("foo", "b", "uid-b"))
+
+	graph, err := b.BuildNamespaceGraphWithOverlay(context.Background(), "foo", testUser(), resources.NewAlwaysAllowAccessChecker(), "mesh")
+	if err != nil {
+		t.Fatalf("BuildNamespaceGraphWithOverlay: %v", err)
+	}
+	if graph.Overlay != "unavailable" {
+		t.Errorf("Overlay = %q, want %q (provider error must degrade, not 5xx)", graph.Overlay, "unavailable")
+	}
+}
+
+func TestBuilder_OverlayMesh_NoMeshInstalledStillSetsMesh(t *testing.T) {
+	// Provider returns no routes — equivalent to "no mesh installed". The
+	// overlay still reports "mesh" because we successfully asked; we just
+	// have nothing to show. "unavailable" is reserved for "we couldn't ask".
+	b := newTestBuilder(&fakeMeshProvider{routes: nil},
+		svc("foo", "a", "uid-a"), svc("foo", "b", "uid-b"))
+
+	graph, err := b.BuildNamespaceGraphWithOverlay(context.Background(), "foo", testUser(), resources.NewAlwaysAllowAccessChecker(), "mesh")
+	if err != nil {
+		t.Fatalf("BuildNamespaceGraphWithOverlay: %v", err)
+	}
+	if graph.Overlay != "mesh" {
+		t.Errorf("Overlay = %q, want %q (empty routes is still 'mesh', not 'unavailable')", graph.Overlay, "mesh")
+	}
+}
+
+func TestBuilder_OverlayMesh_RBACDeniedYieldsNoEdges(t *testing.T) {
+	b := newTestBuilder(&fakeMeshProvider{
+		routes: []servicemesh.TrafficRoute{
+			{Mesh: servicemesh.MeshIstio, Kind: "VirtualService", Namespace: "foo", Hosts: []string{"a"}, Destinations: []servicemesh.RouteDestination{{Host: "b"}}},
+		},
+	}, svc("foo", "a", "uid-a"), svc("foo", "b", "uid-b"))
+
+	graph, err := b.BuildNamespaceGraphWithOverlay(context.Background(), "foo", testUser(), resources.NewAlwaysDenyAccessChecker(), "mesh")
+	if err != nil {
+		t.Fatalf("BuildNamespaceGraphWithOverlay: %v", err)
+	}
+	if graph.Overlay != "mesh" {
+		t.Errorf("Overlay = %q, want %q (RBAC denial still applies the overlay, just with no edges)", graph.Overlay, "mesh")
+	}
+	for _, e := range graph.Edges {
+		if e.Type == EdgeMeshVS || e.Type == EdgeMeshSP {
+			t.Errorf("user denied list-virtualservices but got mesh edge %+v", e)
+		}
+	}
+}
+
+func TestBuilder_OverlayMesh_OnlyAllowedCRDContributesEdges(t *testing.T) {
+	// Mix Istio + Linkerd routes. Allow-all checker → both contribute. We
+	// don't have a fake that allows one CRD group but not another without
+	// stubbing the underlying clientFactory; this test asserts the
+	// allow-all baseline. Per-CRD denial is exercised by the deny-all test
+	// above, which proves the gate is per-(group, resource).
+	b := newTestBuilder(&fakeMeshProvider{
+		routes: []servicemesh.TrafficRoute{
+			{Mesh: servicemesh.MeshIstio, Kind: "VirtualService", Namespace: "foo", Hosts: []string{"a"}, Destinations: []servicemesh.RouteDestination{{Host: "b"}}},
+			{Mesh: servicemesh.MeshLinkerd, Kind: "ServiceProfile", Namespace: "foo", Hosts: []string{"a"}, Destinations: []servicemesh.RouteDestination{{Host: "b"}}},
+		},
+	}, svc("foo", "a", "uid-a"), svc("foo", "b", "uid-b"))
+
+	graph, err := b.BuildNamespaceGraphWithOverlay(context.Background(), "foo", testUser(), resources.NewAlwaysAllowAccessChecker(), "mesh")
+	if err != nil {
+		t.Fatalf("BuildNamespaceGraphWithOverlay: %v", err)
+	}
+	if !findEdge(graph.Edges, "uid-a", "uid-b", EdgeMeshVS) {
+		t.Error("missing mesh_vs edge")
+	}
+	if !findEdge(graph.Edges, "uid-a", "uid-b", EdgeMeshSP) {
+		t.Error("missing mesh_sp edge")
+	}
+}
+
+func TestBuilder_OverlayMesh_TruncationFlagged(t *testing.T) {
+	// To exercise the mesh-edge cap (maxMeshEdges = 2000) without tripping
+	// the unrelated node cap (maxNodes = 2000), use 60 services and one VS
+	// per service that routes to every other service. That yields up to
+	// 60 * 59 = 3540 candidate edges with only 60 nodes — well over the
+	// edge cap and well under the node cap.
+	const n = 60
+	services := make([]*corev1.Service, n)
+	names := make([]string, n)
+	for i := range services {
+		names[i] = "s" + itoa(i)
+		services[i] = svc("foo", names[i], "uid-"+names[i])
+	}
+
+	routes := make([]servicemesh.TrafficRoute, n)
+	for i := range routes {
+		dests := make([]servicemesh.RouteDestination, 0, n-1)
+		for j, target := range names {
+			if j == i {
+				continue
+			}
+			dests = append(dests, servicemesh.RouteDestination{Host: target})
+		}
+		routes[i] = servicemesh.TrafficRoute{
+			Mesh:         servicemesh.MeshIstio,
+			Kind:         "VirtualService",
+			Namespace:    "foo",
+			Name:         "vs-" + names[i],
+			Hosts:        []string{names[i]},
+			Destinations: dests,
+		}
+	}
+
+	b := newTestBuilder(&fakeMeshProvider{routes: routes}, services...)
+
+	graph, err := b.BuildNamespaceGraphWithOverlay(context.Background(), "foo", testUser(), resources.NewAlwaysAllowAccessChecker(), "mesh")
+	if err != nil {
+		t.Fatalf("BuildNamespaceGraphWithOverlay: %v", err)
+	}
+	if !graph.Truncated {
+		t.Error("Truncated = false, want true at mesh-edge cap")
+	}
+
+	var meshEdges int
+	for _, e := range graph.Edges {
+		if e.Type == EdgeMeshVS {
+			meshEdges++
+		}
+	}
+	if meshEdges != maxMeshEdges {
+		t.Errorf("mesh edges = %d, want %d", meshEdges, maxMeshEdges)
+	}
+}
+
+func TestBuilder_OverlayInvalidValueReturnsError(t *testing.T) {
+	b := newTestBuilder(nil, svc("foo", "a", "uid-a"))
+
+	_, err := b.BuildNamespaceGraphWithOverlay(context.Background(), "foo", testUser(), resources.NewAlwaysAllowAccessChecker(), "garbage")
+	if err == nil {
+		t.Fatal("expected error for unsupported overlay")
+	}
+	if !strings.HasPrefix(err.Error(), "unsupported overlay") {
+		t.Errorf("error = %q, want prefix \"unsupported overlay\" (handler dispatches on this)", err.Error())
+	}
+}
+
+// TestHandler_NoOverlayParamUnchanged covers the same byte-level invariant at
+// the HTTP layer: no ?overlay= → no Overlay field in the response.
+func TestHandler_NoOverlayParamUnchanged(t *testing.T) {
+	b := newTestBuilder(&fakeMeshProvider{
+		routes: []servicemesh.TrafficRoute{
+			{Mesh: servicemesh.MeshIstio, Kind: "VirtualService", Namespace: "foo", Hosts: []string{"a"}, Destinations: []servicemesh.RouteDestination{{Host: "b"}}},
+		},
+	}, svc("foo", "a", "uid-a"), svc("foo", "b", "uid-b"))
+
+	h := &Handler{Builder: b, AccessChecker: resources.NewAlwaysAllowAccessChecker(), Logger: slog.Default()}
+	w := callTopologyHandler(t, h, "foo", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if strings.Contains(w.Body.String(), `"overlay"`) {
+		t.Errorf("response contains \"overlay\" field on no-overlay path; want field absent.\nbody: %s", w.Body.String())
+	}
+}
+
+func TestHandler_InvalidOverlayReturns400(t *testing.T) {
+	b := newTestBuilder(nil, svc("foo", "a", "uid-a"))
+	h := &Handler{Builder: b, AccessChecker: resources.NewAlwaysAllowAccessChecker(), Logger: slog.Default()}
+
+	w := callTopologyHandler(t, h, "foo", "garbage")
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for invalid overlay value", w.Code)
+	}
+}
+
+func TestHandler_OverlayMeshIncludesEdges(t *testing.T) {
+	b := newTestBuilder(&fakeMeshProvider{
+		routes: []servicemesh.TrafficRoute{
+			{Mesh: servicemesh.MeshIstio, Kind: "VirtualService", Namespace: "foo", Hosts: []string{"a"}, Destinations: []servicemesh.RouteDestination{{Host: "b"}}},
+		},
+	}, svc("foo", "a", "uid-a"), svc("foo", "b", "uid-b"))
+
+	h := &Handler{Builder: b, AccessChecker: resources.NewAlwaysAllowAccessChecker(), Logger: slog.Default()}
+	w := callTopologyHandler(t, h, "foo", "mesh")
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, `"overlay":"mesh"`) {
+		t.Errorf("response missing overlay=\"mesh\"; body: %s", body)
+	}
+	if !strings.Contains(body, string(EdgeMeshVS)) {
+		t.Errorf("response missing mesh_vs edge type; body: %s", body)
+	}
+}
+
+// callTopologyHandler invokes h.HandleNamespaceGraph for a synthetic request
+// at /api/v1/topology/{namespace}?overlay={overlay}.
+func callTopologyHandler(t *testing.T, h *Handler, namespace, overlay string) *httptest.ResponseRecorder {
+	t.Helper()
+	url := "/api/v1/topology/" + namespace
+	if overlay != "" {
+		url += "?overlay=" + overlay
+	}
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	req = req.WithContext(auth.ContextWithUser(req.Context(), testUser()))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("namespace", namespace)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	h.HandleNamespaceGraph(w, req)
+	return w
+}

--- a/backend/internal/topology/builder_test.go
+++ b/backend/internal/topology/builder_test.go
@@ -73,15 +73,26 @@ func (f *fakeLister) ListHPAs(_ context.Context, _ string) ([]*autoscalingv2.Hor
 	return nil, nil
 }
 
-// fakeMeshProvider returns canned routes (or an error) so we can drive the
-// overlay path deterministically.
+// fakeMeshProvider returns canned routes (or an error) so we can drive
+// the overlay path deterministically. detected defaults to true so most
+// existing tests don't have to opt in; tests covering the no-mesh path
+// set it explicitly.
 type fakeMeshProvider struct {
-	routes []servicemesh.TrafficRoute
-	err    error
+	routes      []servicemesh.TrafficRoute
+	err         error
+	detectedSet bool
+	detected    bool
 }
 
 func (p *fakeMeshProvider) Routes(_ context.Context) ([]servicemesh.TrafficRoute, error) {
 	return p.routes, p.err
+}
+
+func (p *fakeMeshProvider) MeshDetected(_ context.Context) bool {
+	if p.detectedSet {
+		return p.detected
+	}
+	return true
 }
 
 func svc(namespace, name, uid string) *corev1.Service {
@@ -96,7 +107,7 @@ func testUser() *auth.User {
 }
 
 func newTestBuilder(provider MeshRouteProvider, services ...*corev1.Service) *Builder {
-	return NewBuilderWithMesh(&fakeLister{services: services}, provider, slog.Default())
+	return NewBuilder(&fakeLister{services: services}, provider, slog.Default())
 }
 
 // TestBuilder_DefaultPath_NoOverlayField confirms the byte-level invariant
@@ -144,7 +155,7 @@ func TestBuilder_OverlayMesh_HappyPath(t *testing.T) {
 }
 
 func TestBuilder_OverlayMesh_NilProviderUnavailable(t *testing.T) {
-	b := NewBuilder(&fakeLister{services: []*corev1.Service{svc("foo", "a", "uid-a")}}, slog.Default())
+	b := NewBuilder(&fakeLister{services: []*corev1.Service{svc("foo", "a", "uid-a")}}, nil, slog.Default())
 
 	graph, err := b.BuildNamespaceGraphWithOverlay(context.Background(), "foo", testUser(), resources.NewAlwaysAllowAccessChecker(), "mesh")
 	if err != nil {
@@ -173,10 +184,10 @@ func TestBuilder_OverlayMesh_ProviderErrorUnavailable(t *testing.T) {
 	}
 }
 
-func TestBuilder_OverlayMesh_NoMeshInstalledStillSetsMesh(t *testing.T) {
-	// Provider returns no routes — equivalent to "no mesh installed". The
-	// overlay still reports "mesh" because we successfully asked; we just
-	// have nothing to show. "unavailable" is reserved for "we couldn't ask".
+func TestBuilder_OverlayMesh_DetectedButNoRoutesSetsMesh(t *testing.T) {
+	// Mesh is installed (MeshDetected=true) but no routes have been
+	// declared yet. The overlay reports "mesh" (we asked a real mesh);
+	// the empty-edges case is the user's signal that nothing is configured.
 	b := newTestBuilder(&fakeMeshProvider{routes: nil},
 		svc("foo", "a", "uid-a"), svc("foo", "b", "uid-b"))
 
@@ -184,8 +195,25 @@ func TestBuilder_OverlayMesh_NoMeshInstalledStillSetsMesh(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildNamespaceGraphWithOverlay: %v", err)
 	}
-	if graph.Overlay != "mesh" {
-		t.Errorf("Overlay = %q, want %q (empty routes is still 'mesh', not 'unavailable')", graph.Overlay, "mesh")
+	if graph.Overlay != OverlayMesh {
+		t.Errorf("Overlay = %q, want %q (mesh installed, no routes — still 'mesh')", graph.Overlay, OverlayMesh)
+	}
+}
+
+func TestBuilder_OverlayMesh_NotDetectedYieldsUnavailable(t *testing.T) {
+	// No mesh installed in the cluster. The frontend disable path keys
+	// off "unavailable", so this case must NOT report OverlayMesh — that
+	// would leave the user thinking their mesh is silent when in fact
+	// they don't have a mesh at all.
+	b := newTestBuilder(&fakeMeshProvider{detectedSet: true, detected: false},
+		svc("foo", "a", "uid-a"))
+
+	graph, err := b.BuildNamespaceGraphWithOverlay(context.Background(), "foo", testUser(), resources.NewAlwaysAllowAccessChecker(), "mesh")
+	if err != nil {
+		t.Fatalf("BuildNamespaceGraphWithOverlay: %v", err)
+	}
+	if graph.Overlay != OverlayUnavailable {
+		t.Errorf("Overlay = %q, want %q (no mesh installed must yield unavailable)", graph.Overlay, OverlayUnavailable)
 	}
 }
 
@@ -211,11 +239,9 @@ func TestBuilder_OverlayMesh_RBACDeniedYieldsNoEdges(t *testing.T) {
 }
 
 func TestBuilder_OverlayMesh_OnlyAllowedCRDContributesEdges(t *testing.T) {
-	// Mix Istio + Linkerd routes. Allow-all checker → both contribute. We
-	// don't have a fake that allows one CRD group but not another without
-	// stubbing the underlying clientFactory; this test asserts the
-	// allow-all baseline. Per-CRD denial is exercised by the deny-all test
-	// above, which proves the gate is per-(group, resource).
+	// Mix Istio + Linkerd routes. Allow-all checker → both contribute.
+	// This test asserts the allow-all baseline; the partial-RBAC case
+	// is exercised in TestBuilder_OverlayMesh_PartialRBAC.
 	b := newTestBuilder(&fakeMeshProvider{
 		routes: []servicemesh.TrafficRoute{
 			{Mesh: servicemesh.MeshIstio, Kind: "VirtualService", Namespace: "foo", Hosts: []string{"a"}, Destinations: []servicemesh.RouteDestination{{Host: "b"}}},
@@ -232,6 +258,37 @@ func TestBuilder_OverlayMesh_OnlyAllowedCRDContributesEdges(t *testing.T) {
 	}
 	if !findEdge(graph.Edges, "uid-a", "uid-b", EdgeMeshSP) {
 		t.Error("missing mesh_sp edge")
+	}
+}
+
+func TestBuilder_OverlayMesh_PartialRBAC(t *testing.T) {
+	// User can list networking.istio.io/virtualservices but NOT
+	// linkerd.io/serviceprofiles. The overlay must surface mesh_vs
+	// edges and silently drop mesh_sp edges; the headline guarantee
+	// of Phase D's per-CRD-group RBAC story.
+	checker := resources.NewPredicateAccessChecker(func(_, apiGroup, resource, _ string) bool {
+		return apiGroup == "networking.istio.io" && resource == "virtualservices"
+	})
+
+	b := newTestBuilder(&fakeMeshProvider{
+		routes: []servicemesh.TrafficRoute{
+			{Mesh: servicemesh.MeshIstio, Kind: "VirtualService", Namespace: "foo", Hosts: []string{"a"}, Destinations: []servicemesh.RouteDestination{{Host: "b"}}},
+			{Mesh: servicemesh.MeshLinkerd, Kind: "ServiceProfile", Namespace: "foo", Hosts: []string{"a"}, Destinations: []servicemesh.RouteDestination{{Host: "b"}}},
+		},
+	}, svc("foo", "a", "uid-a"), svc("foo", "b", "uid-b"))
+
+	graph, err := b.BuildNamespaceGraphWithOverlay(context.Background(), "foo", testUser(), checker, "mesh")
+	if err != nil {
+		t.Fatalf("BuildNamespaceGraphWithOverlay: %v", err)
+	}
+	if graph.Overlay != OverlayMesh {
+		t.Errorf("Overlay = %q, want %q", graph.Overlay, OverlayMesh)
+	}
+	if !findEdge(graph.Edges, "uid-a", "uid-b", EdgeMeshVS) {
+		t.Error("missing mesh_vs edge — VS group was allowed but no edges emitted")
+	}
+	if findEdge(graph.Edges, "uid-a", "uid-b", EdgeMeshSP) {
+		t.Error("found mesh_sp edge despite SP group denial — RBAC gate is not per-(apiGroup, resource)")
 	}
 }
 
@@ -274,8 +331,13 @@ func TestBuilder_OverlayMesh_TruncationFlagged(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildNamespaceGraphWithOverlay: %v", err)
 	}
-	if !graph.Truncated {
-		t.Error("Truncated = false, want true at mesh-edge cap")
+	// Mesh-edge truncation flips EdgesTruncated specifically — the
+	// existing Truncated flag stays reserved for the maxNodes cap.
+	if !graph.EdgesTruncated {
+		t.Error("EdgesTruncated = false, want true at mesh-edge cap")
+	}
+	if graph.Truncated {
+		t.Error("Truncated = true, want false (node cap not hit)")
 	}
 
 	var meshEdges int

--- a/backend/internal/topology/handler.go
+++ b/backend/internal/topology/handler.go
@@ -1,6 +1,7 @@
 package topology
 
 import (
+	"errors"
 	"log/slog"
 	"net/http"
 
@@ -39,10 +40,12 @@ func (h *Handler) HandleNamespaceGraph(w http.ResponseWriter, r *http.Request) {
 
 	graph, err := h.Builder.BuildNamespaceGraphWithOverlay(r.Context(), namespace, user, h.AccessChecker, overlay)
 	if err != nil {
-		// Validation errors (e.g., unsupported overlay value) surface as 400
-		// with a user-safe message; everything else is a 500.
-		if isInvalidOverlayErr(err) {
-			httputil.WriteError(w, http.StatusBadRequest, err.Error(), "")
+		// Validation errors (unsupported overlay value) surface as 400
+		// with a stable user-message and the offending value in detail —
+		// matching the envelope shape used by /mesh/* peers. Everything
+		// else is a 500.
+		if errors.Is(err, ErrUnsupportedOverlay) {
+			httputil.WriteError(w, http.StatusBadRequest, "unsupported overlay value", overlay)
 			return
 		}
 		h.Logger.Error("failed to build namespace graph", "namespace", namespace, "error", err)
@@ -51,15 +54,4 @@ func (h *Handler) HandleNamespaceGraph(w http.ResponseWriter, r *http.Request) {
 	}
 
 	httputil.WriteData(w, graph)
-}
-
-// isInvalidOverlayErr reports whether err is a builder-level validation
-// failure for an unsupported overlay value. Kept narrow so unrelated
-// errors don't get misclassified as 400.
-func isInvalidOverlayErr(err error) bool {
-	if err == nil {
-		return false
-	}
-	const prefix = "unsupported overlay "
-	return len(err.Error()) >= len(prefix) && err.Error()[:len(prefix)] == prefix
 }

--- a/backend/internal/topology/handler.go
+++ b/backend/internal/topology/handler.go
@@ -19,6 +19,13 @@ type Handler struct {
 
 // HandleNamespaceGraph returns the full resource dependency graph for a namespace.
 // GET /api/v1/topology/{namespace}
+//
+// Optional query parameter:
+//
+//	?overlay=mesh — adds service-to-service mesh edges (Istio VirtualService
+//	  and Linkerd ServiceProfile routing) when the caller has list
+//	  permission on the underlying CRDs. Without this parameter the response
+//	  is byte-identical to the no-overlay path.
 func (h *Handler) HandleNamespaceGraph(w http.ResponseWriter, r *http.Request) {
 	namespace := chi.URLParam(r, "namespace")
 
@@ -28,12 +35,31 @@ func (h *Handler) HandleNamespaceGraph(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	graph, err := h.Builder.BuildNamespaceGraph(r.Context(), namespace, user, h.AccessChecker)
+	overlay := r.URL.Query().Get("overlay")
+
+	graph, err := h.Builder.BuildNamespaceGraphWithOverlay(r.Context(), namespace, user, h.AccessChecker, overlay)
 	if err != nil {
+		// Validation errors (e.g., unsupported overlay value) surface as 400
+		// with a user-safe message; everything else is a 500.
+		if isInvalidOverlayErr(err) {
+			httputil.WriteError(w, http.StatusBadRequest, err.Error(), "")
+			return
+		}
 		h.Logger.Error("failed to build namespace graph", "namespace", namespace, "error", err)
 		httputil.WriteError(w, http.StatusInternalServerError, "failed to build topology graph", "")
 		return
 	}
 
 	httputil.WriteData(w, graph)
+}
+
+// isInvalidOverlayErr reports whether err is a builder-level validation
+// failure for an unsupported overlay value. Kept narrow so unrelated
+// errors don't get misclassified as 400.
+func isInvalidOverlayErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	const prefix = "unsupported overlay "
+	return len(err.Error()) >= len(prefix) && err.Error()[:len(prefix)] == prefix
 }

--- a/backend/internal/topology/mesh_edges.go
+++ b/backend/internal/topology/mesh_edges.go
@@ -1,0 +1,147 @@
+package topology
+
+import (
+	"strings"
+
+	"github.com/kubecenter/kubecenter/internal/servicemesh"
+)
+
+// buildMeshEdges converts mesh routing CRDs into service-to-service edges
+// against an existing nameIndex of "Kind/Name" -> UID. The function is pure:
+// no I/O, no logging, no RBAC. Callers are responsible for filtering routes
+// they're not allowed to surface.
+//
+// Routes outside the requested namespace are skipped. The source service of
+// each edge is resolved from route.Hosts[0]; targets come from
+// route.Destinations[].Host. Hosts that don't resolve to a Service node in
+// the index (typically external hosts or cross-namespace targets) are
+// silently dropped — that's a feature, not a bug.
+//
+// Edges are deduplicated by (source, target, type) so multiple VS objects
+// that converge on the same source/target pair only emit one edge. Emission
+// stops at maxEdges with truncated=true; reuse the existing
+// Graph.Truncated flag at the call site.
+func buildMeshEdges(
+	routes []servicemesh.TrafficRoute,
+	namespace string,
+	nameIndex map[string]string,
+	maxEdges int,
+) (edges []Edge, truncated bool) {
+	if len(routes) == 0 || namespace == "" || nameIndex == nil {
+		return nil, false
+	}
+
+	seen := make(map[string]struct{})
+	add := func(source, target string, t EdgeType) bool {
+		if source == "" || target == "" || source == target {
+			return false
+		}
+		key := source + "->" + target + "/" + string(t)
+		if _, dup := seen[key]; dup {
+			return false
+		}
+		if maxEdges > 0 && len(edges) >= maxEdges {
+			return true // signal cap reached
+		}
+		seen[key] = struct{}{}
+		edges = append(edges, Edge{Source: source, Target: target, Type: t})
+		return false
+	}
+
+	for _, r := range routes {
+		if r.Namespace != namespace {
+			continue
+		}
+
+		var edgeType EdgeType
+		switch r.Mesh {
+		case servicemesh.MeshIstio:
+			// DestinationRule and Gateway don't fit the source->target shape
+			// in D1; only VirtualService routes emit mesh_vs edges.
+			if r.Kind != "VirtualService" {
+				continue
+			}
+			edgeType = EdgeMeshVS
+		case servicemesh.MeshLinkerd:
+			// Only ServiceProfile carries route.destinations in v1.
+			if r.Kind != "ServiceProfile" {
+				continue
+			}
+			edgeType = EdgeMeshSP
+		default:
+			continue
+		}
+
+		var sourceUID string
+		for _, host := range r.Hosts {
+			if uid, ok := resolveServiceHost(host, namespace, nameIndex); ok {
+				sourceUID = uid
+				break
+			}
+		}
+		if sourceUID == "" {
+			continue
+		}
+
+		for _, dest := range r.Destinations {
+			targetUID, ok := resolveServiceHost(dest.Host, namespace, nameIndex)
+			if !ok {
+				continue
+			}
+			if capped := add(sourceUID, targetUID, edgeType); capped {
+				return edges, true
+			}
+		}
+	}
+
+	return edges, false
+}
+
+// resolveServiceHost looks up a mesh route's host string against the topology
+// nameIndex. It accepts the three common Kubernetes service-host shapes:
+//
+//	bare name:        my-svc
+//	namespaced:       my-svc.foo
+//	fully qualified:  my-svc.foo.svc.cluster.local
+//
+// Only hosts that resolve to a Service node in the requested namespace match.
+// Cross-namespace hosts (my-svc.bar from inside namespace foo) and external
+// hosts (api.example.com) return ok=false.
+//
+// Custom cluster domains (clusterDomain != "cluster.local") are a known
+// limitation inherited from Phase B; these hosts won't resolve and the edges
+// will be silently skipped.
+func resolveServiceHost(host, namespace string, nameIndex map[string]string) (string, bool) {
+	if host == "" || namespace == "" {
+		return "", false
+	}
+
+	// Strip the FQDN suffix. We accept .svc.cluster.local and .svc; the
+	// shorter forms still flow through the dot-split below.
+	bare := host
+	for _, suffix := range []string{".svc.cluster.local", ".svc"} {
+		if trimmed, ok := strings.CutSuffix(bare, suffix); ok {
+			bare = trimmed
+			break
+		}
+	}
+
+	// At this point the candidate is either "name" or "name.namespace".
+	parts := strings.Split(bare, ".")
+	switch len(parts) {
+	case 1:
+		// Bare name — same namespace assumed.
+		if uid, ok := nameIndex["Service/"+parts[0]]; ok {
+			return uid, true
+		}
+	case 2:
+		// name.namespace — only resolve when namespace matches.
+		if parts[1] != namespace {
+			return "", false
+		}
+		if uid, ok := nameIndex["Service/"+parts[0]]; ok {
+			return uid, true
+		}
+	}
+	return "", false
+}

--- a/backend/internal/topology/mesh_edges.go
+++ b/backend/internal/topology/mesh_edges.go
@@ -6,34 +6,48 @@ import (
 	"github.com/kubecenter/kubecenter/internal/servicemesh"
 )
 
+// MeshEdgeStats reports outcomes from a buildMeshEdges call so the caller
+// can surface diagnostic information ("we considered N routes, M sources
+// didn't resolve, K destinations didn't resolve") rather than silently
+// dropping unresolved hosts.
+type MeshEdgeStats struct {
+	Truncated         bool
+	Considered        int
+	UnresolvedSources int
+	UnresolvedDests   int
+}
+
 // buildMeshEdges converts mesh routing CRDs into service-to-service edges
-// against an existing nameIndex of "Kind/Name" -> UID. The function is pure:
-// no I/O, no logging, no RBAC. Callers are responsible for filtering routes
-// they're not allowed to surface.
+// against an existing nameIndex of "Kind/Name" -> UID. The function is
+// pure: no I/O, no logging, no RBAC. Callers are responsible for filtering
+// routes they're not allowed to surface.
 //
-// Routes outside the requested namespace are skipped. The source service of
-// each edge is resolved from route.Hosts[0]; targets come from
-// route.Destinations[].Host. Hosts that don't resolve to a Service node in
-// the index (typically external hosts or cross-namespace targets) are
-// silently dropped — that's a feature, not a bug.
+// Routes outside the requested namespace are skipped. The source service
+// of each edge is resolved by walking r.Hosts in order and taking the
+// first host that resolves to a Service node in the index. Targets come
+// from r.Destinations[].Host. Hosts that don't resolve (cross-namespace
+// targets, external hosts, custom cluster-domain FQDNs) are counted in
+// MeshEdgeStats so a caller can surface "N routes had unresolved hosts"
+// instead of leaving a silent empty graph.
 //
 // Edges are deduplicated by (source, target, type) so multiple VS objects
-// that converge on the same source/target pair only emit one edge. Emission
-// stops at maxEdges with truncated=true; reuse the existing
-// Graph.Truncated flag at the call site.
+// that converge on the same source/target pair only emit one edge. Self
+// edges (source == target) are emitted: Istio canary patterns route a
+// single host to subsets of the same Service via DestinationRule weights.
+// Emission stops at maxEdges with stats.Truncated=true.
 func buildMeshEdges(
 	routes []servicemesh.TrafficRoute,
 	namespace string,
 	nameIndex map[string]string,
 	maxEdges int,
-) (edges []Edge, truncated bool) {
+) (edges []Edge, stats MeshEdgeStats) {
 	if len(routes) == 0 || namespace == "" || nameIndex == nil {
-		return nil, false
+		return nil, stats
 	}
 
 	seen := make(map[string]struct{})
 	add := func(source, target string, t EdgeType) bool {
-		if source == "" || target == "" || source == target {
+		if source == "" || target == "" {
 			return false
 		}
 		key := source + "->" + target + "/" + string(t)
@@ -56,8 +70,8 @@ func buildMeshEdges(
 		var edgeType EdgeType
 		switch r.Mesh {
 		case servicemesh.MeshIstio:
-			// DestinationRule and Gateway don't fit the source->target shape
-			// in D1; only VirtualService routes emit mesh_vs edges.
+			// DestinationRule and Gateway don't fit the source->target
+			// shape in D1; only VirtualService routes emit mesh_vs edges.
 			if r.Kind != "VirtualService" {
 				continue
 			}
@@ -72,6 +86,8 @@ func buildMeshEdges(
 			continue
 		}
 
+		stats.Considered++
+
 		var sourceUID string
 		for _, host := range r.Hosts {
 			if uid, ok := resolveServiceHost(host, namespace, nameIndex); ok {
@@ -80,21 +96,24 @@ func buildMeshEdges(
 			}
 		}
 		if sourceUID == "" {
+			stats.UnresolvedSources++
 			continue
 		}
 
 		for _, dest := range r.Destinations {
 			targetUID, ok := resolveServiceHost(dest.Host, namespace, nameIndex)
 			if !ok {
+				stats.UnresolvedDests++
 				continue
 			}
 			if capped := add(sourceUID, targetUID, edgeType); capped {
-				return edges, true
+				stats.Truncated = true
+				return edges, stats
 			}
 		}
 	}
 
-	return edges, false
+	return edges, stats
 }
 
 // resolveServiceHost looks up a mesh route's host string against the topology
@@ -104,21 +123,30 @@ func buildMeshEdges(
 //	namespaced:       my-svc.foo
 //	fully qualified:  my-svc.foo.svc.cluster.local
 //
-// Only hosts that resolve to a Service node in the requested namespace match.
-// Cross-namespace hosts (my-svc.bar from inside namespace foo) and external
-// hosts (api.example.com) return ok=false.
+// Lookup is case-insensitive: DNS hostnames are case-insensitive and Istio
+// VS hosts are user-supplied free-form text, but Kubernetes Service names
+// are RFC 1123 lowercase. We lowercase the host first so an operator who
+// types "MyService.foo" in a VirtualService still resolves to the
+// corresponding Service.
+//
+// Only hosts that resolve to a Service node in the requested namespace
+// match. Cross-namespace hosts (my-svc.bar from inside namespace foo) and
+// external hosts (api.example.com) return ok=false.
 //
 // Custom cluster domains (clusterDomain != "cluster.local") are a known
-// limitation inherited from Phase B; these hosts won't resolve and the edges
-// will be silently skipped.
+// limitation inherited from Phase B; these FQDN-form hosts won't resolve.
+// The bare and namespaced forms still work because they don't depend on
+// the cluster domain.
 func resolveServiceHost(host, namespace string, nameIndex map[string]string) (string, bool) {
 	if host == "" || namespace == "" {
 		return "", false
 	}
 
+	// Lowercase before any matching so case differences in user-supplied
+	// VS hosts don't silently drop edges.
+	bare := strings.ToLower(host)
 	// Strip the FQDN suffix. We accept .svc.cluster.local and .svc; the
 	// shorter forms still flow through the dot-split below.
-	bare := host
 	for _, suffix := range []string{".svc.cluster.local", ".svc"} {
 		if trimmed, ok := strings.CutSuffix(bare, suffix); ok {
 			bare = trimmed

--- a/backend/internal/topology/mesh_edges_test.go
+++ b/backend/internal/topology/mesh_edges_test.go
@@ -62,9 +62,9 @@ func TestBuildMeshEdges_HappyPath_IstioVS(t *testing.T) {
 	idx := makeIndex("a", "b")
 	routes := []servicemesh.TrafficRoute{vsRoute("foo", "vs-a", "a", "b")}
 
-	edges, truncated := buildMeshEdges(routes, "foo", idx, maxMeshEdges)
+	edges, stats := buildMeshEdges(routes, "foo", idx, maxMeshEdges)
 
-	if truncated {
+	if stats.Truncated {
 		t.Fatalf("unexpected truncation")
 	}
 	if len(edges) != 1 {
@@ -172,19 +172,19 @@ func TestBuildMeshEdges_CrossNamespaceHost(t *testing.T) {
 func TestBuildMeshEdges_EmptyAndNilInputs(t *testing.T) {
 	idx := makeIndex("a", "b")
 
-	edges, truncated := buildMeshEdges(nil, "foo", idx, maxMeshEdges)
-	if len(edges) != 0 || truncated {
-		t.Errorf("nil routes: edges=%d truncated=%v, want 0/false", len(edges), truncated)
+	edges, stats := buildMeshEdges(nil, "foo", idx, maxMeshEdges)
+	if len(edges) != 0 || stats.Truncated {
+		t.Errorf("nil routes: edges=%d truncated=%v, want 0/false", len(edges), stats.Truncated)
 	}
 
-	edges, truncated = buildMeshEdges([]servicemesh.TrafficRoute{vsRoute("foo", "v", "a", "b")}, "", idx, maxMeshEdges)
-	if len(edges) != 0 || truncated {
-		t.Errorf("empty namespace: edges=%d truncated=%v, want 0/false", len(edges), truncated)
+	edges, stats = buildMeshEdges([]servicemesh.TrafficRoute{vsRoute("foo", "v", "a", "b")}, "", idx, maxMeshEdges)
+	if len(edges) != 0 || stats.Truncated {
+		t.Errorf("empty namespace: edges=%d truncated=%v, want 0/false", len(edges), stats.Truncated)
 	}
 
-	edges, truncated = buildMeshEdges([]servicemesh.TrafficRoute{vsRoute("foo", "v", "a", "b")}, "foo", nil, maxMeshEdges)
-	if len(edges) != 0 || truncated {
-		t.Errorf("nil index: edges=%d truncated=%v, want 0/false", len(edges), truncated)
+	edges, stats = buildMeshEdges([]servicemesh.TrafficRoute{vsRoute("foo", "v", "a", "b")}, "foo", nil, maxMeshEdges)
+	if len(edges) != 0 || stats.Truncated {
+		t.Errorf("nil index: edges=%d truncated=%v, want 0/false", len(edges), stats.Truncated)
 	}
 }
 
@@ -222,9 +222,9 @@ func TestBuildMeshEdges_Cap(t *testing.T) {
 	}
 
 	routes := []servicemesh.TrafficRoute{vsRoute("foo", "fan", "a", dests...)}
-	edges, truncated := buildMeshEdges(routes, "foo", idx, 2000)
+	edges, stats := buildMeshEdges(routes, "foo", idx, 2000)
 
-	if !truncated {
+	if !stats.Truncated {
 		t.Errorf("truncated = false, want true at cap")
 	}
 	if len(edges) != 2000 {
@@ -289,16 +289,67 @@ func TestBuildMeshEdges_UnknownMeshOrKindSkipped(t *testing.T) {
 	}
 }
 
-func TestBuildMeshEdges_SelfEdgeSkipped(t *testing.T) {
-	// A route whose destination is the same host as its source produces a
-	// self-edge that's not informative; emitter drops it.
+func TestBuildMeshEdges_SelfEdgeAllowed(t *testing.T) {
+	// Istio canary patterns route a single host through DestinationRule
+	// subsets of the same Service: VS hosts:[cart] route to cart-stable
+	// and cart-canary, both of which are subsets of the cart Service.
+	// In topology terms that's a single mesh_vs edge from cart to itself.
+	// Dropping it would silently hide canary traffic from the overlay.
 	idx := makeIndex("a")
 	routes := []servicemesh.TrafficRoute{vsRoute("foo", "vs", "a", "a")}
 
 	edges, _ := buildMeshEdges(routes, "foo", idx, maxMeshEdges)
 
-	if len(edges) != 0 {
-		t.Errorf("edges = %d, want 0 (self-edge a->a should be skipped)", len(edges))
+	if !findEdge(edges, "uid-a", "uid-a", EdgeMeshVS) {
+		t.Errorf("missing self-edge uid-a -> uid-a; got %+v", edges)
+	}
+}
+
+func TestBuildMeshEdges_CaseInsensitiveHostResolution(t *testing.T) {
+	// VirtualService hosts are user-supplied free-form text, but the
+	// underlying Service names are RFC 1123 lowercase. DNS hostnames are
+	// case-insensitive, so an operator typing "MyService" in a VS spec
+	// must still resolve to the lowercase "myservice" Service node.
+	idx := makeIndex("a", "b")
+	routes := []servicemesh.TrafficRoute{
+		vsRoute("foo", "vs-1", "A", "B"),
+		vsRoute("foo", "vs-2", "a", "B.Foo"),
+		vsRoute("foo", "vs-3", "A.foo.svc.cluster.local", "b"),
+	}
+
+	edges, _ := buildMeshEdges(routes, "foo", idx, maxMeshEdges)
+
+	if len(edges) != 1 {
+		t.Fatalf("edges = %d, want 1 (case-insensitive lookups must dedup)", len(edges))
+	}
+	if !findEdge(edges, "uid-a", "uid-b", EdgeMeshVS) {
+		t.Errorf("missing edge uid-a -> uid-b; got %+v", edges)
+	}
+}
+
+func TestBuildMeshEdges_StatsCountsUnresolvedHosts(t *testing.T) {
+	// One route's source host doesn't resolve (external host); two of
+	// another route's destinations don't resolve. Stats should count
+	// each independently so the caller can surface a "N unresolved hosts"
+	// diagnostic instead of returning a silent empty graph.
+	idx := makeIndex("a", "b")
+	routes := []servicemesh.TrafficRoute{
+		// Source unresolvable.
+		vsRoute("foo", "vs-1", "external.example.com", "b"),
+		// Source resolves; two of three destinations don't.
+		vsRoute("foo", "vs-2", "a", "b", "external1.example.com", "external2.example.com"),
+	}
+
+	_, stats := buildMeshEdges(routes, "foo", idx, maxMeshEdges)
+
+	if stats.Considered != 2 {
+		t.Errorf("Considered = %d, want 2", stats.Considered)
+	}
+	if stats.UnresolvedSources != 1 {
+		t.Errorf("UnresolvedSources = %d, want 1", stats.UnresolvedSources)
+	}
+	if stats.UnresolvedDests != 2 {
+		t.Errorf("UnresolvedDests = %d, want 2", stats.UnresolvedDests)
 	}
 }
 

--- a/backend/internal/topology/mesh_edges_test.go
+++ b/backend/internal/topology/mesh_edges_test.go
@@ -1,0 +1,327 @@
+package topology
+
+import (
+	"testing"
+
+	"github.com/kubecenter/kubecenter/internal/servicemesh"
+)
+
+// makeIndex builds a "Kind/Name" -> UID nameIndex for a list of services in a
+// single namespace. Only Service nodes are needed for the mesh-edges tests;
+// the existing graph builder populates this map for other kinds in production.
+func makeIndex(services ...string) map[string]string {
+	idx := make(map[string]string, len(services))
+	for _, name := range services {
+		idx["Service/"+name] = "uid-" + name
+	}
+	return idx
+}
+
+// vsRoute creates an Istio VirtualService TrafficRoute fixture. host is the
+// VS's spec.hosts[0]; dests are spec.{http,tls,tcp}.route[].destination.host
+// values.
+func vsRoute(namespace, name, host string, dests ...string) servicemesh.TrafficRoute {
+	r := servicemesh.TrafficRoute{
+		Mesh:      servicemesh.MeshIstio,
+		Kind:      "VirtualService",
+		Name:      name,
+		Namespace: namespace,
+		Hosts:     []string{host},
+	}
+	for _, d := range dests {
+		r.Destinations = append(r.Destinations, servicemesh.RouteDestination{Host: d})
+	}
+	return r
+}
+
+// spRoute creates a Linkerd ServiceProfile TrafficRoute fixture.
+func spRoute(namespace, name, host string, dests ...string) servicemesh.TrafficRoute {
+	r := servicemesh.TrafficRoute{
+		Mesh:      servicemesh.MeshLinkerd,
+		Kind:      "ServiceProfile",
+		Name:      name,
+		Namespace: namespace,
+		Hosts:     []string{host},
+	}
+	for _, d := range dests {
+		r.Destinations = append(r.Destinations, servicemesh.RouteDestination{Host: d})
+	}
+	return r
+}
+
+func findEdge(edges []Edge, source, target string, t EdgeType) bool {
+	for _, e := range edges {
+		if e.Source == source && e.Target == target && e.Type == t {
+			return true
+		}
+	}
+	return false
+}
+
+func TestBuildMeshEdges_HappyPath_IstioVS(t *testing.T) {
+	idx := makeIndex("a", "b")
+	routes := []servicemesh.TrafficRoute{vsRoute("foo", "vs-a", "a", "b")}
+
+	edges, truncated := buildMeshEdges(routes, "foo", idx, maxMeshEdges)
+
+	if truncated {
+		t.Fatalf("unexpected truncation")
+	}
+	if len(edges) != 1 {
+		t.Fatalf("edges = %d, want 1", len(edges))
+	}
+	if !findEdge(edges, "uid-a", "uid-b", EdgeMeshVS) {
+		t.Errorf("missing mesh_vs edge a->b; got %+v", edges)
+	}
+}
+
+func TestBuildMeshEdges_HappyPath_LinkerdSP(t *testing.T) {
+	idx := makeIndex("a", "b")
+	routes := []servicemesh.TrafficRoute{spRoute("foo", "sp-a", "a", "b")}
+
+	edges, _ := buildMeshEdges(routes, "foo", idx, maxMeshEdges)
+
+	if len(edges) != 1 {
+		t.Fatalf("edges = %d, want 1", len(edges))
+	}
+	if !findEdge(edges, "uid-a", "uid-b", EdgeMeshSP) {
+		t.Errorf("missing mesh_sp edge a->b; got %+v", edges)
+	}
+}
+
+func TestBuildMeshEdges_MultipleDestinations(t *testing.T) {
+	idx := makeIndex("a", "b", "c", "d")
+	routes := []servicemesh.TrafficRoute{vsRoute("foo", "vs-a", "a", "b", "c", "d")}
+
+	edges, _ := buildMeshEdges(routes, "foo", idx, maxMeshEdges)
+
+	if len(edges) != 3 {
+		t.Fatalf("edges = %d, want 3", len(edges))
+	}
+	for _, target := range []string{"uid-b", "uid-c", "uid-d"} {
+		if !findEdge(edges, "uid-a", target, EdgeMeshVS) {
+			t.Errorf("missing edge uid-a -> %s", target)
+		}
+	}
+}
+
+func TestBuildMeshEdges_HostSuffixVariants(t *testing.T) {
+	// All three forms must resolve to the same Service/b UID and dedup to
+	// exactly one edge.
+	idx := makeIndex("a", "b")
+	routes := []servicemesh.TrafficRoute{
+		vsRoute("foo", "vs-1", "a", "b"),
+		vsRoute("foo", "vs-2", "a", "b.foo"),
+		vsRoute("foo", "vs-3", "a", "b.foo.svc.cluster.local"),
+	}
+
+	edges, _ := buildMeshEdges(routes, "foo", idx, maxMeshEdges)
+
+	if len(edges) != 1 {
+		t.Fatalf("edges = %d, want 1 (host suffix variants must dedup)", len(edges))
+	}
+}
+
+func TestBuildMeshEdges_NoMatchingDestination(t *testing.T) {
+	idx := makeIndex("a") // no "b"
+	routes := []servicemesh.TrafficRoute{
+		vsRoute("foo", "vs-a", "a", "external.example.com"),
+		vsRoute("foo", "vs-b", "a", "b"), // b doesn't exist in idx
+	}
+
+	edges, _ := buildMeshEdges(routes, "foo", idx, maxMeshEdges)
+
+	if len(edges) != 0 {
+		t.Errorf("edges = %d, want 0 (unresolvable destinations must be silently dropped)", len(edges))
+	}
+}
+
+func TestBuildMeshEdges_RouteInDifferentNamespace(t *testing.T) {
+	idx := makeIndex("a", "b")
+	routes := []servicemesh.TrafficRoute{vsRoute("bar", "vs-a", "a", "b")}
+
+	edges, _ := buildMeshEdges(routes, "foo", idx, maxMeshEdges)
+
+	if len(edges) != 0 {
+		t.Errorf("edges = %d, want 0 (route in namespace bar must not appear in foo's graph)", len(edges))
+	}
+}
+
+func TestBuildMeshEdges_CrossNamespaceHost(t *testing.T) {
+	// Source host "a.bar" (cross-namespace) should NOT resolve to Service/a
+	// in namespace foo — that would silently merge unrelated services.
+	idx := makeIndex("a", "b")
+	routes := []servicemesh.TrafficRoute{
+		{
+			Mesh:         servicemesh.MeshIstio,
+			Kind:         "VirtualService",
+			Name:         "vs",
+			Namespace:    "foo",
+			Hosts:        []string{"a.bar"},
+			Destinations: []servicemesh.RouteDestination{{Host: "b"}},
+		},
+	}
+
+	edges, _ := buildMeshEdges(routes, "foo", idx, maxMeshEdges)
+
+	if len(edges) != 0 {
+		t.Errorf("edges = %d, want 0 (cross-namespace source host must not resolve)", len(edges))
+	}
+}
+
+func TestBuildMeshEdges_EmptyAndNilInputs(t *testing.T) {
+	idx := makeIndex("a", "b")
+
+	edges, truncated := buildMeshEdges(nil, "foo", idx, maxMeshEdges)
+	if len(edges) != 0 || truncated {
+		t.Errorf("nil routes: edges=%d truncated=%v, want 0/false", len(edges), truncated)
+	}
+
+	edges, truncated = buildMeshEdges([]servicemesh.TrafficRoute{vsRoute("foo", "v", "a", "b")}, "", idx, maxMeshEdges)
+	if len(edges) != 0 || truncated {
+		t.Errorf("empty namespace: edges=%d truncated=%v, want 0/false", len(edges), truncated)
+	}
+
+	edges, truncated = buildMeshEdges([]servicemesh.TrafficRoute{vsRoute("foo", "v", "a", "b")}, "foo", nil, maxMeshEdges)
+	if len(edges) != 0 || truncated {
+		t.Errorf("nil index: edges=%d truncated=%v, want 0/false", len(edges), truncated)
+	}
+}
+
+func TestBuildMeshEdges_RouteWithoutHosts(t *testing.T) {
+	// Hosts empty -> no source service can be resolved -> no edges, no panic.
+	idx := makeIndex("a", "b")
+	routes := []servicemesh.TrafficRoute{
+		{
+			Mesh:         servicemesh.MeshIstio,
+			Kind:         "VirtualService",
+			Name:         "vs",
+			Namespace:    "foo",
+			Destinations: []servicemesh.RouteDestination{{Host: "b"}},
+		},
+	}
+
+	edges, _ := buildMeshEdges(routes, "foo", idx, maxMeshEdges)
+
+	if len(edges) != 0 {
+		t.Errorf("edges = %d, want 0 (route without hosts has no source)", len(edges))
+	}
+}
+
+func TestBuildMeshEdges_Cap(t *testing.T) {
+	idx := makeIndex("a")
+	for i := range 2500 {
+		// Each unique target name must exist in the index, otherwise edges
+		// are dropped before hitting the cap.
+		idx["Service/t"+itoa(i)] = "uid-t" + itoa(i)
+	}
+
+	dests := make([]string, 2500)
+	for i := range dests {
+		dests[i] = "t" + itoa(i)
+	}
+
+	routes := []servicemesh.TrafficRoute{vsRoute("foo", "fan", "a", dests...)}
+	edges, truncated := buildMeshEdges(routes, "foo", idx, 2000)
+
+	if !truncated {
+		t.Errorf("truncated = false, want true at cap")
+	}
+	if len(edges) != 2000 {
+		t.Errorf("edges = %d, want 2000 (cap)", len(edges))
+	}
+}
+
+func TestBuildMeshEdges_DedupAcrossRoutes(t *testing.T) {
+	// Two VirtualService objects that route the same source -> target pair
+	// must produce exactly one edge.
+	idx := makeIndex("a", "b")
+	routes := []servicemesh.TrafficRoute{
+		vsRoute("foo", "vs-1", "a", "b"),
+		vsRoute("foo", "vs-2", "a", "b"),
+	}
+
+	edges, _ := buildMeshEdges(routes, "foo", idx, maxMeshEdges)
+
+	if len(edges) != 1 {
+		t.Errorf("edges = %d, want 1 (duplicate source/target pair must dedup)", len(edges))
+	}
+}
+
+func TestBuildMeshEdges_BothMeshesProduceDistinctEdges(t *testing.T) {
+	// An Istio VS and a Linkerd SP routing the same a -> b pair produce
+	// two edges, not one — different EdgeType means different semantics.
+	idx := makeIndex("a", "b")
+	routes := []servicemesh.TrafficRoute{
+		vsRoute("foo", "vs", "a", "b"),
+		spRoute("foo", "sp", "a", "b"),
+	}
+
+	edges, _ := buildMeshEdges(routes, "foo", idx, maxMeshEdges)
+
+	if len(edges) != 2 {
+		t.Fatalf("edges = %d, want 2 (Istio + Linkerd are distinct edge types)", len(edges))
+	}
+	if !findEdge(edges, "uid-a", "uid-b", EdgeMeshVS) {
+		t.Error("missing mesh_vs edge")
+	}
+	if !findEdge(edges, "uid-a", "uid-b", EdgeMeshSP) {
+		t.Error("missing mesh_sp edge")
+	}
+}
+
+func TestBuildMeshEdges_UnknownMeshOrKindSkipped(t *testing.T) {
+	idx := makeIndex("a", "b")
+	routes := []servicemesh.TrafficRoute{
+		// Unknown mesh
+		{Mesh: servicemesh.MeshType("unknown"), Kind: "VirtualService", Namespace: "foo", Hosts: []string{"a"}, Destinations: []servicemesh.RouteDestination{{Host: "b"}}},
+		// Istio but not VirtualService — DestinationRule, Gateway are deferred from D1.
+		{Mesh: servicemesh.MeshIstio, Kind: "DestinationRule", Namespace: "foo", Hosts: []string{"a"}, Destinations: []servicemesh.RouteDestination{{Host: "b"}}},
+		{Mesh: servicemesh.MeshIstio, Kind: "Gateway", Namespace: "foo", Hosts: []string{"a"}, Destinations: []servicemesh.RouteDestination{{Host: "b"}}},
+		// Linkerd but not ServiceProfile.
+		{Mesh: servicemesh.MeshLinkerd, Kind: "Server", Namespace: "foo", Hosts: []string{"a"}, Destinations: []servicemesh.RouteDestination{{Host: "b"}}},
+	}
+
+	edges, _ := buildMeshEdges(routes, "foo", idx, maxMeshEdges)
+
+	if len(edges) != 0 {
+		t.Errorf("edges = %d, want 0 (unknown mesh and non-routing kinds must be skipped)", len(edges))
+	}
+}
+
+func TestBuildMeshEdges_SelfEdgeSkipped(t *testing.T) {
+	// A route whose destination is the same host as its source produces a
+	// self-edge that's not informative; emitter drops it.
+	idx := makeIndex("a")
+	routes := []servicemesh.TrafficRoute{vsRoute("foo", "vs", "a", "a")}
+
+	edges, _ := buildMeshEdges(routes, "foo", idx, maxMeshEdges)
+
+	if len(edges) != 0 {
+		t.Errorf("edges = %d, want 0 (self-edge a->a should be skipped)", len(edges))
+	}
+}
+
+// itoa avoids importing strconv just for test fixtures.
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	pos := len(buf)
+	neg := false
+	if i < 0 {
+		neg = true
+		i = -i
+	}
+	for i > 0 {
+		pos--
+		buf[pos] = byte('0' + i%10)
+		i /= 10
+	}
+	if neg {
+		pos--
+		buf[pos] = '-'
+	}
+	return string(buf[pos:])
+}

--- a/backend/internal/topology/types.go
+++ b/backend/internal/topology/types.go
@@ -3,10 +3,19 @@ package topology
 import "time"
 
 // Graph is the resource dependency graph for a namespace.
+//
+// Overlay is empty (and JSON-omitted) by default, preserving byte-identical
+// responses for callers that don't pass ?overlay=. Set to "mesh" when the
+// caller requested ?overlay=mesh and a mesh route provider is wired, even
+// if no mesh edges are emitted (e.g., RBAC denies every mesh CRD or no
+// mesh is installed). "unavailable" means the caller asked for the overlay
+// but the provider was nil or returned an error — base graph is returned
+// rather than a 5xx.
 type Graph struct {
 	Nodes      []Node `json:"nodes"`
 	Edges      []Edge `json:"edges"`
 	Truncated  bool   `json:"truncated,omitempty"`
+	Overlay    string `json:"overlay,omitempty"`
 	ComputedAt string `json:"computedAt"`
 }
 
@@ -45,6 +54,13 @@ const (
 	EdgeSelector EdgeType = "selector"
 	EdgeMount    EdgeType = "mount"
 	EdgeIngress  EdgeType = "ingress"
+	// Mesh-overlay edge types. EdgeMeshVS connects an Istio VirtualService's
+	// host service to each destination service it routes to. EdgeMeshSP is
+	// the Linkerd ServiceProfile equivalent. Both are emitted only when the
+	// caller passes ?overlay=mesh AND has list permission on the underlying
+	// CRD group.
+	EdgeMeshVS EdgeType = "mesh_vs"
+	EdgeMeshSP EdgeType = "mesh_sp"
 )
 
 // NewGraph creates a new empty graph with the current timestamp.

--- a/backend/internal/topology/types.go
+++ b/backend/internal/topology/types.go
@@ -4,19 +4,23 @@ import "time"
 
 // Graph is the resource dependency graph for a namespace.
 //
-// Overlay is empty (and JSON-omitted) by default, preserving byte-identical
-// responses for callers that don't pass ?overlay=. Set to "mesh" when the
-// caller requested ?overlay=mesh and a mesh route provider is wired, even
-// if no mesh edges are emitted (e.g., RBAC denies every mesh CRD or no
-// mesh is installed). "unavailable" means the caller asked for the overlay
-// but the provider was nil or returned an error — base graph is returned
-// rather than a 5xx.
+// Overlay is OverlayNone (JSON-omitted) by default, preserving byte-identical
+// responses for callers that don't pass ?overlay=. See Overlay docs for the
+// other values. Truncated signals that some Nodes were dropped at the
+// maxNodes cap; EdgesTruncated signals that some mesh-overlay edges were
+// dropped at the maxMeshEdges cap. The two flags are independent so
+// consumers (e.g. blast-radius BFS) can tell "graph missing nodes" from
+// "graph complete, only some mesh edges capped". Errors carries any
+// per-stage warnings the build accumulated (currently: mesh-overlay
+// host-resolution drops); never holds raw Kubernetes error bodies.
 type Graph struct {
-	Nodes      []Node `json:"nodes"`
-	Edges      []Edge `json:"edges"`
-	Truncated  bool   `json:"truncated,omitempty"`
-	Overlay    string `json:"overlay,omitempty"`
-	ComputedAt string `json:"computedAt"`
+	Nodes           []Node            `json:"nodes"`
+	Edges           []Edge            `json:"edges"`
+	Truncated       bool              `json:"truncated,omitempty"`
+	EdgesTruncated  bool              `json:"edgesTruncated,omitempty"`
+	Overlay         Overlay           `json:"overlay,omitempty"`
+	Errors          map[string]string `json:"errors,omitempty"`
+	ComputedAt      string            `json:"computedAt"`
 }
 
 // Node represents a Kubernetes resource in the graph.
@@ -44,6 +48,24 @@ const (
 	HealthDegraded Health = "degraded"
 	HealthFailing  Health = "failing"
 	HealthUnknown  Health = "unknown"
+)
+
+// Overlay names which optional layer of edges has been folded into the
+// graph. Always returned as a typed value so consumers can discriminate
+// without string literals.
+//
+//	OverlayNone        — no overlay requested (zero value, JSON-omitted)
+//	OverlayMesh        — overlay requested AND a mesh is installed; edges
+//	                     reflect the routes the user has CRD list permission
+//	                     for (may be empty)
+//	OverlayUnavailable — overlay requested but couldn't be applied: provider
+//	                     unwired, fetch errored, or no mesh is installed
+type Overlay string
+
+const (
+	OverlayNone        Overlay = ""
+	OverlayMesh        Overlay = "mesh"
+	OverlayUnavailable Overlay = "unavailable"
 )
 
 // EdgeType classifies the relationship between resources.

--- a/frontend/components/k8s/detail/ServiceOverview.tsx
+++ b/frontend/components/k8s/detail/ServiceOverview.tsx
@@ -69,8 +69,10 @@ export function ServiceOverview({ resource }: { resource: K8sResource }) {
         <KeyValueTable title="Selector" data={spec.selector} />
       )}
 
-      {/* Service mesh golden signals — silently absent for unmeshed
-          services, otherwise refreshes on a 30s cadence. */}
+      {
+        /* Service mesh golden signals — silently absent for unmeshed
+          services, otherwise refreshes on a 30s cadence. */
+      }
       {meta?.namespace && meta?.name && (
         <MeshGoldenSignals
           namespace={meta.namespace}

--- a/frontend/components/k8s/detail/ServiceOverview.tsx
+++ b/frontend/components/k8s/detail/ServiceOverview.tsx
@@ -1,10 +1,12 @@
 import type { K8sResource, Service } from "@/lib/k8s-types.ts";
 import { Field, SectionHeader } from "@/components/ui/Field.tsx";
 import { KeyValueTable } from "./KeyValueTable.tsx";
+import { MeshGoldenSignals } from "@/components/mesh/GoldenSignals.tsx";
 
 export function ServiceOverview({ resource }: { resource: K8sResource }) {
   const s = resource as Service;
   const spec = s.spec;
+  const meta = s.metadata;
 
   return (
     <div class="space-y-4">
@@ -65,6 +67,15 @@ export function ServiceOverview({ resource }: { resource: K8sResource }) {
       {/* Selector */}
       {spec.selector && Object.keys(spec.selector).length > 0 && (
         <KeyValueTable title="Selector" data={spec.selector} />
+      )}
+
+      {/* Service mesh golden signals — silently absent for unmeshed
+          services, otherwise refreshes on a 30s cadence. */}
+      {meta?.namespace && meta?.name && (
+        <MeshGoldenSignals
+          namespace={meta.namespace}
+          service={meta.name}
+        />
       )}
     </div>
   );

--- a/frontend/components/mesh/GoldenSignals.tsx
+++ b/frontend/components/mesh/GoldenSignals.tsx
@@ -1,0 +1,212 @@
+/** Golden Signals card for the Service detail page (Phase D3).
+ *
+ *  Lazy-fetches RPS, error rate, and p50/p95/p99 latency from the mesh
+ *  golden-signals endpoint. The card hides itself when:
+ *    - no service mesh is installed in the cluster
+ *    - the request 4xx's (e.g. service not in mesh, or both meshes
+ *      installed and the auto-detect is ambiguous in v1)
+ *    - the response carries available=true but every metric is zero —
+ *      this matches the "unmeshed service" silent-absence contract;
+ *      genuinely silent meshed services also hide, which is acceptable
+ *      for v1 (the card adds no signal at zero traffic).
+ *
+ *  The card RENDERS (with a "Metrics unavailable" sub-message) when the
+ *  backend reports available=false, so an offline Prometheus is visible
+ *  rather than indistinguishable from "no data".
+ *
+ *  Refresh cadence: 30s, matching the monitoring-dashboard convention.
+ *  Component is rendered from inside the ResourceDetail island, so its
+ *  hooks hydrate without needing a separate islands/ entry.
+ */
+
+import { useSignal } from "@preact/signals";
+import { useEffect } from "preact/hooks";
+import { IS_BROWSER } from "fresh/runtime";
+import { meshApi } from "@/lib/mesh-api.ts";
+import type { GoldenSignals, MeshType } from "@/lib/mesh-types.ts";
+
+const REFRESH_INTERVAL_MS = 30_000;
+
+interface Props {
+  namespace: string;
+  service: string;
+}
+
+export function MeshGoldenSignals({ namespace, service }: Props) {
+  // null = not yet decided / hidden; populated only when we have something
+  // worth rendering. We never set this to a zero-valued meshed signal
+  // (see header comment) — those services hide instead.
+  const data = useSignal<GoldenSignals | null>(null);
+  const offline = useSignal(false);
+  const offlineReason = useSignal<string>("");
+
+  useEffect(() => {
+    if (!IS_BROWSER) return;
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const status = await meshApi.status();
+        const detected: MeshType = status.data.status.detected;
+        if (!detected) {
+          // No mesh installed — hide.
+          if (!cancelled) {
+            data.value = null;
+            offline.value = false;
+          }
+          return;
+        }
+
+        // When both meshes are installed the backend requires an explicit
+        // ?mesh= disambiguator. In v1 we can't infer which mesh manages
+        // this specific service from the frontend, so we hide rather than
+        // guess. (Phase D3 future enhancement: pass workload context.)
+        if (detected === "both") {
+          if (!cancelled) {
+            data.value = null;
+            offline.value = false;
+          }
+          return;
+        }
+
+        const res = await meshApi.goldenSignals({ namespace, service });
+        if (cancelled) return;
+
+        const signals = res.data.signals;
+
+        if (!signals.available) {
+          // Prometheus offline (or full PromQL fan-out failure). Render
+          // the card with the unavailable banner — operators need to
+          // see this rather than silent absence.
+          data.value = null;
+          offline.value = true;
+          offlineReason.value = signals.reason || "metrics_unavailable";
+          return;
+        }
+
+        // available=true. Distinguish "unmeshed (or genuinely silent)
+        // service" from "meshed with traffic" by checking whether ANY
+        // metric is non-zero. A meshed service with traffic always has
+        // at least RPS > 0; a meshed-but-silent service produces no
+        // useful card. Hide both cases.
+        const hasTraffic = signals.rps > 0 ||
+          signals.errorRate > 0 ||
+          signals.p50Ms > 0 ||
+          signals.p95Ms > 0 ||
+          signals.p99Ms > 0;
+        if (!hasTraffic) {
+          data.value = null;
+          offline.value = false;
+          return;
+        }
+
+        data.value = signals;
+        offline.value = false;
+      } catch (_err) {
+        // 4xx (no mesh detected, validation, RBAC denial) — hide silently.
+        // The Service detail page must not surface a toast for an
+        // optional enrichment that didn't apply.
+        if (!cancelled) {
+          data.value = null;
+          offline.value = false;
+        }
+      }
+    }
+
+    load();
+    const id = setInterval(load, REFRESH_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [namespace, service]);
+
+  if (offline.value) {
+    return (
+      <section>
+        <h3 class="mb-2 text-sm font-semibold uppercase tracking-wide text-text-muted">
+          Service Mesh — Golden Signals
+        </h3>
+        <div class="rounded-md border border-border-primary bg-bg-surface p-4 text-sm text-text-secondary">
+          Metrics unavailable
+          <span class="ml-2 text-xs text-text-muted">
+            ({offlineReason.value})
+          </span>
+        </div>
+      </section>
+    );
+  }
+
+  const s = data.value;
+  if (!s) return null;
+
+  return (
+    <section>
+      <h3 class="mb-2 text-sm font-semibold uppercase tracking-wide text-text-muted">
+        Service Mesh — Golden Signals
+        <span class="ml-2 rounded bg-bg-elevated px-1.5 py-0.5 text-xs font-normal text-text-muted">
+          {s.mesh}
+        </span>
+      </h3>
+      <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+        <Metric label="RPS" value={formatRps(s.rps)} />
+        <Metric
+          label="Error rate"
+          value={formatErrorRate(s.errorRate)}
+          tone={s.errorRate >= 0.05
+            ? "error"
+            : s.errorRate >= 0.01
+            ? "warning"
+            : "default"}
+        />
+        <Metric label="p50" value={formatMs(s.p50Ms)} />
+        <Metric label="p95" value={formatMs(s.p95Ms)} />
+        <Metric label="p99" value={formatMs(s.p99Ms)} />
+      </div>
+    </section>
+  );
+}
+
+function Metric(
+  { label, value, tone = "default" }: {
+    label: string;
+    value: string;
+    tone?: "default" | "warning" | "error";
+  },
+) {
+  const valueColor = tone === "error"
+    ? "var(--status-error)"
+    : tone === "warning"
+    ? "var(--status-warning)"
+    : "var(--text-primary)";
+  return (
+    <div class="rounded-md border border-border-primary bg-bg-surface p-3">
+      <div class="text-xs text-text-muted">{label}</div>
+      <div
+        class="mt-1 font-mono text-lg font-semibold"
+        style={{ color: valueColor }}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+// --- Formatters ---
+
+function formatRps(rps: number): string {
+  if (rps >= 1000) return `${(rps / 1000).toFixed(1)}k req/s`;
+  if (rps >= 10) return `${rps.toFixed(0)} req/s`;
+  return `${rps.toFixed(2)} req/s`;
+}
+
+function formatErrorRate(rate: number): string {
+  // Backend convention: fraction in [0, 1]. Render as percentage.
+  return `${(rate * 100).toFixed(2)}%`;
+}
+
+function formatMs(ms: number): string {
+  if (ms >= 1000) return `${(ms / 1000).toFixed(2)}s`;
+  if (ms >= 100) return `${ms.toFixed(0)} ms`;
+  return `${ms.toFixed(1)} ms`;
+}

--- a/frontend/components/mesh/GoldenSignals.tsx
+++ b/frontend/components/mesh/GoldenSignals.tsx
@@ -43,29 +43,35 @@ export function MeshGoldenSignals({ namespace, service }: Props) {
   useEffect(() => {
     if (!IS_BROWSER) return;
     let cancelled = false;
+    // inFlight protects against re-entry: if a load() is still awaiting
+    // when the 30s tick fires, we skip rather than stack concurrent
+    // fetches. On slow networks or during a Prometheus restart the
+    // setInterval cadence can outrun the round-trip; skipping keeps
+    // request count bounded to one per cycle.
+    let inFlight = false;
 
     async function load() {
+      if (inFlight) return;
+      inFlight = true;
       try {
         const status = await meshApi.status();
+        if (cancelled) return;
         const detected: MeshType = status.data.status.detected;
         if (!detected) {
           // No mesh installed — hide.
-          if (!cancelled) {
-            data.value = null;
-            offline.value = false;
-          }
+          data.value = null;
+          offline.value = false;
           return;
         }
 
-        // When both meshes are installed the backend requires an explicit
-        // ?mesh= disambiguator. In v1 we can't infer which mesh manages
-        // this specific service from the frontend, so we hide rather than
-        // guess. (Phase D3 future enhancement: pass workload context.)
+        // When both meshes are installed the backend requires an
+        // explicit ?mesh= disambiguator. In v1 we can't infer which
+        // mesh manages this specific service from the frontend, so we
+        // hide rather than guess. (Future enhancement: pass workload
+        // context from ServiceOverview.)
         if (detected === "both") {
-          if (!cancelled) {
-            data.value = null;
-            offline.value = false;
-          }
+          data.value = null;
+          offline.value = false;
           return;
         }
 
@@ -75,9 +81,9 @@ export function MeshGoldenSignals({ namespace, service }: Props) {
         const signals = res.data.signals;
 
         if (!signals.available) {
-          // Prometheus offline (or full PromQL fan-out failure). Render
-          // the card with the unavailable banner — operators need to
-          // see this rather than silent absence.
+          // Prometheus offline (or full PromQL fan-out failure).
+          // Render the card with the unavailable banner — operators
+          // need to see this rather than silent absence.
           data.value = null;
           offline.value = true;
           offlineReason.value = signals.reason || "metrics_unavailable";
@@ -89,6 +95,13 @@ export function MeshGoldenSignals({ namespace, service }: Props) {
         // metric is non-zero. A meshed service with traffic always has
         // at least RPS > 0; a meshed-but-silent service produces no
         // useful card. Hide both cases.
+        //
+        // Known limitation: the backend reports available=true even
+        // when 5 of 6 PromQL queries failed (partial-success contract,
+        // see internal/servicemesh/metrics.go). A heavily degraded
+        // Prometheus that only answers one query with zeros looks the
+        // same as a silent meshed service here. Surfacing that
+        // distinction requires a backend signal we don't have today.
         const hasTraffic = signals.rps > 0 ||
           signals.errorRate > 0 ||
           signals.p50Ms > 0 ||
@@ -103,13 +116,15 @@ export function MeshGoldenSignals({ namespace, service }: Props) {
         data.value = signals;
         offline.value = false;
       } catch (_err) {
-        // 4xx (no mesh detected, validation, RBAC denial) — hide silently.
-        // The Service detail page must not surface a toast for an
-        // optional enrichment that didn't apply.
+        // 4xx (no mesh detected, validation, RBAC denial) — hide
+        // silently. The Service detail page must not surface a toast
+        // for an optional enrichment that didn't apply.
         if (!cancelled) {
           data.value = null;
           offline.value = false;
         }
+      } finally {
+        inFlight = false;
       }
     }
 

--- a/frontend/islands/NamespaceTopology.tsx
+++ b/frontend/islands/NamespaceTopology.tsx
@@ -11,12 +11,21 @@ import { timeAgo } from "@/lib/timeAgo.ts";
 interface TopoGraph {
   nodes: TopoNode[];
   edges: TopoEdge[];
+  // truncated signals nodes were dropped at maxNodes. edgesTruncated
+  // signals mesh-overlay edges were dropped at maxMeshEdges. They are
+  // independent so consumers can tell "graph missing nodes" from
+  // "graph complete, only some mesh edges capped".
   truncated?: boolean;
+  edgesTruncated?: boolean;
   // Set by the backend when ?overlay=mesh is requested.
   // "mesh" — overlay applied (mesh edges may or may not be present).
-  // "unavailable" — overlay was requested but the route provider was nil
-  // or errored; frontend renders the toggle as disabled with a tooltip.
+  // "unavailable" — overlay was requested but couldn't be applied
+  //                  (no mesh installed, provider unwired, fetch errored).
   overlay?: "mesh" | "unavailable";
+  // Per-stage warnings; currently used for mesh-overlay host-resolution
+  // drops so a custom-cluster-domain namespace doesn't return a silent
+  // empty overlay.
+  errors?: Record<string, string>;
   computedAt: string;
 }
 
@@ -149,12 +158,16 @@ export default function NamespaceTopology() {
   const dragStart = useSignal({ x: 0, y: 0 });
   const panStart = useSignal({ x: 0, y: 0 });
 
-  // meshOverlay drives the "Show mesh traffic" toggle. When true, the next
-  // graph fetch appends ?overlay=mesh; the response's `overlay` field then
-  // tells us whether the backend could honor it. If the backend reports
-  // "unavailable" (no mesh installed or provider unwired), the toggle is
-  // disabled with an explanatory tooltip.
+  // meshOverlay drives the "Show mesh traffic" toggle. When true, the
+  // next graph fetch appends ?overlay=mesh; the response's `overlay`
+  // field then tells us whether the backend could honor it.
   const meshOverlay = useSignal(false);
+  // meshUnavailable latches once the backend reports overlay=unavailable
+  // for this namespace. While latched, the toggle renders disabled +
+  // unchecked and the explanatory tooltip explains why. Resetting the
+  // namespace (or any new graph response that comes back with
+  // overlay !== "unavailable") clears the latch.
+  const meshUnavailable = useSignal(false);
 
   const svgRef = useRef<SVGSVGElement>(null);
   const layoutNodes = useSignal<LayoutNode[]>([]);
@@ -171,6 +184,18 @@ export default function NamespaceTopology() {
       const overlayParam = meshOverlay.value ? "?overlay=mesh" : "";
       const res = await apiGet<TopoGraph>(`/v1/topology/${ns}${overlayParam}`);
       graph.value = res.data;
+      // Latch / unlatch the unavailable state so the toggle renders
+      // disabled+unchecked once we know there's no mesh, and frees up
+      // again when conditions change. Force the user-visible toggle off
+      // whenever we latch — leaving it checked while disabled is the
+      // bug that prompted this latch (browsers ignore clicks on
+      // disabled inputs, so the user couldn't un-check).
+      if (res.data.overlay === "unavailable") {
+        meshUnavailable.value = true;
+        meshOverlay.value = false;
+      } else if (res.data.overlay === "mesh") {
+        meshUnavailable.value = false;
+      }
     } catch (err) {
       error.value = err instanceof Error
         ? err.message
@@ -187,8 +212,19 @@ export default function NamespaceTopology() {
       loading.value = false;
       return;
     }
+    // A different namespace means a different cluster slice — clear the
+    // unavailable latch so the user can probe again.
+    meshUnavailable.value = false;
     fetchGraph();
-  }, [selectedNamespace.value, meshOverlay.value]);
+  }, [selectedNamespace.value]);
+
+  // Re-fetch when the user flips the toggle. Separate effect so the
+  // namespace-change reset above doesn't fight a same-tick toggle change.
+  useEffect(() => {
+    if (!IS_BROWSER) return;
+    if (selectedNamespace.value === "all") return;
+    fetchGraph();
+  }, [meshOverlay.value]);
 
   // ── Layout: custom LR topological sort (no dagre — it uses Node.js builtins) ──
 
@@ -436,38 +472,28 @@ export default function NamespaceTopology() {
             >
               Refresh
             </button>
-            {(() => {
-              // Disable the toggle only after we've actually asked the
-              // backend and learned the mesh isn't available. Before the
-              // first overlay request, we don't know — keep it enabled so
-              // the user can flip it on and find out.
-              const unavailable = meshOverlay.value &&
-                graph.value.overlay === "unavailable";
-              return (
-                <label
-                  class={`ml-2 flex items-center gap-1.5 rounded border border-border-primary bg-bg-surface px-2.5 py-1 text-xs ${
-                    unavailable
-                      ? "cursor-not-allowed text-text-muted opacity-60"
-                      : "cursor-pointer text-text-secondary hover:text-text-primary"
-                  }`}
-                  title={unavailable
-                    ? "No service mesh detected in this cluster"
-                    : "Show Istio VirtualService and Linkerd ServiceProfile traffic edges"}
-                >
-                  <input
-                    type="checkbox"
-                    class="h-3 w-3 cursor-pointer accent-accent disabled:cursor-not-allowed"
-                    checked={meshOverlay.value}
-                    disabled={unavailable}
-                    onChange={(e) => {
-                      meshOverlay.value =
-                        (e.currentTarget as HTMLInputElement).checked;
-                    }}
-                  />
-                  Show mesh traffic
-                </label>
-              );
-            })()}
+            <label
+              class={`ml-2 flex items-center gap-1.5 rounded border border-border-primary bg-bg-surface px-2.5 py-1 text-xs ${
+                meshUnavailable.value
+                  ? "cursor-not-allowed text-text-muted opacity-60"
+                  : "cursor-pointer text-text-secondary hover:text-text-primary"
+              }`}
+              title={meshUnavailable.value
+                ? "No service mesh detected in this cluster"
+                : "Show Istio VirtualService and Linkerd ServiceProfile traffic edges"}
+            >
+              <input
+                type="checkbox"
+                class="h-3 w-3 cursor-pointer accent-accent disabled:cursor-not-allowed"
+                checked={meshOverlay.value}
+                disabled={meshUnavailable.value}
+                onChange={(e) => {
+                  meshOverlay.value =
+                    (e.currentTarget as HTMLInputElement).checked;
+                }}
+              />
+              Show mesh traffic
+            </label>
           </div>
           <div class="flex items-center gap-3">
             {meshOverlay.value && graph.value.overlay === "mesh" && (
@@ -582,7 +608,12 @@ export default function NamespaceTopology() {
             const src = layoutNodeMap.value.get(edge.source);
             const tgt = layoutNodeMap.value.get(edge.target);
             if (!src || !tgt) return null;
-            const style = EDGE_STYLES[edge.type];
+            // Backend EdgeType is a Go string typedef (open enum); a new
+            // type added server-side would land in the response before
+            // any frontend-side TS update. Fall back to the owner style
+            // so an unknown edge renders as a generic dependency line
+            // rather than crashing on style.dasharray of undefined.
+            const style = EDGE_STYLES[edge.type] ?? EDGE_STYLES.owner;
             const op = edgeOpacity(edge.source, edge.target, style.opacity);
             const stroke = style.stroke ?? "var(--border-primary)";
             const markerId = style.markerId ??

--- a/frontend/islands/NamespaceTopology.tsx
+++ b/frontend/islands/NamespaceTopology.tsx
@@ -11,6 +11,12 @@ import { timeAgo } from "@/lib/timeAgo.ts";
 interface TopoGraph {
   nodes: TopoNode[];
   edges: TopoEdge[];
+  truncated?: boolean;
+  // Set by the backend when ?overlay=mesh is requested.
+  // "mesh" — overlay applied (mesh edges may or may not be present).
+  // "unavailable" — overlay was requested but the route provider was nil
+  // or errored; frontend renders the toggle as disabled with a tooltip.
+  overlay?: "mesh" | "unavailable";
   computedAt: string;
 }
 
@@ -26,7 +32,7 @@ interface TopoNode {
 interface TopoEdge {
   source: string;
   target: string;
-  type: "owner" | "selector" | "mount" | "ingress";
+  type: "owner" | "selector" | "mount" | "ingress" | "mesh_vs" | "mesh_sp";
 }
 
 // ── Layout types ──
@@ -53,15 +59,38 @@ const HEALTH_COLORS: Record<TopoNode["health"], string> = {
   unknown: "var(--text-muted)",
 };
 
+// Edge styles. The mesh entries set their own stroke color (themed); base
+// edges use var(--border-primary) at the line element level. The `stroke`
+// property here is consulted only when present, keeping base behavior
+// untouched.
 const EDGE_STYLES: Record<
   TopoEdge["type"],
-  { dasharray: string; opacity: number }
+  { dasharray: string; opacity: number; stroke?: string; markerId?: string }
 > = {
   owner: { dasharray: "", opacity: 0.7 },
   selector: { dasharray: "6,3", opacity: 0.7 },
   mount: { dasharray: "2,2", opacity: 0.4 },
   ingress: { dasharray: "6,3", opacity: 0.7 },
+  // Istio VirtualService traffic edges — primary accent.
+  mesh_vs: {
+    dasharray: "4,2",
+    opacity: 0.85,
+    stroke: "var(--accent)",
+    markerId: "arrow-mesh-vs",
+  },
+  // Linkerd ServiceProfile traffic edges — secondary accent so the two
+  // mesh types are visually distinct when both are installed.
+  mesh_sp: {
+    dasharray: "4,2",
+    opacity: 0.85,
+    stroke: "var(--accent-secondary)",
+    markerId: "arrow-mesh-sp",
+  },
 };
+
+function isMeshEdge(t: TopoEdge["type"]): boolean {
+  return t === "mesh_vs" || t === "mesh_sp";
+}
 
 // ── Kind abbreviations ──
 
@@ -120,6 +149,13 @@ export default function NamespaceTopology() {
   const dragStart = useSignal({ x: 0, y: 0 });
   const panStart = useSignal({ x: 0, y: 0 });
 
+  // meshOverlay drives the "Show mesh traffic" toggle. When true, the next
+  // graph fetch appends ?overlay=mesh; the response's `overlay` field then
+  // tells us whether the backend could honor it. If the backend reports
+  // "unavailable" (no mesh installed or provider unwired), the toggle is
+  // disabled with an explanatory tooltip.
+  const meshOverlay = useSignal(false);
+
   const svgRef = useRef<SVGSVGElement>(null);
   const layoutNodes = useSignal<LayoutNode[]>([]);
   const layoutNodeMap = useSignal<Map<string, LayoutNode>>(new Map());
@@ -132,7 +168,8 @@ export default function NamespaceTopology() {
     loading.value = true;
     error.value = null;
     try {
-      const res = await apiGet<TopoGraph>(`/v1/topology/${ns}`);
+      const overlayParam = meshOverlay.value ? "?overlay=mesh" : "";
+      const res = await apiGet<TopoGraph>(`/v1/topology/${ns}${overlayParam}`);
       graph.value = res.data;
     } catch (err) {
       error.value = err instanceof Error
@@ -151,7 +188,7 @@ export default function NamespaceTopology() {
       return;
     }
     fetchGraph();
-  }, [selectedNamespace.value]);
+  }, [selectedNamespace.value, meshOverlay.value]);
 
   // ── Layout: custom LR topological sort (no dagre — it uses Node.js builtins) ──
 
@@ -399,12 +436,66 @@ export default function NamespaceTopology() {
             >
               Refresh
             </button>
+            {(() => {
+              // Disable the toggle only after we've actually asked the
+              // backend and learned the mesh isn't available. Before the
+              // first overlay request, we don't know — keep it enabled so
+              // the user can flip it on and find out.
+              const unavailable = meshOverlay.value &&
+                graph.value.overlay === "unavailable";
+              return (
+                <label
+                  class={`ml-2 flex items-center gap-1.5 rounded border border-border-primary bg-bg-surface px-2.5 py-1 text-xs ${
+                    unavailable
+                      ? "cursor-not-allowed text-text-muted opacity-60"
+                      : "cursor-pointer text-text-secondary hover:text-text-primary"
+                  }`}
+                  title={unavailable
+                    ? "No service mesh detected in this cluster"
+                    : "Show Istio VirtualService and Linkerd ServiceProfile traffic edges"}
+                >
+                  <input
+                    type="checkbox"
+                    class="h-3 w-3 cursor-pointer accent-accent disabled:cursor-not-allowed"
+                    checked={meshOverlay.value}
+                    disabled={unavailable}
+                    onChange={(e) => {
+                      meshOverlay.value =
+                        (e.currentTarget as HTMLInputElement).checked;
+                    }}
+                  />
+                  Show mesh traffic
+                </label>
+              );
+            })()}
           </div>
-          {graph.value.computedAt && (
-            <span class="text-xs text-text-muted">
-              Updated {timeAgo(graph.value.computedAt)}
-            </span>
-          )}
+          <div class="flex items-center gap-3">
+            {meshOverlay.value && graph.value.overlay === "mesh" && (
+              <div class="flex items-center gap-3 text-xs text-text-muted">
+                <span class="flex items-center gap-1.5">
+                  <span
+                    class="inline-block h-0.5 w-4"
+                    style={{ backgroundColor: "var(--accent)" }}
+                    aria-hidden="true"
+                  />
+                  Istio
+                </span>
+                <span class="flex items-center gap-1.5">
+                  <span
+                    class="inline-block h-0.5 w-4"
+                    style={{ backgroundColor: "var(--accent-secondary)" }}
+                    aria-hidden="true"
+                  />
+                  Linkerd
+                </span>
+              </div>
+            )}
+            {graph.value.computedAt && (
+              <span class="text-xs text-text-muted">
+                Updated {timeAgo(graph.value.computedAt)}
+              </span>
+            )}
+          </div>
         </div>
 
         {/* SVG Graph */}
@@ -462,6 +553,28 @@ export default function NamespaceTopology() {
                 opacity="0.5"
               />
             </marker>
+            <marker
+              id="arrow-mesh-vs"
+              viewBox="0 0 10 6"
+              refX="10"
+              refY="3"
+              markerWidth="8"
+              markerHeight="6"
+              orient="auto"
+            >
+              <path d="M0,0 L10,3 L0,6 Z" fill="var(--accent)" />
+            </marker>
+            <marker
+              id="arrow-mesh-sp"
+              viewBox="0 0 10 6"
+              refX="10"
+              refY="3"
+              markerWidth="8"
+              markerHeight="6"
+              orient="auto"
+            >
+              <path d="M0,0 L10,3 L0,6 Z" fill="var(--accent-secondary)" />
+            </marker>
           </defs>
 
           {/* Edges */}
@@ -471,6 +584,9 @@ export default function NamespaceTopology() {
             if (!src || !tgt) return null;
             const style = EDGE_STYLES[edge.type];
             const op = edgeOpacity(edge.source, edge.target, style.opacity);
+            const stroke = style.stroke ?? "var(--border-primary)";
+            const markerId = style.markerId ??
+              (edge.type === "mount" ? "arrow-mount" : "arrow-default");
             return (
               <line
                 key={`edge-${i}`}
@@ -478,13 +594,11 @@ export default function NamespaceTopology() {
                 y1={src.y}
                 x2={tgt.x}
                 y2={tgt.y}
-                stroke="var(--border-primary)"
-                stroke-width={1.5}
+                stroke={stroke}
+                stroke-width={isMeshEdge(edge.type) ? 2 : 1.5}
                 stroke-dasharray={style.dasharray}
                 opacity={op}
-                marker-end={`url(#arrow-${
-                  edge.type === "mount" ? "mount" : "default"
-                })`}
+                marker-end={`url(#${markerId})`}
               />
             );
           })}

--- a/helm/kubecenter/templates/clusterrole.yaml
+++ b/helm/kubecenter/templates/clusterrole.yaml
@@ -120,6 +120,36 @@ rules:
   - apiGroups: ["templates.gatekeeper.sh"]
     resources: ["constrainttemplates"]
     verbs: ["list", "watch"]
+  # Service Mesh CRDs — Istio (networking + security) and Linkerd
+  # (linkerd.io + policy.linkerd.io). The discoverer + cache layer in
+  # `internal/servicemesh` runs as the service account: it lists CRDs
+  # cluster-wide on a 30s cycle, then handlers apply per-user RBAC via
+  # SelfSubjectAccessReview before returning data. Detail reads and the
+  # topology overlay's per-user filtering use the impersonated client
+  # — no SA grant needed for those paths.
+  - apiGroups: ["networking.istio.io"]
+    resources:
+      - virtualservices
+      - destinationrules
+      - gateways
+      - serviceentries
+    verbs: ["list", "watch"]
+  - apiGroups: ["security.istio.io"]
+    resources:
+      - peerauthentications
+      - authorizationpolicies
+    verbs: ["list", "watch"]
+  - apiGroups: ["linkerd.io"]
+    resources:
+      - serviceprofiles
+    verbs: ["list", "watch"]
+  - apiGroups: ["policy.linkerd.io"]
+    resources:
+      - servers
+      - httproutes
+      - authorizationpolicies
+      - meshtlsauthentications
+    verbs: ["list", "watch"]
   # CRD discovery — list/watch CustomResourceDefinitions for Extensions Hub
   - apiGroups: ["apiextensions.k8s.io"]
     resources:

--- a/plans/service-mesh-observability-phase-d1-topology-backend.md
+++ b/plans/service-mesh-observability-phase-d1-topology-backend.md
@@ -1,0 +1,323 @@
+---
+title: "Service mesh observability — Phase D1: topology overlay backend"
+type: feat
+status: complete
+date: 2026-04-29
+origin: plans/service-mesh-observability.md
+---
+
+# Service mesh observability — Phase D1: topology overlay backend
+
+## Overview
+
+Add opt-in mesh-edge emission to the namespace topology graph behind a new `?overlay=mesh` query parameter. When the caller asks for the overlay and a service mesh (Istio or Linkerd) is installed, the existing `/api/v1/topology/{namespace}` response gains additional service-to-service edges that visualize traffic routing declared by `VirtualService` and Linkerd `ServiceProfile` CRDs. When the caller does not pass the parameter, the response is byte-identical to today.
+
+This is a backend-only PR. Frontend toggle (D2), golden-signals card (D3), and Helm RBAC + docs (D4) are separate units in the same Phase D.
+
+## Problem Frame
+
+Phase 7B's topology graph shows owner, selector, mount, ingress, and HPA edges — but nothing about mesh-managed traffic flow. With Phases A–C now in production, the mesh routing data is already discovered and normalized in `internal/servicemesh` (singleflight + 30s cache). The topology view is the natural place to show it as edges, alongside the existing dependency view.
+
+The parent plan (`plans/service-mesh-observability.md`, lines 547–580) defines this work. Phases A–C are merged (PRs #199, #200, #203, #204); D1 is the next backend unit.
+
+## Requirements Trace
+
+- **R5** *(parent plan)* — Mesh edges visualized on the existing topology graph as an opt-in overlay
+- **R7** *(parent plan)* — RBAC-aware: per-CRD `CanAccessGroupResource` check filters which mesh edges a user sees
+- **R9** *(parent plan)* — `go vet`, `go test ./...` pass; theme tokens only (no frontend in this unit)
+- **Default-response invariance** — Without `?overlay=mesh`, the topology response is byte-identical to today (no new fields, no behavioral change)
+- **Fail-soft** — Overlay requested but mesh not installed → base topology returned, response carries `overlay: "unavailable"`; never a 5xx
+
+## Scope Boundaries
+
+- No frontend changes (overlay toggle, edge styling, legend) — that is Unit D2
+- No golden-signals integration on Service detail — that is Unit D3
+- No Helm/RBAC manifest changes — that is Unit D4
+- No `DestinationRule` edges — DR semantics describe subsets of a single service, not edges between services. A DR-as-node treatment would require adding new node kinds and is deferred (see Key Technical Decisions)
+- No `Gateway` or `ServiceEntry` edges — out of scope for D1; these define ingress/egress relationships, which the existing `EdgeIngress` already covers in spirit
+- No new informer watches — the data already lives in `servicemesh.Handler`'s 30s cache
+- No support for cluster-scoped mesh resources in the overlay — D1 only emits edges between same-namespace services
+
+### Deferred to Separate Tasks
+
+- Frontend toggle and themed edge styling: Unit D2 (next PR)
+- Golden-signals card on Service detail: Unit D3
+- Helm chart RBAC additions for mesh CRD discovery: Unit D4
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `backend/internal/topology/builder.go` — `Builder.BuildNamespaceGraph` is the existing entry point; pattern for reading from a `ResourceLister`, RBAC-gating each kind via `canAccess`, and appending edges via per-builder helpers (`buildOwnerEdges`, `buildServiceSelectorEdges`, etc.). Mesh-edge emission follows the same shape.
+- `backend/internal/topology/types.go` — `EdgeType` constants live here; node-cap constant (`maxNodes = 2000`) lives in `builder.go`.
+- `backend/internal/topology/handler.go` — currently does not parse query params. New overlay handling slots in here.
+- `backend/internal/servicemesh/handler.go` — `Handler.fetchData(ctx)` returns the cached `cachedMeshData{routes, policies, errors, fetchedAt}` populated cluster-wide via service account; per-user RBAC happens at filter time. D1 reuses this exact pattern via a new exported accessor.
+- `backend/internal/servicemesh/types.go` — `TrafficRoute{Mesh, Kind, Name, Namespace, Hosts, Destinations[].Host}` is the contract D1 consumes. `MeshType` discriminator distinguishes Istio vs Linkerd routes.
+- `backend/internal/k8s/resources/access.go:134` — `AccessChecker.CanAccessGroupResource(ctx, user, groups, verb, apiGroup, resource, namespace)` is the right RBAC check for CRD groups (`networking.istio.io/virtualservices`, `linkerd.io/serviceprofiles`).
+- `backend/internal/server/server.go:66,79` — `Handlers.TopologyHandler` and `Handlers.ServiceMeshHandler` are already siblings in the dependency graph, so wiring the mesh handler into the topology builder is straightforward.
+
+### Institutional Learnings
+
+- No `docs/solutions/` entries match topology or mesh-overlay patterns. The most directly applicable internal precedent is Phase A's "service account fetches cluster-wide data, then filter per-user via `CanAccessGroupResource`" — D1 uses the same shape.
+
+### External References
+
+- Skipped. The codebase has strong local patterns (Phase 7B for topology, Phases A–C for mesh) and the unit is internal to a stable interface boundary.
+
+## Key Technical Decisions
+
+- **Reuse `servicemesh.Handler` data over adding informer watches**: The parent plan suggested extending `ResourceLister` with `ListVirtualServices`/`ListServiceProfiles` methods backed by informers. Phase A actually implemented mesh CRD discovery with a dynamic-client + singleflight + 30s cache pattern, so adding informer watches now would duplicate that pipeline and re-introduce the "remote clusters can't use informers" caveat for an additional set of CRDs. Instead, define a small `MeshRouteProvider` interface in `topology` and have `servicemesh.Handler` satisfy it via a new exported `Routes(ctx)` method. *Why*: avoids duplicate caches, keeps remote-cluster behavior consistent, and makes the topology package's dependency on mesh data explicit and minimal.
+
+- **Service-to-service edges only; no CRD-as-node**: Mesh edges connect existing `Service` nodes (host → destination). `VirtualService` and `ServiceProfile` are not added as graph nodes. *Why*: matches the user mental model of "traffic flow", keeps node kinds unchanged (zero migration risk to existing consumers like `topology/handler.go`'s callers and the Phase 7B frontend), and allows D2's frontend to render mesh edges with a distinct style without inventing new node visuals.
+
+- **Drop `mesh_dest` (DestinationRule) edges from D1**: A DestinationRule declares subsets of a single service, not a relationship between two services. Without subset-as-node, there is no meaningful inter-service edge to emit. The parent plan named `mesh_dest` as an edge type but did not specify endpoints; revisit as a node-annotation enhancement after D2 ships if signal demands it.
+
+- **New `Overlay` field on `Graph`, omitempty**: Default response (no `?overlay=` param) leaves `Overlay` zero-value, which JSON-omits — preserving byte-identical Phase 7B response shape. Values: `""` (not requested), `"mesh"` (applied), `"unavailable"` (requested but no mesh installed).
+
+- **Per-CRD RBAC, fail-soft**: For each mesh CRD group the user lacks `list` on, that CRD's edges are silently dropped (no error, no partial-data flag). If the user lacks RBAC on every mesh CRD, the response still carries `overlay: "mesh"` with zero mesh edges added. *Why*: matches the existing topology builder's per-resource `canAccess` posture (forbidden resources silently skipped), and avoids leaking the existence of a mesh CRD via 403 vs 200 timing.
+
+- **Separate edge cap, distinct from node cap**: Add `maxMeshEdges = 2000` in `topology/builder.go`. Mesh edge emission stops at the cap and sets the existing `Graph.Truncated = true` flag. *Why*: a single `VirtualService` can fan out to dozens of destinations; in a 1000-service mesh, this is the only realistic blow-up vector. Re-using the existing `Truncated` flag avoids inventing a second truncation signal.
+
+- **Emit edges via `Hosts` + `Destinations[].Host` lookup against `nameIndex`**: The existing topology `nameIndex` maps `"Kind/Name"` → UID. Source service of a mesh edge is the VS/SP host; target services are each `Destination.Host`. Hosts that do not resolve to a same-namespace `Service` node are silently skipped. *Why*: cross-namespace and external hosts (`*.example.com`, `redis.cache.svc.cluster.local`) are common in mesh routing but are not in the namespace's graph; dropping them is correct, not a bug.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Q: Add VS/SP/DR as graph nodes or use service-to-service edges?** Resolved: service-to-service. See Key Technical Decisions.
+- **Q: How does this consume mesh data without duplicating informers?** Resolved: new `Routes(ctx)` accessor on `servicemesh.Handler` + `MeshRouteProvider` interface in `topology`. See Key Technical Decisions.
+- **Q: Default response invariance?** Resolved: `Overlay` field is `omitempty`, no other shape change.
+
+### Deferred to Implementation
+
+- **Exact host-string normalization for `RouteDestination.Host` lookup.** Mesh routes carry `host: my-svc`, `host: my-svc.namespace`, `host: my-svc.namespace.svc.cluster.local`. The lookup needs to resolve all three to the same `Service` node when present in the namespace. The implementer will write a small `resolveHost(host, namespace, nameIndex)` helper and table-test it; the exact regex/split shape is not worth pre-specifying. The cluster-domain default (`cluster.local` vs custom) is acknowledged as a known limitation per the existing memory note (Phase B mTLS scope boundaries) — D1 inherits the same constraint.
+- **Whether to surface a per-CRD-group `errors` map on the response.** Today's `Graph` shape has no error map. Decision deferred until D2 starts and a concrete UX need emerges; the silent fail-soft posture is sufficient for D1.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```
+                  GET /api/v1/topology/{namespace}?overlay=mesh
+                                    │
+                                    ▼
+                        topology.Handler.HandleNamespaceGraph
+                          │ parses overlay param
+                          ▼
+                        topology.Builder.BuildNamespaceGraph(ctx, ns, user, checker, opts)
+                          │ existing path: pods/services/.../HPAs → nodes + edges
+                          │ new path (when opts.Overlay == "mesh"):
+                          │   1. meshProvider.Routes(ctx)            ← servicemesh.Handler.Routes
+                          │   2. filter to namespace
+                          │   3. for each route's CRD group, CanAccessGroupResource
+                          │   4. buildMeshEdges(filteredRoutes, namespace, nameIndex)
+                          │   5. append to graph.Edges, respect maxMeshEdges
+                          ▼
+                        Graph{Nodes, Edges, Truncated, ComputedAt, Overlay}
+
+  Edge endpoints:  source = nameIndex["Service/" + host(VS or SP)]
+                   target = nameIndex["Service/" + dest.Host]
+  Edge type:       EdgeMeshVS   (Istio VirtualService route → destination)
+                   EdgeMeshSP   (Linkerd ServiceProfile route → destination)
+```
+
+The shape mirrors how `buildIngressEdges` already walks `Ingress.Spec.Rules[].HTTP.Paths[].Backend.Service.Name` and looks the target up in `nameIndex`; mesh-edge emission is analogous, just with mesh-specific host-resolution rules.
+
+## Implementation Units
+
+- [x] **Unit D1.1: Define `MeshRouteProvider` and expose routes from servicemesh handler**
+
+**Goal:** Add a small interface in `topology` for fetching cached mesh routes, and an exported accessor on `servicemesh.Handler` that satisfies it. Establishes the package boundary without coupling `topology` to `servicemesh` internals.
+
+**Requirements:** R5 (foundation)
+
+**Dependencies:** None — `servicemesh.Handler.fetchData` already exists.
+
+**Files:**
+- Modify: `backend/internal/servicemesh/handler.go` (add exported `Routes(ctx context.Context) ([]TrafficRoute, error)`)
+- Modify: `backend/internal/topology/builder.go` (declare `MeshRouteProvider` interface + nil-safe `meshProvider` field on `Builder`)
+- Test: `backend/internal/servicemesh/handler_test.go` (extend existing test file with one case for `Routes`)
+
+**Approach:**
+- `servicemesh.Handler.Routes` is a thin wrapper over `fetchData` that returns the routes slice (cluster-wide, NOT RBAC-filtered — RBAC is the topology builder's responsibility for the overlay scope, mirroring how `fetchData` is unfiltered for `HandleListRoutes` callers).
+- `topology.MeshRouteProvider` interface signature: `Routes(ctx context.Context) ([]servicemesh.TrafficRoute, error)`. Yes, this imports `servicemesh` in `topology` — that import already feels right because the mesh data shape is the contract.
+- `Builder` gains an optional `meshProvider MeshRouteProvider` field. `NewBuilder` keeps its existing signature; add `NewBuilderWithMesh(lister, meshProvider, logger)` or accept a functional option, whichever is more idiomatic in the codebase. (Codebase preference: looking at `Builder` today there are no options; a second constructor is cleaner than adding a setter.)
+
+**Patterns to follow:**
+- `backend/internal/servicemesh/handler.go`'s `cachedMeshData` shape and `fetchData` signature — mirror its return semantics exactly.
+- `backend/internal/topology/builder.go` `ResourceLister` interface as the precedent for "small, behavior-focused interfaces in `topology`".
+
+**Test scenarios:**
+- *Happy path*: `Routes(ctx)` returns the same slice that `HandleListRoutes` would expose pre-RBAC-filter; assert via direct call after seeding `cache` in test.
+- *Edge case*: cache empty → returns empty slice + nil error (no fetch attempted).
+- *Edge case*: cache stale → fetch fires, populates, returns. Verify singleflight coalesces concurrent callers (one fetch when 5 callers race).
+- *Error path*: dynamic client unavailable → returns empty slice + nil error (matches existing `doFetch` behavior for that case).
+
+**Verification:**
+- `go test ./internal/servicemesh/...` passes.
+- New `Routes` method is exported and documented; godoc clearly states "cluster-wide, not RBAC-filtered — caller must filter".
+
+---
+
+- [x] **Unit D1.2: Mesh edge emitter (`mesh_edges.go` + tests)**
+
+**Goal:** Pure function that converts a slice of `servicemesh.TrafficRoute` plus the namespace + nameIndex into a slice of `topology.Edge`, capped and host-resolved. No I/O, no RBAC — those are wired in D1.3.
+
+**Requirements:** R5
+
+**Dependencies:** D1.1 (provides the type), but the emitter itself is a pure function so it can be implemented and tested independently.
+
+**Files:**
+- Modify: `backend/internal/topology/types.go` (add `EdgeMeshVS`, `EdgeMeshSP` constants; add `Overlay string \`json:"overlay,omitempty"\`` field to `Graph`)
+- Create: `backend/internal/topology/mesh_edges.go`
+- Create: `backend/internal/topology/mesh_edges_test.go`
+
+**Approach:**
+- Function signature (directional): `buildMeshEdges(routes []servicemesh.TrafficRoute, namespace string, nameIndex map[string]string, maxEdges int) (edges []Edge, truncated bool)`.
+- Iterates routes; skips routes outside `namespace`; resolves `route.Hosts[0]` to a source service UID via `nameIndex`; for each `Destination`, resolves `dest.Host` to a target service UID; emits an edge typed `EdgeMeshVS` (when `route.Mesh == MeshIstio`) or `EdgeMeshSP` (when `route.Mesh == MeshLinkerd`).
+- Host resolver helper: `resolveHost(host, namespace string, nameIndex map[string]string) (uid string, ok bool)` strips `.namespace.svc.cluster.local` and `.namespace` suffixes before lookup. External hosts (no service match) → `ok=false`, edge skipped.
+- Edge dedup: same `(source, target, type)` triple emitted by multiple routes is collapsed to one edge — match the dedup pattern in `buildIngressEdges`'s `seen` map.
+- Cap: stop at `maxEdges`, return `truncated=true`.
+
+**Patterns to follow:**
+- `buildIngressEdges` in `backend/internal/topology/builder.go` for the `seen` dedup map and `nameIndex` lookup pattern.
+- Edge type constant style in `backend/internal/topology/types.go`.
+
+**Test scenarios:**
+- *Happy path — Istio VS, single destination*: VS in namespace `foo` with `hosts: [a]` and one route to `b` → one `mesh_vs` edge from `Service/a` UID to `Service/b` UID.
+- *Happy path — Linkerd SP*: ServiceProfile in namespace `foo` with `hosts: [a]` and one route to `b` → one `mesh_sp` edge.
+- *Happy path — multiple destinations*: VS routes to `b`, `c`, `d` → three edges, all `mesh_vs`, sharing source.
+- *Happy path — host suffix variants*: route destination `host: b`, `host: b.foo`, `host: b.foo.svc.cluster.local` all resolve to the same `Service/b` UID and dedup to one edge.
+- *Edge case — no matching destination service*: VS routes to `external.example.com` → no edges emitted, no error.
+- *Edge case — VS in different namespace*: route in namespace `bar` while building `foo` → not emitted.
+- *Edge case — empty routes*: nil slice → empty edges, `truncated=false`.
+- *Edge case — routes without hosts*: `Hosts` empty → emitter falls back to `route.Name`'s namespace lookup if applicable, otherwise skips. (Implementer to choose; document what's chosen in code.)
+- *Cap*: 2500 edge candidates → returns 2000 edges, `truncated=true`.
+- *Dedup*: two VS objects routing the same source→target → one edge, not two.
+- *Mesh discriminator*: Istio route → `EdgeMeshVS`; Linkerd route → `EdgeMeshSP`; unknown mesh → no edge (defensive).
+
+**Verification:**
+- `go test ./internal/topology/...` passes.
+- `mesh_edges.go` is pure (no logger, no context, no I/O). Tests run in microseconds.
+
+---
+
+- [x] **Unit D1.3: Builder + handler overlay path**
+
+**Goal:** Wire the overlay flow end-to-end through `Builder.BuildNamespaceGraph` and `Handler.HandleNamespaceGraph`. RBAC checks gate which mesh CRD groups contribute edges; default response is byte-identical to today.
+
+**Requirements:** R5, R7, default-response invariance, fail-soft
+
+**Dependencies:** D1.1 (provider interface), D1.2 (emitter).
+
+**Files:**
+- Modify: `backend/internal/topology/builder.go` (extend `BuildNamespaceGraph` to accept a `BuildOptions{Overlay string}`, or add a parallel `BuildNamespaceGraphWithOptions` to avoid breaking other callers; route to mesh-edge emission when `Overlay == "mesh"`)
+- Modify: `backend/internal/topology/handler.go` (parse `?overlay=` query param, pass through; populate `Graph.Overlay`)
+- Modify: `backend/internal/server/server.go` (pass `ServiceMeshHandler` into `topology.Handler`'s builder construction)
+- Test: `backend/internal/topology/builder_test.go` (add overlay-path cases; existing tests must still pass)
+- Test: `backend/internal/topology/handler_test.go` (create if absent — looks like there's no handler test today; if so, defer to existing test conventions)
+
+**Approach:**
+- Handler reads `r.URL.Query().Get("overlay")`. Empty → call existing path; `"mesh"` → call new path with `Overlay: "mesh"`. Any other value → 400 (`"unsupported overlay"`). The 400 makes typos visible; matching the existing `resolveMeshParam` pattern for invalid input.
+- Builder, when `opts.Overlay == "mesh"`:
+  1. If `b.meshProvider == nil` → set `graph.Overlay = "unavailable"` and return base graph.
+  2. Call `b.meshProvider.Routes(ctx)`. On error, log + degrade to `graph.Overlay = "unavailable"` (do not 5xx).
+  3. Filter routes to `namespace`.
+  4. For each unique CRD group present in the filtered routes (`networking.istio.io/virtualservices`, `linkerd.io/serviceprofiles`), call `checker.CanAccessGroupResource(ctx, user, ..., "list", apiGroup, resource, namespace)`. Drop routes whose CRD the user can't list.
+  5. Call `buildMeshEdges(filteredRoutes, namespace, nameIndex, maxMeshEdges)`. Append edges. If emitter returned `truncated=true`, set `graph.Truncated = true`.
+  6. Set `graph.Overlay = "mesh"`.
+- Detection of "mesh installed" is implicit via `Routes(ctx)` returning a non-empty slice (or via a separate `Detected()` accessor — implementer's call). If routes are empty and the call succeeded → `Overlay = "mesh"` with zero mesh edges (not "unavailable"). "Unavailable" is reserved for "provider unwired or errored".
+- `maxMeshEdges = 2000` defined in `builder.go` near `maxNodes`.
+
+**Patterns to follow:**
+- `backend/internal/topology/builder.go`'s `canAccess` helper as the RBAC-check pattern (though this unit needs `CanAccessGroupResource`, not `CanAccess`).
+- `backend/internal/servicemesh/handler.go`'s `filterByRBAC[T]` for the per-CRD-group access cache pattern (one SSAR per CRD-group/namespace pair, not per route).
+
+**Test scenarios:**
+- *Default path unchanged (regression)*: no `?overlay=` query → response shape and content byte-identical to pre-D1 (no `Overlay` field present, no mesh edges, no behavior change). Assert via response-fixture diff against a known baseline.
+- *Happy path — Istio installed, user has VS list permission*: `?overlay=mesh` → response includes `mesh_vs` edges; `Overlay == "mesh"`.
+- *Happy path — both meshes installed*: `?overlay=mesh` → response includes both `mesh_vs` and `mesh_sp` edges.
+- *Edge case — overlay requested, no mesh installed*: provider returns empty slice → `Overlay == "mesh"`, no mesh edges added, base graph intact.
+- *Edge case — overlay requested, provider unwired (nil)*: → `Overlay == "unavailable"`, base graph intact.
+- *Edge case — overlay requested, provider errors*: → `Overlay == "unavailable"`, error logged, no 5xx.
+- *Edge case — invalid overlay value*: `?overlay=garbage` → 400 with user-safe message.
+- *RBAC — user lacks VS access*: user can't list `networking.istio.io/virtualservices` in the namespace → no `mesh_vs` edges, but `mesh_sp` edges still emitted if user has SP access. `Overlay == "mesh"`.
+- *RBAC — user lacks every mesh CRD*: no mesh edges, `Overlay == "mesh"`. Equivalent to "no mesh edges to show".
+- *RBAC — checker errors*: `CanAccessGroupResource` returns error → that CRD's edges are dropped (fail-closed); other CRDs proceed. Logged.
+- *Cap*: provider returns 2500 routes that would each emit one edge → response has exactly 2000 mesh edges, `Truncated == true`.
+- *Cross-cluster invariant*: any test that builds a graph for a non-local cluster context (if test infra supports it) must not reach the mesh provider — D1 leaves that invariant intact because the existing builder is local-cluster-only and remote topology is currently routed elsewhere. *(Verify with the current routing layer; if remote topology already 403s, no extra check needed.)*
+
+**Verification:**
+- `cd backend && go vet ./... && go test ./...` passes (run repo-wide per CLAUDE.md, not scoped).
+- A baseline-fixture diff confirms the no-overlay response shape is unchanged.
+- Manual smoke against homelab once Istio is installed: `curl /api/v1/topology/<ns>?overlay=mesh` returns mesh edges; `curl /api/v1/topology/<ns>` returns the original shape.
+
+---
+
+- [x] **Unit D1.4: Wire `ServiceMeshHandler` into topology builder construction in server bootstrap**
+
+**Goal:** In `server.go`, pass `ServiceMeshHandler` (which now satisfies `MeshRouteProvider`) into the topology builder so D1.3's overlay path actually has data in production.
+
+**Requirements:** R5 (final wiring)
+
+**Dependencies:** D1.1, D1.3.
+
+**Files:**
+- Modify: `backend/internal/server/server.go` (the dependency wiring site for `TopologyHandler`)
+
+**Approach:**
+- Wherever `topology.NewBuilder` is currently invoked, switch to `topology.NewBuilderWithMesh(lister, deps.ServiceMeshHandler, logger)` (or whichever construction shape D1.1 settled on). `ServiceMeshHandler` is already constructed before `TopologyHandler` in the existing init order — confirm during implementation; if not, swap order. No new fields on the `Handlers` struct.
+
+**Patterns to follow:**
+- Existing wiring pattern in `backend/internal/server/server.go` for sibling handlers.
+
+**Test scenarios:**
+- Test expectation: none — pure wiring change. Behavior is covered by D1.3's tests (which rely on `Builder` being constructed with a non-nil provider) and by the homelab smoke.
+
+**Verification:**
+- `cd backend && go vet ./...` clean.
+- Server starts; `/api/v1/topology/<ns>?overlay=mesh` returns mesh edges on a cluster with a mesh installed.
+
+## System-Wide Impact
+
+- **Interaction graph:** New dependency edge from `topology.Builder` to `servicemesh.Handler` (via `MeshRouteProvider` interface). No middleware changes. No new routes — the existing `/api/v1/topology/{namespace}` route gains a query parameter. No WebSocket changes.
+- **Error propagation:** Mesh-overlay failures are absorbed at the builder layer (set `Overlay = "unavailable"`, log, continue). Base topology never fails because of a mesh failure. CRD RBAC errors are fail-closed for that CRD only.
+- **State lifecycle risks:** None new. Mesh data lives in `servicemesh.Handler`'s 30s cache; topology becomes a read-only consumer. No write paths.
+- **API surface parity:** `Graph.Overlay` is the single new field, `omitempty`. Frontend Phase 7B's existing topology page and the diagnostics blast-radius view (which also consumes `Graph`) see no behavioral difference unless they pass the new query param.
+- **Integration coverage:**
+  (a) Mesh installed + RBAC granted → mesh edges in response.
+  (b) Mesh installed + partial RBAC (VS yes, SP no) → only VS edges.
+  (c) Mesh not installed + overlay requested → `Overlay = "mesh"`, zero mesh edges.
+  (d) Provider unwired or errored → `Overlay = "unavailable"`, base graph intact.
+  (e) Default request (no `?overlay`) → response byte-identical to pre-D1.
+- **Unchanged invariants:**
+  - `/api/v1/topology/<ns>` without `?overlay` is byte-identical to today.
+  - `topology.Graph` field set is unchanged except for the new `Overlay omitempty` field.
+  - `internal/servicemesh` package's existing handler behavior is unchanged. The new exported `Routes(ctx)` method is additive.
+  - Remote-cluster topology (if any path reaches it) is untouched. D1 inherits whatever the current local-cluster-only assumption is.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Default response shape drift breaks Phase 7B frontend or diagnostics consumers | `Overlay omitempty`, response-fixture diff test, manual `curl` against pre-/post-PR baselines during smoke. |
+| Mesh route fetch latency adds to topology endpoint p95 | Reuses the existing 30s cache; the only synchronous cost in the typical case is a map lookup. Provider error path is fail-soft, never blocks the base graph. |
+| Cardinality blow-up on a 1000-service mesh | `maxMeshEdges = 2000`, dedup by `(source, target, type)`, and `Truncated` flag. |
+| User can list services but not VirtualService → confusing partial graph | Documented behavior: missing CRD list permission silently drops that CRD's edges. Phase D2 frontend will surface "mesh edges are filtered by your CRD permissions" via help text on the toggle. |
+| Mesh data exposed to a non-admin user via topology that they wouldn't see in `/api/v1/mesh/routing` | The same `CanAccessGroupResource` check used by `HandleListRoutes`'s `filterByRBAC` runs here. No new RBAC bypass path. |
+| Custom cluster domain (`cluster.svc.example.org`) breaks host resolution | Inherits the known limitation already accepted in Phase B (per memory: `project_servicemesh_scope_boundaries.md`). Document in code comment. Not a regression. |
+| Remote cluster passes through this path and dereferences a nil mesh provider | Builder's nil-check sets `Overlay = "unavailable"` and returns base graph. Defensive, not a 5xx. |
+
+## Documentation / Operational Notes
+
+- No README/docs changes in this unit. D4 covers Helm + docs + roadmap-tick.
+- After merge, append a one-line bullet to the parent plan's "Phase D" status note (`plans/service-mesh-observability.md`). Do not mark roadmap item #6 complete until D1–D4 are all merged.
+
+## Sources & References
+
+- **Origin document:** [plans/service-mesh-observability.md](service-mesh-observability.md), Unit D1 (lines 547–580)
+- **Phase A precedent:** [plans/service-mesh-observability.md](service-mesh-observability.md), Phase A (singleflight + 30s cache, RBAC filter pattern)
+- **Topology builder:** `backend/internal/topology/builder.go` (existing edge emission patterns)
+- **Mesh data shape:** `backend/internal/servicemesh/types.go` (`TrafficRoute`)
+- **RBAC check:** `backend/internal/k8s/resources/access.go:134` (`CanAccessGroupResource`)
+- **Recent service mesh PRs:** #199 (Phase A), #200 (Phase B), #203 (Phase B follow-ups), #204 (Phase C frontend)

--- a/plans/service-mesh-observability.md
+++ b/plans/service-mesh-observability.md
@@ -1,7 +1,7 @@
 ---
 title: feat — Service Mesh Observability (Istio + Linkerd)
 type: feat
-status: active
+status: complete
 date: 2026-04-16
 roadmap: "#6"
 ---
@@ -630,7 +630,7 @@ Phases deliver independently-shippable PRs. Each phase is reviewed and merged be
 
 ---
 
-- [ ] **Unit D4: Helm chart + docs**
+- [x] **Unit D4: Helm chart + docs**
 
 **Goal:** Helm chart updates + smoke documentation.
 

--- a/plans/service-mesh-observability.md
+++ b/plans/service-mesh-observability.md
@@ -604,7 +604,7 @@ Phases deliver independently-shippable PRs. Each phase is reviewed and merged be
 
 ---
 
-- [ ] **Unit D3: Golden signals on service detail**
+- [x] **Unit D3: Golden signals on service detail**
 
 **Goal:** Surface RPS, p50/p95/p99 latency, and error rate on the existing Service detail page when the service is meshed.
 

--- a/plans/service-mesh-observability.md
+++ b/plans/service-mesh-observability.md
@@ -580,7 +580,7 @@ Phases deliver independently-shippable PRs. Each phase is reviewed and merged be
 
 ---
 
-- [ ] **Unit D2: Frontend topology overlay toggle**
+- [x] **Unit D2: Frontend topology overlay toggle**
 
 **Goal:** "Show mesh traffic" toggle on `/observability/topology` renders mesh edges with a distinct style.
 


### PR DESCRIPTION
## Summary
Closes out service mesh observability (roadmap item #6). Builds on Phases A–C (#199 / #200 / #203 / #204) with four units that deliver:

- **D1 — Topology overlay backend.** New `?overlay=mesh` query parameter on `GET /api/v1/topology/{namespace}` emits service-to-service mesh edges (Istio `VirtualService` and Linkerd `ServiceProfile` routes) with per-CRD-group RBAC fail-closed via `CanAccessGroupResource`. The `Graph.Overlay` response field is `omitempty`, so the no-overlay path is byte-identical to today.
- **D2 — Frontend toggle.** "Show mesh traffic" toolbar checkbox on `/observability/topology` themed with `var(--accent)` (Istio) and `var(--accent-secondary)` (Linkerd). Disables itself with a tooltip when the backend reports `overlay: "unavailable"`. Inline legend appears next to "Updated X ago" while active.
- **D3 — Golden signals on Service detail.** Inline RPS / error rate / p50 / p95 / p99 latency card with 30s refresh. Silently absent for unmeshed services and zero-traffic baselines; renders "Metrics unavailable" only when Prometheus is offline so operators see infrastructure issues distinctly.
- **D4 — Helm + docs.** Explicit `list, watch` ClusterRole grants for the four mesh CRD groups (Istio + Linkerd), matching the gitops/policy precedent. CLAUDE.md roadmap item #6 marked complete; Phase 12 entry added to Build Progress.

Plan: [plans/service-mesh-observability.md](plans/service-mesh-observability.md) (parent) and [plans/service-mesh-observability-phase-d1-topology-backend.md](plans/service-mesh-observability-phase-d1-topology-backend.md) (D1 detail).

## Architecture notes
- **Reuse over replication:** `topology.MeshRouteProvider` interface backed by `servicemesh.Handler.Routes(ctx)` keeps the existing singleflight + 30s cache pipeline as the single source of mesh route data. No new informer watches.
- **Service-to-service edges only:** mesh edges connect existing `Service` nodes via `nameIndex` lookup with name / namespaced / FQDN host-form variants. No new node kinds; D2 frontend doesn't have to invent visuals.
- **`mesh_dest` deferred:** `DestinationRule` describes subsets of one service rather than service-to-service relationships; emitting an inter-service edge would require adding subset-as-node, which is out of scope for D1.
- **Per-CRD RBAC fail-closed:** users without list permission on `networking.istio.io/virtualservices` see no `mesh_vs` edges; missing `linkerd.io/serviceprofiles` drops `mesh_sp` edges. Either path independent — partial visibility is the documented behavior.
- **Custom cluster domain limitation:** hosts under `cluster.svc.example.org` won't resolve. Inherited from the Phase B scope boundary, called out in the D1 plan.
- **`detected: "both"` on Service detail:** card hides itself because the backend's `resolveMeshParam` requires an explicit `?mesh=` disambiguator when both meshes are present and v1 has no per-service mesh resolution. Future enhancement when workload context flows through.

## Test plan
- [x] `cd backend && go vet ./... && go test ./...` passes repo-wide
- [x] Topology package gains 25 new tests — pure-emitter coverage (happy / edge / cap / dedup / cross-namespace / host suffix variants / unknown mesh) plus builder + handler integration (default-path invariance, RBAC denial, nil/erroring provider, edge-cap truncation, 400 on bad overlay)
- [x] Servicemesh package gains 2 new tests for `Handler.Routes(ctx)` (cache view, nil dyn client)
- [x] `deno lint` + `deno check` clean on all touched files; repo-wide `deno check` baseline (40 errors) unchanged
- [ ] **Homelab smoke** — install with Istio (or Linkerd) running, exercise:
  - [ ] `/observability/topology?overlay=mesh` shows mesh edges
  - [ ] No-mesh cluster: toggle disables itself with tooltip
  - [ ] Service detail page in a meshed namespace renders the golden-signals card with live values
  - [ ] Service detail in an unmeshed namespace shows no card
  - [ ] Backend logs free of permission errors after Helm reinstall
- [ ] `make helm-lint` and `make helm-template` (CI) — left to the GitHub Actions run since neither binary is on PATH locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)