### PR TITLE
fix(servicemesh): D-review follow-ups — partial-metrics surface + universal cluster-domain

### DIFF
--- a/backend/internal/servicemesh/metrics.go
+++ b/backend/internal/servicemesh/metrics.go
@@ -56,10 +56,46 @@ type GoldenSignals struct {
 // (destination_service_name) and Linkerd's inbound-authority labels
 // (authority=...) are incompatible shapes — no shared template set.
 type goldenSignalsTemplates struct {
-	rps       monitoring.QueryTemplate
-	errorNum  monitoring.QueryTemplate
-	errorDen  monitoring.QueryTemplate
-	latencyP  func(q string) monitoring.QueryTemplate
+	rps      monitoring.QueryTemplate
+	errorNum monitoring.QueryTemplate
+	errorDen monitoring.QueryTemplate
+	latencyP func(q string) monitoring.QueryTemplate
+}
+
+// goldenSignalQueryNames is the single ordered source of truth for the
+// six PromQL query identifiers exposed by goldenSignalsForService. The
+// fan-out map and the MissingQueries iteration both walk this slice so
+// they can't silently drift apart. Adding a seventh signal requires
+// updating this slice AND queryTemplate (compile-time enforced for the
+// latter via the default panic).
+var goldenSignalQueryNames = []string{
+	"rps",
+	"errorNum",
+	"errorDen",
+	"p50",
+	"p95",
+	"p99",
+}
+
+// queryTemplate selects the QueryTemplate for a given goldenSignalQueryNames
+// entry. Panics on unknown names so a typo or stale slice is caught at
+// init / first call rather than silently rendering an empty PromQL string.
+func queryTemplate(t goldenSignalsTemplates, name string) monitoring.QueryTemplate {
+	switch name {
+	case "rps":
+		return t.rps
+	case "errorNum":
+		return t.errorNum
+	case "errorDen":
+		return t.errorDen
+	case "p50":
+		return t.latencyP("0.50")
+	case "p95":
+		return t.latencyP("0.95")
+	case "p99":
+		return t.latencyP("0.99")
+	}
+	panic(fmt.Sprintf("servicemesh: queryTemplate: unknown query name %q (must match goldenSignalQueryNames)", name))
 }
 
 // istioTemplates use the v1.18+ Istio standard metric names. Labels
@@ -159,13 +195,16 @@ func goldenSignalsForService(ctx context.Context, pc *monitoring.PrometheusClien
 	// Render all queries up front. Any render failure is a validation
 	// error — the injected values failed the monitoring package's k8s-name
 	// check — and should surface to the caller as a 400.
-	queries := map[string]monitoring.QueryTemplate{
-		"rps":      templates.rps,
-		"errorNum": templates.errorNum,
-		"errorDen": templates.errorDen,
-		"p50":      templates.latencyP("0.50"),
-		"p95":      templates.latencyP("0.95"),
-		"p99":      templates.latencyP("0.99"),
+	//
+	// goldenSignalQueryNames is the single ordered source of truth for
+	// the six PromQL query identifiers. The map is built by iterating
+	// it, and MissingQueries is populated by iterating the same slice,
+	// so adding a seventh signal is a one-line change in goldenSignalQueryNames
+	// (plus a corresponding case in queryTemplate) — it can no longer
+	// silently desync the partial-success surface from the fan-out.
+	queries := make(map[string]monitoring.QueryTemplate, len(goldenSignalQueryNames))
+	for _, name := range goldenSignalQueryNames {
+		queries[name] = queryTemplate(templates, name)
 	}
 
 	rendered := make(map[string]string, len(queries))
@@ -232,8 +271,9 @@ func goldenSignalsForService(ctx context.Context, pc *monitoring.PrometheusClien
 	// Surface partial success so the UI can flag a degraded Prometheus
 	// (one query answering with zeros vs all six answering) rather than
 	// silently rendering zeros that look like an idle service. Iterate
-	// in stable order so the response shape is deterministic.
-	for _, name := range []string{"rps", "errorNum", "errorDen", "p50", "p95", "p99"} {
+	// goldenSignalQueryNames so the ordering is deterministic AND tied
+	// to the same slice the fan-out used.
+	for _, name := range goldenSignalQueryNames {
 		if _, ok := results[name]; !ok {
 			result.MissingQueries = append(result.MissingQueries, name)
 		}

--- a/backend/internal/servicemesh/metrics.go
+++ b/backend/internal/servicemesh/metrics.go
@@ -27,13 +27,22 @@ const promQueryTimeout = 2 * time.Second
 // single service. All values are zero when no traffic was observed —
 // Available stays true so the UI can distinguish "silent service" from
 // "metrics subsystem offline".
+//
+// MissingQueries names any of the six PromQL fan-out queries that
+// failed (timed out, returned no scalar, or errored). It's omitted on a
+// fully-successful response so callers can treat absence as success.
+// When non-empty AND Available=true the response represents partial
+// data; the UI surfaces this so a heavily-degraded Prometheus answering
+// only one query with zeros isn't indistinguishable from a silent
+// meshed service.
 type GoldenSignals struct {
 	Mesh      MeshType `json:"mesh"`
 	Namespace string   `json:"namespace"`
 	Service   string   `json:"service"`
 
-	Available bool   `json:"available"`
-	Reason    string `json:"reason,omitempty"` // populated only when Available=false
+	Available      bool     `json:"available"`
+	Reason         string   `json:"reason,omitempty"`         // populated only when Available=false
+	MissingQueries []string `json:"missingQueries,omitempty"` // populated when partial-success
 
 	RPS       float64 `json:"rps"`
 	ErrorRate float64 `json:"errorRate"` // fraction 0..1
@@ -219,6 +228,16 @@ func goldenSignalsForService(ctx context.Context, pc *monitoring.PrometheusClien
 	result.P50Ms = nanToZero(results["p50"])
 	result.P95Ms = nanToZero(results["p95"])
 	result.P99Ms = nanToZero(results["p99"])
+
+	// Surface partial success so the UI can flag a degraded Prometheus
+	// (one query answering with zeros vs all six answering) rather than
+	// silently rendering zeros that look like an idle service. Iterate
+	// in stable order so the response shape is deterministic.
+	for _, name := range []string{"rps", "errorNum", "errorDen", "p50", "p95", "p99"} {
+		if _, ok := results[name]; !ok {
+			result.MissingQueries = append(result.MissingQueries, name)
+		}
+	}
 
 	return result, nil
 }

--- a/backend/internal/servicemesh/metrics_test.go
+++ b/backend/internal/servicemesh/metrics_test.go
@@ -1,6 +1,7 @@
 package servicemesh
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -425,6 +426,19 @@ func TestGoldenSignalsForService_AllSucceedHasNoMissingQueries(t *testing.T) {
 	}
 	if len(got.MissingQueries) != 0 {
 		t.Errorf("MissingQueries = %v, want empty (all queries succeeded)", got.MissingQueries)
+	}
+
+	// Lock the wire-format contract end-to-end: omitempty on a nil slice
+	// keeps the field out of the JSON. A future refactor that
+	// preallocates the slice (e.g. make([]string, 0, 6)) would silently
+	// start emitting "missingQueries":[] and break the frontend's
+	// "treat absence as success" assumption — this assertion catches it.
+	body, jerr := json.Marshal(got)
+	if jerr != nil {
+		t.Fatalf("marshal: %v", jerr)
+	}
+	if bytes.Contains(body, []byte("missingQueries")) {
+		t.Errorf("JSON body contains \"missingQueries\" on a fully-successful response; want field omitted.\nbody: %s", body)
 	}
 }
 

--- a/backend/internal/servicemesh/metrics_test.go
+++ b/backend/internal/servicemesh/metrics_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"slices"
 	"strings"
 	"testing"
 
@@ -390,6 +391,40 @@ func TestGoldenSignalsForService_PartialFailure(t *testing.T) {
 	}
 	if got.P99Ms != 0 {
 		t.Errorf("P99 = %v, want 0 (query failed so no value)", got.P99Ms)
+	}
+	// Partial-success surface: the failed P99 query should appear in
+	// MissingQueries so the UI can flag the response as degraded.
+	if !slices.Contains(got.MissingQueries, "p99") {
+		t.Errorf("MissingQueries = %v, want it to include 'p99' (partial-success contract)", got.MissingQueries)
+	}
+}
+
+// TestGoldenSignalsForService_AllSucceedHasNoMissingQueries locks the
+// happy-path invariant that MissingQueries is empty (and thus
+// JSON-omitted) when every query returns. The frontend treats
+// MissingQueries as the authoritative "is this response degraded?"
+// signal, so a stray entry in the all-good case would cause spurious
+// "Partial metrics" warnings in the UI.
+func TestGoldenSignalsForService_AllSucceedHasNoMissingQueries(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"status":"success","data":{"resultType":"vector","result":[{"metric":{},"value":[1,"42"]}]}}`)
+	}))
+	defer srv.Close()
+	pc, err := monitoring.NewPrometheusClient(srv.URL)
+	if err != nil {
+		t.Fatalf("prom client: %v", err)
+	}
+
+	got, gerr := goldenSignalsForService(context.Background(), pc, MeshIstio, "shop", "cart")
+	if gerr != nil {
+		t.Fatalf("unexpected error: %v", gerr)
+	}
+	if !got.Available {
+		t.Fatalf("Available = false, want true")
+	}
+	if len(got.MissingQueries) != 0 {
+		t.Errorf("MissingQueries = %v, want empty (all queries succeeded)", got.MissingQueries)
 	}
 }
 

--- a/backend/internal/topology/mesh_edges.go
+++ b/backend/internal/topology/mesh_edges.go
@@ -116,27 +116,30 @@ func buildMeshEdges(
 	return edges, stats
 }
 
-// resolveServiceHost looks up a mesh route's host string against the topology
-// nameIndex. It accepts the three common Kubernetes service-host shapes:
+// resolveServiceHost looks up a mesh route's host string against the
+// topology nameIndex. It accepts the three common Kubernetes service-
+// host shapes:
 //
 //	bare name:        my-svc
 //	namespaced:       my-svc.foo
-//	fully qualified:  my-svc.foo.svc.cluster.local
+//	fully qualified:  my-svc.foo.svc.<cluster-domain>
 //
-// Lookup is case-insensitive: DNS hostnames are case-insensitive and Istio
-// VS hosts are user-supplied free-form text, but Kubernetes Service names
-// are RFC 1123 lowercase. We lowercase the host first so an operator who
-// types "MyService.foo" in a VirtualService still resolves to the
-// corresponding Service.
+// Lookup is case-insensitive: DNS hostnames are case-insensitive and
+// Istio VS hosts are user-supplied free-form text, but Kubernetes
+// Service names are RFC 1123 lowercase. We lowercase the host first so
+// an operator who types "MyService.foo" in a VirtualService still
+// resolves to the corresponding Service.
+//
+// Custom cluster domains are supported transparently. Rather than
+// matching the literal "cluster.local" tail (which fails for clusters
+// using --cluster-domain=k8s.example.com or similar), we split at the
+// first ".svc." separator and take everything before it. This works for
+// any cluster domain because the ".svc." separator is canonical in the
+// Kubernetes service-FQDN format regardless of the trailing domain.
 //
 // Only hosts that resolve to a Service node in the requested namespace
-// match. Cross-namespace hosts (my-svc.bar from inside namespace foo) and
-// external hosts (api.example.com) return ok=false.
-//
-// Custom cluster domains (clusterDomain != "cluster.local") are a known
-// limitation inherited from Phase B; these FQDN-form hosts won't resolve.
-// The bare and namespaced forms still work because they don't depend on
-// the cluster domain.
+// match. Cross-namespace hosts (my-svc.bar from inside namespace foo)
+// and external hosts (api.example.com) return ok=false.
 func resolveServiceHost(host, namespace string, nameIndex map[string]string) (string, bool) {
 	if host == "" || namespace == "" {
 		return "", false
@@ -145,13 +148,15 @@ func resolveServiceHost(host, namespace string, nameIndex map[string]string) (st
 	// Lowercase before any matching so case differences in user-supplied
 	// VS hosts don't silently drop edges.
 	bare := strings.ToLower(host)
-	// Strip the FQDN suffix. We accept .svc.cluster.local and .svc; the
-	// shorter forms still flow through the dot-split below.
-	for _, suffix := range []string{".svc.cluster.local", ".svc"} {
-		if trimmed, ok := strings.CutSuffix(bare, suffix); ok {
-			bare = trimmed
-			break
-		}
+	// Strip the cluster-domain suffix by splitting at ".svc." (the
+	// canonical k8s service-FQDN separator). "name.namespace.svc.<any>"
+	// becomes "name.namespace" without depending on the cluster domain
+	// being "cluster.local". Plain ".svc" with nothing after it is
+	// handled by the trailing CutSuffix.
+	if idx := strings.Index(bare, ".svc."); idx >= 0 {
+		bare = bare[:idx]
+	} else if trimmed, ok := strings.CutSuffix(bare, ".svc"); ok {
+		bare = trimmed
 	}
 
 	// At this point the candidate is either "name" or "name.namespace".

--- a/backend/internal/topology/mesh_edges_test.go
+++ b/backend/internal/topology/mesh_edges_test.go
@@ -327,6 +327,29 @@ func TestBuildMeshEdges_CaseInsensitiveHostResolution(t *testing.T) {
 	}
 }
 
+func TestBuildMeshEdges_CustomClusterDomainResolves(t *testing.T) {
+	// Clusters with --cluster-domain other than the default still produce
+	// canonical "<svc>.<ns>.svc.<domain>" FQDNs in mesh routes. Splitting
+	// at the first ".svc." separator (rather than literal-matching the
+	// trailing domain) makes the resolver work uniformly across cluster
+	// configurations without requiring an external config knob.
+	idx := makeIndex("a", "b")
+	routes := []servicemesh.TrafficRoute{
+		vsRoute("foo", "vs-default", "a", "b.foo.svc.cluster.local"),
+		vsRoute("foo", "vs-custom", "a", "b.foo.svc.k8s.example.com"),
+		vsRoute("foo", "vs-shorter", "a", "b.foo.svc.cluster"),
+	}
+
+	edges, _ := buildMeshEdges(routes, "foo", idx, maxMeshEdges)
+
+	if len(edges) != 1 {
+		t.Fatalf("edges = %d, want 1 (cluster-domain variants must dedup to one edge)", len(edges))
+	}
+	if !findEdge(edges, "uid-a", "uid-b", EdgeMeshVS) {
+		t.Errorf("missing edge uid-a -> uid-b across cluster-domain variants; got %+v", edges)
+	}
+}
+
 func TestBuildMeshEdges_StatsCountsUnresolvedHosts(t *testing.T) {
 	// One route's source host doesn't resolve (external host); two of
 	// another route's destinations don't resolve. Stats should count

--- a/frontend/components/mesh/GoldenSignals.tsx
+++ b/frontend/components/mesh/GoldenSignals.tsx
@@ -94,20 +94,18 @@ export function MeshGoldenSignals({ namespace, service }: Props) {
         // service" from "meshed with traffic" by checking whether ANY
         // metric is non-zero. A meshed service with traffic always has
         // at least RPS > 0; a meshed-but-silent service produces no
-        // useful card. Hide both cases.
-        //
-        // Known limitation: the backend reports available=true even
-        // when 5 of 6 PromQL queries failed (partial-success contract,
-        // see internal/servicemesh/metrics.go). A heavily degraded
-        // Prometheus that only answers one query with zeros looks the
-        // same as a silent meshed service here. Surfacing that
-        // distinction requires a backend signal we don't have today.
+        // useful card. Hide both cases — UNLESS the backend signaled
+        // partial success via missingQueries, in which case we render
+        // so operators can see "Prometheus is degraded" rather than
+        // "service is silent". This closes the all-zero ambiguity that
+        // existed before the missingQueries surface was added.
         const hasTraffic = signals.rps > 0 ||
           signals.errorRate > 0 ||
           signals.p50Ms > 0 ||
           signals.p95Ms > 0 ||
           signals.p99Ms > 0;
-        if (!hasTraffic) {
+        const partial = (signals.missingQueries?.length ?? 0) > 0;
+        if (!hasTraffic && !partial) {
           data.value = null;
           offline.value = false;
           return;
@@ -155,16 +153,36 @@ export function MeshGoldenSignals({ namespace, service }: Props) {
   const s = data.value;
   if (!s) return null;
 
+  const missing = s.missingQueries ?? [];
   return (
     <section>
-      <h3 class="mb-2 text-sm font-semibold uppercase tracking-wide text-text-muted">
+      <h3 class="mb-2 flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-text-muted">
         Service Mesh — Golden Signals
-        <span class="ml-2 rounded bg-bg-elevated px-1.5 py-0.5 text-xs font-normal text-text-muted">
+        <span class="rounded bg-bg-elevated px-1.5 py-0.5 text-xs font-normal text-text-muted">
           {s.mesh}
         </span>
+        {missing.length > 0 && (
+          <span
+            class="rounded px-1.5 py-0.5 text-xs font-normal"
+            style={{
+              backgroundColor:
+                "color-mix(in srgb, var(--status-warning) 15%, transparent)",
+              color: "var(--status-warning)",
+            }}
+            title={`Prometheus didn't answer: ${
+              missing.join(", ")
+            }. Values for those queries are missing; the rest are still live.`}
+          >
+            Partial metrics
+          </span>
+        )}
       </h3>
       <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
-        <Metric label="RPS" value={formatRps(s.rps)} />
+        <Metric
+          label="RPS"
+          value={formatRps(s.rps)}
+          missing={missing.includes("rps")}
+        />
         <Metric
           label="Error rate"
           value={formatErrorRate(s.errorRate)}
@@ -173,22 +191,54 @@ export function MeshGoldenSignals({ namespace, service }: Props) {
             : s.errorRate >= 0.01
             ? "warning"
             : "default"}
+          missing={missing.includes("errorNum") ||
+            missing.includes("errorDen")}
         />
-        <Metric label="p50" value={formatMs(s.p50Ms)} />
-        <Metric label="p95" value={formatMs(s.p95Ms)} />
-        <Metric label="p99" value={formatMs(s.p99Ms)} />
+        <Metric
+          label="p50"
+          value={formatMs(s.p50Ms)}
+          missing={missing.includes("p50")}
+        />
+        <Metric
+          label="p95"
+          value={formatMs(s.p95Ms)}
+          missing={missing.includes("p95")}
+        />
+        <Metric
+          label="p99"
+          value={formatMs(s.p99Ms)}
+          missing={missing.includes("p99")}
+        />
       </div>
     </section>
   );
 }
 
 function Metric(
-  { label, value, tone = "default" }: {
+  { label, value, tone = "default", missing = false }: {
     label: string;
     value: string;
     tone?: "default" | "warning" | "error";
+    missing?: boolean;
   },
 ) {
+  // When the underlying PromQL query failed, render the value muted
+  // with an em dash so operators can tell the displayed zero is "no
+  // data" rather than "no traffic". The card-level "Partial metrics"
+  // badge gives the broader context.
+  if (missing) {
+    return (
+      <div
+        class="rounded-md border border-border-primary bg-bg-surface p-3"
+        title={`${label}: query did not return; value below is unavailable`}
+      >
+        <div class="text-xs text-text-muted">{label}</div>
+        <div class="mt-1 font-mono text-lg font-semibold text-text-muted">
+          —
+        </div>
+      </div>
+    );
+  }
   const valueColor = tone === "error"
     ? "var(--status-error)"
     : tone === "warning"

--- a/frontend/components/mesh/GoldenSignals.tsx
+++ b/frontend/components/mesh/GoldenSignals.tsx
@@ -5,14 +5,19 @@
  *    - no service mesh is installed in the cluster
  *    - the request 4xx's (e.g. service not in mesh, or both meshes
  *      installed and the auto-detect is ambiguous in v1)
- *    - the response carries available=true but every metric is zero —
- *      this matches the "unmeshed service" silent-absence contract;
- *      genuinely silent meshed services also hide, which is acceptable
- *      for v1 (the card adds no signal at zero traffic).
+ *    - the response carries available=true, every metric is zero, AND
+ *      missingQueries is empty (the unmeshed-or-genuinely-silent case;
+ *      the card adds no signal there).
  *
- *  The card RENDERS (with a "Metrics unavailable" sub-message) when the
- *  backend reports available=false, so an offline Prometheus is visible
- *  rather than indistinguishable from "no data".
+ *  The card RENDERS in three meaningful states:
+ *    - available=false (Prometheus offline): "Metrics unavailable"
+ *      sub-message with the backend reason.
+ *    - available=true with at least one non-zero metric: full tile
+ *      grid with values and tone-coded error rate.
+ *    - available=true with all-zero metrics BUT missingQueries
+ *      non-empty: tile grid renders with em-dashes for the failed
+ *      queries plus a "Partial metrics" badge, so a heavily-degraded
+ *      Prometheus is visible distinct from a silent meshed service.
  *
  *  Refresh cadence: 30s, matching the monitoring-dashboard convention.
  *  Component is rendered from inside the ResourceDetail island, so its

--- a/frontend/lib/mesh-types.ts
+++ b/frontend/lib/mesh-types.ts
@@ -123,6 +123,14 @@ export interface GoldenSignals {
   available: boolean;
   /** Populated only when `available` is false. */
   reason?: string;
+  /**
+   * Names of PromQL queries (rps, errorNum, errorDen, p50, p95, p99) that
+   * failed during a partial-success response. Empty / absent on a fully
+   * successful fetch. The UI uses this to flag a degraded Prometheus
+   * response (one query answering with zeros) distinctly from a silent
+   * meshed service (every query answering with zeros).
+   */
+  missingQueries?: string[];
   rps: number;
   /** Fraction in [0, 1]. */
   errorRate: number;


### PR DESCRIPTION
## Summary
Closes the two findings deliberately deferred from the Phase D review (#205): the GoldenSignals all-zero ambiguity (#12) and the custom cluster-domain host-resolution gap (#20). Both turned out to be considerably smaller than initially scoped and are paid down here as a single small follow-up rather than punted to roadmap items.

- **#12 — Partial-metrics surface.** Backend `GoldenSignals` gains a `MissingQueries []string` field listing any of the six PromQL fan-out queries that didn't return. Frontend treats it as the authoritative "is this response degraded?" signal: card shows a themed "Partial metrics" badge, individual metric tiles render em-dash + muted color when their query is in the missing set. Card visibility no longer hinges on `hasTraffic` alone — partial responses render with all-zero values so a heavily-degraded Prometheus is visible *distinct* from a silent meshed service.
- **#20 — Universal cluster-domain.** `resolveServiceHost` switched from literal-suffix matching (`.svc.cluster.local`) to splitting at the canonical `.svc.` separator. Works uniformly across all cluster domains (`cluster.local`, `k8s.example.com`, `svc.example.io`, etc.) without requiring a new config knob.

## Tests
- [x] `TestBuildMeshEdges_CustomClusterDomainResolves` — default, custom, and shorter cluster-domain forms dedup to a single edge.
- [x] `TestGoldenSignalsForService_AllSucceedHasNoMissingQueries` — `MissingQueries` is empty when every query returns (omitempty invariant the frontend depends on).
- [x] Existing `TestGoldenSignalsForService_PartialResultsAreUsed` extended to assert `p99` lands in `MissingQueries` after its query fails.
- [x] Repo-wide `go vet ./... && go test ./...` clean
- [x] `deno fmt --check` + `deno lint` + `deno check` clean on touched frontend files
- [ ] **Homelab smoke** — Service detail in a meshed namespace renders the "Partial metrics" badge correctly when one PromQL query is intentionally broken; topology overlay edges resolve in a cluster with custom `--cluster-domain`

🤖 Generated with [Claude Code](https://claude.com/claude-code)