### PR TITLE
feat(externalsecrets): Phase A — backend observatory + Helm RBAC (#8)

### DIFF
--- a/backend/cmd/kubecenter/main.go
+++ b/backend/cmd/kubecenter/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kubecenter/kubecenter/internal/auth"
 	"github.com/kubecenter/kubecenter/internal/config"
 	"github.com/kubecenter/kubecenter/internal/diagnostics"
+	"github.com/kubecenter/kubecenter/internal/externalsecrets"
 	"github.com/kubecenter/kubecenter/internal/gitops"
 	"github.com/kubecenter/kubecenter/internal/gitprovider"
 	"github.com/kubecenter/kubecenter/internal/k8s"
@@ -692,6 +693,11 @@ func main() {
 	cmPoller := certmanager.NewPoller(k8sClient, cmDisc, cmHandler, notifService, logger)
 	go cmPoller.Start(ctx)
 
+	// External Secrets Operator integration (Phase A — observatory). Poller
+	// + alerting wire in Phase D; persistence + drift history in Phase C.
+	esoDisc := externalsecrets.NewDiscoverer(k8sClient, logger)
+	esoHandler := externalsecrets.NewHandler(k8sClient, esoDisc, accessChecker, auditLogger, notifService, logger)
+
 	// Gateway API integration
 	gwDisc := gateway.NewDiscoverer(k8sClient, logger)
 	gwHandler := gateway.NewHandler(k8sClient, gwDisc, accessChecker, logger)
@@ -736,6 +742,7 @@ func main() {
 		LimitsHandler:      limitsHandler,
 		VeleroHandler:      veleroHandler,
 		CertManagerHandler: cmHandler,
+		ExternalSecretsHandler: esoHandler,
 		GatewayHandler:     gwHandler,
 		ServiceMeshHandler: meshHandler,
 		CRDHandler:         crdHandler,

--- a/backend/internal/externalsecrets/discovery.go
+++ b/backend/internal/externalsecrets/discovery.go
@@ -7,43 +7,47 @@ import (
 	"sync"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/discovery"
 
 	"github.com/kubecenter/kubecenter/internal/k8s"
 )
 
-const (
-	// staleDuration is how long a cached discovery probe stays fresh before a
-	// follow-up Status() call triggers a re-probe. Matches the cert-manager
-	// precedent — we re-probe rarely because operators don't install/uninstall
-	// the operator on a 5-min cadence.
-	staleDuration = 5 * time.Minute
-
-	// externalSecretsNS is the conventional namespace ESO ships into via the
-	// upstream Helm chart. Used only for version detection; the discoverer
-	// works regardless of what namespace ESO actually runs in (it falls back
-	// to "version unknown" if the deployment isn't found).
-	externalSecretsNS = "external-secrets"
-)
+// staleDuration is how long a cached discovery probe stays fresh before a
+// follow-up Status() call triggers a re-probe. Matches the cert-manager
+// precedent — we re-probe rarely because operators don't install/uninstall
+// the operator on a 5-min cadence.
+const staleDuration = 5 * time.Minute
 
 // Discoverer probes the cluster for ESO CRDs and maintains cached discovery
-// state. Concurrent calls to Status are safe; Probe serializes through the
-// write lock.
+// state. Concurrent calls to Status are safe; Probe is non-blocking under
+// the write lock — see commitStatus for the lock model.
 type Discoverer struct {
 	k8sClient *k8s.ClientFactory
 	logger    *slog.Logger
 
 	mu     sync.RWMutex
 	status ESOStatus
+
+	// discoOverride / depListOverride: test-only seams. Production wiring
+	// leaves them nil — the real probe reads from the k8s ClientFactory.
+	// Keeping seams as func fields (rather than full interface injection)
+	// matches the handler.go pattern and avoids inventing a new abstraction.
+	discoOverride   func() discovery.DiscoveryInterface
+	depListOverride func(ctx context.Context, opts metav1.ListOptions) (*appsv1.DeploymentList, error)
 }
 
-// NewDiscoverer creates an ESO discoverer.
+// NewDiscoverer creates an ESO discoverer. The cached status starts with a
+// zero-value LastChecked so the first Status() call falls through to a
+// real Probe — otherwise the discoverer would report Detected=false (the
+// zero-value status) for the full staleDuration window after restart.
 func NewDiscoverer(k8sClient *k8s.ClientFactory, logger *slog.Logger) *Discoverer {
 	return &Discoverer{
 		k8sClient: k8sClient,
 		logger:    logger,
 		status: ESOStatus{
-			LastChecked: time.Now().UTC(),
+			LastChecked: time.Time{},
 		},
 	}
 }
@@ -66,14 +70,16 @@ func (d *Discoverer) Status(ctx context.Context) ESOStatus {
 }
 
 // Probe checks if external-secrets.io/v1 CRDs exist on the cluster and
-// updates the cached status. Safe to call concurrently — only one probe runs
-// at a time via the write lock.
+// updates the cached status. Safe to call concurrently. The two blocking
+// API-server calls (discovery + Deployments.List) run WITHOUT any lock
+// held; only the cache read / write are guarded. A double-check at the
+// write site short-circuits piled-up concurrent probes when an earlier
+// probe already refreshed the cache.
 func (d *Discoverer) Probe(ctx context.Context) ESOStatus {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
 	now := time.Now().UTC()
-	disco := d.k8sClient.DiscoveryClient()
+
+	disco := d.discovery()
+	listDeps := d.deploymentLister()
 
 	status := ESOStatus{
 		LastChecked: now,
@@ -82,7 +88,7 @@ func (d *Discoverer) Probe(ctx context.Context) ESOStatus {
 	resources, err := disco.ServerResourcesForGroupVersion(GroupName + "/v1")
 	if err != nil || resources == nil {
 		d.logger.Debug("ESO CRDs not found", "error", err)
-		d.status = status
+		d.commitStatus(status)
 		return status
 	}
 
@@ -95,22 +101,22 @@ func (d *Discoverer) Probe(ctx context.Context) ESOStatus {
 	}
 	if !hasExternalSecret {
 		d.logger.Debug("ESO ExternalSecret CRD not found")
-		d.status = status
+		d.commitStatus(status)
 		return status
 	}
 
 	status.Detected = true
 
-	// Best-effort version detection from the conventional install namespace.
-	// Failure here is silent — a cluster with ESO installed in a non-standard
-	// namespace still gets Detected=true, just without a Version string.
-	cs := d.k8sClient.BaseClientset()
-	deps, err := cs.AppsV1().Deployments(externalSecretsNS).List(ctx, metav1.ListOptions{
+	// Best-effort version detection across all namespaces (operators
+	// frequently install ESO into a non-conventional namespace; keying
+	// detection to a hardcoded namespace would silently fail). The
+	// LabelSelector keeps the result set small.
+	deps, err := listDeps(ctx, metav1.ListOptions{
 		LabelSelector: "app.kubernetes.io/name=external-secrets",
 	})
-	if err == nil && len(deps.Items) > 0 {
-		status.Namespace = externalSecretsNS
+	if err == nil && deps != nil && len(deps.Items) > 0 {
 		dep := deps.Items[0]
+		status.Namespace = dep.Namespace
 		if v, ok := dep.Labels["app.kubernetes.io/version"]; ok {
 			status.Version = v
 		} else if len(dep.Spec.Template.Spec.Containers) > 0 {
@@ -121,7 +127,7 @@ func (d *Discoverer) Probe(ctx context.Context) ESOStatus {
 		}
 	}
 
-	d.status = status
+	d.commitStatus(status)
 	d.logger.Info("ESO discovery completed",
 		"detected", status.Detected,
 		"namespace", status.Namespace,
@@ -129,6 +135,37 @@ func (d *Discoverer) Probe(ctx context.Context) ESOStatus {
 	)
 
 	return status
+}
+
+func (d *Discoverer) discovery() discovery.DiscoveryInterface {
+	if d.discoOverride != nil {
+		return d.discoOverride()
+	}
+	return d.k8sClient.DiscoveryClient()
+}
+
+func (d *Discoverer) deploymentLister() func(ctx context.Context, opts metav1.ListOptions) (*appsv1.DeploymentList, error) {
+	if d.depListOverride != nil {
+		return d.depListOverride
+	}
+	cs := d.k8sClient.BaseClientset()
+	return func(ctx context.Context, opts metav1.ListOptions) (*appsv1.DeploymentList, error) {
+		return cs.AppsV1().Deployments("").List(ctx, opts)
+	}
+}
+
+// commitStatus writes the probe result under the write lock with a
+// double-check: if a concurrent probe already refreshed the cache while we
+// were doing the network calls, that result wins (it's at least as fresh as
+// ours). Without the double-check, two concurrent probes could thrash the
+// cached LastChecked back and forth.
+func (d *Discoverer) commitStatus(status ESOStatus) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if !d.status.LastChecked.IsZero() && time.Since(d.status.LastChecked) < staleDuration {
+		return
+	}
+	d.status = status
 }
 
 // IsAvailable returns true if ESO was detected on the cluster. Cheap — uses

--- a/backend/internal/externalsecrets/discovery.go
+++ b/backend/internal/externalsecrets/discovery.go
@@ -1,0 +1,138 @@
+package externalsecrets
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubecenter/kubecenter/internal/k8s"
+)
+
+const (
+	// staleDuration is how long a cached discovery probe stays fresh before a
+	// follow-up Status() call triggers a re-probe. Matches the cert-manager
+	// precedent — we re-probe rarely because operators don't install/uninstall
+	// the operator on a 5-min cadence.
+	staleDuration = 5 * time.Minute
+
+	// externalSecretsNS is the conventional namespace ESO ships into via the
+	// upstream Helm chart. Used only for version detection; the discoverer
+	// works regardless of what namespace ESO actually runs in (it falls back
+	// to "version unknown" if the deployment isn't found).
+	externalSecretsNS = "external-secrets"
+)
+
+// Discoverer probes the cluster for ESO CRDs and maintains cached discovery
+// state. Concurrent calls to Status are safe; Probe serializes through the
+// write lock.
+type Discoverer struct {
+	k8sClient *k8s.ClientFactory
+	logger    *slog.Logger
+
+	mu     sync.RWMutex
+	status ESOStatus
+}
+
+// NewDiscoverer creates an ESO discoverer.
+func NewDiscoverer(k8sClient *k8s.ClientFactory, logger *slog.Logger) *Discoverer {
+	return &Discoverer{
+		k8sClient: k8sClient,
+		logger:    logger,
+		status: ESOStatus{
+			LastChecked: time.Now().UTC(),
+		},
+	}
+}
+
+// Status returns a copy of the cached discovery status. If the cached entry
+// is older than staleDuration, the call falls through to Probe. The cache is
+// pessimistic about freshness — a re-probe after the TTL is cheap (one
+// discovery call), and the alternative ("trust forever") would mask
+// uninstalls.
+func (d *Discoverer) Status(ctx context.Context) ESOStatus {
+	d.mu.RLock()
+	if time.Since(d.status.LastChecked) < staleDuration {
+		status := d.status
+		d.mu.RUnlock()
+		return status
+	}
+	d.mu.RUnlock()
+
+	return d.Probe(ctx)
+}
+
+// Probe checks if external-secrets.io/v1 CRDs exist on the cluster and
+// updates the cached status. Safe to call concurrently — only one probe runs
+// at a time via the write lock.
+func (d *Discoverer) Probe(ctx context.Context) ESOStatus {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	now := time.Now().UTC()
+	disco := d.k8sClient.DiscoveryClient()
+
+	status := ESOStatus{
+		LastChecked: now,
+	}
+
+	resources, err := disco.ServerResourcesForGroupVersion(GroupName + "/v1")
+	if err != nil || resources == nil {
+		d.logger.Debug("ESO CRDs not found", "error", err)
+		d.status = status
+		return status
+	}
+
+	hasExternalSecret := false
+	for _, r := range resources.APIResources {
+		if r.Kind == "ExternalSecret" {
+			hasExternalSecret = true
+			break
+		}
+	}
+	if !hasExternalSecret {
+		d.logger.Debug("ESO ExternalSecret CRD not found")
+		d.status = status
+		return status
+	}
+
+	status.Detected = true
+
+	// Best-effort version detection from the conventional install namespace.
+	// Failure here is silent — a cluster with ESO installed in a non-standard
+	// namespace still gets Detected=true, just without a Version string.
+	cs := d.k8sClient.BaseClientset()
+	deps, err := cs.AppsV1().Deployments(externalSecretsNS).List(ctx, metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/name=external-secrets",
+	})
+	if err == nil && len(deps.Items) > 0 {
+		status.Namespace = externalSecretsNS
+		dep := deps.Items[0]
+		if v, ok := dep.Labels["app.kubernetes.io/version"]; ok {
+			status.Version = v
+		} else if len(dep.Spec.Template.Spec.Containers) > 0 {
+			img := dep.Spec.Template.Spec.Containers[0].Image
+			if i := strings.LastIndex(img, ":"); i >= 0 && i < len(img)-1 {
+				status.Version = img[i+1:]
+			}
+		}
+	}
+
+	d.status = status
+	d.logger.Info("ESO discovery completed",
+		"detected", status.Detected,
+		"namespace", status.Namespace,
+		"version", status.Version,
+	)
+
+	return status
+}
+
+// IsAvailable returns true if ESO was detected on the cluster. Cheap — uses
+// the cached status; only triggers a re-probe if the cache is stale.
+func (d *Discoverer) IsAvailable(ctx context.Context) bool {
+	return d.Status(ctx).Detected
+}

--- a/backend/internal/externalsecrets/discovery_test.go
+++ b/backend/internal/externalsecrets/discovery_test.go
@@ -1,0 +1,157 @@
+package externalsecrets
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/discovery"
+	discoveryfake "k8s.io/client-go/discovery/fake"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+)
+
+// fakeDiscovery returns a stand-in DiscoveryInterface that responds with the
+// given resource list for the ESO group/version. Unrelated groups return an
+// empty resource list.
+func fakeDiscoveryWith(resources *metav1.APIResourceList) discovery.DiscoveryInterface {
+	cs := kubefake.NewClientset()
+	disc := cs.Discovery().(*discoveryfake.FakeDiscovery)
+	if resources != nil {
+		disc.Resources = []*metav1.APIResourceList{resources}
+	}
+	return disc
+}
+
+func TestDiscovererProbe_NotInstalled(t *testing.T) {
+	d := &Discoverer{
+		logger:        slog.Default(),
+		discoOverride: func() discovery.DiscoveryInterface { return fakeDiscoveryWith(nil) },
+		depListOverride: func(_ context.Context, _ metav1.ListOptions) (*appsv1.DeploymentList, error) {
+			return &appsv1.DeploymentList{}, nil
+		},
+	}
+
+	status := d.Probe(context.Background())
+	if status.Detected {
+		t.Errorf("Detected = true; want false on cluster without ESO CRDs")
+	}
+	if status.LastChecked.IsZero() {
+		t.Errorf("LastChecked is zero; want recent timestamp")
+	}
+}
+
+func TestDiscovererProbe_DiscoveryError(t *testing.T) {
+	// FakeDiscovery returns the empty default when Resources is nil — the
+	// "not installed" test exercises that path. A genuine discovery error
+	// is harder to simulate without a custom DiscoveryInterface; the
+	// not-installed test covers the equivalent observable behaviour
+	// (Detected=false on no resources). Skipped to keep the test set
+	// focused; real probe error handling lives behind the same code path.
+	t.Skip("covered by NotInstalled — fake discovery client doesn't emit errors")
+}
+
+func TestDiscovererProbe_Detected(t *testing.T) {
+	resourceList := &metav1.APIResourceList{
+		GroupVersion: GroupName + "/v1",
+		APIResources: []metav1.APIResource{
+			{Name: "externalsecrets", Kind: "ExternalSecret", Namespaced: true},
+			{Name: "secretstores", Kind: "SecretStore", Namespaced: true},
+		},
+	}
+
+	deps := &appsv1.DeploymentList{
+		Items: []appsv1.Deployment{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "external-secrets",
+					Namespace: "eso-system",
+					Labels:    map[string]string{"app.kubernetes.io/version": "0.14.2"},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Image: "ghcr.io/external-secrets/external-secrets:0.14.2"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	d := &Discoverer{
+		logger:        slog.Default(),
+		discoOverride: func() discovery.DiscoveryInterface { return fakeDiscoveryWith(resourceList) },
+		depListOverride: func(_ context.Context, _ metav1.ListOptions) (*appsv1.DeploymentList, error) {
+			return deps, nil
+		},
+	}
+
+	status := d.Probe(context.Background())
+	if !status.Detected {
+		t.Fatalf("Detected = false; want true")
+	}
+	if status.Namespace != "eso-system" {
+		t.Errorf("Namespace = %q; want eso-system (read from deployment, not hardcoded)", status.Namespace)
+	}
+	if status.Version != "0.14.2" {
+		t.Errorf("Version = %q; want 0.14.2", status.Version)
+	}
+}
+
+func TestDiscovererProbe_DetectedNoVersion(t *testing.T) {
+	// CRDs present but no Deployment with the labelselector — Detected stays
+	// true, Version + Namespace silently empty.
+	resourceList := &metav1.APIResourceList{
+		GroupVersion: GroupName + "/v1",
+		APIResources: []metav1.APIResource{
+			{Name: "externalsecrets", Kind: "ExternalSecret", Namespaced: true},
+		},
+	}
+
+	d := &Discoverer{
+		logger:        slog.Default(),
+		discoOverride: func() discovery.DiscoveryInterface { return fakeDiscoveryWith(resourceList) },
+		depListOverride: func(_ context.Context, _ metav1.ListOptions) (*appsv1.DeploymentList, error) {
+			return &appsv1.DeploymentList{}, nil
+		},
+	}
+
+	status := d.Probe(context.Background())
+	if !status.Detected {
+		t.Errorf("Detected = false; want true (CRD exists)")
+	}
+	if status.Version != "" || status.Namespace != "" {
+		t.Errorf("Version/Namespace = %q/%q; want both empty when deployment not located", status.Version, status.Namespace)
+	}
+}
+
+func TestDiscovererProbe_DeploymentListError(t *testing.T) {
+	// CRDs present but the Deployments list errors — Detected stays true
+	// (we have CRDs), Version + Namespace silently empty (the version probe
+	// is best-effort).
+	resourceList := &metav1.APIResourceList{
+		GroupVersion: GroupName + "/v1",
+		APIResources: []metav1.APIResource{
+			{Name: "externalsecrets", Kind: "ExternalSecret", Namespaced: true},
+		},
+	}
+
+	d := &Discoverer{
+		logger:        slog.Default(),
+		discoOverride: func() discovery.DiscoveryInterface { return fakeDiscoveryWith(resourceList) },
+		depListOverride: func(_ context.Context, _ metav1.ListOptions) (*appsv1.DeploymentList, error) {
+			return nil, errors.New("deployments list forbidden")
+		},
+	}
+
+	status := d.Probe(context.Background())
+	if !status.Detected {
+		t.Errorf("Detected = false; want true (CRD presence is the gate, not deployment list)")
+	}
+}

--- a/backend/internal/externalsecrets/handler.go
+++ b/backend/internal/externalsecrets/handler.go
@@ -2,6 +2,7 @@ package externalsecrets
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"sync"
@@ -57,18 +58,29 @@ type Handler struct {
 	cache      *cachedData
 	cacheGen   uint64
 
+	// dynOverride / dynForUserOverride / clientForUserOverride are test-only
+	// seams. Production wiring leaves them nil — the real handler delegates
+	// to K8sClient. They live as struct fields rather than constructor
+	// parameters so handler-level tests don't have to build a fake
+	// ClientFactory from scratch (the factory holds a *rest.Config that
+	// FakeDynamicClient can't substitute for cleanly). The cert-manager
+	// precedent has no handler tests at all, so it doesn't have these
+	// seams; the comparison isn't apples-to-apples. Keeping the seams is a
+	// deliberate architectural choice: the small surface in this struct
+	// buys us the ability to test RBAC behaviour, drift resolution, and
+	// the cache layer as a unit, which catches real bugs the cert-manager
+	// package can only surface in integration tests.
+
 	// dynOverride, when non-nil, replaces K8sClient.BaseDynamicClient() for
-	// service-account list calls. Test-only seam — production wiring leaves
-	// this nil.
+	// service-account list calls.
 	dynOverride dynamic.Interface
 
 	// dynForUserOverride, when non-nil, replaces K8sClient.DynamicClientForUser
-	// for impersonated CRD fetches in detail endpoints. Test-only seam.
+	// for impersonated CRD fetches in detail endpoints.
 	dynForUserOverride func(username string, groups []string) (dynamic.Interface, error)
 
 	// clientForUserOverride, when non-nil, replaces K8sClient.ClientForUser
 	// for impersonated typed client lookups (synced-Secret RV check).
-	// Test-only seam.
 	clientForUserOverride func(username string, groups []string) (kubernetes.Interface, error)
 }
 
@@ -105,17 +117,29 @@ func (h *Handler) clientForUser(username string, groups []string) (kubernetes.In
 // cachedData is the per-Handler snapshot. Built once per cacheTTL via
 // fetchAll. Each slice carries the service-account view; per-user RBAC
 // filtering happens at read time so the cache is shared across users.
+//
+// errors carries per-CRD list-call failures from the most recent fetchAll.
+// Keys are short CRD identifiers (`externalsecrets`, `clusterexternalsecrets`,
+// `secretstores`, `clustersecretstores`, `pushsecrets`); values are
+// human-readable error strings (never raw API server bodies). Mirrors the
+// service-mesh Phase D `errors` map pattern. Empty / nil when all CRDs fetched
+// cleanly. Surfaced separately from the per-CRD slice so a failed CRD
+// preserves the last-known-good slice rather than collapsing to empty.
 type cachedData struct {
 	externalSecrets        []ExternalSecret
 	clusterExternalSecrets []ClusterExternalSecret
 	stores                 []SecretStore
 	clusterStores          []SecretStore
 	pushSecrets            []PushSecret
+	errors                 map[string]string
 	fetchedAt              time.Time
 }
 
 // NewHandler creates an ESO observatory handler. NotifService may be nil; cache
 // invalidation events fire only when it's set (matches cert-manager precedent).
+// Logger may be nil; falls back to slog.Default() so a struct-literal misuse
+// elsewhere (or a future call site that forgets to pass logger) doesn't panic
+// the first time the handler logs.
 func NewHandler(
 	k8sClient *k8s.ClientFactory,
 	discoverer *Discoverer,
@@ -124,6 +148,9 @@ func NewHandler(
 	notifService *notifications.NotificationService,
 	logger *slog.Logger,
 ) *Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
 	return &Handler{
 		K8sClient:     k8sClient,
 		Discoverer:    discoverer,
@@ -200,6 +227,11 @@ func filterByRBAC[T namespacedResource](ctx context.Context, h *Handler, user *a
 // getCached returns the cached snapshot, refreshing it if stale.
 // Singleflight collapses concurrent refreshes — a thundering herd of
 // dashboard polls produces exactly one fetchAll call per cacheTTL window.
+//
+// The singleflight key embeds cacheGen so an InvalidateCache call splits a
+// new wave of requests into a fresh in-flight fetch rather than waiting on
+// the pre-invalidation fetch's result. Phase A has no cache-invalidating
+// call sites; this is dormant pre-Phase E but cheap to keep correct now.
 func (h *Handler) getCached(ctx context.Context) (*cachedData, error) {
 	h.cacheMu.RLock()
 	if h.cache != nil && time.Since(h.cache.fetchedAt) < cacheTTL {
@@ -210,7 +242,8 @@ func (h *Handler) getCached(ctx context.Context) (*cachedData, error) {
 	gen := h.cacheGen
 	h.cacheMu.RUnlock()
 
-	result, err, _ := h.fetchGroup.Do("all", func() (any, error) {
+	key := fmt.Sprintf("all-%d", gen)
+	result, err, _ := h.fetchGroup.Do(key, func() (any, error) {
 		return h.fetchAll(ctx, gen)
 	})
 	if err != nil {
@@ -220,15 +253,26 @@ func (h *Handler) getCached(ctx context.Context) (*cachedData, error) {
 }
 
 // fetchAll concurrently lists all five ESO CRDs from the service-account
-// dynamic client and normalizes them. Per-CRD failures are isolated and
-// logged — one failed CRD does not erase the other four from the response.
+// dynamic client and normalizes them. Per-CRD failures are isolated: a failed
+// CRD's slice stays nil, the error is recorded in cachedData.errors, and the
+// previous cache's last-known-good slice is preserved on the rebuild. One
+// failed CRD does not erase the other four from the response.
+//
+// ListOptions{ResourceVersion: "0"} serves all 5 lists from the API server's
+// watch cache rather than going to etcd — same data freshness, lower etcd
+// cost, no semantic change.
+//
 // errgroup is used for context-cancellation hygiene; fail-fast semantics are
-// suppressed by always returning nil from each g.Go body.
+// suppressed by always returning nil from each g.Go body. After g.Wait the
+// parent ctx is re-checked so a cancelled / timed-out fetch produces an
+// error rather than a half-empty cache.
 func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error) {
 	ctx, cancel := context.WithTimeout(ctx, fetchTimeout)
 	defer cancel()
 
 	dynClient := h.dynClient()
+
+	listOpts := metav1.ListOptions{ResourceVersion: "0"}
 
 	var (
 		externalSecrets        []ExternalSecret
@@ -238,13 +282,26 @@ func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error)
 		pushSecrets            []PushSecret
 	)
 
+	var (
+		errMu  sync.Mutex
+		errMap map[string]string
+	)
+	recordErr := func(crd string, err error) {
+		errMu.Lock()
+		defer errMu.Unlock()
+		if errMap == nil {
+			errMap = map[string]string{}
+		}
+		errMap[crd] = err.Error()
+	}
+
 	g, gctx := errgroup.WithContext(ctx)
 
 	g.Go(func() error {
-		list, err := dynClient.Resource(ExternalSecretGVR).Namespace("").List(gctx, metav1.ListOptions{})
+		list, err := dynClient.Resource(ExternalSecretGVR).Namespace("").List(gctx, listOpts)
 		if err != nil {
 			h.Logger.Warn("list externalsecrets failed", "error", err)
-			externalSecrets = []ExternalSecret{}
+			recordErr("externalsecrets", err)
 			return nil
 		}
 		externalSecrets = make([]ExternalSecret, 0, len(list.Items))
@@ -255,10 +312,10 @@ func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error)
 	})
 
 	g.Go(func() error {
-		list, err := dynClient.Resource(ClusterExternalSecretGVR).Namespace("").List(gctx, metav1.ListOptions{})
+		list, err := dynClient.Resource(ClusterExternalSecretGVR).Namespace("").List(gctx, listOpts)
 		if err != nil {
 			h.Logger.Warn("list clusterexternalsecrets failed", "error", err)
-			clusterExternalSecrets = []ClusterExternalSecret{}
+			recordErr("clusterexternalsecrets", err)
 			return nil
 		}
 		clusterExternalSecrets = make([]ClusterExternalSecret, 0, len(list.Items))
@@ -269,10 +326,10 @@ func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error)
 	})
 
 	g.Go(func() error {
-		list, err := dynClient.Resource(SecretStoreGVR).Namespace("").List(gctx, metav1.ListOptions{})
+		list, err := dynClient.Resource(SecretStoreGVR).Namespace("").List(gctx, listOpts)
 		if err != nil {
 			h.Logger.Warn("list secretstores failed", "error", err)
-			stores = []SecretStore{}
+			recordErr("secretstores", err)
 			return nil
 		}
 		stores = make([]SecretStore, 0, len(list.Items))
@@ -283,10 +340,10 @@ func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error)
 	})
 
 	g.Go(func() error {
-		list, err := dynClient.Resource(ClusterSecretStoreGVR).Namespace("").List(gctx, metav1.ListOptions{})
+		list, err := dynClient.Resource(ClusterSecretStoreGVR).Namespace("").List(gctx, listOpts)
 		if err != nil {
 			h.Logger.Warn("list clustersecretstores failed", "error", err)
-			clusterStores = []SecretStore{}
+			recordErr("clustersecretstores", err)
 			return nil
 		}
 		clusterStores = make([]SecretStore, 0, len(list.Items))
@@ -297,10 +354,10 @@ func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error)
 	})
 
 	g.Go(func() error {
-		list, err := dynClient.Resource(PushSecretGVR).Namespace("").List(gctx, metav1.ListOptions{})
+		list, err := dynClient.Resource(PushSecretGVR).Namespace("").List(gctx, listOpts)
 		if err != nil {
 			h.Logger.Warn("list pushsecrets failed", "error", err)
-			pushSecrets = []PushSecret{}
+			recordErr("pushsecrets", err)
 			return nil
 		}
 		pushSecrets = make([]PushSecret, 0, len(list.Items))
@@ -310,11 +367,57 @@ func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error)
 		return nil
 	})
 
-	// Per-CRD goroutines never return errors above, so g.Wait() can only
-	// surface a context cancellation. Treat that as a hard failure — a
-	// timed-out fetch shouldn't poison the cache.
-	if err := g.Wait(); err != nil {
+	// Per-CRD goroutines never return errors, so g.Wait() returns nil even
+	// when the parent ctx has been cancelled / timed out. Re-check the parent
+	// ctx explicitly: a cancelled fetch must NOT poison the cache with an
+	// empty snapshot for the next 30s.
+	_ = g.Wait()
+	if err := ctx.Err(); err != nil {
 		return nil, err
+	}
+
+	// Preserve last-known-good for any CRD that failed: read the prior cache
+	// snapshot and keep its slice for failed CRDs. If no prior snapshot
+	// exists (cold cache), nil stays nil — the handler treats nil as the
+	// signal to fall through to the per-CRD overlay path on next read.
+	h.cacheMu.RLock()
+	prior := h.cache
+	h.cacheMu.RUnlock()
+	if prior != nil && errMap != nil {
+		if _, failed := errMap["externalsecrets"]; failed && externalSecrets == nil {
+			externalSecrets = prior.externalSecrets
+		}
+		if _, failed := errMap["clusterexternalsecrets"]; failed && clusterExternalSecrets == nil {
+			clusterExternalSecrets = prior.clusterExternalSecrets
+		}
+		if _, failed := errMap["secretstores"]; failed && stores == nil {
+			stores = prior.stores
+		}
+		if _, failed := errMap["clustersecretstores"]; failed && clusterStores == nil {
+			clusterStores = prior.clusterStores
+		}
+		if _, failed := errMap["pushsecrets"]; failed && pushSecrets == nil {
+			pushSecrets = prior.pushSecrets
+		}
+	}
+
+	// Default any still-nil slice to an empty slice so handlers never write
+	// JSON null for a CRD that had no last-known-good. Empty slice is the
+	// frontend-safe shape.
+	if externalSecrets == nil {
+		externalSecrets = []ExternalSecret{}
+	}
+	if clusterExternalSecrets == nil {
+		clusterExternalSecrets = []ClusterExternalSecret{}
+	}
+	if stores == nil {
+		stores = []SecretStore{}
+	}
+	if clusterStores == nil {
+		clusterStores = []SecretStore{}
+	}
+	if pushSecrets == nil {
+		pushSecrets = []PushSecret{}
 	}
 
 	data := &cachedData{
@@ -323,6 +426,7 @@ func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error)
 		stores:                 stores,
 		clusterStores:          clusterStores,
 		pushSecrets:            pushSecrets,
+		errors:                 errMap,
 		fetchedAt:              time.Now(),
 	}
 
@@ -467,6 +571,11 @@ func (h *Handler) HandleGetExternalSecret(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	if !h.Discoverer.IsAvailable(r.Context()) {
+		httputil.WriteError(w, http.StatusServiceUnavailable, "ESO not detected", "")
+		return
+	}
+
 	ns := chi.URLParam(r, "namespace")
 	name := chi.URLParam(r, "name")
 
@@ -498,7 +607,7 @@ func (h *Handler) HandleGetExternalSecret(w http.ResponseWriter, r *http.Request
 	}
 
 	es := normalizeExternalSecret(obj)
-	es.DriftStatus = h.resolveDriftStatus(r.Context(), user, &es)
+	es.DriftStatus, es.DriftUnknownReason = h.resolveDriftStatus(r.Context(), user, &es)
 	es.Status = DeriveStatus(es)
 
 	httputil.WriteData(w, es)
@@ -509,6 +618,11 @@ func (h *Handler) HandleGetExternalSecret(w http.ResponseWriter, r *http.Request
 func (h *Handler) HandleGetClusterExternalSecret(w http.ResponseWriter, r *http.Request) {
 	user, ok := httputil.RequireUser(w, r)
 	if !ok {
+		return
+	}
+
+	if !h.Discoverer.IsAvailable(r.Context()) {
+		httputil.WriteError(w, http.StatusServiceUnavailable, "ESO not detected", "")
 		return
 	}
 
@@ -560,6 +674,11 @@ func (h *Handler) handleGetStore(w http.ResponseWriter, r *http.Request, scope s
 		return
 	}
 
+	if !h.Discoverer.IsAvailable(r.Context()) {
+		httputil.WriteError(w, http.StatusServiceUnavailable, "ESO not detected", "")
+		return
+	}
+
 	name := chi.URLParam(r, "name")
 	ns := ""
 	resource := "clustersecretstores"
@@ -607,6 +726,11 @@ func (h *Handler) HandleGetPushSecret(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if !h.Discoverer.IsAvailable(r.Context()) {
+		httputil.WriteError(w, http.StatusServiceUnavailable, "ESO not detected", "")
+		return
+	}
+
 	ns := chi.URLParam(r, "namespace")
 	name := chi.URLParam(r, "name")
 
@@ -640,8 +764,23 @@ func (h *Handler) HandleGetPushSecret(w http.ResponseWriter, r *http.Request) {
 	httputil.WriteData(w, normalizePushSecret(obj))
 }
 
+// Reasons populated alongside DriftStatus=Unknown so the UI can explain WHY
+// drift wasn't resolvable. Empty string means DriftStatus was definite
+// (InSync or Drifted). Frontend treats unknown values as the generic
+// "drift not resolvable" copy.
+const (
+	DriftReasonNoSyncedRV    = "no_synced_rv"
+	DriftReasonNoTargetName  = "no_target_name"
+	DriftReasonSecretDeleted = "secret_deleted"
+	DriftReasonRBACDenied    = "rbac_denied"
+	DriftReasonTransient     = "transient_error"
+	DriftReasonClientError   = "client_error"
+)
+
 // resolveDriftStatus resolves the live drift state of an ExternalSecret by
-// looking up the synced Secret's current resourceVersion. Returns one of:
+// looking up the synced Secret's current resourceVersion. Returns
+// (DriftStatus, reason) where reason is non-empty only when DriftStatus
+// is Unknown.
 //
 //   - DriftUnknown when the provider doesn't populate syncedResourceVersion,
 //     when the synced Secret has been deleted, or when the requesting user
@@ -651,32 +790,39 @@ func (h *Handler) HandleGetPushSecret(w http.ResponseWriter, r *http.Request) {
 //
 // The caller is responsible for re-applying DeriveStatus afterwards so
 // Drifted overlays the base Synced status.
-func (h *Handler) resolveDriftStatus(ctx context.Context, user *auth.User, es *ExternalSecret) DriftStatus {
+func (h *Handler) resolveDriftStatus(ctx context.Context, user *auth.User, es *ExternalSecret) (DriftStatus, string) {
 	if es.SyncedResourceVersion == "" {
-		return DriftUnknown
+		return DriftUnknown, DriftReasonNoSyncedRV
 	}
 	if es.TargetSecretName == "" {
-		return DriftUnknown
+		return DriftUnknown, DriftReasonNoTargetName
 	}
 	cs, err := h.clientForUser(user.KubernetesUsername, user.KubernetesGroups)
 	if err != nil {
 		h.Logger.Warn("create impersonating typed client for drift check", "error", err)
-		return DriftUnknown
+		return DriftUnknown, DriftReasonClientError
 	}
 	secret, err := cs.CoreV1().Secrets(es.Namespace).Get(ctx, es.TargetSecretName, metav1.GetOptions{})
 	if err != nil {
-		// Forbidden / NotFound / any other error → degrade to Unknown.
-		// The ExternalSecret detail endpoint stays 200 even when drift can't
-		// be resolved; the ES itself exists, only its drift signal is missing.
-		if !apierrors.IsForbidden(err) && !apierrors.IsNotFound(err) {
+		switch {
+		case apierrors.IsNotFound(err):
+			// Synced Secret missing is abnormal — log louder so an operator
+			// can correlate against the ES detail page.
+			h.Logger.Warn("synced secret missing for drift check",
+				"namespace", es.Namespace,
+				"name", es.TargetSecretName)
+			return DriftUnknown, DriftReasonSecretDeleted
+		case apierrors.IsForbidden(err):
+			return DriftUnknown, DriftReasonRBACDenied
+		default:
 			h.Logger.Warn("get synced secret for drift check",
 				"namespace", es.Namespace,
 				"name", es.TargetSecretName,
 				"error", err)
+			return DriftUnknown, DriftReasonTransient
 		}
-		return DriftUnknown
 	}
-	return computeDriftStatus(es.SyncedResourceVersion, secret.ResourceVersion)
+	return computeDriftStatus(es.SyncedResourceVersion, secret.ResourceVersion), ""
 }
 
 // computeDriftStatus is the pure comparison used by resolveDriftStatus.

--- a/backend/internal/externalsecrets/handler.go
+++ b/backend/internal/externalsecrets/handler.go
@@ -1,0 +1,757 @@
+package externalsecrets
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/singleflight"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/kubecenter/kubecenter/internal/audit"
+	"github.com/kubecenter/kubecenter/internal/auth"
+	"github.com/kubecenter/kubecenter/internal/httputil"
+	"github.com/kubecenter/kubecenter/internal/k8s"
+	"github.com/kubecenter/kubecenter/internal/k8s/resources"
+	"github.com/kubecenter/kubecenter/internal/notifications"
+)
+
+const (
+	// cacheTTL caps how long the cached service-account-fetched snapshot
+	// stays fresh. Matches Phase 11A. Annotation edits and CRD writes take
+	// up to this long to surface in list responses.
+	cacheTTL = 30 * time.Second
+
+	// fetchTimeout bounds each fetchAll cycle. Five concurrent CRD lists
+	// against a healthy API server complete in well under 10s; the timeout
+	// catches a wedged etcd or a flapping CRD watch without hanging the
+	// HTTP request indefinitely.
+	fetchTimeout = 10 * time.Second
+)
+
+// Handler serves ESO observatory HTTP endpoints. Phase A surface is read-only
+// (status + 5 list + 5 detail endpoints in U3). Write actions and the bulk
+// refresh job model land in Phase E.
+//
+// Concurrency model:
+//   - One in-flight fetchAll at a time per Handler (singleflight).
+//   - One cache snapshot, replaced atomically when fetch completes.
+//   - cacheGen guards against torn writes from concurrent invalidations.
+type Handler struct {
+	K8sClient     *k8s.ClientFactory
+	Discoverer    *Discoverer
+	AccessChecker *resources.AccessChecker
+	AuditLogger   audit.Logger
+	NotifService  *notifications.NotificationService
+	Logger        *slog.Logger
+
+	fetchGroup singleflight.Group
+	cacheMu    sync.RWMutex
+	cache      *cachedData
+	cacheGen   uint64
+
+	// dynOverride, when non-nil, replaces K8sClient.BaseDynamicClient() for
+	// service-account list calls. Test-only seam — production wiring leaves
+	// this nil.
+	dynOverride dynamic.Interface
+
+	// dynForUserOverride, when non-nil, replaces K8sClient.DynamicClientForUser
+	// for impersonated CRD fetches in detail endpoints. Test-only seam.
+	dynForUserOverride func(username string, groups []string) (dynamic.Interface, error)
+
+	// clientForUserOverride, when non-nil, replaces K8sClient.ClientForUser
+	// for impersonated typed client lookups (synced-Secret RV check).
+	// Test-only seam.
+	clientForUserOverride func(username string, groups []string) (kubernetes.Interface, error)
+}
+
+// dynClient returns the dynamic client to use for service-account-scoped
+// list calls. Tests inject dynOverride; production reads BaseDynamicClient
+// from the K8sClient factory.
+func (h *Handler) dynClient() dynamic.Interface {
+	if h.dynOverride != nil {
+		return h.dynOverride
+	}
+	return h.K8sClient.BaseDynamicClient()
+}
+
+// dynForUser returns an impersonating dynamic client for the requesting user.
+// Tests inject dynForUserOverride; production delegates to the K8sClient
+// factory so RBAC is enforced by the API server itself.
+func (h *Handler) dynForUser(username string, groups []string) (dynamic.Interface, error) {
+	if h.dynForUserOverride != nil {
+		return h.dynForUserOverride(username, groups)
+	}
+	return h.K8sClient.DynamicClientForUser(username, groups)
+}
+
+// clientForUser returns an impersonating typed client for the requesting
+// user. Used by detail endpoints to look up the synced Secret's live
+// resourceVersion for drift detection.
+func (h *Handler) clientForUser(username string, groups []string) (kubernetes.Interface, error) {
+	if h.clientForUserOverride != nil {
+		return h.clientForUserOverride(username, groups)
+	}
+	return h.K8sClient.ClientForUser(username, groups)
+}
+
+// cachedData is the per-Handler snapshot. Built once per cacheTTL via
+// fetchAll. Each slice carries the service-account view; per-user RBAC
+// filtering happens at read time so the cache is shared across users.
+type cachedData struct {
+	externalSecrets        []ExternalSecret
+	clusterExternalSecrets []ClusterExternalSecret
+	stores                 []SecretStore
+	clusterStores          []SecretStore
+	pushSecrets            []PushSecret
+	fetchedAt              time.Time
+}
+
+// NewHandler creates an ESO observatory handler. NotifService may be nil; cache
+// invalidation events fire only when it's set (matches cert-manager precedent).
+func NewHandler(
+	k8sClient *k8s.ClientFactory,
+	discoverer *Discoverer,
+	accessChecker *resources.AccessChecker,
+	auditLogger audit.Logger,
+	notifService *notifications.NotificationService,
+	logger *slog.Logger,
+) *Handler {
+	return &Handler{
+		K8sClient:     k8sClient,
+		Discoverer:    discoverer,
+		AccessChecker: accessChecker,
+		AuditLogger:   auditLogger,
+		NotifService:  notifService,
+		Logger:        logger,
+	}
+}
+
+// InvalidateCache forces the next read to re-fetch from the API server.
+// Bumps cacheGen so an in-flight fetch from before invalidation cannot
+// overwrite a fresh cache populated after.
+//
+// Phase A has no write actions, so this method is dormant until Phase E /
+// Phase D wire the first cache-invalidating call sites. Exported now so the
+// future wiring lands as a small additive change.
+func (h *Handler) InvalidateCache() {
+	h.cacheMu.Lock()
+	h.cacheGen++
+	h.cache = nil
+	h.cacheMu.Unlock()
+}
+
+// canAccess checks a single (verb, resource, namespace) tuple via the
+// AccessChecker. Phase A only ever passes "list" / "get"; write verbs land
+// in Phases D / E.
+func (h *Handler) canAccess(ctx context.Context, user *auth.User, verb, resource, namespace string) bool {
+	can, err := h.AccessChecker.CanAccessGroupResource(
+		ctx,
+		user.KubernetesUsername,
+		user.KubernetesGroups,
+		verb,
+		GroupName,
+		resource,
+		namespace,
+	)
+	return err == nil && can
+}
+
+// namespacedResource is implemented by types that carry a Kubernetes
+// namespace. The two cluster-scoped kinds (ClusterExternalSecret,
+// cluster-scope SecretStore) skip this filter and use a single
+// CanAccessGroupResource call with empty namespace.
+type namespacedResource interface {
+	getNamespace() string
+}
+
+func (e ExternalSecret) getNamespace() string { return e.Namespace }
+func (s SecretStore) getNamespace() string    { return s.Namespace }
+func (p PushSecret) getNamespace() string     { return p.Namespace }
+
+// filterByRBAC returns only items the user can access in their respective
+// namespaces. Caches per-namespace allow decisions inside a single call so a
+// list of 1000 ExternalSecrets across 10 namespaces issues 10
+// SelfSubjectAccessReviews, not 1000.
+func filterByRBAC[T namespacedResource](ctx context.Context, h *Handler, user *auth.User, resource string, items []T) []T {
+	nsAllow := map[string]bool{}
+	out := make([]T, 0, len(items))
+	for _, item := range items {
+		ns := item.getNamespace()
+		allowed, ok := nsAllow[ns]
+		if !ok {
+			allowed = h.canAccess(ctx, user, "get", resource, ns)
+			nsAllow[ns] = allowed
+		}
+		if allowed {
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
+// getCached returns the cached snapshot, refreshing it if stale.
+// Singleflight collapses concurrent refreshes — a thundering herd of
+// dashboard polls produces exactly one fetchAll call per cacheTTL window.
+func (h *Handler) getCached(ctx context.Context) (*cachedData, error) {
+	h.cacheMu.RLock()
+	if h.cache != nil && time.Since(h.cache.fetchedAt) < cacheTTL {
+		data := h.cache
+		h.cacheMu.RUnlock()
+		return data, nil
+	}
+	gen := h.cacheGen
+	h.cacheMu.RUnlock()
+
+	result, err, _ := h.fetchGroup.Do("all", func() (any, error) {
+		return h.fetchAll(ctx, gen)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*cachedData), nil
+}
+
+// fetchAll concurrently lists all five ESO CRDs from the service-account
+// dynamic client and normalizes them. Per-CRD failures are isolated and
+// logged — one failed CRD does not erase the other four from the response.
+// errgroup is used for context-cancellation hygiene; fail-fast semantics are
+// suppressed by always returning nil from each g.Go body.
+func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error) {
+	ctx, cancel := context.WithTimeout(ctx, fetchTimeout)
+	defer cancel()
+
+	dynClient := h.dynClient()
+
+	var (
+		externalSecrets        []ExternalSecret
+		clusterExternalSecrets []ClusterExternalSecret
+		stores                 []SecretStore
+		clusterStores          []SecretStore
+		pushSecrets            []PushSecret
+	)
+
+	g, gctx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		list, err := dynClient.Resource(ExternalSecretGVR).Namespace("").List(gctx, metav1.ListOptions{})
+		if err != nil {
+			h.Logger.Warn("list externalsecrets failed", "error", err)
+			externalSecrets = []ExternalSecret{}
+			return nil
+		}
+		externalSecrets = make([]ExternalSecret, 0, len(list.Items))
+		for i := range list.Items {
+			externalSecrets = append(externalSecrets, normalizeExternalSecret(&list.Items[i]))
+		}
+		return nil
+	})
+
+	g.Go(func() error {
+		list, err := dynClient.Resource(ClusterExternalSecretGVR).Namespace("").List(gctx, metav1.ListOptions{})
+		if err != nil {
+			h.Logger.Warn("list clusterexternalsecrets failed", "error", err)
+			clusterExternalSecrets = []ClusterExternalSecret{}
+			return nil
+		}
+		clusterExternalSecrets = make([]ClusterExternalSecret, 0, len(list.Items))
+		for i := range list.Items {
+			clusterExternalSecrets = append(clusterExternalSecrets, normalizeClusterExternalSecret(&list.Items[i]))
+		}
+		return nil
+	})
+
+	g.Go(func() error {
+		list, err := dynClient.Resource(SecretStoreGVR).Namespace("").List(gctx, metav1.ListOptions{})
+		if err != nil {
+			h.Logger.Warn("list secretstores failed", "error", err)
+			stores = []SecretStore{}
+			return nil
+		}
+		stores = make([]SecretStore, 0, len(list.Items))
+		for i := range list.Items {
+			stores = append(stores, normalizeSecretStore(&list.Items[i], "Namespaced"))
+		}
+		return nil
+	})
+
+	g.Go(func() error {
+		list, err := dynClient.Resource(ClusterSecretStoreGVR).Namespace("").List(gctx, metav1.ListOptions{})
+		if err != nil {
+			h.Logger.Warn("list clustersecretstores failed", "error", err)
+			clusterStores = []SecretStore{}
+			return nil
+		}
+		clusterStores = make([]SecretStore, 0, len(list.Items))
+		for i := range list.Items {
+			clusterStores = append(clusterStores, normalizeSecretStore(&list.Items[i], "Cluster"))
+		}
+		return nil
+	})
+
+	g.Go(func() error {
+		list, err := dynClient.Resource(PushSecretGVR).Namespace("").List(gctx, metav1.ListOptions{})
+		if err != nil {
+			h.Logger.Warn("list pushsecrets failed", "error", err)
+			pushSecrets = []PushSecret{}
+			return nil
+		}
+		pushSecrets = make([]PushSecret, 0, len(list.Items))
+		for i := range list.Items {
+			pushSecrets = append(pushSecrets, normalizePushSecret(&list.Items[i]))
+		}
+		return nil
+	})
+
+	// Per-CRD goroutines never return errors above, so g.Wait() can only
+	// surface a context cancellation. Treat that as a hard failure — a
+	// timed-out fetch shouldn't poison the cache.
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	data := &cachedData{
+		externalSecrets:        externalSecrets,
+		clusterExternalSecrets: clusterExternalSecrets,
+		stores:                 stores,
+		clusterStores:          clusterStores,
+		pushSecrets:            pushSecrets,
+		fetchedAt:              time.Now(),
+	}
+
+	h.cacheMu.Lock()
+	if h.cacheGen == gen {
+		h.cache = data
+	}
+	h.cacheMu.Unlock()
+
+	return data, nil
+}
+
+// CachedExternalSecrets returns the cached ExternalSecret list. Used by the
+// Phase C poller (Unit 10) and the Phase D dispatch (Unit 13) so they share
+// the same singleflight + cache layer the HTTP path uses.
+func (h *Handler) CachedExternalSecrets(ctx context.Context) ([]ExternalSecret, error) {
+	data, err := h.getCached(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return data.externalSecrets, nil
+}
+
+// HandleStatus returns the ESO discovery status. Cheap — reads the
+// discoverer's cached status (re-probe is bounded by staleDuration).
+func (h *Handler) HandleStatus(w http.ResponseWriter, r *http.Request) {
+	if _, ok := httputil.RequireUser(w, r); !ok {
+		return
+	}
+	httputil.WriteData(w, h.Discoverer.Status(r.Context()))
+}
+
+// HandleListExternalSecrets returns ExternalSecrets the user can access,
+// optionally filtered by ?namespace=.
+func (h *Handler) HandleListExternalSecrets(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	if !h.Discoverer.IsAvailable(r.Context()) {
+		httputil.WriteData(w, []ExternalSecret{})
+		return
+	}
+
+	data, err := h.getCached(r.Context())
+	if err != nil {
+		h.Logger.Error("failed to fetch external secrets", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to fetch external secrets", "")
+		return
+	}
+
+	filtered := filterByRBAC(r.Context(), h, user, "externalsecrets", data.externalSecrets)
+	if ns := r.URL.Query().Get("namespace"); ns != "" {
+		nsFiltered := make([]ExternalSecret, 0, len(filtered))
+		for _, e := range filtered {
+			if e.Namespace == ns {
+				nsFiltered = append(nsFiltered, e)
+			}
+		}
+		filtered = nsFiltered
+	}
+
+	httputil.WriteData(w, filtered)
+}
+
+// HandleListClusterExternalSecrets returns cluster-scoped ClusterExternalSecrets.
+// Permissive-read: any user with `list clusterexternalsecrets` cluster-wide
+// sees them; users without the grant get an empty list silently rather than a
+// 403 (avoids existence-leak via timing).
+func (h *Handler) HandleListClusterExternalSecrets(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	if !h.Discoverer.IsAvailable(r.Context()) {
+		httputil.WriteData(w, []ClusterExternalSecret{})
+		return
+	}
+
+	if !h.canAccess(r.Context(), user, "list", "clusterexternalsecrets", "") {
+		httputil.WriteData(w, []ClusterExternalSecret{})
+		return
+	}
+
+	data, err := h.getCached(r.Context())
+	if err != nil {
+		h.Logger.Error("failed to fetch cluster external secrets", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to fetch cluster external secrets", "")
+		return
+	}
+	httputil.WriteData(w, data.clusterExternalSecrets)
+}
+
+// HandleListStores returns namespaced SecretStores.
+func (h *Handler) HandleListStores(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	if !h.Discoverer.IsAvailable(r.Context()) {
+		httputil.WriteData(w, []SecretStore{})
+		return
+	}
+
+	data, err := h.getCached(r.Context())
+	if err != nil {
+		h.Logger.Error("failed to fetch secret stores", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to fetch secret stores", "")
+		return
+	}
+
+	filtered := filterByRBAC(r.Context(), h, user, "secretstores", data.stores)
+	if ns := r.URL.Query().Get("namespace"); ns != "" {
+		nsFiltered := make([]SecretStore, 0, len(filtered))
+		for _, s := range filtered {
+			if s.Namespace == ns {
+				nsFiltered = append(nsFiltered, s)
+			}
+		}
+		filtered = nsFiltered
+	}
+
+	httputil.WriteData(w, filtered)
+}
+
+// HandleGetExternalSecret returns a single ExternalSecret with drift status
+// resolved against the live synced Secret's resourceVersion. The list
+// endpoint never resolves drift — that would be N+1 impersonated Gets — so
+// this endpoint is the source of truth for DriftStatus.
+//
+// RBAC: chi middleware ValidateURLParams runs before this handler. The
+// impersonating dynamic client enforces RBAC at the API server, so a user
+// without `get externalsecret` perm sees 404 from the dynamic Get below.
+// The pre-check via canAccess avoids the round-trip for clearly-unauthorized
+// requests.
+func (h *Handler) HandleGetExternalSecret(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	ns := chi.URLParam(r, "namespace")
+	name := chi.URLParam(r, "name")
+
+	if !h.canAccess(r.Context(), user, "get", "externalsecrets", ns) {
+		httputil.WriteError(w, http.StatusForbidden, "access denied", "")
+		return
+	}
+
+	dynClient, err := h.dynForUser(user.KubernetesUsername, user.KubernetesGroups)
+	if err != nil {
+		h.Logger.Error("create impersonating dynamic client", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "internal error", "")
+		return
+	}
+
+	obj, err := dynClient.Resource(ExternalSecretGVR).Namespace(ns).Get(r.Context(), name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsForbidden(err) {
+			httputil.WriteError(w, http.StatusForbidden, "access denied", "")
+			return
+		}
+		if apierrors.IsNotFound(err) {
+			httputil.WriteError(w, http.StatusNotFound, "external secret not found", "")
+			return
+		}
+		h.Logger.Error("get externalsecret", "namespace", ns, "name", name, "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to fetch external secret", "")
+		return
+	}
+
+	es := normalizeExternalSecret(obj)
+	es.DriftStatus = h.resolveDriftStatus(r.Context(), user, &es)
+	es.Status = DeriveStatus(es)
+
+	httputil.WriteData(w, es)
+}
+
+// HandleGetClusterExternalSecret returns a single ClusterExternalSecret.
+// Cluster-scoped — no namespace param.
+func (h *Handler) HandleGetClusterExternalSecret(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	name := chi.URLParam(r, "name")
+
+	if !h.canAccess(r.Context(), user, "get", "clusterexternalsecrets", "") {
+		httputil.WriteError(w, http.StatusForbidden, "access denied", "")
+		return
+	}
+
+	dynClient, err := h.dynForUser(user.KubernetesUsername, user.KubernetesGroups)
+	if err != nil {
+		h.Logger.Error("create impersonating dynamic client", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "internal error", "")
+		return
+	}
+
+	obj, err := dynClient.Resource(ClusterExternalSecretGVR).Namespace("").Get(r.Context(), name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsForbidden(err) {
+			httputil.WriteError(w, http.StatusForbidden, "access denied", "")
+			return
+		}
+		if apierrors.IsNotFound(err) {
+			httputil.WriteError(w, http.StatusNotFound, "cluster external secret not found", "")
+			return
+		}
+		h.Logger.Error("get clusterexternalsecret", "name", name, "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to fetch cluster external secret", "")
+		return
+	}
+
+	httputil.WriteData(w, normalizeClusterExternalSecret(obj))
+}
+
+// HandleGetStore returns a single namespaced SecretStore.
+func (h *Handler) HandleGetStore(w http.ResponseWriter, r *http.Request) {
+	h.handleGetStore(w, r, "Namespaced")
+}
+
+// HandleGetClusterStore returns a single ClusterSecretStore.
+func (h *Handler) HandleGetClusterStore(w http.ResponseWriter, r *http.Request) {
+	h.handleGetStore(w, r, "Cluster")
+}
+
+func (h *Handler) handleGetStore(w http.ResponseWriter, r *http.Request, scope string) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	name := chi.URLParam(r, "name")
+	ns := ""
+	resource := "clustersecretstores"
+	gvr := ClusterSecretStoreGVR
+	if scope == "Namespaced" {
+		ns = chi.URLParam(r, "namespace")
+		resource = "secretstores"
+		gvr = SecretStoreGVR
+	}
+
+	if !h.canAccess(r.Context(), user, "get", resource, ns) {
+		httputil.WriteError(w, http.StatusForbidden, "access denied", "")
+		return
+	}
+
+	dynClient, err := h.dynForUser(user.KubernetesUsername, user.KubernetesGroups)
+	if err != nil {
+		h.Logger.Error("create impersonating dynamic client", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "internal error", "")
+		return
+	}
+
+	obj, err := dynClient.Resource(gvr).Namespace(ns).Get(r.Context(), name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsForbidden(err) {
+			httputil.WriteError(w, http.StatusForbidden, "access denied", "")
+			return
+		}
+		if apierrors.IsNotFound(err) {
+			httputil.WriteError(w, http.StatusNotFound, "store not found", "")
+			return
+		}
+		h.Logger.Error("get store", "scope", scope, "namespace", ns, "name", name, "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to fetch store", "")
+		return
+	}
+
+	httputil.WriteData(w, normalizeSecretStore(obj, scope))
+}
+
+// HandleGetPushSecret returns a single PushSecret.
+func (h *Handler) HandleGetPushSecret(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	ns := chi.URLParam(r, "namespace")
+	name := chi.URLParam(r, "name")
+
+	if !h.canAccess(r.Context(), user, "get", "pushsecrets", ns) {
+		httputil.WriteError(w, http.StatusForbidden, "access denied", "")
+		return
+	}
+
+	dynClient, err := h.dynForUser(user.KubernetesUsername, user.KubernetesGroups)
+	if err != nil {
+		h.Logger.Error("create impersonating dynamic client", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "internal error", "")
+		return
+	}
+
+	obj, err := dynClient.Resource(PushSecretGVR).Namespace(ns).Get(r.Context(), name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsForbidden(err) {
+			httputil.WriteError(w, http.StatusForbidden, "access denied", "")
+			return
+		}
+		if apierrors.IsNotFound(err) {
+			httputil.WriteError(w, http.StatusNotFound, "push secret not found", "")
+			return
+		}
+		h.Logger.Error("get pushsecret", "namespace", ns, "name", name, "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to fetch push secret", "")
+		return
+	}
+
+	httputil.WriteData(w, normalizePushSecret(obj))
+}
+
+// resolveDriftStatus resolves the live drift state of an ExternalSecret by
+// looking up the synced Secret's current resourceVersion. Returns one of:
+//
+//   - DriftUnknown when the provider doesn't populate syncedResourceVersion,
+//     when the synced Secret has been deleted, or when the requesting user
+//     lacks `get secret` perm on the target namespace
+//   - DriftInSync when syncedResourceVersion matches the live Secret's RV
+//   - DriftDrifted when the RVs differ (operator likely edited the Secret)
+//
+// The caller is responsible for re-applying DeriveStatus afterwards so
+// Drifted overlays the base Synced status.
+func (h *Handler) resolveDriftStatus(ctx context.Context, user *auth.User, es *ExternalSecret) DriftStatus {
+	if es.SyncedResourceVersion == "" {
+		return DriftUnknown
+	}
+	if es.TargetSecretName == "" {
+		return DriftUnknown
+	}
+	cs, err := h.clientForUser(user.KubernetesUsername, user.KubernetesGroups)
+	if err != nil {
+		h.Logger.Warn("create impersonating typed client for drift check", "error", err)
+		return DriftUnknown
+	}
+	secret, err := cs.CoreV1().Secrets(es.Namespace).Get(ctx, es.TargetSecretName, metav1.GetOptions{})
+	if err != nil {
+		// Forbidden / NotFound / any other error → degrade to Unknown.
+		// The ExternalSecret detail endpoint stays 200 even when drift can't
+		// be resolved; the ES itself exists, only its drift signal is missing.
+		if !apierrors.IsForbidden(err) && !apierrors.IsNotFound(err) {
+			h.Logger.Warn("get synced secret for drift check",
+				"namespace", es.Namespace,
+				"name", es.TargetSecretName,
+				"error", err)
+		}
+		return DriftUnknown
+	}
+	return computeDriftStatus(es.SyncedResourceVersion, secret.ResourceVersion)
+}
+
+// computeDriftStatus is the pure comparison used by resolveDriftStatus.
+// Extracted as a separate function so the comparison can be unit-tested
+// without the impersonating-client setup. Empty syncedRV (provider doesn't
+// populate the field) maps to Unknown rather than guessing InSync, which
+// matches the requirements doc's tri-state contract (R20).
+func computeDriftStatus(syncedRV, liveRV string) DriftStatus {
+	if syncedRV == "" {
+		return DriftUnknown
+	}
+	if syncedRV == liveRV {
+		return DriftInSync
+	}
+	return DriftDrifted
+}
+
+// HandleListClusterStores returns ClusterSecretStores. Permissive-read like
+// ClusterExternalSecrets — see HandleListClusterExternalSecrets for rationale.
+func (h *Handler) HandleListClusterStores(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	if !h.Discoverer.IsAvailable(r.Context()) {
+		httputil.WriteData(w, []SecretStore{})
+		return
+	}
+
+	if !h.canAccess(r.Context(), user, "list", "clustersecretstores", "") {
+		httputil.WriteData(w, []SecretStore{})
+		return
+	}
+
+	data, err := h.getCached(r.Context())
+	if err != nil {
+		h.Logger.Error("failed to fetch cluster secret stores", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to fetch cluster secret stores", "")
+		return
+	}
+	httputil.WriteData(w, data.clusterStores)
+}
+
+// HandleListPushSecrets returns PushSecrets the user can access, optionally
+// filtered by ?namespace=. Read-only in v1 — write surface deferred until
+// usage signals demand.
+func (h *Handler) HandleListPushSecrets(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	if !h.Discoverer.IsAvailable(r.Context()) {
+		httputil.WriteData(w, []PushSecret{})
+		return
+	}
+
+	data, err := h.getCached(r.Context())
+	if err != nil {
+		h.Logger.Error("failed to fetch push secrets", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to fetch push secrets", "")
+		return
+	}
+
+	filtered := filterByRBAC(r.Context(), h, user, "pushsecrets", data.pushSecrets)
+	if ns := r.URL.Query().Get("namespace"); ns != "" {
+		nsFiltered := make([]PushSecret, 0, len(filtered))
+		for _, p := range filtered {
+			if p.Namespace == ns {
+				nsFiltered = append(nsFiltered, p)
+			}
+		}
+		filtered = nsFiltered
+	}
+
+	httputil.WriteData(w, filtered)
+}

--- a/backend/internal/externalsecrets/handler_test.go
+++ b/backend/internal/externalsecrets/handler_test.go
@@ -3,6 +3,7 @@ package externalsecrets
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -20,6 +22,7 @@ import (
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes"
 	kubefake "k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
 
 	"github.com/go-chi/chi/v5"
 
@@ -137,6 +140,51 @@ func makeClusterStore(name, uid string) *unstructured.Unstructured {
 			"metadata":   map[string]any{"name": name, "uid": uid},
 			"spec":       map[string]any{"provider": map[string]any{"vault": map[string]any{}}},
 			"status":     map[string]any{},
+		},
+	}
+}
+
+// makeCES builds a ClusterExternalSecret with a minimal Ready=True status.
+func makeCES(name, uid string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "external-secrets.io/v1",
+			"kind":       "ClusterExternalSecret",
+			"metadata":   map[string]any{"name": name, "uid": uid},
+			"spec": map[string]any{
+				"externalSecretSpec": map[string]any{
+					"refreshInterval": "1h",
+					"secretStoreRef":  map[string]any{"name": "vault", "kind": "ClusterSecretStore"},
+					"target":          map[string]any{"name": name + "-secret"},
+				},
+			},
+			"status": map[string]any{
+				"conditions": []any{
+					map[string]any{"type": "Ready", "status": "True"},
+				},
+			},
+		},
+	}
+}
+
+// makePushSecret builds a PushSecret with a single store ref and Ready=True.
+func makePushSecret(ns, name, uid string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "external-secrets.io/v1",
+			"kind":       "PushSecret",
+			"metadata":   map[string]any{"name": name, "namespace": ns, "uid": uid},
+			"spec": map[string]any{
+				"secretStoreRefs": []any{
+					map[string]any{"name": "vault", "kind": "SecretStore"},
+				},
+				"selector": map[string]any{
+					"secret": map[string]any{"name": name + "-source"},
+				},
+			},
+			"status": map[string]any{
+				"conditions": []any{map[string]any{"type": "Ready", "status": "True"}},
+			},
 		},
 	}
 }
@@ -438,12 +486,15 @@ func TestCacheHit_SingleflightCollapse(t *testing.T) {
 	wg.Wait()
 
 	// 5 list calls per fetchAll. Singleflight collapses N concurrent
-	// HandleList invocations into 1 fetchAll. Allow up to 2 fetchAll cycles
-	// (10 list calls) to tolerate scheduler races where the first request
-	// finishes before another arrives — the requirement is "not 50."
+	// HandleList invocations into 1 fetchAll. The bounds catch two distinct
+	// failure modes:
+	//   - calls < 5: fetchAll never ran (broken cache wiring)
+	//   - calls > 10: singleflight not collapsing (each request fetched)
+	// The 5-floor verifies at least one fetchAll ran (5 CRD lists); the
+	// 10-ceiling allows up to 2 fetchAll cycles for scheduler races.
 	calls := counter.listCalls.Load()
-	if calls > 10 {
-		t.Errorf("dynClient.List invoked %d times across 10 concurrent requests; expected <=10 (5 per fetchAll, 1-2 fetchAlls)", calls)
+	if calls < 5 || calls > 10 {
+		t.Errorf("dynClient.List invoked %d times across 10 concurrent requests; expected 5-10 (5 per fetchAll, 1-2 fetchAlls)", calls)
 	}
 }
 
@@ -661,6 +712,9 @@ func TestHandleGetExternalSecret_DriftUnknownNoSyncedRV(t *testing.T) {
 	if env.Data.DriftStatus != DriftUnknown {
 		t.Errorf("DriftStatus = %q; want %q", env.Data.DriftStatus, DriftUnknown)
 	}
+	if env.Data.DriftUnknownReason != DriftReasonNoSyncedRV {
+		t.Errorf("DriftUnknownReason = %q; want %q", env.Data.DriftUnknownReason, DriftReasonNoSyncedRV)
+	}
 	if env.Data.Status != StatusSynced {
 		t.Errorf("Status = %q; want %q (no overlay when drift unknown)", env.Data.Status, StatusSynced)
 	}
@@ -689,6 +743,9 @@ func TestHandleGetExternalSecret_SyncedSecretDeleted(t *testing.T) {
 	_ = json.Unmarshal(w.Body.Bytes(), &env)
 	if env.Data.DriftStatus != DriftUnknown {
 		t.Errorf("DriftStatus = %q; want %q", env.Data.DriftStatus, DriftUnknown)
+	}
+	if env.Data.DriftUnknownReason != DriftReasonSecretDeleted {
+		t.Errorf("DriftUnknownReason = %q; want %q", env.Data.DriftUnknownReason, DriftReasonSecretDeleted)
 	}
 }
 
@@ -796,4 +853,317 @@ func TestFetchAll_EmptyClusterReturnsEmptyLists(t *testing.T) {
 			t.Errorf("%s len = %d; want 0", name, n)
 		}
 	}
+}
+
+// --- F4: drift resolution when impersonating user lacks `get secret` perm ---
+
+func TestHandleGetExternalSecret_DriftRBACForbiddenOnSecret(t *testing.T) {
+	ns, name := "apps", "db-creds"
+	es := makeES(ns, name, "uid-1")
+	status, _ := es.Object["status"].(map[string]any)
+	status["syncedResourceVersion"] = "100"
+
+	// AccessChecker permits the ES; the typed-client's CoreV1.Secrets().Get()
+	// returns 403 — modelling a user who has `get externalsecret` but not
+	// `get secret` on the target namespace.
+	dynFake := newEsoFakeDynClient(es)
+	typedFake := kubefake.NewClientset()
+	typedFake.PrependReactor("get", "secrets", func(_ clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(
+			schema.GroupResource{Resource: "secrets"}, name+"-secret",
+			errors.New("user cannot get secret in this namespace"),
+		)
+	})
+
+	h := &Handler{
+		Discoverer:    detectedDiscoverer(),
+		AccessChecker: resources.NewAlwaysAllowAccessChecker(),
+		Logger:        slog.Default(),
+		dynForUserOverride: func(string, []string) (dynamic.Interface, error) {
+			return dynFake, nil
+		},
+		clientForUserOverride: func(string, []string) (kubernetes.Interface, error) {
+			return typedFake, nil
+		},
+	}
+
+	w := httptest.NewRecorder()
+	r := withUser(httptest.NewRequest(http.MethodGet, "/", nil), &auth.User{KubernetesUsername: "u"})
+	r = urlWithChiParams(r, map[string]string{"namespace": ns, "name": name})
+	h.HandleGetExternalSecret(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200 (ES still returned even when drift can't be resolved); body = %s", w.Code, w.Body.String())
+	}
+	var env struct {
+		Data ExternalSecret `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if env.Data.DriftStatus != DriftUnknown {
+		t.Errorf("DriftStatus = %q; want %q", env.Data.DriftStatus, DriftUnknown)
+	}
+	if env.Data.DriftUnknownReason != DriftReasonRBACDenied {
+		t.Errorf("DriftUnknownReason = %q; want %q", env.Data.DriftUnknownReason, DriftReasonRBACDenied)
+	}
+	if env.Data.Name != name {
+		t.Errorf("ES Name = %q; want %q (ES itself should still be returned)", env.Data.Name, name)
+	}
+}
+
+// --- F3: per-CRD list-error isolation ------------------------------------
+
+func TestFetchAll_PerCRDFailureIsolated(t *testing.T) {
+	es := makeES("apps", "es1", "uid-1")
+	cs := makeClusterStore("global-vault", "uid-cs")
+	store := makeStore("apps", "vault", "uid-store")
+	ps := makePushSecret("apps", "ps1", "uid-ps")
+
+	fakeClient := newEsoFakeDynClient(es, cs, store, ps)
+	fakeClient.PrependReactor("list", "externalsecrets", func(_ clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("etcd timeout on externalsecrets")
+	})
+
+	h := &Handler{
+		Discoverer:    detectedDiscoverer(),
+		AccessChecker: resources.NewAlwaysAllowAccessChecker(),
+		Logger:        slog.Default(),
+		dynOverride:   fakeClient,
+	}
+
+	data, err := h.getCached(context.Background())
+	if err != nil {
+		t.Fatalf("getCached: %v", err)
+	}
+	if got, ok := data.errors["externalsecrets"]; !ok || got == "" {
+		t.Errorf("errors[externalsecrets] = %q; want non-empty", got)
+	}
+	if len(data.clusterStores) != 1 {
+		t.Errorf("clusterStores len = %d; want 1 (other CRDs should survive)", len(data.clusterStores))
+	}
+	if len(data.stores) != 1 {
+		t.Errorf("stores len = %d; want 1", len(data.stores))
+	}
+	if len(data.pushSecrets) != 1 {
+		t.Errorf("pushSecrets len = %d; want 1", len(data.pushSecrets))
+	}
+	// Failed CRD with no prior cache → empty slice (frontend-safe), not nil.
+	if data.externalSecrets == nil {
+		t.Errorf("externalSecrets is nil; want empty slice (frontend-safe)")
+	}
+	if len(data.externalSecrets) != 0 {
+		t.Errorf("externalSecrets len = %d; want 0 on cold-cache failure", len(data.externalSecrets))
+	}
+}
+
+func TestFetchAll_PerCRDFailurePreservesLastKnownGood(t *testing.T) {
+	es := makeES("apps", "es1", "uid-1")
+
+	// Reactor toggles: first fetch succeeds, second fetch errors. We use an
+	// atomic counter so the state is visible across goroutines.
+	var fetchCount atomic.Int32
+	fakeClient := newEsoFakeDynClient(es)
+	fakeClient.PrependReactor("list", "externalsecrets", func(_ clienttesting.Action) (bool, runtime.Object, error) {
+		if fetchCount.Add(1) > 1 {
+			return true, nil, errors.New("transient API server error")
+		}
+		return false, nil, nil // first call → default reactor (returns es)
+	})
+
+	h := &Handler{
+		Discoverer:    detectedDiscoverer(),
+		AccessChecker: resources.NewAlwaysAllowAccessChecker(),
+		Logger:        slog.Default(),
+		dynOverride:   fakeClient,
+	}
+
+	// First fetch: success — populates cache.
+	data, err := h.getCached(context.Background())
+	if err != nil {
+		t.Fatalf("first getCached: %v", err)
+	}
+	if len(data.externalSecrets) != 1 {
+		t.Fatalf("first fetch externalSecrets len = %d; want 1", len(data.externalSecrets))
+	}
+
+	// Force expiry so the second getCached re-fetches.
+	h.cacheMu.Lock()
+	h.cache.fetchedAt = time.Now().Add(-2 * cacheTTL)
+	h.cacheMu.Unlock()
+
+	// Second fetch: externalsecrets fails — last-known-good must survive.
+	data, err = h.getCached(context.Background())
+	if err != nil {
+		t.Fatalf("second getCached: %v", err)
+	}
+	if _, ok := data.errors["externalsecrets"]; !ok {
+		t.Errorf("expected errors[externalsecrets] after second fetch")
+	}
+	if len(data.externalSecrets) != 1 {
+		t.Errorf("externalSecrets len = %d; want 1 (last-known-good preserved)", len(data.externalSecrets))
+	}
+}
+
+// --- F1 / F24: context cancellation must NOT poison the cache -----------
+
+func TestFetchAll_ContextCancellation(t *testing.T) {
+	h := &Handler{
+		Discoverer:    detectedDiscoverer(),
+		AccessChecker: resources.NewAlwaysAllowAccessChecker(),
+		Logger:        slog.Default(),
+		dynOverride:   newEsoFakeDynClient(),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel
+
+	_, err := h.getCached(ctx)
+	if err == nil {
+		t.Errorf("expected error from cancelled context")
+	}
+	h.cacheMu.RLock()
+	cached := h.cache
+	h.cacheMu.RUnlock()
+	if cached != nil {
+		t.Errorf("cache should not be populated after cancelled fetch (would cause 30s blackout); got %+v", cached)
+	}
+}
+
+// --- F21: list ClusterExternalSecret RBAC denial -----------------------
+
+func TestHandleListClusterExternalSecrets_PermissiveReadDenied(t *testing.T) {
+	ces := makeCES("global-creds", "uid-ces")
+
+	h := &Handler{
+		Discoverer:    detectedDiscoverer(),
+		AccessChecker: resources.NewAlwaysDenyAccessChecker(),
+		Logger:        slog.Default(),
+		dynOverride:   newEsoFakeDynClient(ces),
+	}
+
+	w := httptest.NewRecorder()
+	r := withUser(httptest.NewRequest(http.MethodGet, "/", nil),
+		&auth.User{KubernetesUsername: "u"})
+	h.HandleListClusterExternalSecrets(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d; want 200 (silent empty, not 403)", w.Code)
+	}
+	got := decodeArray[ClusterExternalSecret](t, w)
+	if len(got) != 0 {
+		t.Errorf("got %d ClusterExternalSecrets; want 0 (denied user sees empty list)", len(got))
+	}
+}
+
+// --- F22: detail endpoints for cluster-scoped + push secret ------------
+
+func TestHandleGetClusterExternalSecret_HappyPath(t *testing.T) {
+	ces := makeCES("global-creds", "uid-ces")
+	h := detailHandler([]runtime.Object{ces}, nil, resources.NewAlwaysAllowAccessChecker())
+
+	w := httptest.NewRecorder()
+	r := withUser(httptest.NewRequest(http.MethodGet, "/", nil), &auth.User{KubernetesUsername: "u"})
+	r = urlWithChiParams(r, map[string]string{"name": "global-creds"})
+	h.HandleGetClusterExternalSecret(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; body = %s", w.Code, w.Body.String())
+	}
+	var env struct {
+		Data ClusterExternalSecret `json:"data"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &env)
+	if env.Data.Name != "global-creds" || env.Data.UID != "uid-ces" {
+		t.Errorf("CES = %+v", env.Data)
+	}
+}
+
+func TestHandleGetClusterExternalSecret_RBACDenied(t *testing.T) {
+	ces := makeCES("global-creds", "uid-ces")
+	h := detailHandler([]runtime.Object{ces}, nil, resources.NewAlwaysDenyAccessChecker())
+
+	w := httptest.NewRecorder()
+	r := withUser(httptest.NewRequest(http.MethodGet, "/", nil), &auth.User{KubernetesUsername: "u"})
+	r = urlWithChiParams(r, map[string]string{"name": "global-creds"})
+	h.HandleGetClusterExternalSecret(w, r)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d; want 403", w.Code)
+	}
+}
+
+func TestHandleGetPushSecret_HappyPath(t *testing.T) {
+	ps := makePushSecret("apps", "ps1", "uid-ps")
+	h := detailHandler([]runtime.Object{ps}, nil, resources.NewAlwaysAllowAccessChecker())
+
+	w := httptest.NewRecorder()
+	r := withUser(httptest.NewRequest(http.MethodGet, "/", nil), &auth.User{KubernetesUsername: "u"})
+	r = urlWithChiParams(r, map[string]string{"namespace": "apps", "name": "ps1"})
+	h.HandleGetPushSecret(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; body = %s", w.Code, w.Body.String())
+	}
+	var env struct {
+		Data PushSecret `json:"data"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &env)
+	if env.Data.Name != "ps1" || env.Data.Namespace != "apps" {
+		t.Errorf("PushSecret = %+v", env.Data)
+	}
+	if env.Data.SourceSecretName != "ps1-source" {
+		t.Errorf("SourceSecretName = %q; want ps1-source", env.Data.SourceSecretName)
+	}
+}
+
+func TestHandleGetPushSecret_RBACDenied(t *testing.T) {
+	ps := makePushSecret("apps", "ps1", "uid-ps")
+	h := detailHandler([]runtime.Object{ps}, nil, resources.NewAlwaysDenyAccessChecker())
+
+	w := httptest.NewRecorder()
+	r := withUser(httptest.NewRequest(http.MethodGet, "/", nil), &auth.User{KubernetesUsername: "u"})
+	r = urlWithChiParams(r, map[string]string{"namespace": "apps", "name": "ps1"})
+	h.HandleGetPushSecret(w, r)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d; want 403", w.Code)
+	}
+}
+
+// --- F23: dynForUser error branch on detail endpoints --------------------
+
+func TestHandleGetExternalSecret_DynForUserError(t *testing.T) {
+	h := &Handler{
+		Discoverer:    detectedDiscoverer(),
+		AccessChecker: resources.NewAlwaysAllowAccessChecker(),
+		Logger:        slog.Default(),
+		dynForUserOverride: func(string, []string) (dynamic.Interface, error) {
+			return nil, errors.New("impersonation client init failed")
+		},
+		clientForUserOverride: func(string, []string) (kubernetes.Interface, error) {
+			return kubefake.NewClientset(), nil
+		},
+	}
+
+	w := httptest.NewRecorder()
+	r := withUser(httptest.NewRequest(http.MethodGet, "/", nil), &auth.User{KubernetesUsername: "u"})
+	r = urlWithChiParams(r, map[string]string{"namespace": "apps", "name": "x"})
+	h.HandleGetExternalSecret(w, r)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d; want 500", w.Code)
+	}
+	if !contains(w.Body.String(), "internal error") {
+		t.Errorf("body = %s; want 'internal error'", w.Body.String())
+	}
+}
+
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
 }

--- a/backend/internal/externalsecrets/handler_test.go
+++ b/backend/internal/externalsecrets/handler_test.go
@@ -1,0 +1,799 @@
+package externalsecrets
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/kubecenter/kubecenter/internal/auth"
+	"github.com/kubecenter/kubecenter/internal/k8s/resources"
+)
+
+// --- Test fixtures ---------------------------------------------------------
+
+func esoScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	for gvr, kind := range map[schema.GroupVersionResource]string{
+		ExternalSecretGVR:        "ExternalSecret",
+		ClusterExternalSecretGVR: "ClusterExternalSecret",
+		SecretStoreGVR:           "SecretStore",
+		ClusterSecretStoreGVR:    "ClusterSecretStore",
+		PushSecretGVR:            "PushSecret",
+	} {
+		gv := schema.GroupVersion{Group: gvr.Group, Version: gvr.Version}
+		scheme.AddKnownTypeWithName(gv.WithKind(kind), &unstructured.Unstructured{})
+		scheme.AddKnownTypeWithName(gv.WithKind(kind+"List"), &unstructured.UnstructuredList{})
+	}
+	return scheme
+}
+
+func newEsoFakeDynClient(objects ...runtime.Object) *dynamicfake.FakeDynamicClient {
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		ExternalSecretGVR:        "ExternalSecretList",
+		ClusterExternalSecretGVR: "ClusterExternalSecretList",
+		SecretStoreGVR:           "SecretStoreList",
+		ClusterSecretStoreGVR:    "ClusterSecretStoreList",
+		PushSecretGVR:            "PushSecretList",
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(esoScheme(), gvrToListKind, objects...)
+}
+
+// detectedDiscoverer returns a Discoverer pre-seeded with detected=true so
+// list handlers don't short-circuit on the IsAvailable() empty-state path.
+func detectedDiscoverer() *Discoverer {
+	return &Discoverer{
+		logger: slog.Default(),
+		status: ESOStatus{
+			Detected:    true,
+			LastChecked: time.Now().UTC(),
+		},
+	}
+}
+
+// undetectedDiscoverer returns a Discoverer pre-seeded with detected=false so
+// list handlers exercise the empty-state path.
+func undetectedDiscoverer() *Discoverer {
+	return &Discoverer{
+		logger: slog.Default(),
+		status: ESOStatus{
+			Detected:    false,
+			LastChecked: time.Now().UTC(),
+		},
+	}
+}
+
+// withUser injects an *auth.User into the request context using the same
+// helper key the real auth middleware uses.
+func withUser(r *http.Request, u *auth.User) *http.Request {
+	if u == nil {
+		return r
+	}
+	return r.WithContext(auth.ContextWithUser(r.Context(), u))
+}
+
+// makeES builds an unstructured ExternalSecret with the given identity and a
+// minimal Ready=True status so it normalizes to StatusSynced.
+func makeES(ns, name, uid string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "external-secrets.io/v1",
+			"kind":       "ExternalSecret",
+			"metadata": map[string]any{
+				"name": name, "namespace": ns, "uid": uid,
+			},
+			"spec": map[string]any{
+				"refreshInterval": "1h",
+				"secretStoreRef":  map[string]any{"name": "vault", "kind": "SecretStore"},
+				"target":          map[string]any{"name": name + "-secret"},
+			},
+			"status": map[string]any{
+				"conditions": []any{
+					map[string]any{"type": "Ready", "status": "True", "reason": "SecretSynced"},
+				},
+			},
+		},
+	}
+}
+
+// makeStore builds a SecretStore with vault provider and Ready=True.
+func makeStore(ns, name, uid string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "external-secrets.io/v1",
+			"kind":       "SecretStore",
+			"metadata":   map[string]any{"name": name, "namespace": ns, "uid": uid},
+			"spec":       map[string]any{"provider": map[string]any{"vault": map[string]any{}}},
+			"status": map[string]any{
+				"conditions": []any{map[string]any{"type": "Ready", "status": "True"}},
+			},
+		},
+	}
+}
+
+// makeClusterStore builds a ClusterSecretStore (cluster-scoped — no namespace).
+func makeClusterStore(name, uid string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "external-secrets.io/v1",
+			"kind":       "ClusterSecretStore",
+			"metadata":   map[string]any{"name": name, "uid": uid},
+			"spec":       map[string]any{"provider": map[string]any{"vault": map[string]any{}}},
+			"status":     map[string]any{},
+		},
+	}
+}
+
+func decodeArray[T any](t *testing.T, w *httptest.ResponseRecorder) []T {
+	t.Helper()
+	var env struct {
+		Data []T `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode: %v\nbody: %s", err, w.Body.String())
+	}
+	return env.Data
+}
+
+func decodeStatus(t *testing.T, w *httptest.ResponseRecorder) ESOStatus {
+	t.Helper()
+	var env struct {
+		Data ESOStatus `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode: %v\nbody: %s", err, w.Body.String())
+	}
+	return env.Data
+}
+
+// --- Status endpoint -------------------------------------------------------
+
+func TestHandleStatus_ESONotInstalled(t *testing.T) {
+	h := &Handler{
+		Discoverer:    undetectedDiscoverer(),
+		AccessChecker: resources.NewAlwaysAllowAccessChecker(),
+		Logger:        slog.Default(),
+	}
+
+	w := httptest.NewRecorder()
+	r := withUser(httptest.NewRequest(http.MethodGet, "/", nil), &auth.User{KubernetesUsername: "u"})
+	h.HandleStatus(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status code = %d; want 200", w.Code)
+	}
+	st := decodeStatus(t, w)
+	if st.Detected {
+		t.Errorf("Detected = true; want false")
+	}
+}
+
+func TestHandleStatus_ESOInstalled(t *testing.T) {
+	d := detectedDiscoverer()
+	d.status.Namespace = "external-secrets"
+	d.status.Version = "0.14.0"
+
+	h := &Handler{
+		Discoverer:    d,
+		AccessChecker: resources.NewAlwaysAllowAccessChecker(),
+		Logger:        slog.Default(),
+	}
+
+	w := httptest.NewRecorder()
+	r := withUser(httptest.NewRequest(http.MethodGet, "/", nil), &auth.User{KubernetesUsername: "u"})
+	h.HandleStatus(w, r)
+
+	st := decodeStatus(t, w)
+	if !st.Detected || st.Version != "0.14.0" {
+		t.Errorf("status = %+v; want detected/0.14.0", st)
+	}
+}
+
+// --- ESO not installed: list endpoints all return [] HTTP 200 --------------
+
+func TestListEndpoints_ESONotInstalled(t *testing.T) {
+	h := &Handler{
+		Discoverer:    undetectedDiscoverer(),
+		AccessChecker: resources.NewAlwaysAllowAccessChecker(),
+		Logger:        slog.Default(),
+	}
+
+	user := &auth.User{KubernetesUsername: "u"}
+	endpoints := []func(http.ResponseWriter, *http.Request){
+		h.HandleListExternalSecrets,
+		h.HandleListClusterExternalSecrets,
+		h.HandleListStores,
+		h.HandleListClusterStores,
+		h.HandleListPushSecrets,
+	}
+
+	for i, ep := range endpoints {
+		w := httptest.NewRecorder()
+		r := withUser(httptest.NewRequest(http.MethodGet, "/", nil), user)
+		ep(w, r)
+		if w.Code != http.StatusOK {
+			t.Errorf("endpoint #%d: status = %d; want 200", i, w.Code)
+		}
+		// Decode as raw json so we don't have to know the type for each
+		var env struct {
+			Data []any `json:"data"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &env); err != nil {
+			t.Errorf("endpoint #%d decode: %v", i, err)
+		}
+		if env.Data == nil {
+			t.Errorf("endpoint #%d data is nil — frontend treats null as error", i)
+		}
+		if len(env.Data) != 0 {
+			t.Errorf("endpoint #%d data len = %d; want 0", i, len(env.Data))
+		}
+	}
+}
+
+// --- Happy list with full RBAC -------------------------------------------
+
+func TestHandleListExternalSecrets_AllVisible(t *testing.T) {
+	es1 := makeES("apps", "es1", "uid-1")
+	es2 := makeES("platform", "es2", "uid-2")
+	store := makeStore("apps", "vault", "uid-store")
+
+	h := &Handler{
+		Discoverer:    detectedDiscoverer(),
+		AccessChecker: resources.NewAlwaysAllowAccessChecker(),
+		Logger:        slog.Default(),
+		dynOverride:   newEsoFakeDynClient(es1, es2, store),
+	}
+
+	w := httptest.NewRecorder()
+	r := withUser(httptest.NewRequest(http.MethodGet, "/", nil),
+		&auth.User{KubernetesUsername: "u", KubernetesGroups: []string{"g"}})
+	h.HandleListExternalSecrets(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	got := decodeArray[ExternalSecret](t, w)
+	if len(got) != 2 {
+		t.Errorf("got %d ExternalSecrets; want 2", len(got))
+	}
+}
+
+// --- Namespace query filter ----------------------------------------------
+
+func TestHandleListExternalSecrets_NamespaceFilter(t *testing.T) {
+	es1 := makeES("apps", "es1", "uid-1")
+	es2 := makeES("platform", "es2", "uid-2")
+
+	h := &Handler{
+		Discoverer:    detectedDiscoverer(),
+		AccessChecker: resources.NewAlwaysAllowAccessChecker(),
+		Logger:        slog.Default(),
+		dynOverride:   newEsoFakeDynClient(es1, es2),
+	}
+
+	w := httptest.NewRecorder()
+	r := withUser(httptest.NewRequest(http.MethodGet, "/?namespace=apps", nil),
+		&auth.User{KubernetesUsername: "u"})
+	h.HandleListExternalSecrets(w, r)
+
+	got := decodeArray[ExternalSecret](t, w)
+	if len(got) != 1 || got[0].Namespace != "apps" {
+		t.Errorf("filter result = %+v; want only apps-ns", got)
+	}
+}
+
+// --- Permissive-read on cluster-scoped resources -------------------------
+
+func TestHandleListClusterStores_PermissiveReadGrant(t *testing.T) {
+	cs := makeClusterStore("global-vault", "uid-cs")
+
+	h := &Handler{
+		Discoverer:    detectedDiscoverer(),
+		AccessChecker: resources.NewAlwaysAllowAccessChecker(),
+		Logger:        slog.Default(),
+		dynOverride:   newEsoFakeDynClient(cs),
+	}
+
+	w := httptest.NewRecorder()
+	r := withUser(httptest.NewRequest(http.MethodGet, "/", nil),
+		&auth.User{KubernetesUsername: "u", KubernetesGroups: []string{"g"}})
+	h.HandleListClusterStores(w, r)
+
+	got := decodeArray[SecretStore](t, w)
+	if len(got) != 1 {
+		t.Errorf("got %d ClusterSecretStores; want 1", len(got))
+	}
+}
+
+func TestHandleListClusterStores_PermissiveReadDenied(t *testing.T) {
+	cs := makeClusterStore("global-vault", "uid-cs")
+
+	h := &Handler{
+		Discoverer:    detectedDiscoverer(),
+		AccessChecker: resources.NewAlwaysDenyAccessChecker(),
+		Logger:        slog.Default(),
+		dynOverride:   newEsoFakeDynClient(cs),
+	}
+
+	w := httptest.NewRecorder()
+	r := withUser(httptest.NewRequest(http.MethodGet, "/", nil),
+		&auth.User{KubernetesUsername: "u"})
+	h.HandleListClusterStores(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d; want 200 (silent empty, not 403)", w.Code)
+	}
+	got := decodeArray[SecretStore](t, w)
+	if len(got) != 0 {
+		t.Errorf("got %d ClusterSecretStores; want 0 (denied user sees empty list)", len(got))
+	}
+}
+
+// --- Namespaced-resource RBAC: predicate filter --------------------------
+
+func TestHandleListExternalSecrets_NamespacedRBACFilter(t *testing.T) {
+	es1 := makeES("apps", "es1", "uid-1")
+	es2 := makeES("platform", "es2", "uid-2")
+
+	// Predicate: only "apps" namespace allowed.
+	checker := resources.NewPredicateAccessChecker(func(verb, group, resource, namespace string) bool {
+		return namespace == "apps"
+	})
+
+	h := &Handler{
+		Discoverer:    detectedDiscoverer(),
+		AccessChecker: checker,
+		Logger:        slog.Default(),
+		dynOverride:   newEsoFakeDynClient(es1, es2),
+	}
+
+	w := httptest.NewRecorder()
+	r := withUser(httptest.NewRequest(http.MethodGet, "/", nil),
+		&auth.User{KubernetesUsername: "u", KubernetesGroups: []string{"g"}})
+	h.HandleListExternalSecrets(w, r)
+
+	got := decodeArray[ExternalSecret](t, w)
+	if len(got) != 1 || got[0].Namespace != "apps" {
+		t.Errorf("filter result = %+v; want only apps-ns ES", got)
+	}
+}
+
+// --- Cache hit / TTL semantics -------------------------------------------
+
+// countingDynClient wraps a fake dynamic client to count list invocations
+// per resource. Used to verify singleflight collapsing.
+type countingDynClient struct {
+	dynamic.Interface
+	listCalls atomic.Int64
+}
+
+func (c *countingDynClient) Resource(gvr schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+	return &countingNRI{NamespaceableResourceInterface: c.Interface.Resource(gvr), parent: c}
+}
+
+type countingNRI struct {
+	dynamic.NamespaceableResourceInterface
+	parent *countingDynClient
+}
+
+func (c *countingNRI) Namespace(ns string) dynamic.ResourceInterface {
+	return &countingRI{ResourceInterface: c.NamespaceableResourceInterface.Namespace(ns), parent: c.parent}
+}
+
+func (c *countingNRI) List(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	c.parent.listCalls.Add(1)
+	return c.NamespaceableResourceInterface.List(ctx, opts)
+}
+
+type countingRI struct {
+	dynamic.ResourceInterface
+	parent *countingDynClient
+}
+
+func (c *countingRI) List(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	c.parent.listCalls.Add(1)
+	return c.ResourceInterface.List(ctx, opts)
+}
+
+func TestCacheHit_SingleflightCollapse(t *testing.T) {
+	es := makeES("apps", "es1", "uid-1")
+	fakeClient := newEsoFakeDynClient(es)
+	counter := &countingDynClient{Interface: fakeClient}
+
+	h := &Handler{
+		Discoverer:    detectedDiscoverer(),
+		AccessChecker: resources.NewAlwaysAllowAccessChecker(),
+		Logger:        slog.Default(),
+		dynOverride:   counter,
+	}
+
+	// Fire 10 concurrent list calls — singleflight should collapse to one fetchAll
+	// (which itself dispatches 5 list calls, one per CRD).
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Go(func() {
+			w := httptest.NewRecorder()
+			r := withUser(httptest.NewRequest(http.MethodGet, "/", nil),
+				&auth.User{KubernetesUsername: "u"})
+			h.HandleListExternalSecrets(w, r)
+		})
+	}
+	wg.Wait()
+
+	// 5 list calls per fetchAll. Singleflight collapses N concurrent
+	// HandleList invocations into 1 fetchAll. Allow up to 2 fetchAll cycles
+	// (10 list calls) to tolerate scheduler races where the first request
+	// finishes before another arrives — the requirement is "not 50."
+	calls := counter.listCalls.Load()
+	if calls > 10 {
+		t.Errorf("dynClient.List invoked %d times across 10 concurrent requests; expected <=10 (5 per fetchAll, 1-2 fetchAlls)", calls)
+	}
+}
+
+func TestCacheTTL_ReFetchAfterExpiry(t *testing.T) {
+	es := makeES("apps", "es1", "uid-1")
+	fakeClient := newEsoFakeDynClient(es)
+	counter := &countingDynClient{Interface: fakeClient}
+
+	h := &Handler{
+		Discoverer:    detectedDiscoverer(),
+		AccessChecker: resources.NewAlwaysAllowAccessChecker(),
+		Logger:        slog.Default(),
+		dynOverride:   counter,
+	}
+
+	// First fetch
+	if _, err := h.getCached(context.Background()); err != nil {
+		t.Fatalf("first getCached: %v", err)
+	}
+	first := counter.listCalls.Load()
+
+	// Force expiry by mutating fetchedAt
+	h.cacheMu.Lock()
+	h.cache.fetchedAt = time.Now().Add(-2 * cacheTTL)
+	h.cacheMu.Unlock()
+
+	if _, err := h.getCached(context.Background()); err != nil {
+		t.Fatalf("second getCached: %v", err)
+	}
+	second := counter.listCalls.Load()
+
+	if second <= first {
+		t.Errorf("expected re-fetch after TTL expiry: first=%d second=%d", first, second)
+	}
+}
+
+func TestInvalidateCache(t *testing.T) {
+	es := makeES("apps", "es1", "uid-1")
+	fakeClient := newEsoFakeDynClient(es)
+	counter := &countingDynClient{Interface: fakeClient}
+
+	h := &Handler{
+		Discoverer:    detectedDiscoverer(),
+		AccessChecker: resources.NewAlwaysAllowAccessChecker(),
+		Logger:        slog.Default(),
+		dynOverride:   counter,
+	}
+
+	if _, err := h.getCached(context.Background()); err != nil {
+		t.Fatalf("first getCached: %v", err)
+	}
+	first := counter.listCalls.Load()
+
+	h.InvalidateCache()
+	if h.cache != nil {
+		t.Errorf("InvalidateCache didn't clear cache")
+	}
+
+	if _, err := h.getCached(context.Background()); err != nil {
+		t.Fatalf("second getCached: %v", err)
+	}
+	second := counter.listCalls.Load()
+
+	if second <= first {
+		t.Errorf("expected re-fetch after InvalidateCache: first=%d second=%d", first, second)
+	}
+}
+
+// --- Empty fake-dynamic-client scenario: 5 CRDs all return empty lists ---
+
+// --- Drift status helper -------------------------------------------------
+
+func TestComputeDriftStatus(t *testing.T) {
+	cases := []struct {
+		name     string
+		syncedRV string
+		liveRV   string
+		want     DriftStatus
+	}{
+		{"empty-synced-RV-unknown", "", "12345", DriftUnknown},
+		{"matching-RVs-in-sync", "12345", "12345", DriftInSync},
+		{"differing-RVs-drifted", "12345", "12346", DriftDrifted},
+		{"empty-live-RV-drifted", "12345", "", DriftDrifted},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := computeDriftStatus(tc.syncedRV, tc.liveRV)
+			if got != tc.want {
+				t.Errorf("computeDriftStatus(%q, %q) = %q; want %q",
+					tc.syncedRV, tc.liveRV, got, tc.want)
+			}
+		})
+	}
+}
+
+// --- Detail endpoint with drift resolution -------------------------------
+
+// urlWithChiParams attaches chi route params to a request context. The
+// Get<...> handlers read namespace/name via chi.URLParam; in production a
+// route definition supplies those, in tests we must inject them directly.
+func urlWithChiParams(r *http.Request, params map[string]string) *http.Request {
+	rctx := chi.NewRouteContext()
+	for k, v := range params {
+		rctx.URLParams.Add(k, v)
+	}
+	return r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+}
+
+// detailHandler builds a Handler with all overrides wired for detail tests.
+// The fakeKubeSecret param, when non-nil, is preloaded into the typed-client
+// fake so the drift check can find it.
+func detailHandler(esObjs []runtime.Object, fakeKubeSecret *corev1.Secret, accessChecker *resources.AccessChecker) *Handler {
+	dynFake := newEsoFakeDynClient(esObjs...)
+	var typedFake kubernetes.Interface = kubefake.NewClientset()
+	if fakeKubeSecret != nil {
+		typedFake = kubefake.NewClientset(fakeKubeSecret)
+	}
+	return &Handler{
+		Discoverer:    detectedDiscoverer(),
+		AccessChecker: accessChecker,
+		Logger:        slog.Default(),
+		dynForUserOverride: func(string, []string) (dynamic.Interface, error) {
+			return dynFake, nil
+		},
+		clientForUserOverride: func(string, []string) (kubernetes.Interface, error) {
+			return typedFake, nil
+		},
+	}
+}
+
+func TestHandleGetExternalSecret_DriftInSync(t *testing.T) {
+	ns, name := "apps", "db-creds"
+	targetSecret := name + "-secret" // matches makeES convention
+	es := makeES(ns, name, "uid-1")
+	// Set syncedResourceVersion on the ES status
+	status, _ := es.Object["status"].(map[string]any)
+	status["syncedResourceVersion"] = "100"
+
+	syncedSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: targetSecret, Namespace: ns, ResourceVersion: "100"},
+	}
+
+	h := detailHandler([]runtime.Object{es}, syncedSecret, resources.NewAlwaysAllowAccessChecker())
+
+	w := httptest.NewRecorder()
+	r := withUser(httptest.NewRequest(http.MethodGet, "/", nil), &auth.User{KubernetesUsername: "u"})
+	r = urlWithChiParams(r, map[string]string{"namespace": ns, "name": name})
+	h.HandleGetExternalSecret(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; body = %s", w.Code, w.Body.String())
+	}
+	var env struct {
+		Data ExternalSecret `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if env.Data.DriftStatus != DriftInSync {
+		t.Errorf("DriftStatus = %q; want %q", env.Data.DriftStatus, DriftInSync)
+	}
+	if env.Data.Status != StatusSynced {
+		t.Errorf("Status = %q; want %q (drift in-sync should not overlay)", env.Data.Status, StatusSynced)
+	}
+}
+
+func TestHandleGetExternalSecret_DriftDetected(t *testing.T) {
+	ns, name := "apps", "db-creds"
+	targetSecret := name + "-secret"
+	es := makeES(ns, name, "uid-1")
+	status, _ := es.Object["status"].(map[string]any)
+	status["syncedResourceVersion"] = "100"
+
+	// Live Secret has a different RV — drift detected
+	syncedSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: targetSecret, Namespace: ns, ResourceVersion: "101"},
+	}
+
+	h := detailHandler([]runtime.Object{es}, syncedSecret, resources.NewAlwaysAllowAccessChecker())
+
+	w := httptest.NewRecorder()
+	r := withUser(httptest.NewRequest(http.MethodGet, "/", nil), &auth.User{KubernetesUsername: "u"})
+	r = urlWithChiParams(r, map[string]string{"namespace": ns, "name": name})
+	h.HandleGetExternalSecret(w, r)
+
+	var env struct {
+		Data ExternalSecret `json:"data"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &env)
+	if env.Data.DriftStatus != DriftDrifted {
+		t.Errorf("DriftStatus = %q; want %q", env.Data.DriftStatus, DriftDrifted)
+	}
+	if env.Data.Status != StatusDrifted {
+		t.Errorf("Status = %q; want %q (drift overlay on Synced)", env.Data.Status, StatusDrifted)
+	}
+}
+
+func TestHandleGetExternalSecret_DriftUnknownNoSyncedRV(t *testing.T) {
+	ns, name := "apps", "db-creds"
+	es := makeES(ns, name, "uid-1")
+	// status.syncedResourceVersion is intentionally absent — provider
+	// doesn't populate it, so drift can't be determined.
+
+	h := detailHandler([]runtime.Object{es}, nil, resources.NewAlwaysAllowAccessChecker())
+
+	w := httptest.NewRecorder()
+	r := withUser(httptest.NewRequest(http.MethodGet, "/", nil), &auth.User{KubernetesUsername: "u"})
+	r = urlWithChiParams(r, map[string]string{"namespace": ns, "name": name})
+	h.HandleGetExternalSecret(w, r)
+
+	var env struct {
+		Data ExternalSecret `json:"data"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &env)
+	if env.Data.DriftStatus != DriftUnknown {
+		t.Errorf("DriftStatus = %q; want %q", env.Data.DriftStatus, DriftUnknown)
+	}
+	if env.Data.Status != StatusSynced {
+		t.Errorf("Status = %q; want %q (no overlay when drift unknown)", env.Data.Status, StatusSynced)
+	}
+}
+
+func TestHandleGetExternalSecret_SyncedSecretDeleted(t *testing.T) {
+	ns, name := "apps", "db-creds"
+	es := makeES(ns, name, "uid-1")
+	status, _ := es.Object["status"].(map[string]any)
+	status["syncedResourceVersion"] = "100"
+
+	// No synced Secret in the typed-client — Get returns NotFound.
+	h := detailHandler([]runtime.Object{es}, nil, resources.NewAlwaysAllowAccessChecker())
+
+	w := httptest.NewRecorder()
+	r := withUser(httptest.NewRequest(http.MethodGet, "/", nil), &auth.User{KubernetesUsername: "u"})
+	r = urlWithChiParams(r, map[string]string{"namespace": ns, "name": name})
+	h.HandleGetExternalSecret(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d; want 200 (ES exists even though Secret is missing)", w.Code)
+	}
+	var env struct {
+		Data ExternalSecret `json:"data"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &env)
+	if env.Data.DriftStatus != DriftUnknown {
+		t.Errorf("DriftStatus = %q; want %q", env.Data.DriftStatus, DriftUnknown)
+	}
+}
+
+func TestHandleGetExternalSecret_RBACDenied(t *testing.T) {
+	ns, name := "apps", "db-creds"
+	es := makeES(ns, name, "uid-1")
+
+	h := detailHandler([]runtime.Object{es}, nil, resources.NewAlwaysDenyAccessChecker())
+
+	w := httptest.NewRecorder()
+	r := withUser(httptest.NewRequest(http.MethodGet, "/", nil), &auth.User{KubernetesUsername: "u"})
+	r = urlWithChiParams(r, map[string]string{"namespace": ns, "name": name})
+	h.HandleGetExternalSecret(w, r)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d; want 403 (denied user)", w.Code)
+	}
+}
+
+func TestHandleGetExternalSecret_NotFound(t *testing.T) {
+	h := detailHandler(nil, nil, resources.NewAlwaysAllowAccessChecker())
+
+	w := httptest.NewRecorder()
+	r := withUser(httptest.NewRequest(http.MethodGet, "/", nil), &auth.User{KubernetesUsername: "u"})
+	r = urlWithChiParams(r, map[string]string{"namespace": "apps", "name": "missing"})
+	h.HandleGetExternalSecret(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d; want 404", w.Code)
+	}
+}
+
+func TestHandleGetStore_HappyPath(t *testing.T) {
+	ns, name := "apps", "vault"
+	store := makeStore(ns, name, "uid-store")
+
+	h := detailHandler([]runtime.Object{store}, nil, resources.NewAlwaysAllowAccessChecker())
+
+	w := httptest.NewRecorder()
+	r := withUser(httptest.NewRequest(http.MethodGet, "/", nil), &auth.User{KubernetesUsername: "u"})
+	r = urlWithChiParams(r, map[string]string{"namespace": ns, "name": name})
+	h.HandleGetStore(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; body = %s", w.Code, w.Body.String())
+	}
+	var env struct {
+		Data SecretStore `json:"data"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &env)
+	if env.Data.Provider != "vault" || env.Data.Scope != "Namespaced" {
+		t.Errorf("store = %+v", env.Data)
+	}
+}
+
+func TestHandleGetClusterStore_HappyPath(t *testing.T) {
+	cs := makeClusterStore("global-vault", "uid-cs")
+
+	h := detailHandler([]runtime.Object{cs}, nil, resources.NewAlwaysAllowAccessChecker())
+
+	w := httptest.NewRecorder()
+	r := withUser(httptest.NewRequest(http.MethodGet, "/", nil), &auth.User{KubernetesUsername: "u"})
+	r = urlWithChiParams(r, map[string]string{"name": "global-vault"})
+	h.HandleGetClusterStore(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; body = %s", w.Code, w.Body.String())
+	}
+	var env struct {
+		Data SecretStore `json:"data"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &env)
+	if env.Data.Scope != "Cluster" || env.Data.Namespace != "" {
+		t.Errorf("clusterstore = %+v", env.Data)
+	}
+}
+
+func TestFetchAll_EmptyClusterReturnsEmptyLists(t *testing.T) {
+	h := &Handler{
+		Discoverer:    detectedDiscoverer(),
+		AccessChecker: resources.NewAlwaysAllowAccessChecker(),
+		Logger:        slog.Default(),
+		dynOverride:   newEsoFakeDynClient(),
+	}
+
+	data, err := h.getCached(context.Background())
+	if err != nil {
+		t.Fatalf("getCached: %v", err)
+	}
+	if data.externalSecrets == nil ||
+		data.clusterExternalSecrets == nil ||
+		data.stores == nil ||
+		data.clusterStores == nil ||
+		data.pushSecrets == nil {
+		t.Errorf("nil slice in cache: %+v", data)
+	}
+	for name, n := range map[string]int{
+		"externalSecrets":        len(data.externalSecrets),
+		"clusterExternalSecrets": len(data.clusterExternalSecrets),
+		"stores":                 len(data.stores),
+		"clusterStores":          len(data.clusterStores),
+		"pushSecrets":            len(data.pushSecrets),
+	} {
+		if n != 0 {
+			t.Errorf("%s len = %d; want 0", name, n)
+		}
+	}
+}

--- a/backend/internal/externalsecrets/normalize.go
+++ b/backend/internal/externalsecrets/normalize.go
@@ -1,0 +1,456 @@
+package externalsecrets
+
+import (
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// computeBaseStatus derives the BASE Status from the Ready condition only.
+// Callers layer threshold-aware overlays (Stale, Drifted) via DeriveStatus.
+//
+// Rules:
+//   - Ready=True  → Synced
+//   - Ready=False → SyncFailed
+//   - Ready=Unknown / no value → Refreshing if condition exists, Unknown if absent
+//
+// "Conditions entirely absent" maps to Unknown — a brand-new ExternalSecret
+// the controller hasn't reconciled yet. Once the controller writes any
+// condition the ES is at least Refreshing.
+func computeBaseStatus(readyStatus string, hasConditions bool) Status {
+	switch readyStatus {
+	case "True":
+		return StatusSynced
+	case "False":
+		return StatusSyncFailed
+	case "Unknown":
+		return StatusRefreshing
+	default:
+		if hasConditions {
+			return StatusRefreshing
+		}
+		return StatusUnknown
+	}
+}
+
+// DeriveStatus overlays the threshold-aware states (Stale, Drifted) onto the
+// base Status. Precedence:
+//
+//	SyncFailed > Refreshing > Stale > Drifted > Synced > Unknown
+//
+// Drift never overrides failure — a Failed cert with detected drift stays
+// Failed, because the operator's bigger problem is the failure. Stale wins
+// over Drifted because a stale ExternalSecret may not have the latest source
+// data, so the drift signal is unreliable.
+//
+// Stale check requires both a non-zero stale-threshold AND a LastSyncTime —
+// without LastSyncTime we have no anchor to compute "older than." A zero
+// stale-threshold means the resolver hasn't run yet (Phase A); the function
+// silently no-ops the Stale overlay rather than guessing a default.
+func DeriveStatus(es ExternalSecret) Status {
+	// Failure / refreshing dominate — never overlay Stale or Drifted on top.
+	if es.Status == StatusSyncFailed || es.Status == StatusRefreshing {
+		return es.Status
+	}
+
+	// Stale overlay: only applies when the base is Synced AND we have both
+	// a resolved threshold and a last-sync anchor.
+	if es.Status == StatusSynced && es.StaleAfterMinutes > 0 && es.LastSyncTime != nil {
+		stale := time.Since(*es.LastSyncTime) >= time.Duration(es.StaleAfterMinutes)*time.Minute
+		if stale {
+			return StatusStale
+		}
+	}
+
+	// Drift overlay: only when base is Synced and the live RV check ran.
+	if es.Status == StatusSynced && es.DriftStatus == DriftDrifted {
+		return StatusDrifted
+	}
+
+	return es.Status
+}
+
+// normalizeExternalSecret converts an unstructured ESO ExternalSecret into our
+// typed shape. The DriftStatus field is left as DriftUnknown — the live
+// resourceVersion lookup happens only on the detail endpoint (see Unit 3 of
+// the plan; list view explicitly avoids the N+1 impersonated Get).
+func normalizeExternalSecret(u *unstructured.Unstructured) ExternalSecret {
+	obj := u.Object
+
+	spec, _ := obj["spec"].(map[string]any)
+	if spec == nil {
+		spec = map[string]any{}
+	}
+	status, _ := obj["status"].(map[string]any)
+	if status == nil {
+		status = map[string]any{}
+	}
+
+	storeRef := readStoreRef(spec)
+	targetSecret := readTargetSecret(spec)
+	refreshInterval := stringFrom(spec, "refreshInterval")
+
+	readyStatus, reason, message := readReadyCondition(status)
+	_, hasConditions := status["conditions"].([]any)
+	baseStatus := computeBaseStatus(readyStatus, hasConditions)
+
+	syncedRV := stringFrom(status, "syncedResourceVersion")
+	lastSync := parseTimeField(status, "refreshTime")
+
+	return ExternalSecret{
+		Namespace:             u.GetNamespace(),
+		Name:                  u.GetName(),
+		UID:                   string(u.GetUID()),
+		Status:                baseStatus,
+		DriftStatus:           DriftUnknown,
+		ReadyReason:           reason,
+		ReadyMessage:          message,
+		StoreRef:              storeRef,
+		TargetSecretName:      targetSecret,
+		RefreshInterval:       refreshInterval,
+		LastSyncTime:          lastSync,
+		SyncedResourceVersion: syncedRV,
+	}
+}
+
+// normalizeClusterExternalSecret converts a ClusterExternalSecret. Spec
+// embeds an externalSecretSpec — we read storeRef and target from inside it.
+func normalizeClusterExternalSecret(u *unstructured.Unstructured) ClusterExternalSecret {
+	obj := u.Object
+
+	spec, _ := obj["spec"].(map[string]any)
+	if spec == nil {
+		spec = map[string]any{}
+	}
+	status, _ := obj["status"].(map[string]any)
+	if status == nil {
+		status = map[string]any{}
+	}
+
+	embedded, _ := spec["externalSecretSpec"].(map[string]any)
+	if embedded == nil {
+		embedded = map[string]any{}
+	}
+
+	storeRef := readStoreRef(embedded)
+	targetSecret := readTargetSecret(embedded)
+	refreshInterval := stringFrom(embedded, "refreshInterval")
+	if refreshInterval == "" {
+		refreshInterval = stringFrom(spec, "refreshTime")
+	}
+
+	readyStatus, reason, message := readReadyCondition(status)
+	_, hasConditions := status["conditions"].([]any)
+
+	provisioned := stringSliceFrom(status, "provisionedNamespaces")
+	failed := failedNamespacesFrom(status)
+	namespaces := stringSliceFrom(spec, "namespaces")
+	selectors := namespaceSelectorsFrom(spec)
+
+	return ClusterExternalSecret{
+		Name:                   u.GetName(),
+		UID:                    string(u.GetUID()),
+		Status:                 computeBaseStatus(readyStatus, hasConditions),
+		ReadyReason:            reason,
+		ReadyMessage:           message,
+		StoreRef:               storeRef,
+		TargetSecretName:       targetSecret,
+		RefreshInterval:        refreshInterval,
+		Namespaces:             namespaces,
+		NamespaceSelectors:     selectors,
+		ProvisionedNamespaces:  provisioned,
+		FailedNamespaces:       failed,
+		ExternalSecretBaseName: stringFrom(spec, "externalSecretName"),
+	}
+}
+
+// normalizeSecretStore converts a SecretStore or ClusterSecretStore. scope
+// must be "Namespaced" or "Cluster" — there is no way to derive it from the
+// unstructured object alone since the kind name lives on the GVR, not the
+// payload.
+func normalizeSecretStore(u *unstructured.Unstructured, scope string) SecretStore {
+	obj := u.Object
+
+	spec, _ := obj["spec"].(map[string]any)
+	if spec == nil {
+		spec = map[string]any{}
+	}
+	status, _ := obj["status"].(map[string]any)
+	if status == nil {
+		status = map[string]any{}
+	}
+
+	provider, providerSpec := detectProvider(spec)
+
+	readyStatus, reason, message := readReadyCondition(status)
+	_, hasConditions := status["conditions"].([]any)
+	baseStatus := computeBaseStatus(readyStatus, hasConditions)
+
+	ready := readyStatus == "True"
+	return SecretStore{
+		Namespace:    u.GetNamespace(),
+		Name:         u.GetName(),
+		UID:          string(u.GetUID()),
+		Scope:        scope,
+		Status:       baseStatus,
+		Ready:        ready,
+		ReadyReason:  reason,
+		ReadyMessage: message,
+		Provider:     provider,
+		ProviderSpec: providerSpec,
+	}
+}
+
+// normalizePushSecret converts a PushSecret. Selector is the source Secret
+// name; storeRefs is the list of destinations.
+func normalizePushSecret(u *unstructured.Unstructured) PushSecret {
+	obj := u.Object
+
+	spec, _ := obj["spec"].(map[string]any)
+	if spec == nil {
+		spec = map[string]any{}
+	}
+	status, _ := obj["status"].(map[string]any)
+	if status == nil {
+		status = map[string]any{}
+	}
+
+	readyStatus, reason, message := readReadyCondition(status)
+	_, hasConditions := status["conditions"].([]any)
+
+	storeRefs := readStoreRefList(spec)
+	sourceSecret := readPushSourceSecret(spec)
+	refreshInterval := stringFrom(spec, "refreshInterval")
+	lastSync := parseTimeField(status, "refreshTime")
+
+	return PushSecret{
+		Namespace:        u.GetNamespace(),
+		Name:             u.GetName(),
+		UID:              string(u.GetUID()),
+		Status:           computeBaseStatus(readyStatus, hasConditions),
+		ReadyReason:      reason,
+		ReadyMessage:     message,
+		StoreRefs:        storeRefs,
+		SourceSecretName: sourceSecret,
+		RefreshInterval:  refreshInterval,
+		LastSyncTime:     lastSync,
+	}
+}
+
+// readStoreRef reads spec.secretStoreRef from any ESO spec block (ES, CES.spec.externalSecretSpec).
+func readStoreRef(spec map[string]any) StoreRef {
+	ref, _ := spec["secretStoreRef"].(map[string]any)
+	return StoreRef{
+		Name: stringFrom(ref, "name"),
+		Kind: stringFrom(ref, "kind"),
+	}
+}
+
+// readStoreRefList reads spec.secretStoreRefs (PushSecret has many).
+func readStoreRefList(spec map[string]any) []StoreRef {
+	raw, ok := spec["secretStoreRefs"].([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]StoreRef, 0, len(raw))
+	for _, r := range raw {
+		m, ok := r.(map[string]any)
+		if !ok {
+			continue
+		}
+		out = append(out, StoreRef{
+			Name: stringFrom(m, "name"),
+			Kind: stringFrom(m, "kind"),
+		})
+	}
+	return out
+}
+
+// readTargetSecret reads the synced-Secret name. ESO normalizes this to
+// spec.target.name; if that's missing we fall back to spec.target.template.
+// metadata.name (template-driven naming) and finally to status.binding.name.
+func readTargetSecret(spec map[string]any) string {
+	target, _ := spec["target"].(map[string]any)
+	if target == nil {
+		return ""
+	}
+	if name := stringFrom(target, "name"); name != "" {
+		return name
+	}
+	tmpl, _ := target["template"].(map[string]any)
+	if tmpl != nil {
+		meta, _ := tmpl["metadata"].(map[string]any)
+		if meta != nil {
+			if name := stringFrom(meta, "name"); name != "" {
+				return name
+			}
+		}
+	}
+	return ""
+}
+
+// readPushSourceSecret reads the source Secret name from a PushSecret's
+// spec.selector.secret.name field.
+func readPushSourceSecret(spec map[string]any) string {
+	sel, _ := spec["selector"].(map[string]any)
+	if sel == nil {
+		return ""
+	}
+	secret, _ := sel["secret"].(map[string]any)
+	if secret == nil {
+		return ""
+	}
+	return stringFrom(secret, "name")
+}
+
+// detectProvider returns the provider key (e.g. "vault") and the
+// spec.provider.<provider> sub-object verbatim. Only the first key is
+// honored — ESO's schema constrains the provider block to a oneOf, so a
+// well-formed object has exactly one key.
+func detectProvider(spec map[string]any) (string, map[string]any) {
+	provider, _ := spec["provider"].(map[string]any)
+	if provider == nil {
+		return "", nil
+	}
+	for k, v := range provider {
+		spec, _ := v.(map[string]any)
+		return k, spec
+	}
+	return "", nil
+}
+
+// stringSliceFrom safely extracts a top-level string slice from a map.
+func stringSliceFrom(m map[string]any, key string) []string {
+	raw, ok := m[key].([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, r := range raw {
+		if s, ok := r.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// failedNamespacesFrom reads ClusterExternalSecret status.failedNamespaces,
+// which is a list of {namespace, reason} objects. We surface the namespace
+// names only — the per-namespace reason can be fetched by drilling into the
+// detail page.
+func failedNamespacesFrom(status map[string]any) []string {
+	raw, ok := status["failedNamespaces"].([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, r := range raw {
+		m, ok := r.(map[string]any)
+		if !ok {
+			continue
+		}
+		if ns := stringFrom(m, "namespace"); ns != "" {
+			out = append(out, ns)
+		}
+	}
+	return out
+}
+
+// namespaceSelectorsFrom collapses spec.namespaceSelectors / spec.namespaceSelector
+// into a flat string slice for display purposes. We read the selector's
+// matchLabels keys so the UI can show "matches: app=production" — full
+// LabelSelector reconstruction would require importing apimachinery types we
+// don't otherwise need here.
+func namespaceSelectorsFrom(spec map[string]any) []string {
+	out := []string{}
+
+	// spec.namespaceSelector — single LabelSelector
+	if sel, ok := spec["namespaceSelector"].(map[string]any); ok {
+		out = append(out, formatLabelSelector(sel)...)
+	}
+
+	// spec.namespaceSelectors — list of LabelSelectors (newer syntax)
+	if list, ok := spec["namespaceSelectors"].([]any); ok {
+		for _, r := range list {
+			if sel, ok := r.(map[string]any); ok {
+				out = append(out, formatLabelSelector(sel)...)
+			}
+		}
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// formatLabelSelector renders a LabelSelector's matchLabels as "k=v" strings.
+// matchExpressions are compressed to "<key> <op>" (without rendering the value
+// list) — full expression rendering is the frontend's job if it wants it; the
+// API surface here is for at-a-glance display.
+func formatLabelSelector(sel map[string]any) []string {
+	out := []string{}
+	if labels, ok := sel["matchLabels"].(map[string]any); ok {
+		for k, v := range labels {
+			if s, ok := v.(string); ok {
+				out = append(out, k+"="+s)
+			}
+		}
+	}
+	if exprs, ok := sel["matchExpressions"].([]any); ok {
+		for _, r := range exprs {
+			m, ok := r.(map[string]any)
+			if !ok {
+				continue
+			}
+			out = append(out, strings.TrimSpace(stringFrom(m, "key")+" "+stringFrom(m, "operator")))
+		}
+	}
+	return out
+}
+
+// readReadyCondition iterates status.conditions looking for type=Ready and
+// returns (status, reason, message). Empty strings if not found.
+func readReadyCondition(obj map[string]any) (status, reason, message string) {
+	conditions, ok := obj["conditions"].([]any)
+	if !ok {
+		return "", "", ""
+	}
+	for _, c := range conditions {
+		cm, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		if t, _ := cm["type"].(string); t == "Ready" {
+			status, _ = cm["status"].(string)
+			reason, _ = cm["reason"].(string)
+			message, _ = cm["message"].(string)
+			return
+		}
+	}
+	return "", "", ""
+}
+
+// stringFrom safely extracts a string value from a map.
+func stringFrom(m map[string]any, key string) string {
+	if m == nil {
+		return ""
+	}
+	s, _ := m[key].(string)
+	return s
+}
+
+// parseTimeField parses an RFC3339 timestamp from a nested map path. Returns
+// nil on any error or missing value.
+func parseTimeField(obj map[string]any, fields ...string) *time.Time {
+	s, found, err := unstructured.NestedString(obj, fields...)
+	if err != nil || !found || s == "" {
+		return nil
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return nil
+	}
+	return &t
+}

--- a/backend/internal/externalsecrets/normalize.go
+++ b/backend/internal/externalsecrets/normalize.go
@@ -55,9 +55,10 @@ func DeriveStatus(es ExternalSecret) Status {
 	}
 
 	// Stale overlay: only applies when the base is Synced AND we have both
-	// a resolved threshold and a last-sync anchor.
-	if es.Status == StatusSynced && es.StaleAfterMinutes > 0 && es.LastSyncTime != nil {
-		stale := time.Since(*es.LastSyncTime) >= time.Duration(es.StaleAfterMinutes)*time.Minute
+	// a resolved threshold and a last-sync anchor. StaleAfterMinutes is a
+	// pointer — nil means the resolver hasn't populated it (Phase A pre-D).
+	if es.Status == StatusSynced && es.StaleAfterMinutes != nil && *es.StaleAfterMinutes > 0 && es.LastSyncTime != nil {
+		stale := time.Since(*es.LastSyncTime) >= time.Duration(*es.StaleAfterMinutes)*time.Minute
 		if stale {
 			return StatusStale
 		}

--- a/backend/internal/externalsecrets/normalize_test.go
+++ b/backend/internal/externalsecrets/normalize_test.go
@@ -38,6 +38,7 @@ func TestDeriveStatus(t *testing.T) {
 		t := now.Add(-d)
 		return &t
 	}
+	mins := func(n int) *int { return &n }
 
 	cases := []struct {
 		name string
@@ -48,7 +49,7 @@ func TestDeriveStatus(t *testing.T) {
 			name: "fresh-synced",
 			es: ExternalSecret{
 				Status:            StatusSynced,
-				StaleAfterMinutes: 60,
+				StaleAfterMinutes: mins(60),
 				LastSyncTime:      freshly(5 * time.Minute),
 				DriftStatus:       DriftInSync,
 			},
@@ -58,7 +59,7 @@ func TestDeriveStatus(t *testing.T) {
 			name: "stale-overlay",
 			es: ExternalSecret{
 				Status:            StatusSynced,
-				StaleAfterMinutes: 30,
+				StaleAfterMinutes: mins(30),
 				LastSyncTime:      freshly(45 * time.Minute),
 			},
 			want: StatusStale,
@@ -83,7 +84,7 @@ func TestDeriveStatus(t *testing.T) {
 			name: "stale-never-overrides-failure",
 			es: ExternalSecret{
 				Status:            StatusSyncFailed,
-				StaleAfterMinutes: 5,
+				StaleAfterMinutes: mins(5),
 				LastSyncTime:      freshly(60 * time.Minute),
 			},
 			want: StatusSyncFailed,
@@ -92,7 +93,7 @@ func TestDeriveStatus(t *testing.T) {
 			name: "stale-wins-over-drift",
 			es: ExternalSecret{
 				Status:            StatusSynced,
-				StaleAfterMinutes: 30,
+				StaleAfterMinutes: mins(30),
 				LastSyncTime:      freshly(60 * time.Minute),
 				DriftStatus:       DriftDrifted,
 			},
@@ -102,7 +103,16 @@ func TestDeriveStatus(t *testing.T) {
 			name: "no-threshold-no-stale-overlay",
 			es: ExternalSecret{
 				Status:            StatusSynced,
-				StaleAfterMinutes: 0, // resolver hasn't run
+				StaleAfterMinutes: nil, // resolver hasn't run (Phase A)
+				LastSyncTime:      freshly(99 * time.Hour),
+			},
+			want: StatusSynced,
+		},
+		{
+			name: "zero-threshold-no-stale-overlay",
+			es: ExternalSecret{
+				Status:            StatusSynced,
+				StaleAfterMinutes: mins(0), // resolver explicitly resolved zero
 				LastSyncTime:      freshly(99 * time.Hour),
 			},
 			want: StatusSynced,
@@ -111,7 +121,7 @@ func TestDeriveStatus(t *testing.T) {
 			name: "no-lastsync-no-stale-overlay",
 			es: ExternalSecret{
 				Status:            StatusSynced,
-				StaleAfterMinutes: 30,
+				StaleAfterMinutes: mins(30),
 				LastSyncTime:      nil,
 			},
 			want: StatusSynced,

--- a/backend/internal/externalsecrets/normalize_test.go
+++ b/backend/internal/externalsecrets/normalize_test.go
@@ -1,0 +1,501 @@
+package externalsecrets
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestComputeBaseStatus(t *testing.T) {
+	cases := []struct {
+		name          string
+		readyStatus   string
+		hasConditions bool
+		want          Status
+	}{
+		{"ready-true", "True", true, StatusSynced},
+		{"ready-false", "False", true, StatusSyncFailed},
+		{"ready-unknown-explicit", "Unknown", true, StatusRefreshing},
+		{"no-ready-but-has-other-conditions", "", true, StatusRefreshing},
+		{"no-conditions-at-all", "", false, StatusUnknown},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := computeBaseStatus(tc.readyStatus, tc.hasConditions)
+			if got != tc.want {
+				t.Errorf("computeBaseStatus(%q, %v) = %q; want %q",
+					tc.readyStatus, tc.hasConditions, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDeriveStatus(t *testing.T) {
+	now := time.Now()
+	freshly := func(d time.Duration) *time.Time {
+		t := now.Add(-d)
+		return &t
+	}
+
+	cases := []struct {
+		name string
+		es   ExternalSecret
+		want Status
+	}{
+		{
+			name: "fresh-synced",
+			es: ExternalSecret{
+				Status:            StatusSynced,
+				StaleAfterMinutes: 60,
+				LastSyncTime:      freshly(5 * time.Minute),
+				DriftStatus:       DriftInSync,
+			},
+			want: StatusSynced,
+		},
+		{
+			name: "stale-overlay",
+			es: ExternalSecret{
+				Status:            StatusSynced,
+				StaleAfterMinutes: 30,
+				LastSyncTime:      freshly(45 * time.Minute),
+			},
+			want: StatusStale,
+		},
+		{
+			name: "drift-overlay",
+			es: ExternalSecret{
+				Status:      StatusSynced,
+				DriftStatus: DriftDrifted,
+			},
+			want: StatusDrifted,
+		},
+		{
+			name: "drift-never-overrides-failure",
+			es: ExternalSecret{
+				Status:      StatusSyncFailed,
+				DriftStatus: DriftDrifted,
+			},
+			want: StatusSyncFailed,
+		},
+		{
+			name: "stale-never-overrides-failure",
+			es: ExternalSecret{
+				Status:            StatusSyncFailed,
+				StaleAfterMinutes: 5,
+				LastSyncTime:      freshly(60 * time.Minute),
+			},
+			want: StatusSyncFailed,
+		},
+		{
+			name: "stale-wins-over-drift",
+			es: ExternalSecret{
+				Status:            StatusSynced,
+				StaleAfterMinutes: 30,
+				LastSyncTime:      freshly(60 * time.Minute),
+				DriftStatus:       DriftDrifted,
+			},
+			want: StatusStale,
+		},
+		{
+			name: "no-threshold-no-stale-overlay",
+			es: ExternalSecret{
+				Status:            StatusSynced,
+				StaleAfterMinutes: 0, // resolver hasn't run
+				LastSyncTime:      freshly(99 * time.Hour),
+			},
+			want: StatusSynced,
+		},
+		{
+			name: "no-lastsync-no-stale-overlay",
+			es: ExternalSecret{
+				Status:            StatusSynced,
+				StaleAfterMinutes: 30,
+				LastSyncTime:      nil,
+			},
+			want: StatusSynced,
+		},
+		{
+			name: "drift-unknown-no-overlay",
+			es: ExternalSecret{
+				Status:      StatusSynced,
+				DriftStatus: DriftUnknown,
+			},
+			want: StatusSynced,
+		},
+		{
+			name: "refreshing-stays-refreshing",
+			es: ExternalSecret{
+				Status:      StatusRefreshing,
+				DriftStatus: DriftDrifted,
+			},
+			want: StatusRefreshing,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := DeriveStatus(tc.es)
+			if got != tc.want {
+				t.Errorf("DeriveStatus(%+v) = %q; want %q", tc.es, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestThresholdSourceValid(t *testing.T) {
+	cases := map[ThresholdSource]bool{
+		ThresholdSourceDefault:            true,
+		ThresholdSourceExternalSecret:     true,
+		ThresholdSourceSecretStore:        true,
+		ThresholdSourceClusterSecretStore: true,
+		"":                                false,
+		"junk":                            false,
+		"issuer":                          false, // would have been valid in cert-manager — guard prevents accidental cross-pollination
+	}
+	for src, want := range cases {
+		if got := src.Valid(); got != want {
+			t.Errorf("ThresholdSource(%q).Valid() = %v; want %v", src, got, want)
+		}
+	}
+}
+
+func TestNormalizeExternalSecret_Happy(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	u := &unstructured.Unstructured{
+		Object: map[string]any{
+			"metadata": map[string]any{
+				"name":      "db-creds",
+				"namespace": "apps",
+				"uid":       "uid-001",
+			},
+			"spec": map[string]any{
+				"refreshInterval": "1h",
+				"secretStoreRef": map[string]any{
+					"name": "vault-store",
+					"kind": "SecretStore",
+				},
+				"target": map[string]any{
+					"name": "synced-db-creds",
+				},
+			},
+			"status": map[string]any{
+				"refreshTime":           now.Format(time.RFC3339),
+				"syncedResourceVersion": "12345",
+				"conditions": []any{
+					map[string]any{
+						"type":   "Ready",
+						"status": "True",
+						"reason": "SecretSynced",
+					},
+				},
+			},
+		},
+	}
+
+	es := normalizeExternalSecret(u)
+	if es.Name != "db-creds" || es.Namespace != "apps" || es.UID != "uid-001" {
+		t.Fatalf("identity wrong: %+v", es)
+	}
+	if es.Status != StatusSynced {
+		t.Errorf("Status = %q; want %q", es.Status, StatusSynced)
+	}
+	if es.DriftStatus != DriftUnknown {
+		t.Errorf("DriftStatus = %q; want %q (list view never resolves drift)", es.DriftStatus, DriftUnknown)
+	}
+	if es.StoreRef.Name != "vault-store" || es.StoreRef.Kind != "SecretStore" {
+		t.Errorf("StoreRef = %+v; want vault-store/SecretStore", es.StoreRef)
+	}
+	if es.TargetSecretName != "synced-db-creds" {
+		t.Errorf("TargetSecretName = %q; want synced-db-creds", es.TargetSecretName)
+	}
+	if es.RefreshInterval != "1h" {
+		t.Errorf("RefreshInterval = %q; want 1h", es.RefreshInterval)
+	}
+	if es.SyncedResourceVersion != "12345" {
+		t.Errorf("SyncedResourceVersion = %q; want 12345", es.SyncedResourceVersion)
+	}
+	if es.LastSyncTime == nil || !es.LastSyncTime.Equal(now) {
+		t.Errorf("LastSyncTime = %v; want %v", es.LastSyncTime, now)
+	}
+	if es.ReadyReason != "SecretSynced" {
+		t.Errorf("ReadyReason = %q; want SecretSynced", es.ReadyReason)
+	}
+}
+
+func TestNormalizeExternalSecret_FailureCondition(t *testing.T) {
+	u := &unstructured.Unstructured{
+		Object: map[string]any{
+			"metadata": map[string]any{"name": "x", "namespace": "y", "uid": "z"},
+			"spec":     map[string]any{},
+			"status": map[string]any{
+				"conditions": []any{
+					map[string]any{
+						"type":    "Ready",
+						"status":  "False",
+						"reason":  "AuthFailed",
+						"message": "vault auth refused",
+					},
+				},
+			},
+		},
+	}
+	es := normalizeExternalSecret(u)
+	if es.Status != StatusSyncFailed {
+		t.Errorf("Status = %q; want %q", es.Status, StatusSyncFailed)
+	}
+	if es.ReadyReason != "AuthFailed" {
+		t.Errorf("ReadyReason = %q", es.ReadyReason)
+	}
+	if es.ReadyMessage != "vault auth refused" {
+		t.Errorf("ReadyMessage = %q", es.ReadyMessage)
+	}
+}
+
+func TestNormalizeExternalSecret_NoConditions(t *testing.T) {
+	u := &unstructured.Unstructured{
+		Object: map[string]any{
+			"metadata": map[string]any{"name": "x", "namespace": "y", "uid": "z"},
+			"spec":     map[string]any{},
+			"status":   map[string]any{},
+		},
+	}
+	es := normalizeExternalSecret(u)
+	if es.Status != StatusUnknown {
+		t.Errorf("Status = %q; want %q (no conditions = brand new ES)", es.Status, StatusUnknown)
+	}
+}
+
+func TestNormalizeExternalSecret_TargetTemplateName(t *testing.T) {
+	// target.template.metadata.name fallback when target.name is absent
+	u := &unstructured.Unstructured{
+		Object: map[string]any{
+			"metadata": map[string]any{"name": "x", "namespace": "y", "uid": "z"},
+			"spec": map[string]any{
+				"target": map[string]any{
+					"template": map[string]any{
+						"metadata": map[string]any{
+							"name": "tmpl-secret-name",
+						},
+					},
+				},
+			},
+			"status": map[string]any{},
+		},
+	}
+	es := normalizeExternalSecret(u)
+	if es.TargetSecretName != "tmpl-secret-name" {
+		t.Errorf("TargetSecretName = %q; want tmpl-secret-name", es.TargetSecretName)
+	}
+}
+
+func TestNormalizeSecretStore_ProviderDetection(t *testing.T) {
+	cases := []struct {
+		name         string
+		spec         map[string]any
+		wantProvider string
+		wantReady    bool
+	}{
+		{
+			name: "vault-ready",
+			spec: map[string]any{
+				"provider": map[string]any{
+					"vault": map[string]any{
+						"server": "https://vault.example.com",
+						"path":   "secret",
+					},
+				},
+			},
+			wantProvider: "vault",
+		},
+		{
+			name: "aws-secretsmanager",
+			spec: map[string]any{
+				"provider": map[string]any{
+					"aws": map[string]any{
+						"service": "SecretsManager",
+						"region":  "us-east-1",
+					},
+				},
+			},
+			wantProvider: "aws",
+		},
+		{
+			name: "kubernetes-provider",
+			spec: map[string]any{
+				"provider": map[string]any{
+					"kubernetes": map[string]any{
+						"remoteNamespace": "source-ns",
+					},
+				},
+			},
+			wantProvider: "kubernetes",
+		},
+		{
+			name:         "no-provider",
+			spec:         map[string]any{},
+			wantProvider: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			u := &unstructured.Unstructured{
+				Object: map[string]any{
+					"metadata": map[string]any{"name": "s", "namespace": "n", "uid": "u"},
+					"spec":     tc.spec,
+					"status": map[string]any{
+						"conditions": []any{
+							map[string]any{"type": "Ready", "status": "True"},
+						},
+					},
+				},
+			}
+			s := normalizeSecretStore(u, "Namespaced")
+			if s.Provider != tc.wantProvider {
+				t.Errorf("Provider = %q; want %q", s.Provider, tc.wantProvider)
+			}
+			if s.Scope != "Namespaced" {
+				t.Errorf("Scope = %q; want Namespaced", s.Scope)
+			}
+			if s.Status != StatusSynced {
+				t.Errorf("Status = %q; want %q", s.Status, StatusSynced)
+			}
+			if !s.Ready {
+				t.Errorf("Ready = false; want true")
+			}
+		})
+	}
+}
+
+func TestNormalizeSecretStore_ClusterScope(t *testing.T) {
+	u := &unstructured.Unstructured{
+		Object: map[string]any{
+			"metadata": map[string]any{"name": "global", "uid": "uid-css"},
+			"spec":     map[string]any{"provider": map[string]any{"vault": map[string]any{}}},
+			"status":   map[string]any{},
+		},
+	}
+	s := normalizeSecretStore(u, "Cluster")
+	if s.Namespace != "" {
+		t.Errorf("Namespace = %q; want empty for ClusterSecretStore", s.Namespace)
+	}
+	if s.Scope != "Cluster" {
+		t.Errorf("Scope = %q", s.Scope)
+	}
+}
+
+func TestNormalizeClusterExternalSecret(t *testing.T) {
+	u := &unstructured.Unstructured{
+		Object: map[string]any{
+			"metadata": map[string]any{"name": "fanout", "uid": "uid-ces"},
+			"spec": map[string]any{
+				"externalSecretSpec": map[string]any{
+					"refreshInterval": "30m",
+					"secretStoreRef": map[string]any{
+						"name": "global-vault",
+						"kind": "ClusterSecretStore",
+					},
+					"target": map[string]any{"name": "shared-creds"},
+				},
+				"namespaces": []any{"apps", "platform"},
+				"namespaceSelector": map[string]any{
+					"matchLabels": map[string]any{
+						"tier": "production",
+					},
+				},
+			},
+			"status": map[string]any{
+				"conditions": []any{
+					map[string]any{"type": "Ready", "status": "True"},
+				},
+				"provisionedNamespaces": []any{"apps", "platform"},
+				"failedNamespaces": []any{
+					map[string]any{"namespace": "edge", "reason": "PermissionDenied"},
+				},
+			},
+		},
+	}
+
+	ces := normalizeClusterExternalSecret(u)
+	if ces.Name != "fanout" || ces.UID != "uid-ces" {
+		t.Errorf("identity wrong: %+v", ces)
+	}
+	if ces.Status != StatusSynced {
+		t.Errorf("Status = %q", ces.Status)
+	}
+	if ces.StoreRef.Name != "global-vault" || ces.StoreRef.Kind != "ClusterSecretStore" {
+		t.Errorf("StoreRef = %+v", ces.StoreRef)
+	}
+	if ces.TargetSecretName != "shared-creds" {
+		t.Errorf("TargetSecretName = %q", ces.TargetSecretName)
+	}
+	if len(ces.Namespaces) != 2 {
+		t.Errorf("Namespaces = %v", ces.Namespaces)
+	}
+	if len(ces.ProvisionedNamespaces) != 2 {
+		t.Errorf("ProvisionedNamespaces = %v", ces.ProvisionedNamespaces)
+	}
+	if len(ces.FailedNamespaces) != 1 || ces.FailedNamespaces[0] != "edge" {
+		t.Errorf("FailedNamespaces = %v", ces.FailedNamespaces)
+	}
+	if len(ces.NamespaceSelectors) == 0 {
+		t.Errorf("NamespaceSelectors = %v; expected at least 1 from matchLabels", ces.NamespaceSelectors)
+	}
+}
+
+func TestNormalizePushSecret(t *testing.T) {
+	u := &unstructured.Unstructured{
+		Object: map[string]any{
+			"metadata": map[string]any{"name": "push-x", "namespace": "apps", "uid": "uid-push"},
+			"spec": map[string]any{
+				"refreshInterval": "1h",
+				"selector": map[string]any{
+					"secret": map[string]any{"name": "source-secret"},
+				},
+				"secretStoreRefs": []any{
+					map[string]any{"name": "vault-1", "kind": "SecretStore"},
+					map[string]any{"name": "vault-cluster", "kind": "ClusterSecretStore"},
+				},
+			},
+			"status": map[string]any{
+				"conditions": []any{
+					map[string]any{"type": "Ready", "status": "True"},
+				},
+			},
+		},
+	}
+
+	ps := normalizePushSecret(u)
+	if ps.Name != "push-x" || ps.SourceSecretName != "source-secret" {
+		t.Errorf("PushSecret identity wrong: %+v", ps)
+	}
+	if len(ps.StoreRefs) != 2 {
+		t.Errorf("StoreRefs len = %d; want 2", len(ps.StoreRefs))
+	}
+	if ps.StoreRefs[0].Kind != "SecretStore" || ps.StoreRefs[1].Kind != "ClusterSecretStore" {
+		t.Errorf("StoreRefs kinds: %+v", ps.StoreRefs)
+	}
+	if ps.Status != StatusSynced {
+		t.Errorf("Status = %q", ps.Status)
+	}
+}
+
+func TestParseTimeField(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	good := map[string]any{"refreshTime": now.Format(time.RFC3339)}
+	if got := parseTimeField(good, "refreshTime"); got == nil || !got.Equal(now) {
+		t.Errorf("parseTimeField(good) = %v; want %v", got, now)
+	}
+
+	bad := map[string]any{"refreshTime": "not-a-time"}
+	if got := parseTimeField(bad, "refreshTime"); got != nil {
+		t.Errorf("parseTimeField(bad) = %v; want nil", got)
+	}
+
+	missing := map[string]any{}
+	if got := parseTimeField(missing, "refreshTime"); got != nil {
+		t.Errorf("parseTimeField(missing) = %v; want nil", got)
+	}
+}

--- a/backend/internal/externalsecrets/types.go
+++ b/backend/internal/externalsecrets/types.go
@@ -55,6 +55,15 @@ const (
 // distinction between Drifted (operator-edited the Secret) and Unknown (the
 // provider doesn't populate syncedResourceVersion, so we cannot tell) is
 // surfaced to operators rather than collapsed into one boolean.
+//
+// Wire contract: the LIST endpoint OMITS this field entirely (drift
+// resolution requires a per-ES impersonated `get secret` which would N+1
+// the list). Callers must treat the absence of `driftStatus` on a list
+// item as DriftUnknown — never as DriftInSync. The DETAIL endpoint always
+// populates it. Phase C's Unit 11 will add a coarse
+// `lastObservedDriftStatus` to the list response sourced from the
+// poller's persisted history; the contract above still holds (absence ==
+// Unknown) for the detail-vs-list split.
 type DriftStatus string
 
 const (
@@ -63,30 +72,10 @@ const (
 	DriftUnknown DriftStatus = "Unknown"
 )
 
-// Annotation keys honored by the resolver chain (resource > store >
-// clusterstore > default). Values must be positive integers (minutes), with a
-// 5-minute floor for stale-after to prevent self-DoS against the 60s poller
-// cadence. Invalid values are logged and silently fall through to the next
-// layer of the chain. Phase D's resolver populates the resolved values on each
-// ExternalSecret; Phase A leaves the annotation-resolved fields at zero.
-const (
-	AnnotationStaleAfterMinutes = "kubecenter.io/eso-stale-after-minutes"
-	AnnotationAlertOnRecovery   = "kubecenter.io/eso-alert-on-recovery"
-	AnnotationAlertOnLifecycle  = "kubecenter.io/eso-alert-on-lifecycle"
-)
-
-// DefaultStaleFallbackMinutes is the package-default stale threshold used when
-// the resolver chain produces no value AND the ExternalSecret's
-// spec.refreshInterval is unparseable / unset. Matches the 2h fallback in
-// requirement R17.
-const DefaultStaleFallbackMinutes = 120
-
-// MinStaleAfterMinutes is the floor enforced on the eso-stale-after-minutes
-// annotation. Values below this are rejected by the resolver and fall through
-// to the next layer of the chain. The floor exists to prevent operators from
-// accidentally configuring a threshold tighter than the 60s poller cadence,
-// which would mark every ExternalSecret as Stale on every poll.
-const MinStaleAfterMinutes = 5
+// Annotation keys, default thresholds, and the floor for stale-after-minutes
+// are owned by Phase D's `thresholds.go`. Phase A keeps the annotation-resolved
+// fields zero/nil and ships no resolver. The constants live alongside the
+// resolver they parameterize so the package surface here stays minimal.
 
 // ThresholdSource enumerates which layer of the resolution chain supplied an
 // annotation-resolved value. Used by the UI to surface "Stale at: 60m
@@ -134,8 +123,9 @@ type StoreRef struct {
 // ExternalSecret resource.
 //
 // The annotation-resolved fields (StaleAfterMinutes, AlertOnRecovery,
-// AlertOnLifecycle) are zero in Phase A and populated by Phase D's resolver.
-// JSON `omitempty` keeps the response shape clean until then.
+// AlertOnLifecycle, plus the *Source sibling fields) are nil/empty in
+// Phase A and populated by Phase D's resolver. JSON `omitempty` keeps the
+// response shape clean until then.
 type ExternalSecret struct {
 	Namespace             string      `json:"namespace"`
 	Name                  string      `json:"name"`
@@ -151,12 +141,28 @@ type ExternalSecret struct {
 	SyncedResourceVersion string      `json:"syncedResourceVersion,omitempty"`
 
 	// Phase D — annotation-resolved threshold fields. omitempty hides them
-	// until Phase D's resolver populates them.
-	StaleAfterMinutes       int             `json:"staleAfterMinutes,omitempty"`
+	// until Phase D's resolver populates them. Each value carries a
+	// ThresholdSource sibling so the UI can attribute "Stale at 60m
+	// (Store apps/vault-store)" rather than collapsing all sources into one
+	// boolean. StaleAfterMinutes is *int (rather than int) so the wire shape
+	// distinguishes "resolver hasn't run / Phase A" (omitted) from
+	// "resolver ran, no value resolved" (zero) — matches SecretStore's
+	// nullable shape and lets DeriveStatus key on presence rather than
+	// truthiness.
+	StaleAfterMinutes       *int            `json:"staleAfterMinutes,omitempty"`
 	StaleAfterMinutesSource ThresholdSource `json:"staleAfterMinutesSource,omitempty"`
 	AlertOnRecovery         *bool           `json:"alertOnRecovery,omitempty"`
 	AlertOnRecoverySource   ThresholdSource `json:"alertOnRecoverySource,omitempty"`
 	AlertOnLifecycle        *bool           `json:"alertOnLifecycle,omitempty"`
+	AlertOnLifecycleSource  ThresholdSource `json:"alertOnLifecycleSource,omitempty"`
+
+	// DriftUnknownReason disambiguates a DriftStatus=Unknown response. Empty
+	// when DriftStatus is not Unknown. Allowed values: `no_synced_rv`,
+	// `no_target_name`, `secret_deleted`, `rbac_denied`, `transient_error`,
+	// `client_error`, `secret_not_owned`. Frontend renders this as a
+	// hover-tooltip under the drift indicator so an operator can see WHY
+	// drift wasn't resolvable rather than guessing.
+	DriftUnknownReason string `json:"driftUnknownReason,omitempty"`
 }
 
 // ClusterExternalSecret is the API representation of a ClusterExternalSecret —

--- a/backend/internal/externalsecrets/types.go
+++ b/backend/internal/externalsecrets/types.go
@@ -1,0 +1,225 @@
+// Package externalsecrets provides External Secrets Operator (ESO) integration for k8sCenter.
+//
+// Mirrors the cert-manager package layout 1:1 (discovery → normalize → cached
+// handler with singleflight + RBAC). Surfaces the five v1 CRDs of the ESO API
+// as observatory endpoints under /api/v1/externalsecrets/*. Write actions
+// (force-sync, bulk refresh) are deferred to Phase E; persistence and drift
+// detection ship in Phase C; alerting + annotation thresholds ship in Phase D.
+package externalsecrets
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// GroupName is the API group ESO publishes its v1 CRDs under. Exported for
+// RBAC checks (CanAccessGroupResource) and the Helm chart's ClusterRole grant.
+const GroupName = "external-secrets.io"
+
+// GVR constants for external-secrets.io/v1 resources. v1 was promoted to GA in
+// ESO v0.14 (mid-2025); v1beta1 is served-but-not-stored and is handled
+// transparently by the dynamic client.
+var (
+	ExternalSecretGVR = schema.GroupVersionResource{
+		Group: GroupName, Version: "v1", Resource: "externalsecrets",
+	}
+	ClusterExternalSecretGVR = schema.GroupVersionResource{
+		Group: GroupName, Version: "v1", Resource: "clusterexternalsecrets",
+	}
+	SecretStoreGVR = schema.GroupVersionResource{
+		Group: GroupName, Version: "v1", Resource: "secretstores",
+	}
+	ClusterSecretStoreGVR = schema.GroupVersionResource{
+		Group: GroupName, Version: "v1", Resource: "clustersecretstores",
+	}
+	PushSecretGVR = schema.GroupVersionResource{
+		Group: GroupName, Version: "v1", Resource: "pushsecrets",
+	}
+)
+
+// Status represents the computed lifecycle state of an ExternalSecret.
+type Status string
+
+const (
+	StatusSynced     Status = "Synced"
+	StatusSyncFailed Status = "SyncFailed"
+	StatusRefreshing Status = "Refreshing"
+	StatusStale      Status = "Stale"
+	StatusDrifted    Status = "Drifted"
+	StatusUnknown    Status = "Unknown"
+)
+
+// DriftStatus is a tri-state indicator of whether an ExternalSecret's synced
+// Secret matches the resource version it was last reconciled against. The
+// distinction between Drifted (operator-edited the Secret) and Unknown (the
+// provider doesn't populate syncedResourceVersion, so we cannot tell) is
+// surfaced to operators rather than collapsed into one boolean.
+type DriftStatus string
+
+const (
+	DriftInSync  DriftStatus = "InSync"
+	DriftDrifted DriftStatus = "Drifted"
+	DriftUnknown DriftStatus = "Unknown"
+)
+
+// Annotation keys honored by the resolver chain (resource > store >
+// clusterstore > default). Values must be positive integers (minutes), with a
+// 5-minute floor for stale-after to prevent self-DoS against the 60s poller
+// cadence. Invalid values are logged and silently fall through to the next
+// layer of the chain. Phase D's resolver populates the resolved values on each
+// ExternalSecret; Phase A leaves the annotation-resolved fields at zero.
+const (
+	AnnotationStaleAfterMinutes = "kubecenter.io/eso-stale-after-minutes"
+	AnnotationAlertOnRecovery   = "kubecenter.io/eso-alert-on-recovery"
+	AnnotationAlertOnLifecycle  = "kubecenter.io/eso-alert-on-lifecycle"
+)
+
+// DefaultStaleFallbackMinutes is the package-default stale threshold used when
+// the resolver chain produces no value AND the ExternalSecret's
+// spec.refreshInterval is unparseable / unset. Matches the 2h fallback in
+// requirement R17.
+const DefaultStaleFallbackMinutes = 120
+
+// MinStaleAfterMinutes is the floor enforced on the eso-stale-after-minutes
+// annotation. Values below this are rejected by the resolver and fall through
+// to the next layer of the chain. The floor exists to prevent operators from
+// accidentally configuring a threshold tighter than the 60s poller cadence,
+// which would mark every ExternalSecret as Stale on every poll.
+const MinStaleAfterMinutes = 5
+
+// ThresholdSource enumerates which layer of the resolution chain supplied an
+// annotation-resolved value. Used by the UI to surface "Stale at: 60m
+// (Store apps/vault-store)" rather than collapsing all sources into a single
+// "annotation set" boolean.
+type ThresholdSource string
+
+const (
+	ThresholdSourceDefault            ThresholdSource = "default"
+	ThresholdSourceExternalSecret     ThresholdSource = "externalsecret"
+	ThresholdSourceSecretStore        ThresholdSource = "secretstore"
+	ThresholdSourceClusterSecretStore ThresholdSource = "clustersecretstore"
+)
+
+// Valid reports whether s is one of the four enum constants. Used at write
+// sites as a belt-and-suspenders guard so a future Go-side bug cannot emit an
+// out-of-enum string that would break the frontend's exhaustive switch.
+func (s ThresholdSource) Valid() bool {
+	switch s {
+	case ThresholdSourceDefault,
+		ThresholdSourceExternalSecret,
+		ThresholdSourceSecretStore,
+		ThresholdSourceClusterSecretStore:
+		return true
+	}
+	return false
+}
+
+// ESOStatus is returned by GET /externalsecrets/status.
+type ESOStatus struct {
+	Detected    bool      `json:"detected"`
+	Namespace   string    `json:"namespace,omitempty"`
+	Version     string    `json:"version,omitempty"`
+	LastChecked time.Time `json:"lastChecked"`
+}
+
+// StoreRef identifies the SecretStore or ClusterSecretStore that an
+// ExternalSecret reads from.
+type StoreRef struct {
+	Name string `json:"name"`
+	Kind string `json:"kind"` // "SecretStore" or "ClusterSecretStore"
+}
+
+// ExternalSecret is the API representation of an external-secrets.io/v1
+// ExternalSecret resource.
+//
+// The annotation-resolved fields (StaleAfterMinutes, AlertOnRecovery,
+// AlertOnLifecycle) are zero in Phase A and populated by Phase D's resolver.
+// JSON `omitempty` keeps the response shape clean until then.
+type ExternalSecret struct {
+	Namespace             string      `json:"namespace"`
+	Name                  string      `json:"name"`
+	UID                   string      `json:"uid"`
+	Status                Status      `json:"status"`
+	DriftStatus           DriftStatus `json:"driftStatus,omitempty"`
+	ReadyReason           string      `json:"readyReason,omitempty"`
+	ReadyMessage          string      `json:"readyMessage,omitempty"`
+	StoreRef              StoreRef    `json:"storeRef"`
+	TargetSecretName      string      `json:"targetSecretName,omitempty"`
+	RefreshInterval       string      `json:"refreshInterval,omitempty"` // e.g. "1h"
+	LastSyncTime          *time.Time  `json:"lastSyncTime,omitempty"`
+	SyncedResourceVersion string      `json:"syncedResourceVersion,omitempty"`
+
+	// Phase D — annotation-resolved threshold fields. omitempty hides them
+	// until Phase D's resolver populates them.
+	StaleAfterMinutes       int             `json:"staleAfterMinutes,omitempty"`
+	StaleAfterMinutesSource ThresholdSource `json:"staleAfterMinutesSource,omitempty"`
+	AlertOnRecovery         *bool           `json:"alertOnRecovery,omitempty"`
+	AlertOnRecoverySource   ThresholdSource `json:"alertOnRecoverySource,omitempty"`
+	AlertOnLifecycle        *bool           `json:"alertOnLifecycle,omitempty"`
+}
+
+// ClusterExternalSecret is the API representation of a ClusterExternalSecret —
+// the cluster-scoped form that fans an ExternalSecret out across multiple
+// namespaces selected by NamespaceSelector / Namespaces fields.
+type ClusterExternalSecret struct {
+	Name                   string   `json:"name"`
+	UID                    string   `json:"uid"`
+	Status                 Status   `json:"status"`
+	ReadyReason            string   `json:"readyReason,omitempty"`
+	ReadyMessage           string   `json:"readyMessage,omitempty"`
+	StoreRef               StoreRef `json:"storeRef"`
+	TargetSecretName       string   `json:"targetSecretName,omitempty"`
+	RefreshInterval        string   `json:"refreshInterval,omitempty"`
+	NamespaceSelectors     []string `json:"namespaceSelectors,omitempty"`
+	Namespaces             []string `json:"namespaces,omitempty"`
+	ProvisionedNamespaces  []string `json:"provisionedNamespaces,omitempty"`
+	FailedNamespaces       []string `json:"failedNamespaces,omitempty"`
+	ExternalSecretBaseName string   `json:"externalSecretBaseName,omitempty"`
+}
+
+// SecretStore is the API representation of a SecretStore or ClusterSecretStore.
+// Scope distinguishes the two: "Namespaced" or "Cluster".
+//
+// Provider names the source-store family ("vault", "aws", "gcp", etc.) so the
+// frontend can render provider-specific affordances. ProviderSpec carries the
+// raw spec.provider.<provider> sub-object verbatim (map[string]any, never
+// typed) — per L7.1 we deliberately avoid pulling per-provider Go SDKs into
+// go.mod just for type-checking the spec.
+type SecretStore struct {
+	Namespace    string         `json:"namespace,omitempty"` // empty for ClusterSecretStore
+	Name         string         `json:"name"`
+	UID          string         `json:"uid"`
+	Scope        string         `json:"scope"` // "Namespaced" or "Cluster"
+	Status       Status         `json:"status"`
+	Ready        bool           `json:"ready"`
+	ReadyReason  string         `json:"readyReason,omitempty"`
+	ReadyMessage string         `json:"readyMessage,omitempty"`
+	Provider     string         `json:"provider"`
+	ProviderSpec map[string]any `json:"providerSpec,omitempty"`
+
+	// Phase D — annotation-resolved threshold fields. Pointer types so the
+	// resolver can distinguish "store didn't set this" (nil) from "store
+	// set it to zero" (which would be invalid and rejected anyway, but the
+	// nullability still matters for chain inheritance).
+	StaleAfterMinutes *int  `json:"staleAfterMinutes,omitempty"`
+	AlertOnRecovery   *bool `json:"alertOnRecovery,omitempty"`
+	AlertOnLifecycle  *bool `json:"alertOnLifecycle,omitempty"`
+}
+
+// PushSecret is the API representation of a PushSecret — the inverse-direction
+// CRD that pushes a Kubernetes Secret out to a source store. Read-only in v1
+// per the requirements doc; spec is intentionally surfaced (cluster admin
+// controls who has list pushsecrets via RBAC).
+type PushSecret struct {
+	Namespace        string     `json:"namespace"`
+	Name             string     `json:"name"`
+	UID              string     `json:"uid"`
+	Status           Status     `json:"status"`
+	ReadyReason      string     `json:"readyReason,omitempty"`
+	ReadyMessage     string     `json:"readyMessage,omitempty"`
+	StoreRefs        []StoreRef `json:"storeRefs"`
+	SourceSecretName string     `json:"sourceSecretName,omitempty"`
+	RefreshInterval  string     `json:"refreshInterval,omitempty"`
+	LastSyncTime     *time.Time `json:"lastSyncTime,omitempty"`
+}

--- a/backend/internal/externalsecrets/types_hash_test.go
+++ b/backend/internal/externalsecrets/types_hash_test.go
@@ -1,0 +1,72 @@
+package externalsecrets
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestExportedTypeShapeStability pins a sha256 hash of the exported field
+// names and types of every public type whose JSON shape the frontend
+// depends on. Any future addition / removal / rename / type-change of a
+// public field — or any change to its `json:` tag — will fail this test
+// with a clear "now=<new>, was=<old>" diagnostic, forcing the author to
+// update the corresponding TS interface in `frontend/lib/eso-types.ts`
+// (Phase B) at the same time.
+//
+// This is the Go-side half of the Go-TS hash test specified in Plan Unit 7.
+// When the frontend lands, the TS side will pin the same set of fields with
+// a corresponding hash; the two together prevent silent Go-TS drift.
+//
+// Updating a hash should be a deliberate two-line change paired with the TS
+// update — not a casual edit. If you're tempted to "just fix the test,"
+// stop and confirm the frontend interface was updated first.
+func TestExportedTypeShapeStability(t *testing.T) {
+	cases := []struct {
+		typ  any
+		name string
+		want string
+	}{
+		{ESOStatus{}, "ESOStatus", "7fb5df5cb8e9ada236f3ae25bed45554ac8e83e4d8e951a230941022be4c0ed5"},
+		{StoreRef{}, "StoreRef", "15c933f766a870488523aa0d28de892afe8570ddf6327b016ca5da9eb421bb35"},
+		{ExternalSecret{}, "ExternalSecret", "cf0615f46c9a4c444601000a14c8fa7a516ada471ee14ee5305e2b35806ff1e4"},
+		{ClusterExternalSecret{}, "ClusterExternalSecret", "40ae7c0a5334702fc888b7a6e86f2018d6d670b8ab9b07a67004ca682e51caf5"},
+		{SecretStore{}, "SecretStore", "a6aa435026eda8cf349a40867c54515ae641a671a1f3da063da58485919943cb"},
+		{PushSecret{}, "PushSecret", "55992ade35cc28828ec5b7a0a58dddbb8a98c52ad3c174ed31cbda2c17b57abb"},
+	}
+
+	for _, tc := range cases {
+		got := shapeHash(tc.typ)
+		if got != tc.want {
+			t.Errorf("type %s shape hash drifted: now=%s, was=%s — update frontend/lib/eso-types.ts to match the new Go shape, then update this test's `want` constant", tc.name, got, tc.want)
+		}
+	}
+}
+
+// shapeHash deterministically encodes the exported-field signature of a
+// struct value into a sha256 hex digest. Field order is normalized via sort
+// so reordering source-level field declarations doesn't trigger spurious
+// drift; the JSON tag is included because that's the wire-shape contract,
+// not the Go-level field name.
+func shapeHash(v any) string {
+	t := reflect.TypeOf(v)
+	if t.Kind() != reflect.Struct {
+		return "non-struct"
+	}
+	parts := make([]string, 0, t.NumField())
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if !f.IsExported() {
+			continue
+		}
+		// FieldName + Go type + json tag. Three independent dimensions a
+		// frontend consumer cares about.
+		parts = append(parts, f.Name+":"+f.Type.String()+":"+f.Tag.Get("json"))
+	}
+	sort.Strings(parts)
+	h := sha256.Sum256([]byte(strings.Join(parts, ";")))
+	return hex.EncodeToString(h[:])
+}

--- a/backend/internal/externalsecrets/types_hash_test.go
+++ b/backend/internal/externalsecrets/types_hash_test.go
@@ -57,8 +57,7 @@ func shapeHash(v any) string {
 		return "non-struct"
 	}
 	parts := make([]string, 0, t.NumField())
-	for i := 0; i < t.NumField(); i++ {
-		f := t.Field(i)
+	for f := range t.Fields() {
 		if !f.IsExported() {
 			continue
 		}

--- a/backend/internal/server/routes.go
+++ b/backend/internal/server/routes.go
@@ -171,6 +171,11 @@ func (s *Server) registerRoutes() {
 				s.registerCertManagerRoutes(ar)
 			}
 
+			// External Secrets Operator routes — only registered if ESO handler is available
+			if s.ExternalSecretsHandler != nil {
+				s.registerExternalSecretsRoutes(ar)
+			}
+
 			// Gateway API routes — only registered if gateway handler is available
 			if s.GatewayHandler != nil {
 				s.registerGatewayRoutes(ar)
@@ -613,6 +618,41 @@ func (s *Server) registerCertManagerRoutes(ar chi.Router) {
 			Post("/certificates/{namespace}/{name}/renew", h.HandleRenew)
 		cr.With(middleware.RateLimit(yamlRL), resources.ValidateURLParams).
 			Post("/certificates/{namespace}/{name}/reissue", h.HandleReissue)
+	})
+}
+
+// registerExternalSecretsRoutes wires Phase A observatory endpoints under
+// /externalsecrets. Write actions (force-sync, bulk refresh) ship in Phase E.
+func (s *Server) registerExternalSecretsRoutes(ar chi.Router) {
+	h := s.ExternalSecretsHandler
+	ar.Route("/externalsecrets", func(er chi.Router) {
+		// Discovery + status
+		er.Get("/status", h.HandleStatus)
+
+		// ExternalSecret list + detail
+		er.Get("/externalsecrets", h.HandleListExternalSecrets)
+		er.With(resources.ValidateURLParams).
+			Get("/externalsecrets/{namespace}/{name}", h.HandleGetExternalSecret)
+
+		// ClusterExternalSecret list + detail (cluster-scoped — name only)
+		er.Get("/clusterexternalsecrets", h.HandleListClusterExternalSecrets)
+		er.With(resources.ValidateURLParams).
+			Get("/clusterexternalsecrets/{name}", h.HandleGetClusterExternalSecret)
+
+		// SecretStore list + detail
+		er.Get("/stores", h.HandleListStores)
+		er.With(resources.ValidateURLParams).
+			Get("/stores/{namespace}/{name}", h.HandleGetStore)
+
+		// ClusterSecretStore list + detail
+		er.Get("/clusterstores", h.HandleListClusterStores)
+		er.With(resources.ValidateURLParams).
+			Get("/clusterstores/{name}", h.HandleGetClusterStore)
+
+		// PushSecret list + detail (read-only in v1)
+		er.Get("/pushsecrets", h.HandleListPushSecrets)
+		er.With(resources.ValidateURLParams).
+			Get("/pushsecrets/{namespace}/{name}", h.HandleGetPushSecret)
 	})
 }
 

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kubecenter/kubecenter/internal/auth"
 	"github.com/kubecenter/kubecenter/internal/config"
 	"github.com/kubecenter/kubecenter/internal/diagnostics"
+	"github.com/kubecenter/kubecenter/internal/externalsecrets"
 	"github.com/kubecenter/kubecenter/internal/gateway"
 	"github.com/kubecenter/kubecenter/internal/gitops"
 	"github.com/kubecenter/kubecenter/internal/k8s"
@@ -75,6 +76,7 @@ type Server struct {
 	LimitsHandler      *limits.Handler
 	VeleroHandler      *velero.Handler
 	CertManagerHandler *certmanager.Handler
+	ExternalSecretsHandler *externalsecrets.Handler
 	GatewayHandler     *gateway.Handler
 	ServiceMeshHandler *servicemesh.Handler
 	CRDHandler         *resources.GenericCRDHandler
@@ -121,6 +123,7 @@ type Deps struct {
 	LimitsHandler      *limits.Handler
 	VeleroHandler      *velero.Handler
 	CertManagerHandler *certmanager.Handler
+	ExternalSecretsHandler *externalsecrets.Handler
 	GatewayHandler     *gateway.Handler
 	ServiceMeshHandler *servicemesh.Handler
 	CRDHandler         *resources.GenericCRDHandler
@@ -273,6 +276,11 @@ func New(deps Deps) *Server {
 	// Cert-Manager handler
 	if deps.CertManagerHandler != nil {
 		s.CertManagerHandler = deps.CertManagerHandler
+	}
+
+	// External Secrets Operator handler (Phase A — observatory)
+	if deps.ExternalSecretsHandler != nil {
+		s.ExternalSecretsHandler = deps.ExternalSecretsHandler
 	}
 
 	// Gateway API handler

--- a/docs/brainstorms/2026-04-29-external-secrets-operator-requirements.md
+++ b/docs/brainstorms/2026-04-29-external-secrets-operator-requirements.md
@@ -1,0 +1,199 @@
+---
+date: 2026-04-29
+topic: external-secrets-operator
+---
+
+# External Secrets Operator integration
+
+## Summary
+
+A feature-complete External Secrets Operator integration under `/security/external-secrets/*`: observatory + per-provider wizards + chain topology graph + Notification Center alerting + four operational lenses (drift detection, sync diff history, bulk refresh, per-store rate / quota awareness). End state covers everything popular operators actually use; phased delivery is acceptable.
+
+---
+
+## Problem Frame
+
+Production secrets in real clusters rarely live in raw `Secret` resources — they're synced from HashiCorp Vault, AWS Secrets Manager / Parameter Store, Azure Key Vault, GCP Secret Manager, or one of a long tail of SaaS / on-prem stores via the External Secrets Operator (ESO). Today, an operator answering "is this secret healthy?" or "when did it last sync?" has to drop to `kubectl get externalsecret -A`, decode the `status.conditions` array by hand, then `kubectl describe` to chase the SecretStore reference, then trace which Pods mount the synced k8s Secret to know what's at risk.
+
+When something flaps — an auth method expires, a Vault path moves, a provider rate-limits — the only feedback channel is a CRD condition that nobody is reading until a workload errors out. There's no observatory surface, no alerting wired to anything operators actually watch, no creation UX that doesn't require hand-rolling a YAML manifest, no way to see at a glance which workloads break if a particular store goes down, and no audit history that survives a CRD reconcile.
+
+Two existing observatory phases give us the pattern: cert-manager (Phase 11A: CRD discovery, normalized types, RBAC, 30s cache; Phase 11B: per-provider creation wizards; Phase 13: per-resource annotation overrides) and service mesh (Phase 12: per-CRD-group RBAC, sync-state notifications, topology overlay). ESO observatory is the natural next member of that family — same pipeline, expanded entity set, and one new pattern (persistent sync history) that this feature establishes for future observatory work.
+
+---
+
+## Actors
+
+- A1. **Platform admin** — full-cluster visibility. Creates and maintains `ClusterSecretStore` resources for the org's source systems, configures default alert thresholds, audits credential rotations, runs bulk refresh actions during failover events.
+- A2. **Tenant operator** — per-namespace ESO operations. Creates `ExternalSecret` resources for their workloads, picks from the `SecretStore` / `ClusterSecretStore` resources made available by the platform admin, sees alerts for their own namespace's sync failures, drills the chain graph to understand workload impact.
+- A3. **ESO controller** — the system actor we observe. Performs source-system authentication and sync; produces `status.conditions`, `status.refreshTime`, `status.syncedResourceVersion`. We never replace its work or hold its credentials.
+
+---
+
+## Key Flows
+
+- F1. **Create an ExternalSecret via wizard**
+  - **Trigger:** Tenant operator clicks "New ExternalSecret" on the list page.
+  - **Actors:** A2.
+  - **Steps:** Pick a target namespace; pick a `SecretStore` or `ClusterSecretStore` from the visible (RBAC-filtered) list; pick which keys to sync (with type-ahead against the store's available paths when supported by the provider); set the target `Secret` name and refresh interval; preview the rendered manifest in Monaco; apply via server-side apply.
+  - **Outcome:** ExternalSecret is created; the first sync attempt is observable on the detail page on the next ESO reconcile (typically within the resource's refresh interval).
+  - **Covered by:** R12, R13, R14.
+
+- F2. **Investigate a sync failure**
+  - **Trigger:** Notification Center alert fires (`externalsecret.sync_failed`) and the operator clicks through.
+  - **Actors:** A2.
+  - **Steps:** Land on the ExternalSecret detail page; see the failure reason from `status.conditions`; review the persistent sync history timeline (last N attempts with outcomes); follow the linkout to the source system's UI for deeper audit; identify whether the failure is auth (store-side), data (key not found), or transient (timeout).
+  - **Outcome:** Operator has enough signal to decide between "fix the store config", "fix the ExternalSecret spec", or "wait for the next retry".
+  - **Covered by:** R6, R7, R20, R21.
+
+- F3. **Bulk refresh after a Vault failover**
+  - **Trigger:** Platform admin completes a Vault failover and wants to force-resync every ExternalSecret backed by the affected store.
+  - **Actors:** A1.
+  - **Steps:** Open the SecretStore (or ClusterSecretStore) detail page; click "Refresh all dependent ExternalSecrets"; confirm via the standard destructive-action dialog; observe the fan-out as each ExternalSecret in the result set transitions through `Refreshing` to `Synced` (or surfaces a fresh failure).
+  - **Outcome:** Every ExternalSecret backed by the store has been force-synced via the ESO `force-sync` annotation; the action is recorded in the audit log with the admin's identity.
+  - **Covered by:** R26, R27.
+
+- F4. **Drill the chain to find affected workloads**
+  - **Trigger:** A SecretStore goes unhealthy; operator wants to know which workloads break.
+  - **Actors:** A1, A2.
+  - **Steps:** Open the SecretStore detail page; switch to the "Chain" tab to see the topology graph; trace upstream to the auth Secret and downstream to ExternalSecrets → synced k8s Secrets → consuming workloads (Pods / Deployments / StatefulSets / DaemonSets); identify the blast radius.
+  - **Outcome:** Operator has a definitive list of workloads at risk and can prioritize remediation.
+  - **Covered by:** R9, R10, R11.
+
+---
+
+## Requirements
+
+**Observatory (read paths)**
+- R1. The backend lists every ESO entity in scope: `ExternalSecret`, `ClusterExternalSecret`, `SecretStore`, `ClusterSecretStore`, and `PushSecret` (read-only — see Scope Boundaries) — across all namespaces visible to the requesting user.
+- R2. CRD presence is auto-detected; if ESO is not installed, the `/security/external-secrets/*` routes render an "ESO not detected" empty state with installation guidance, never 5xx.
+- R3. List and detail responses are RBAC-filtered using the same `CanAccessGroupResource` permissive-read model as Phase 11A — k8s RBAC governs visibility; spec details (including auth method config) are visible to anyone with CRD-list permission. Note: auth-method spec references a k8s `Secret` for credentials; the credentials themselves stay behind that Secret's own RBAC and are never returned by these endpoints.
+- R4. Read paths use a singleflight + short cache (matching the Phase 11A 30s default) so a request fan-out doesn't multiply load on the API server.
+- R5. Each entity surfaces a normalized status enum (`Synced` / `SyncFailed` / `Refreshing` / `Stale`) plus the underlying ESO condition reason and message, last-successful-sync timestamp, and source-store reference.
+
+**Sync history (persistent timeline)**
+- R6. Per-`ExternalSecret` sync attempts are persisted in PostgreSQL with outcome (`success` / `failure` / `partial`), reason, message, timestamp, and the diff key-set (see R21). `partial` denotes a sync where some keys were retrieved successfully and others were rejected by the provider (e.g., partial path-permission denial). Retention default matches the existing audit log (90 days).
+- R7. The detail page renders the history as a reverse-chronological timeline. Each entry links to the source system's UI for the same time window when the provider supports a deep-link shape (Vault path URL, AWS console, Azure portal, GCP console, 1Password item).
+- R8. The timeline survives an ExternalSecret renaming or namespace move via UID-stable storage; restoring a deleted ExternalSecret does not resurrect old history (UID changes).
+
+**Chain visualization (topology)**
+- R9. A `Chain` view (per ExternalSecret, per SecretStore, and as a standalone page) renders the secret chain as a graph: auth `Secret` → `SecretStore` / `ClusterSecretStore` → `ExternalSecret` → synced `Secret` → consuming workloads (Pods / Deployments / StatefulSets / DaemonSets / Jobs / CronJobs).
+- R10. The chain reuses the Phase 7B topology layout / SVG renderer; new edge types extend the existing `EdgeType` enum without changing default-response semantics for callers who don't request the chain. When a chain would exceed the Phase 7B 2000-node cap (e.g., a widely-shared `ClusterSecretStore`), the response truncates and surfaces a `truncated: true` flag with the omitted-node count so the UI can render a "showing N of M" notice rather than a silently-clipped graph.
+- R11. Chain rendering is RBAC-aware — nodes the user can't see are omitted; edges that would cross an invisible node are dropped silently rather than rendered as orphans.
+
+**Wizards**
+- R12. A universal `ExternalSecret` wizard creates new ExternalSecrets against any visible SecretStore / ClusterSecretStore — provider-agnostic. The wizard supports cert-manager-style preview-then-apply with Monaco YAML preview.
+- R13. Per-provider `SecretStore` and `ClusterSecretStore` wizards exist for the top + medium tier (12 providers): HashiCorp Vault (token / kubernetes / approle / jwt / cert auth methods), AWS Secrets Manager, AWS Parameter Store, Azure Key Vault (managed identity / service principal), GCP Secret Manager (workload identity / service account key), Akeyless, Doppler, 1Password Connect, Bitwarden Secrets Manager, CyberArk Conjur, Kubernetes provider (cross-namespace secret syncing within the cluster, distinct from the k8s API itself), Infisical.
+- R14. Niche providers (Pulumi ESC, Passbolt, Keeper, Onboardbase, Oracle Cloud Vault, Alibaba KMS, custom webhook) are creatable via the existing YAML editor with provider-templates seeded for convenience; no per-provider wizard.
+
+**Alerting**
+- R15. Notification Center events fire by default for failure transitions: `externalsecret.sync_failed`, `externalsecret.stale` (sync older than threshold), `secretstore.unhealthy`, `clustersecretstore.unhealthy`.
+- R16. Recovery transitions also fire by default: `externalsecret.recovered`, `secretstore.recovered`, `clustersecretstore.recovered` (separate dedupe keys from the failure events so recovery alerts aren't suppressed by a recently-cleared failure).
+- R17. Per-resource annotation overrides on `ExternalSecret`, `SecretStore`, and `ClusterSecretStore` adjust the defaults: `kubecenter.io/eso-stale-after-minutes` (default: 2× refresh interval; falls back to 2h when refresh interval is unset, matching the ESO controller default), `kubecenter.io/eso-alert-on-recovery` (default: true). Resolution chain matches Phase 13 (resource > store > clusterstore > package default).
+- R18. Lifecycle events (`created`, `deleted`, `first_synced`) are OFF by default but can be opted in per resource via `kubecenter.io/eso-alert-on-lifecycle`.
+- R19. Invalid annotation values log and silently fall through to the next resolution layer (no `thresholdConflict` flag — that condition is reserved for resolved warn-vs-crit ordering conflicts where warn ≥ crit, matching Phase 13 parity).
+
+**Drift detection + sync diff (key-level)**
+- R20. The detail page surfaces a tri-state drift status: `Drifted` when the synced k8s Secret's `resourceVersion` differs from `status.syncedResourceVersion` (the Secret was edited out-of-band since the last sync), `InSync` when they match, and `Unknown` when `status.syncedResourceVersion` is empty (the provider implementation does not populate it; drift cannot be determined). `Drifted` surfaces in the dashboard drift tile with a note that the next successful sync will overwrite the local edit; `Unknown` surfaces with a note that the provider does not expose drift state.
+- R21. Each persisted history entry carries a key-level diff: which keys were `added`, `removed`, or `changed` between the previous synced data and this sync's data. Values are never stored or surfaced — only key names.
+
+**Bulk refresh actions**
+- R22. The SecretStore / ClusterSecretStore detail page exposes "Refresh all dependent ExternalSecrets" — fans out the ESO `force-sync` annotation to every ExternalSecret backed by the store. Result set is RBAC-filtered to the requesting user's visible ExternalSecrets, and the confirmation dialog renders the resolved target list (count + namespaces) before execution so the user sees exactly what scope they're acting on. The fan-out reports per-resource outcome as `{succeeded, failed, skipped}` with the failure reason for each (RBAC-rejected at apply time, optimistic-lock conflict, transient API error, etc.); the audit log captures both the request scope and the post-fan-out outcome — not just the action trigger.
+- R23. The namespace overview page exposes "Refresh all ExternalSecrets in this namespace" with the same fan-out behavior.
+- R24. Bulk actions go through the impersonating client; the action and the result set are written to the existing audit log with the requesting user identity.
+
+**Per-store rate / quota awareness**
+- R25. Per-store access counts are tracked from ESO's Prometheus metrics (`externalsecret_sync_calls_total`, `externalsecret_sync_calls_error`, and the per-provider request metrics ESO publishes) via the existing Prometheus proxy — rate-counter only, no source-system API calls. Surfaces on the SecretStore detail and the dashboard. When Prometheus is unavailable, the panel degrades to "rate metrics offline" rather than fabricating zero-counts.
+- R26. For paid-tier providers (AWS Secrets Manager, AWS Parameter Store, GCP Secret Manager, Azure Key Vault), a cost-tier estimate is computed from static rate cards baked into the codebase (refreshed periodically). Displayed as "estimated $X.XX in the last 24h" with caveats. For self-hosted / flat-rate providers (Vault, Kubernetes provider), the estimate is omitted and only request-rate is shown.
+
+**Dashboard**
+- R27. A dashboard page at `/security/external-secrets` aggregates: total ExternalSecrets cluster-wide with health histogram (Synced / Refreshing / SyncFailed / Stale / Drifted), SecretStore inventory by provider type (donut), recent sync failures (last 24h table), top failure-reason groupings, and per-store cost-tier estimate cards.
+- R28. The dashboard is RBAC-filtered using the same model as the list pages — non-admins see counts scoped to namespaces they can read.
+
+**Helm + docs**
+- R29. The Helm `ClusterRole` gains explicit `list` / `watch` grants for `external-secrets.io/v1` CRDs (the 5 entities in R1), matching the Phase 11A / Phase 12 pattern. No new write verbs; bulk actions use the impersonating user client.
+- R30. CLAUDE.md gains a Phase entry covering the integration; README.md "Security & Governance" features list mentions the ESO observatory; roadmap item #8 is checked off.
+
+**Persistence migration**
+- R31. A `golang-migrate` step adds `external_secrets` to the Notification Center event-source enum and creates the `eso_sync_history` table (`uid`, `namespace`, `name`, `attempt_at`, `outcome`, `reason`, `message`, `diff_keys_added`, `diff_keys_removed`, `diff_keys_changed`) with the appropriate indexes for the timeline-by-uid and the recent-failures-cluster-wide queries.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R5, R15.** Given an ExternalSecret in `apps` namespace currently `Synced`, when the source store starts returning `permission denied` and ESO records `status.conditions[Ready] = False`, the next observatory poll flips the normalized status to `SyncFailed` and emits a single `externalsecret.sync_failed` event to Notification Center with the reason from the condition. Dedupe is keyed by `(uid, kind="externalsecret.sync_failed")`; a subsequent reason change while still failing does not re-fire.
+- AE2. **Covers R16.** Given an ExternalSecret currently `SyncFailed` with a notification already dispatched, when the next reconcile produces `Ready = True`, the observatory emits a single `externalsecret.recovered` event using a separate dedupe key — not suppressed by the prior failure dedupe entry.
+- AE3. **Covers R17, R19.** Given an ExternalSecret with annotation `kubecenter.io/eso-stale-after-minutes: "5"` and the referenced SecretStore with annotation `kubecenter.io/eso-stale-after-minutes: "60"`, when the ExternalSecret hasn't synced for 6 minutes, the stale event fires (resource-level annotation wins). Given the resource sets `kubecenter.io/eso-alert-on-recovery: "potato"`, the parser rejects it and the resource silently falls through to the store-level value; the detail response carries no `thresholdConflict` flag because that flag is reserved for resolved warn-vs-crit ordering conflicts (warn ≥ crit), not for invalid-value rejection.
+- AE4. **Covers R20.** Given an ExternalSecret has synced and produced a k8s Secret at resourceVersion `12345`, when an operator runs `kubectl edit secret` and bumps it to `12346`, the next observatory poll sees `syncedResourceVersion=12345` ≠ live `resourceVersion=12346` and flags the ExternalSecret as `Drifted` on the detail page. The next successful sync clears the flag.
+- AE5. **Covers R22, R24.** Given a SecretStore with 47 dependent ExternalSecrets across 6 namespaces and a tenant operator who can list ExternalSecrets in only 2 of those namespaces, when the operator triggers "Refresh all dependent ExternalSecrets" on the store detail page, the fan-out targets only the ExternalSecrets in the 2 namespaces the operator can see; the audit log records the action with that scoped result set.
+
+---
+
+## Success Criteria
+
+- An operator can open `/security/external-secrets` and answer "is anything broken right now and which workloads are affected?" in under 30 seconds without dropping to `kubectl`.
+- An operator can create a working ExternalSecret pointing at a Vault / AWS / Azure / GCP store via wizard without writing YAML by hand.
+- A `secretstore.unhealthy` notification reaches the operator's chosen channel (in-app, Slack, email, webhook per Notification Center config) within one polling cycle of the underlying Ready transition.
+- After a Vault failover, the platform admin can force-resync every dependent ExternalSecret via one click, with the action audit-logged.
+- The chain graph correctly renders the auth Secret → store → ExternalSecret → synced Secret → consuming workloads relationship for at least the four most common shapes (Vault token auth + Pod env mount; AWS IAM auth + Deployment env mount; GCP workload identity + StatefulSet volume mount; ClusterSecretStore + cross-namespace consumer).
+- An operator can see per-store request rate on the SecretStore detail and the dashboard, plus a cost-tier estimate where the underlying store is paid-tier (AWS Secrets Manager, AWS Parameter Store, Azure Key Vault, GCP Secret Manager). The estimate degrades cleanly to "rate metrics offline" when Prometheus is unavailable.
+- Per-provider creation wizards exist for the top + medium tier (12 stores covering the ~95% real-world install base). Niche providers (Pulumi ESC, Passbolt, Keeper, Onboardbase, Oracle Cloud Vault, Alibaba KMS, custom webhook) are creatable via the YAML editor with provider-templates seeded.
+- Downstream `ce-plan` can break this requirements doc into implementation phases without inventing product behavior, scope boundaries, or success criteria.
+
+---
+
+## Scope Boundaries
+
+- We do NOT authenticate to source stores (Vault, AWS, GCP, Azure) on the user's behalf — only the ESO controller does. The integration consumes ESO's status; it never holds source-store credentials.
+- We do NOT install, upgrade, or manage the ESO controller itself. Out of scope for this feature; would be a separate "operator lifecycle management" initiative.
+- We do NOT provide a cross-cluster aggregated "fleet view" of ESO state. The existing X-Cluster-ID routing applies (the integration works correctly per cluster), but a "all clusters at once" dashboard is a separate feature.
+- We do NOT ship dedicated wizards for the niche provider tail (Pulumi ESC, Passbolt, Keeper, Onboardbase, Oracle Cloud Vault, Alibaba KMS, custom webhook). YAML editor only.
+- We do NOT integrate with source-system billing APIs for live cost data. Cost-tier estimates use static rate cards refreshed periodically.
+- We do NOT proxy or re-render source-system audit logs. Linkout only.
+- We do NOT include a `PushSecret` write/edit wizard in v1 — read-only observability is sufficient. PushSecret is uncommon in production and the wizard work doesn't earn its keep until usage signals demand.
+
+---
+
+## Key Decisions
+
+- **Permissive-read multi-tenancy (cert-manager parity).** The simplest contract; mirrors Phase 11A. Operators with a stricter tenant story can layer Kubernetes RBAC; we don't need a second redaction model.
+- **Persistent sync-history in PostgreSQL.** ESO's CRD status carries only the last-attempt outcome. A persisted timeline is the only way to surface flapping patterns and key-level diffs across syncs without re-fetching the source. Follows the existing Phase 8B daily compliance-snapshot precedent and the audit log's UID-stable-history precedent — no new persistence pattern.
+- **Linkout, not embed, for source-system context.** Authenticating to Vault / AWS / GCP / Azure on the user's behalf would replicate ESO's job badly. Deep-linking to the source UI gives operators full audit power with zero new auth surface.
+- **Top + medium tier wizards (12 providers).** Covers the ~95% real-world install base without exploding into per-provider work for niche stores. Niche providers ship via YAML editor with templates.
+- **Failure + recovery alerts with per-resource overrides (Phase 13 parity).** Recovery alerts confirm fixes worked without polling. Per-resource annotations let operators mute noise on chatty integrations or tighten thresholds on critical secrets. Single canonical resolution chain matches Phase 13's pattern.
+- **Topology-style chain visualization, not a separate UI primitive.** Reuses Phase 7B's topology builder + renderer; new edge types extend the existing enum. No parallel graph-rendering library introduced.
+- **No PushSecret wizard in v1.** PushSecret reverses ESO's flow (k8s Secret → external store). Uncommon enough to defer; observability is sufficient.
+
+---
+
+## Dependencies / Assumptions
+
+- ESO is installed as a CRD-providing controller in the target cluster; its `external-secrets.io/v1` CRDs are the source of truth (v1 went GA in ESO v0.14, mid-2025). `v1beta1` remains served for compatibility but is no longer the storage version; older clusters running only v1alpha1 are out of scope (could be added later).
+- The Notification Center (roadmap item #1, shipped) accepts new event source `external_secrets` and rule-routing for the new event kinds.
+- The audit logger (existing) accepts the bulk-refresh action and result-set shape.
+- The PostgreSQL migration framework (`golang-migrate`, existing) accepts the new `eso_sync_history` table without conflict.
+- The Phase 7B topology builder accepts new `EdgeType` constants without breaking existing consumers (Phase D mesh overlay set the precedent).
+- The frontend Monaco editor is available for the wizard preview step (existing).
+- The frontend toast / dialog / wizard-stepper components exist and are theme-token-only (existing).
+- Helm chart can grow read-only ClusterRole entries for ESO CRDs without disrupting the existing wildcard or per-feature grants (Phase 12 set the precedent).
+
+---
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+- [Affects R12, R13][Product/UX] Path-discovery contract for the wizard type-ahead step. The 12-provider wizard surface needs a single product contract — does the wizard offer type-ahead only when the provider supports listing (Vault `LIST`, AWS `ListSecrets`, GCP `projects.secrets.list`, etc.), or always offer it and degrade silently? Recommended pre-decision: type-ahead opt-in per provider, free-text fallback whenever a provider can't list, with a small inline "this provider doesn't expose path discovery — enter the path manually" hint. Resolve before planning so wizard work doesn't fork halfway through.
+
+### Deferred to Planning
+
+- [Affects R6, R7][Technical] Storage shape for the persisted sync-history table — schema columns, partitioning, retention enforcement (TTL job vs cron). Audit-log retention pattern is the closest precedent. R31 sets the column outline; planning resolves indexes, partitioning, and retention enforcement.
+- [Affects R9, R10][Technical] How exactly the chain graph composes with the existing Phase 7B topology — single shared graph builder with a new `?include=eso-chain` overlay, or a parallel builder under `internal/externalsecrets/topology.go`. Both have precedent (Phase D mesh overlay vs separate builder).
+- [Affects R26][Needs research] Reasonable rate-card data shape and refresh cadence for the cost-tier estimate. AWS / GCP / Azure publish JSON pricing APIs; embedding a snapshot vs. fetching at runtime is a maintenance trade-off.
+- [Affects R20][Technical] Per-provider coverage of `status.syncedResourceVersion`. R20's `Unknown` state absorbs the gap; planning enumerates which providers populate it so the dashboard's drift tile can show "tracked / not-tracked-by-provider" honestly.
+- [Affects R22][Technical] Bulk refresh implementation: whether to fan out the `force-sync` annotation patch directly or use ESO's `Refresh()` SDK if/when available. Patch is provider-agnostic.
+
+### FYI / Planning-stage details
+
+- Frontend route + SubNav layout (`/security/external-secrets/{index,external-secrets,stores,cluster-stores,push-secrets,chain}`), empty states for each list view, wizard interaction-state matrix, and the notification-routing table for the new event kinds — design-lens flagged. Planning owns the artifacts; brainstorm doesn't need to lock them.
+- Multi-cluster (X-Cluster-ID) routing applies automatically via the existing ClusterRouter pattern; no per-cluster work surfaces in this requirements doc.
+- The "permissive-read" decision (KD-1) inherits the same caveat as Phase 11A: if a tenant operator can list a `ClusterSecretStore`, they can read its `spec.provider.*` config (which references an auth Secret but never the credentials). Stricter tenancy is layered via Kubernetes RBAC.

--- a/helm/kubecenter/templates/clusterrole.yaml
+++ b/helm/kubecenter/templates/clusterrole.yaml
@@ -150,6 +150,31 @@ rules:
       - authorizationpolicies
       - meshtlsauthentications
     verbs: ["list", "watch"]
+  # External Secrets Operator (ESO) CRDs — explicit list/watch grants for
+  # the discoverer + 30s cache layer in `internal/externalsecrets`. Detail
+  # reads use the impersonated client (which the API server RBACs against
+  # the requesting user), so no `get` grant is needed here. Write actions
+  # (force-sync, bulk refresh — Phase E) impersonate as well.
+  - apiGroups: ["external-secrets.io"]
+    resources:
+      - externalsecrets
+      - clusterexternalsecrets
+      - secretstores
+      - clustersecretstores
+      - pushsecrets
+    verbs: ["list", "watch"]
+  # core/secrets get/list — required by the Phase C ESO sync-history poller
+  # to compute key-level diff between successive sync attempts. The poller
+  # has no requesting-user context (it runs as the platform SA), so it must
+  # read synced Secret keys via the SA. This expands the SA's cluster-wide
+  # privilege to read every Secret's key-set (values are NEVER stored or
+  # logged — only key names appear in the diff). Operators in stricter
+  # environments can remove this rule; the diff feature degrades to
+  # "outcome only, no key-set" but the timeline + drift detection +
+  # alerting all continue to work.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
   # CRD discovery — list/watch CustomResourceDefinitions for Extensions Hub
   - apiGroups: ["apiextensions.k8s.io"]
     resources:

--- a/helm/kubecenter/templates/clusterrole.yaml
+++ b/helm/kubecenter/templates/clusterrole.yaml
@@ -163,18 +163,16 @@ rules:
       - clustersecretstores
       - pushsecrets
     verbs: ["list", "watch"]
-  # core/secrets get/list — required by the Phase C ESO sync-history poller
-  # to compute key-level diff between successive sync attempts. The poller
-  # has no requesting-user context (it runs as the platform SA), so it must
-  # read synced Secret keys via the SA. This expands the SA's cluster-wide
-  # privilege to read every Secret's key-set (values are NEVER stored or
-  # logged — only key names appear in the diff). Operators in stricter
-  # environments can remove this rule; the diff feature degrades to
-  # "outcome only, no key-set" but the timeline + drift detection +
-  # alerting all continue to work.
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list"]
+  # NOTE: cluster-wide get/list on core/secrets is intentionally NOT granted
+  # to the platform service account in Phase A. The Phase C ESO sync-history
+  # poller (Unit 10) needs it to compute key-level diff between successive
+  # sync attempts and will add the grant in that PR. Phase A's drift
+  # resolution path uses an impersonated client (see resolveDriftStatus in
+  # internal/externalsecrets/handler.go), so it doesn't depend on this grant.
+  # Keeping the grant out of Phase A holds the architectural-boundary
+  # comment at line 20 ("secrets are fetched on-demand via impersonated
+  # client, not cached in informer") intact until Phase C's consumer code
+  # actually requires it.
   # CRD discovery — list/watch CustomResourceDefinitions for Extensions Hub
   - apiGroups: ["apiextensions.k8s.io"]
     resources:

--- a/plans/external-secrets-operator-integration.md
+++ b/plans/external-secrets-operator-integration.md
@@ -1,0 +1,1166 @@
+---
+title: "External Secrets Operator integration (#8)"
+type: feat
+status: active
+date: 2026-04-29
+origin: docs/brainstorms/2026-04-29-external-secrets-operator-requirements.md
+---
+
+# External Secrets Operator integration (#8)
+
+## Overview
+
+Feature-complete ESO integration under `/security/external-secrets/*`: observatory + per-provider wizards + chain topology graph + Notification Center alerting + four operational lenses (drift detection, sync diff history, bulk refresh, per-store rate / quota awareness). Phased delivery so each phase ships against a working baseline; no phase introduces a half-broken UX.
+
+The integration mirrors and extends four existing pipelines: Phase 11A (cert-manager observatory: CRD discovery + RBAC + 30s cache), Phase 11B (cert-manager wizards: WizardInput interface + Monaco preview), Phase 13 (annotation-resolution chain: cert > issuer > clusterissuer > default), and Phase 12 (topology overlay: `?overlay=mesh` extension pattern).
+
+## Requirements Trace
+
+R-IDs reference [docs/brainstorms/2026-04-29-external-secrets-operator-requirements.md](../docs/brainstorms/2026-04-29-external-secrets-operator-requirements.md).
+
+| Requirement | Owning phase | Owning unit(s) |
+|---|---|---|
+| R1, R2, R3, R4, R5 (observatory) | A | 1, 2, 3 |
+| R6, R8, R21 (history) | C | 9, 10 |
+| R20 (drift, tri-state) | C | 11 |
+| R9, R10, R11 (chain topology) | I | 21, 22 |
+| R12 (universal ExternalSecret wizard) | G | 17 |
+| R13 (per-provider Store wizards × 12) | H | 18, 19, 20 |
+| R14 (niche-provider YAML templates) | H | 20 |
+| R15, R16 (failure + recovery alerts) | D | 13 |
+| R17, R18, R19 (annotation chain) | D | 12 |
+| R22, R23, R24 (bulk refresh) | E | 14, 15 |
+| R25, R26 (per-store rate / cost) | F | 16 |
+| R27, R28 (dashboard) | B | 7, 8 |
+| R29 (Helm RBAC) | A | 6 |
+| R30 (docs flip) | J | 23 |
+| R31 (golang-migrate) | D, C, E | 12 (000010 source enum), 9 (000011 history), 15 (000012 bulk-refresh jobs) |
+
+## Resolved Before Planning
+
+- **Wizard path-discovery scope: Kubernetes provider only in v1.** Cross-provider path-discovery (Vault `LIST` on KV, AWS `ListSecrets`, GCP / Azure / 1Password listing) requires k8sCenter to authenticate against the source store, which contradicts the "k8sCenter never holds source-store credentials" scope boundary and creates an SSRF surface on the user-supplied `prefix=` parameter. v1 ships path-discovery only for the Kubernetes provider (genuinely k8s-RBAC-mediated — listing Secrets in the source namespace). All other 11 providers in R13 ship with a free-text path field with an inline hint ("this provider doesn't expose path discovery — enter the path manually"). Cross-provider path-discovery is deferred to a v2 with an explicit per-provider auth-model design.
+- **Poller diff-key computation requires Helm `get/list secrets` grant.** R21 requires the persistent history to carry a key-level diff. The poller has no requesting-user context, so it must read synced Secret keys via the platform service account. Phase J's Helm chart adds `get/list` on `core/secrets` cluster-wide. This is a meaningful expansion of the platform SA's privilege; documented explicitly. Operators in stricter environments can remove the grant — the diff feature degrades to "outcome only, no key-set" but the timeline still functions.
+- **ClusterSecretStore visibility uses permissive-read (matches requirements R3).** Cluster-scoped resources are RBAC-filtered via `CanAccessGroupResource` exactly like namespaced resources — a tenant operator with explicit `list clustersecretstores` grant can see them. No additional `auth.IsAdmin` gate. Operators wanting stricter tenancy layer it via Kubernetes RBAC.
+- **PushSecret v1 scope.** Read-only observatory only. Listed in R1 with read-only tag; no wizard, no actions. Matches scope-boundary line in the requirements doc. Note: PushSecret spec is intentionally surfaced (selector + remoteRef paths visible to anyone with `list pushsecrets`); cluster admin controls who has that grant.
+- **`thresholdConflict` semantics.** Reserved for warn-vs-crit ordering conflicts only (Phase 13 parity). ESO's stale/recovery annotations don't have an ordering relationship; invalid values silently fall through with no flag (R19).
+- **`eso-stale-after-minutes` minimum floor: 5 minutes.** Annotation values below 5 are rejected (logged + fall through to next layer) to prevent self-DoS via aggressive stale thresholds against the 60s poller cadence.
+
+## Scope Boundaries
+
+- **No source-store credential handling.** ESO holds the source-store creds; we never authenticate against Vault / AWS / GCP / Azure on the user's behalf. Linkout to source UI is the only cross-system surface.
+- **No ESO controller lifecycle management.** Install/upgrade/restart of ESO itself is out of scope; would be a separate "operator lifecycle" initiative.
+- **No cross-cluster fleet view.** X-Cluster-ID per-cluster routing applies (the integration works correctly per cluster); a "all clusters at once" dashboard is a separate feature.
+- **No PushSecret write/edit wizard in v1.** Read-only observatory is sufficient; PushSecret write surface deferred until usage signals demand.
+- **No source-system audit log proxying.** Linkout only.
+- **No live billing API integration.** Cost-tier estimates use static rate cards refreshed periodically; not connected to AWS/GCP/Azure billing APIs.
+- **No `v1alpha1` ESO support.** v1 is GA in ESO v0.14+ (mid-2025); v1beta1 served-but-not-stored handled transparently by dynamic client. v1alpha1-only clusters are out of scope.
+
+## Phases
+
+| # | Phase | Units | Depends on |
+|---|---|---|---|
+| A | Backend observatory + Helm RBAC | 1–4, 6 | — |
+| B | Frontend observatory | 7–8 | A |
+| D | Alerting + annotation thresholds | 12–13 | A |
+| C | Persistence: history table + drift detection | 9–11 | A, D |
+| E | Bulk refresh actions | 14–15 | A |
+| F | Per-store rate + cost-tier panel | 16 | A, B |
+| G | Universal ExternalSecret wizard | 17 | A |
+| H | Per-provider SecretStore wizards | 18–20 | G |
+| I | Chain visualization (topology overlay) | 21–22 | A, B |
+| J | Final docs + roadmap flip | 23 | A–I |
+
+Phase ordering is **A → B → D → C → E → F → G → H → I → J**. Alerting (D) ships before persistent history (C) because notification dispatch reads from in-memory poller state, not the history table — operators get paging value sooner. Phase C then adds the timeline UI and drift detection on top.
+
+Phase A delivers the foundation; Phase B is the first user-facing slice. The integration's value lands cumulatively across Phases A–F. Each phase ships its own PR.
+
+**Unit 5 deleted.** Static metric-name constants live in `cost_tier.go` (Phase F) — no separate config endpoint needed.
+
+---
+
+## Phase A — Backend observatory + Helm RBAC
+
+Mirrors Phase 11A 1:1. Creates the `internal/externalsecrets/` package, five normalized CRD types, the singleflight + 30s cache handler, RBAC filtering via `CanAccessGroupResource`, and the explicit ClusterRole grant. Status / list / detail endpoints land in this phase.
+
+### Unit 1: Package skeleton — discovery + types + normalize
+
+**Goal:** Stand up `internal/externalsecrets/` with CRD discovery (mirrors `certmanager/discovery.go`), normalized type definitions for the 5 CRDs, and pure normalize functions.
+
+**Requirements:** R1, R2 (CRD discovery + auto-detect)
+
+**Dependencies:** None.
+
+**Files:**
+- Create: `backend/internal/externalsecrets/discovery.go` — `Discoverer.Probe()` against `external-secrets.io/v1`, `IsAvailable()` gate, 5-min status cache.
+- Create: `backend/internal/externalsecrets/types.go` — GVR constants, `Status` enum (`Synced` / `SyncFailed` / `Refreshing` / `Stale` / `Drifted` / `Unknown`), normalized types (`ExternalSecret`, `ClusterExternalSecret`, `SecretStore`, `ClusterSecretStore`, `PushSecret`), annotation key constants, `DriftStatus` tri-state enum (`InSync` / `Drifted` / `Unknown`), `ThresholdSource` enum + `Valid()` belt-and-suspenders guard.
+- Create: `backend/internal/externalsecrets/normalize.go` — pure `normalize<Kind>(*unstructured.Unstructured)` functions. `DeriveStatus(es ExternalSecret, drift DriftStatus) Status` extracted from normalize so it can re-run after drift resolution.
+- Create: `backend/internal/externalsecrets/normalize_test.go` — table-driven coverage for each kind: happy path, missing fields, unknown condition reasons, stale-vs-fresh detection, drift state propagation.
+
+**Approach:**
+- GVRs: `external-secrets.io/v1` for `externalsecrets`, `clusterexternalsecrets`, `secretstores`, `clustersecretstores`, `pushsecrets`. Group constant `GroupName = "external-secrets.io"` exported for RBAC + Helm.
+- `ExternalSecret` carries `Namespace`, `Name`, `UID`, `RefreshInterval` (parsed `time.Duration`), `LastSyncTime`, `SyncedResourceVersion` (string, may be empty), `StoreRef` (`Name` + `Kind`: `SecretStore` | `ClusterSecretStore`), `TargetSecretName`, condition fields (`ReadyReason`, `ReadyMessage`), and `Status` (Status), `DriftStatus` (DriftStatus). Annotation-resolved fields (`StaleAfterMinutes int`, `AlertOnRecovery *bool`, `AlertOnLifecycle *bool`) populated by Phase D resolver — initialized to zero-values here. Per-key source attribution applies only to `StaleAfterMinutesSource` and `AlertOnRecoverySource` (integers / debugging-relevant booleans); `AlertOnLifecycle` is a simple boolean opt-in with no source attribution since the UI only needs "lifecycle alerts on/off" not "from which layer."
+- `SecretStore` / `ClusterSecretStore` carry the same shape minus consumer-specific fields, plus `Provider` (string type — `"vault"`, `"aws"`, `"gcp"`, etc.) and `ProviderSpec` (`map[string]any` — never typed-imported, per L7.1).
+- `Status` derivation:
+  - `SyncFailed` when `Ready=False` (any reason).
+  - `Refreshing` when `Ready=Unknown` (controller mid-reconcile).
+  - `Stale` when last sync older than `StaleAfterMinutes` (resolved threshold; default 2× `RefreshInterval`, fallback 2h per R17).
+  - `Drifted` when `DriftStatus == Drifted` AND base status is `Synced` (drift never overrides failure).
+  - `Synced` otherwise.
+  - `Unknown` only when status conditions are entirely absent (very young resource).
+- `DriftStatus`: `Unknown` when `SyncedResourceVersion` is empty (provider doesn't populate it); `InSync` when `SyncedResourceVersion == liveResourceVersion`; `Drifted` otherwise. The `liveResourceVersion` lookup is a separate read (Phase A handler resolves it for detail; list view reports `Unknown` to avoid N+1 lookups — explicit decision documented in Unit 3).
+
+**Patterns to follow:**
+- `backend/internal/certmanager/discovery.go` — 5-minute cache, lazy probe.
+- `backend/internal/certmanager/types.go` — annotation key consts, `ThresholdSource` + `Valid()` (PR #207, L3.5).
+- `backend/internal/certmanager/normalize.go` — pure unstructured → typed.
+
+**Test scenarios:**
+- *Happy*: `ExternalSecret` with `Ready=True`, fresh `lastRefreshTime` → `Status == Synced`.
+- *Failure*: `Ready=False`, reason `"AuthFailed"` → `Status == SyncFailed`.
+- *Refreshing*: `Ready=Unknown` → `Status == Refreshing`.
+- *Stale*: `Ready=True` but `lastRefreshTime` older than 2× refresh interval (with no annotation) → `Status == Stale`.
+- *Drift unknown*: `SyncedResourceVersion == ""` → `DriftStatus == Unknown`, base status preserved.
+- *Drift in-sync*: `SyncedResourceVersion == "12345"`, live RV `"12345"` → `DriftStatus == InSync`.
+- *Drift detected*: `SyncedResourceVersion == "12345"`, live RV `"12346"`, base `Ready=True` → `Status == Drifted`.
+- *Drift never overrides failure*: drift detected but `Ready=False` → `Status == SyncFailed` (failure wins).
+- *Discovery missing CRDs*: `Probe()` against cluster without ESO CRDs → `IsAvailable() == false`, no error.
+
+**Verification:** `go test ./internal/externalsecrets/...` passes.
+
+---
+
+### Unit 2: Handler — singleflight + 30s cache + RBAC + list/status endpoints
+
+**Goal:** The canonical handler shape — concurrent CRD lists via `errgroup`, singleflight collapsing concurrent fetches, 30s cached response, per-namespace RBAC filtering. List + status endpoints expose the cached snapshot.
+
+**Requirements:** R3 (RBAC), R4 (singleflight + cache), R5 (normalized status surfaces)
+
+**Dependencies:** Unit 1.
+
+**Files:**
+- Create: `backend/internal/externalsecrets/handler.go` — `Handler` struct + `HandleStatus`, `HandleListExternalSecrets`, `HandleListClusterExternalSecrets`, `HandleListStores`, `HandleListClusterStores`, `HandleListPushSecrets`. Internal `fetchAll(ctx)` with five `g.Go` blocks. `getCached()` → `singleflight.Group.Do("all", fetchAll)`.
+- Create: `backend/internal/externalsecrets/handler_test.go` — table-driven RBAC and cache hit/miss tests.
+
+**Approach:**
+- Cache TTL = 30s, matching Phase 11A. `cacheTTL = 30 * time.Second`. Generation counter for `InvalidateCache` (write actions in Phase E call this).
+- Service-account fetch (cluster-wide), per-user RBAC filter at read time. Mirrors Phase 11A. Per-CRD-group RBAC: `CanAccessGroupResource(ctx, user, groups, "list", "external-secrets.io", "<resource>", namespace)`.
+- Cluster-scoped resources (`ClusterExternalSecret`, `ClusterSecretStore`) filtered via `CanAccessGroupResource` with empty namespace — permissive-read (matches requirements R3). A tenant operator with explicit `list clustersecretstores` grant sees them; users without the grant get an empty list silently. No `auth.IsAdmin` gate. Namespaced items use `filterByRBAC[T]` generic helper copied verbatim from `internal/certmanager/handler.go`.
+- 5 concurrent CRD lists: `dynClient.Resource(GVR).Namespace("").List(ctx, metav1.ListOptions{})` — five `g.Go` blocks under `errgroup.WithContext` with 10s timeout. Empty CRD (not installed) returns empty slice, never errors.
+- `HandleStatus` endpoint: returns `{detected: bool, namespace: string, version: string, lastChecked: time}` from the discoverer cache; cheap, no fetch trigger.
+- Empty-state pattern (L1.1): when `!Discoverer.IsAvailable()`, all list handlers return `[]` with HTTP 200, never 5xx.
+- RBAC fail-closed (L2.1): `auth.IsAdmin` gate on cluster-wide queries when namespace == "".
+
+**Patterns to follow:**
+- `backend/internal/certmanager/handler.go:147–162` — `filterByRBAC[T namespacedResource]` generic.
+- `backend/internal/certmanager/handler.go:107–118` — `canAccess()` thin wrapper around `CanAccessGroupResource`.
+- `backend/internal/certmanager/handler.go:183–262` — `fetchAll` with `errgroup`.
+
+**Test scenarios:**
+- *Happy list*: user with `list externalsecrets` in `apps` ns → response includes `apps`-ns ExternalSecrets only.
+- *Permissive read with grant*: user with explicit `list clustersecretstore` grant → sees ClusterSecretStore list.
+- *Permissive read denied*: user without `list clustersecretstore` grant → empty ClusterSecretStore list, HTTP 200, not 403.
+- *ESO not installed integration test*: fake k8s client with zero ESO CRDs registered → all 11 endpoints return 200 with `[]` / `{detected: false}`; verifies the full handler path through `errgroup`'s 5 g.Go blocks, not just the discoverer flag.
+- *Cache hit*: two concurrent `HandleListExternalSecrets` requests → `fetchAll` invoked exactly once (singleflight).
+- *Cache TTL*: third request after 31s → `fetchAll` re-invoked.
+- *CRDs missing*: `IsAvailable() == false` → list endpoints return `[]`, status endpoint returns `{detected: false}`.
+- *Per-CRD failure isolated*: ExternalSecret list errors but SecretStore list succeeds → response includes SecretStores; ExternalSecrets returns empty with logged error (g.Go doesn't fail-fast in our wrapper).
+
+**Verification:** `go test ./internal/externalsecrets/...` passes; race detector clean (`go test -race`).
+
+---
+
+### Unit 3: Detail endpoints + drift resolution
+
+**Goal:** Per-resource detail endpoints. Detail endpoint resolves `liveResourceVersion` for the synced k8s Secret to populate `DriftStatus`. Use impersonating client for detail (per L1.3 — Phase B mistake).
+
+**Requirements:** R3, R5, R20
+
+**Dependencies:** Units 1, 2.
+
+**Files:**
+- Modify: `backend/internal/externalsecrets/handler.go` — add `HandleGetExternalSecret`, `HandleGetClusterExternalSecret`, `HandleGetStore`, `HandleGetClusterStore`, `HandleGetPushSecret`.
+- Modify: `backend/internal/externalsecrets/handler_test.go` — detail-endpoint cases.
+
+**Approach:**
+- Use `K8sClient.DynamicClientForUser(user.KubernetesUsername, user.KubernetesGroups)` — RBAC enforced by k8s API itself, not our checker. Phase 11A pattern.
+- Detail endpoint additionally fetches the synced `Secret` (impersonated `coreV1Client.Secrets(ns).Get`) to read `liveResourceVersion`. Resolves `DriftStatus` per Unit 1 logic. List view does not — too expensive (N+1) — list reports `DriftStatus = Unknown` for live data and the detail page is the source of truth.
+- Detail response includes the cached threshold-resolved fields (Phase D fills these). Phase A leaves them at zero so the response shape is final from day one.
+- Drift status surfaced in response with explanatory hint ("provider does not expose syncedResourceVersion") for `Unknown` per the requirements doc.
+
+**Test scenarios:**
+- *Happy detail*: ExternalSecret detail with synced Secret RV match → `DriftStatus = InSync`.
+- *Drift detected*: `syncedResourceVersion=A`, live `B` → `DriftStatus = Drifted`, `Status = Drifted`.
+- *Drift unknown*: `syncedResourceVersion=""` (provider doesn't populate) → `DriftStatus = Unknown`.
+- *Synced Secret deleted*: ExternalSecret status says Ready but referenced Secret missing → `DriftStatus = Unknown`, log line; detail returns 200 (not 404 — the ExternalSecret exists).
+- *Impersonation forbidden*: user with `get externalsecret` but not `get secret` perm → drift returns `Unknown` (impersonated Get returns 403; we capture and degrade silently).
+
+**Verification:** `go test ./internal/externalsecrets/...`.
+
+---
+
+### Unit 4: Routes wiring + ClusterContext middleware
+
+**Goal:** Register the handler on the chi router under `/api/v1/externalsecrets/*`. Multi-cluster routing applies via existing X-Cluster-ID middleware.
+
+**Requirements:** Wires R1-R5 to HTTP.
+
+**Dependencies:** Units 2, 3.
+
+**Files:**
+- Modify: `backend/internal/server/routes.go` — register handler routes under `/externalsecrets`.
+- Modify: `backend/internal/server/server.go` (or wherever handlers are wired) — instantiate `externalsecrets.Handler` with `K8sClient`, `Discoverer`, `AccessChecker`, `AuditLogger`, `NotifService`, `Logger`.
+
+**Approach:**
+- Routes:
+  - `GET /externalsecrets/status`
+  - `GET /externalsecrets/externalsecrets`
+  - `GET /externalsecrets/externalsecrets/{ns}/{name}`
+  - `GET /externalsecrets/clusterexternalsecrets`
+  - `GET /externalsecrets/clusterexternalsecrets/{name}`
+  - `GET /externalsecrets/stores`
+  - `GET /externalsecrets/stores/{ns}/{name}`
+  - `GET /externalsecrets/clusterstores`
+  - `GET /externalsecrets/clusterstores/{name}`
+  - `GET /externalsecrets/pushsecrets`
+  - `GET /externalsecrets/pushsecrets/{ns}/{name}`
+- Bulk-action and force-sync routes deferred to Phase E.
+
+**Verification:** `make test-backend`; integration smoke against a cluster with ESO installed.
+
+---
+
+### Unit 5: ~~PrometheusRule discovery hook~~ — DELETED
+
+Removed during plan review. The metric-name constants live in `cost_tier.go` (Unit 16); the frontend imports them as TS string constants directly, exactly as the Phase 12 mesh golden-signals panel does. No separate metadata endpoint needed.
+
+---
+
+### Unit 6: Helm ClusterRole grant + chart wiring
+
+**Goal:** Explicit `list` / `watch` grants for `external-secrets.io` CRDs. No write verbs — bulk actions use impersonating client.
+
+**Requirements:** R29
+
+**Dependencies:** None (independent of code units).
+
+**Files:**
+- Modify: `helm/kubecenter/templates/clusterrole.yaml` — append a block after the existing Istio/Linkerd grants (lines 123–146 in current chart per L9 of repo research).
+
+**Approach:**
+- Blocks:
+  ```yaml
+  - apiGroups: ["external-secrets.io"]
+    resources:
+      - externalsecrets
+      - clusterexternalsecrets
+      - secretstores
+      - clustersecretstores
+      - pushsecrets
+    verbs: ["list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  ```
+- The `core/secrets` `get/list` grant is required by the poller in Unit 10 to read synced Secret keys for diff-key computation (R21). This is a meaningful expansion of the platform SA's privilege — the SA gains cluster-wide Secret read. Document the trade-off explicitly: a k8sCenter compromise yields cluster-wide synced-Secret read access. Operators in stricter environments can remove this block; the diff feature degrades to "outcome only, no key-set" but the timeline still functions, drift detection still works, and notifications still fire.
+- The existing Helm wildcard catch-all (`apiGroups: ["*"]; verbs: ["list"]`) at `clusterrole.yaml:160-162` already authorizes `list` on every CRD; the explicit ESO block is defense-in-depth documentation, not net-new authorization. The `core/secrets` `get` grant IS net-new (the wildcard is `list`-only).
+- Get verb on ESO CRDs is implicit through the impersonating client for detail endpoints.
+
+**Verification:**
+- `make helm-lint` clean.
+- `make helm-template` produces clusterrole containing the new block.
+
+---
+
+## Phase B — Frontend observatory
+
+Routes, list views, detail views, dashboard. Theme tokens only (no hardcoded Tailwind colors). Mirrors Phase 11A frontend layout.
+
+### Unit 7: Routes + list islands + nav
+
+**Goal:** Six list / chain pages (ExternalSecrets, ClusterExternalSecrets, SecretStores, ClusterSecretStores, PushSecrets, Chain) + dashboard at index. New nav-rail domain section ("External Secrets") with its own SubNav, parallel to GitOps and Backup. TS types mirror backend.
+
+**Requirements:** R2 (routes render empty state when CRDs missing), R5 (status surfaced), R9 (standalone Chain page), R28 (RBAC scoped — frontend reflects backend-filtered counts)
+
+**Dependencies:** Phase A (endpoints exist).
+
+**Files:**
+- Create: `frontend/lib/eso-types.ts` — TS interfaces mirroring backend types: `Status`, `DriftStatus`, `ExternalSecret`, `ClusterExternalSecret`, `SecretStore`, `ClusterSecretStore`, `PushSecret`, `ESOStatus`. Add a Go-side `eso_types_hash_test.go` (in Phase A) that hashes the exported field set of each Go struct and pins the hash; failure forces a TS update — prevents silent Go-TS drift.
+- Create: `frontend/lib/eso-api.ts` — typed client (`listExternalSecrets`, `getExternalSecret`, `listStores`, etc., `getStatus`).
+- Create: `frontend/routes/external-secrets/index.tsx` — landing page (redirect to dashboard).
+- Create: `frontend/routes/external-secrets/external-secrets.tsx`, `cluster-external-secrets.tsx`, `stores.tsx`, `cluster-stores.tsx`, `push-secrets.tsx`, `chain.tsx`.
+- Create: `frontend/islands/ESOExternalSecretsList.tsx`, `ESOClusterExternalSecretsList.tsx`, `ESOStoresList.tsx`, `ESOClusterStoresList.tsx`, `ESOPushSecretsList.tsx`.
+- Create: `frontend/islands/ESOChainPage.tsx` — standalone chain page (R9): namespace selector + topology overlay pre-toggled to `eso-chain`. Wraps `NamespaceTopology` with the chain-overlay default.
+- Create: `frontend/components/eso/ESOStatusBadge.tsx` — themed status badge using CSS custom property tokens: `Synced` → `var(--success)`, `SyncFailed` → `var(--error)`, `Refreshing` → `var(--accent)`, `Stale` → `var(--warning)`, `Drifted` → `var(--accent-secondary)`, `Unknown` → `var(--muted)`. **Theme palette extension:** if `--warning` and `--accent-secondary` aren't already present in all 7 themes, this PR adds them — touches all theme files. Verify in `frontend/static/themes/*.css` before starting.
+- Create: `frontend/components/eso/ESOSubNav.tsx` — tab strip with live counts pulled from the dashboard summary endpoint.
+- Modify: `frontend/lib/constants.ts` — add new top-level domain section "External Secrets" to the nav rail (parallel to GitOps and Backup). **Do not extend Security SubNav** — it already has 11 entries; +5 ESO tabs would create a 16-tab strip with no grouping. ESO gets its own icon + SubNav.
+- Modify: `frontend/components/Sidebar.tsx` (or equivalent nav-rail component) — wire the new "External Secrets" domain section.
+- Modify: `frontend/islands/CommandPalette.tsx` — add quick actions for "External Secrets list", "Stores list", "Chain", "New ExternalSecret" (creation entries deferred until Phase G ships).
+
+**Per-list empty-state copy (installed-but-empty case):**
+
+| List | Copy | CTA |
+|---|---|---|
+| ExternalSecrets | "No ExternalSecrets in this namespace. Create one to start syncing secrets from a SecretStore." | "New ExternalSecret" (Phase G) |
+| ClusterExternalSecrets | "No ClusterExternalSecrets visible. These sync the same Secret to multiple namespaces." | (no CTA — admin-managed) |
+| SecretStores | "No SecretStores in this namespace. ExternalSecrets require a SecretStore to function." | "New SecretStore" (Phase H) |
+| ClusterSecretStores | "No ClusterSecretStores visible. Your permissions may restrict visibility, or no ClusterSecretStores exist." | (no CTA — admin-managed) |
+| PushSecrets | "No PushSecrets in this namespace. PushSecrets push Kubernetes Secrets back out to a source store (uncommon)." | (no CTA — read-only in v1) |
+
+**Approach:**
+- Theme tokens only: `var(--success)`, `var(--accent)`, `var(--muted)`, etc. No hardcoded `text-green-500`. (CLAUDE.md Phase 6C lesson.) Canonical reference for theme-token-compliant wizard sub-components: `frontend/components/wizard/IssuerForm.tsx` — match its variable usage.
+- List filter inputs: namespace filter on `ESOExternalSecretsList`. **Debounce 300ms + AbortController + sequence guard from day one** (L7.8) — match `frontend/islands/CertificatesList.tsx` precedent for debounce-ms.
+- Empty states: when `getStatus().detected === false`, render an "ESO not detected" tile with installation guidance + link to docs (R2 contract). Per-list installed-but-empty copy is in the table above.
+- Permission-gated islands: hide bulk-refresh button when user lacks the `update externalsecret` cluster-wide perm (frontend uses `SelfSubjectRulesReview` cache).
+- ESOStatusBadge handles all six values. Drift on the **list view** is represented by the status badge alone (`Drifted` value); no separate drift pill on list rows — the badge IS the drift signal. The detail page uses a separate `ESODriftIndicator` (Unit 11) that adds tri-state hint text.
+
+**Patterns to follow:**
+- `frontend/islands/CertificatesList.tsx`, `frontend/islands/IssuersList.tsx` — list shape + filter wiring.
+- `frontend/components/ui/PolicyBadges.tsx` — multi-variant badge component pattern.
+- `frontend/components/SubNav.tsx` — tab strip with live counts (precedent in Phase 11A).
+
+**Test scenarios:**
+- (No frontend component-test culture in this repo; follow Phase 11A precedent. Verification is `deno task check` + manual smoke.)
+
+**Verification:**
+- `cd frontend && deno task check` clean (REPO-WIDE per CLAUDE.md rule 4).
+- Smoke against homelab: list pages render with cluster data, namespace filter works without race-condition jitter, empty state renders when ESO uninstalled.
+
+---
+
+### Unit 8: Detail islands + Dashboard
+
+**Goal:** Per-CRD detail page (one component per kind, switching layout via prop). Dashboard at `/external-secrets/dashboard` (or `/external-secrets/`) anchored on a sync-health hero ring; aggregates store inventory, recent failures with affected-workload counts, top reasons.
+
+**Requirements:** R5, R20 (drift surfaced on detail), R27, R28
+
+**Dependencies:** Unit 7.
+
+**Files:**
+- Create: `frontend/routes/external-secrets/external-secrets/[ns]/[name].tsx` (and parallel routes for the other kinds).
+- Create: `frontend/islands/ESOExternalSecretDetail.tsx` — top section: status badge, drift indicator, source store reference (linked), refresh interval, last-sync time. Tabs: Overview / YAML / Events / History (Phase C-populated; tab is present but empty until Phase C ships) / Chain (Phase I). Tab is rendered with "History will be populated once persistence ships" placeholder until Phase C; this prevents the detail island from needing a v2 reshape post-Phase-C.
+- Create: `frontend/islands/ESOStoreDetail.tsx`, `ESOClusterStoreDetail.tsx`, `ESOPushSecretDetail.tsx`.
+- Create: `frontend/routes/external-secrets/dashboard.tsx` (or alias index).
+- Create: `frontend/islands/ESODashboard.tsx` — **hero**: sync-health ring `X of Y ExternalSecrets synced` (compliance-dashboard GaugeRing precedent). **Secondary cards row**: SyncFailed count, Stale count, Drifted count, Unknown count. **Tertiary**: store-by-provider donut, per-provider cost-tier estimate cards (Phase F-populated). **Failure table**: "Broken ExternalSecrets right now" — for each failed/stale ES, show the count of consuming workloads (Pods/Deployments/StatefulSets that mount the synced Secret) with drill-link to the Chain tab. This combined view serves the Success Criterion ("which workloads are affected in 30s"). Top-reasons grouping below.
+- Create: `frontend/components/eso/ESODriftIndicator.tsx` — tri-state: Drifted (`var(--accent-secondary)` + "next sync will overwrite" hint + "Revert drift" button that triggers Unit 14's force-sync), InSync (no badge or muted check), Unknown (muted + "provider does not expose drift state" hint). Matches R20.
+
+**Approach:**
+- Detail page: use `WizardStepper` *no* — detail is a non-wizard read view. Mirror `CertificateDetail.tsx` shape: top metadata table, condition reasons, related-resources panel.
+- Drift indicator inline next to the status badge on detail page; on list page it's a small pill.
+- Dashboard: SVG donut for provider distribution; reuse the chart primitives from Phase 8B compliance dashboard if compatible, otherwise inline.
+- Recent-failures table: 24h window, last 50 entries, links to detail page.
+- All cards use theme tokens. Cost-tier card stub here (returns "—" placeholder); Phase F populates it.
+
+**Patterns to follow:**
+- `frontend/islands/CertificateDetail.tsx` — metadata table, source attribution display, exhaustive `switch` on enum values.
+- `frontend/islands/ComplianceDashboard.tsx` — gauge ring + severity bars + per-namespace table.
+- `frontend/islands/PolicyDashboard.tsx` — engine-status cards.
+
+**Verification:**
+- `deno task check` clean.
+- Smoke: dashboard renders with health histogram, drift indicator surfaces correctly for synthetic Drifted / InSync / Unknown ESes.
+
+---
+
+## Phase C — Persistence: history table + drift detection
+
+PostgreSQL migration for `eso_sync_history`. Poller persistence hook. Drift-aware history entries. Phase D's source-enum migration is moved earlier in the schedule (Phase D landing before C means Phase D ships its own migration first — see Unit 12).
+
+### Unit 9: Migration 000011 — `eso_sync_history` table
+
+**Goal:** Schema for the persistent sync timeline. UID-keyed (R8), three text[] columns for diff key-sets (R31), flat table with DELETE-WHERE retention.
+
+**Requirements:** R6, R8, R21, R31
+
+**Dependencies:** Phase D's migration 000010 (source enum extension) lands first per the new phase order.
+
+**Files:**
+- Create: `backend/internal/store/migrations/000011_create_eso_sync_history.up.sql`.
+- Create: `backend/internal/store/migrations/000011_create_eso_sync_history.down.sql`.
+
+**Approach:**
+- Schema (flat table, matches R31's column shape):
+  ```sql
+  CREATE TABLE eso_sync_history (
+      id BIGSERIAL PRIMARY KEY,
+      cluster_id UUID NOT NULL,
+      uid TEXT NOT NULL,                      -- ExternalSecret UID (R8)
+      namespace TEXT NOT NULL,
+      name TEXT NOT NULL,
+      attempt_at TIMESTAMPTZ NOT NULL,
+      outcome TEXT NOT NULL CHECK (outcome IN ('success', 'failure', 'partial')),
+      reason TEXT,                            -- short ESO condition reason
+      message TEXT,                           -- longer ESO condition message
+      diff_keys_added TEXT[] NOT NULL DEFAULT '{}',     -- R31
+      diff_keys_removed TEXT[] NOT NULL DEFAULT '{}',   -- R31
+      diff_keys_changed TEXT[] NOT NULL DEFAULT '{}',   -- R31
+      synced_resource_version TEXT            -- snapshot at attempt time (drift baseline)
+  );
+
+  CREATE INDEX idx_eso_sync_history_uid_attempt ON eso_sync_history (uid, attempt_at DESC);
+  CREATE INDEX idx_eso_sync_history_cluster_failures ON eso_sync_history (cluster_id, attempt_at DESC) WHERE outcome != 'success';
+  CREATE UNIQUE INDEX idx_eso_sync_history_dedup ON eso_sync_history (uid, attempt_at);
+
+  COMMENT ON TABLE eso_sync_history IS
+      'Per-ExternalSecret sync attempt history. UID-keyed (R8); 90-day retention via DELETE-WHERE. ' ||
+      'Partition candidate: if steady-state row count exceeds 10M, migrate to monthly RANGE partitioning on attempt_at.';
+  ```
+- Volume justification: realistic insert rate is governed by ExternalSecret refresh interval (`ON CONFLICT DO NOTHING` keys on `(uid, attempt_at)` where `attempt_at = lastRefreshTime`). At 1000 ESes with 1h refresh × 90 days = ~2.16M steady-state rows. Compliance-snapshots and audit-log precedents both use flat tables with this volume class. Partitioning is deferred to a future operational migration if steady-state exceeds 10M rows.
+- Three `text[]` columns (R31 specification) for diff key-sets — simpler queries than JSONB path expressions, type-checked, exact-match index-friendly.
+- Unique index `(uid, attempt_at)` enables `INSERT ... ON CONFLICT DO NOTHING` for restart-safe idempotent inserts (L5.3).
+- Down migration: `DROP TABLE eso_sync_history;`
+
+**Patterns to follow:**
+- `backend/internal/store/migrations/000005_create_compliance_snapshots.up.sql` — `cluster_id` typing, idempotent insert pattern.
+- `backend/internal/store/migrations/000001_create_audit_logs.up.sql` — naming convention, flat-table + retention model.
+
+**Test scenarios:**
+- Migration applies clean from `000010` (Phase D's source-enum extension).
+- Down migration removes the table cleanly.
+- `INSERT ON CONFLICT DO NOTHING` against `(uid, attempt_at)`: second insert returns 0 rows affected.
+- `text[]` round-trip: insert with `diff_keys_added = ARRAY['key1', 'key2']`; SELECT returns same array.
+
+**Verification:**
+- `make test-backend` includes migration round-trip.
+- Manual: `migrate -path ./internal/store/migrations -database "$DATABASE_URL" up` clean against fresh PG.
+
+---
+
+### Unit 10: Sync-history persistence in poller
+
+**Goal:** Each observatory cycle compares the current `(syncedResourceVersion, attempt_at)` against the latest persisted entry. New attempt → INSERT; same → skip. Diff keys computed against the prior synced data.
+
+**Requirements:** R6, R8, R21
+
+**Dependencies:** Unit 9, Phase A (poller stub).
+
+**Files:**
+- Create: `backend/internal/externalsecrets/poller.go` — 60s ticker, local cluster only (matches Phase 11A constraint). Calls `Handler.CachedExternalSecrets(ctx)` for the resolved-status snapshot, computes diff vs prior synced data, INSERTs new history rows, emits notifications (Phase D wiring).
+- Create: `backend/internal/externalsecrets/poller_test.go` — table-driven attempt-comparison + dedupe tests.
+- Create: `backend/internal/store/eso_history.go` — `Store.AppendESOHistory(ctx, entry)`, `Store.QueryESOHistory(ctx, uid, limit)`, `Store.RunESOHistoryRetention(ctx)`, `Store.EnsureESOHistoryPartitions(ctx)`.
+- Modify: `backend/internal/server/server.go` — start the poller alongside the cert-manager poller; wire the retention goroutine.
+
+**Approach:**
+- Diff computation: read the synced k8s Secret's `Data` keys via the platform service account (which has cluster-wide `get/list secrets` per Unit 6's Helm grant addition). The poller has no requesting-user context and cannot impersonate. The Helm grant is documented as a meaningful privilege expansion in Unit 6; operators in stricter environments can remove the grant and the diff feature degrades to "outcome only, no key-set" while the timeline still functions. Compare against the prior history entry's `diff_keys_*` baseline (we store the resolved key-set per attempt; the "baseline" is the prior attempt's resolved key-set). Emit `{added, removed, changed}` arrays of key names. **Values are never stored or logged.**
+- `attempt_at` resolution: use `lastRefreshTime` from ESO status when available, else `now()`. Always at second granularity.
+- INSERT pattern: `INSERT INTO eso_sync_history (...) VALUES (...) ON CONFLICT (uid, attempt_at) DO NOTHING` — idempotent under poller restart (L5.3).
+- `cluster_id` provenance: read from the platform's local-cluster registry at poller startup; cached for the poller's lifetime. The poller is local-cluster-only (Phase 11A constraint); cluster_id never changes mid-process.
+- Retention goroutine: 1h tick, `DELETE FROM eso_sync_history WHERE attempt_at < now() - INTERVAL '90 days'`. Notifications-service retention precedent.
+- Drift snapshotting: each entry stores `synced_resource_version` as recorded during this attempt. Drift detection at read time compares the live Secret RV against the *latest* history entry's `synced_resource_version` (already in cache; one fewer impersonated Get).
+- Dedupe-key shape (L4.1, L4.2): in-memory dedupe map for notifications keyed by `(cluster_id, uid, kind enum)` — `kind` is one of `synced` / `stale` / `failed` / `recovered`. Bucket-as-enum, not ms-diff. Failure and recovery have **separate dedupe keys** (L4.1 — explicitly required by R16). Cluster_id in the key prevents collision across multi-cluster routing.
+- **Restart recovery for the prev-bucket map**: on startup, query `nc_notifications` for the most-recent `external_secrets`-source notification per `(resource_kind, resource_ns, resource_name)` to seed the prev-bucket map. Without this, a process restart between failure and recovery causes the recovery alert to be silently suppressed (cert-manager precedent has the same bug). Add `Store.RecentBySourceAndKind(ctx, source, withinHours int)` to the notifications store.
+
+**Patterns to follow:**
+- `backend/internal/certmanager/poller.go` — 60s ticker, dedupe-by-uid map, local-cluster-only constraint.
+- L5.5 — retention via `DELETE WHERE` after each insert, not separate cron.
+
+**Test scenarios:**
+- *First sync*: ExternalSecret with no prior history, fresh `lastRefreshTime` → INSERT row with `outcome=success`, all three `diff_keys_*` empty arrays.
+- *Repeat sync, no change*: same `lastRefreshTime` as last poll → INSERT skipped via `ON CONFLICT`.
+- *New successful sync*: new `lastRefreshTime`, Secret data changed → INSERT row with `diff_keys_added`, `diff_keys_removed`, `diff_keys_changed` populated.
+- *Failure transition*: `Ready=False` → INSERT row with `outcome=failure`, reason from condition, no diff (failure wins).
+- *Partial outcome* (R6 definition): synthetic ESO condition message indicating per-key denial → INSERT with `outcome=partial`. (Requires inspecting `status.binding.name`'s key-set against the source path key-set; only emit `partial` when both sets are non-empty and differ.)
+- *Restart safety*: poller restarts mid-window → next tick re-reads the same `(uid, attempt_at)`; ON CONFLICT swallows.
+- *Restart recovery emission*: ES failed at T-5min, process restart at T-2min, ES recovers at T-1min → `Store.RecentBySourceAndKind` seeds prev-bucket=Failure → recovery event fires (without seeding, recovery would be silently suppressed).
+- *Retention*: row at `now() - 91d` is purged on next retention tick.
+- *Helm grant removed degradation*: platform SA without `get secrets` perm → diff_keys_* fields empty in all inserted rows; outcome/reason still populated; timeline still functional.
+- *ES delete + recreate*: ES with name `apps/db-creds` deleted, recreated at same name → fresh UID → no history collision (UID-keyed storage).
+
+**Verification:**
+- `go test ./internal/externalsecrets/... -count=10` (L7.5 — flush map-iteration-order flakes).
+- Manual: tail PG `eso_sync_history`, observe rows after a homelab annotated sync.
+
+---
+
+### Unit 11: Drift detection wiring on detail + dashboard tile
+
+**Goal:** Detail-page drift indicator reflects tri-state `DriftStatus` and offers a "Revert drift" action. Dashboard surfaces drift count alongside other secondary metrics.
+
+**Requirements:** R20, R27
+
+**Dependencies:** Phase B (detail island), Unit 3 (drift resolved on detail), Unit 14 (force-sync — for the Revert button).
+
+**Files:**
+- Modify: `frontend/islands/ESOExternalSecretDetail.tsx` — render `ESODriftIndicator` in the metadata header. The "Revert drift" button is wired here (calls Unit 14's force-sync endpoint with confirmation).
+- Modify: `frontend/islands/ESODashboard.tsx` — Drift count surfaces in the secondary cards row alongside SyncFailed / Stale / Unknown counts (per Unit 8).
+- Modify: `backend/internal/externalsecrets/handler.go` — list response for ExternalSecrets includes a coarse drift hint (`lastObservedDriftStatus: DriftStatus` derived from cached snapshots only, not impersonated Get N+1).
+
+**Approach:**
+- List view drift hint is best-effort: when poller has run at least once, the cached ExternalSecret carries `LastObservedDriftStatus` (from the most recent persisted history entry). When no history yet, hint is `Unknown`. Detail page does the live-RV check; this is the source of truth.
+- Drift staleness SLA (document for operators): a fresh `kubectl edit secret` takes up to ~90s to surface in the dashboard count (60s poller cycle + 30s handler cache). The detail page is always fresh (live RV check on every request). The dashboard claim is best-effort, the detail page is source of truth — make this explicit in the operator docs (Phase J).
+- Drift requires `get secret` on the synced Secret. A user with `get externalsecret` but not `get secret` on the target sees `DriftStatus: Unknown` permanently. Document in Phase J.
+- "Revert drift" button: triggers the same force-sync patch from Unit 14. Confirmation dialog: "This will overwrite the local Secret edit with the source store's value. Continue?"
+
+**Verification:**
+- `deno task check` clean.
+- Smoke: induce drift via `kubectl edit secret`, see detail page flip from `InSync` → `Drifted` after the next poll cycle (~60s).
+
+---
+
+## Phase D — Alerting + annotation thresholds
+
+Notification Center wiring (source enum, dedupe, recovery), per-resource annotation chain (`stale-after-minutes`, `alert-on-recovery`, `alert-on-lifecycle`). Lands BEFORE Phase C — operators get paging value before the persistent timeline ships.
+
+### Unit 12: Notification source enum + migration 000010 + annotation resolver + dispatch metadata flag
+
+**Goal:** Add `external_secrets` to the Go source enum, extend the migration's CHECK constraint (drifted from the Go enum per L4.3 — fix here while we're touching the file), wire annotation resolver, add `SuppressResourceFields` dispatch flag.
+
+**Requirements:** R17, R18, R19, R31
+
+**Dependencies:** Unit 1 (annotation key consts), Phase 13 precedent.
+
+**Files:**
+- Modify: `backend/internal/notifications/types.go` — add `SourceExternalSecrets Source = "external_secrets"`. Add `SuppressResourceFields bool` field to the `Notification` struct.
+- Modify: `backend/internal/notifications/service.go` — `sendSlack` and `sendWebhook` honor `SuppressResourceFields`: when true, omit `ResourceNS`/`ResourceName` from the Slack block body and the webhook JSON payload. ESO events set this true by default — defeats the tenant-leakage path that the RBAC-generic title alone doesn't close.
+- Create: `backend/internal/store/migrations/000010_extend_nc_source_enum.up.sql` — single-transaction `ALTER TABLE nc_notifications DROP CONSTRAINT nc_notifications_source_check; ALTER TABLE nc_notifications ADD CONSTRAINT nc_notifications_source_check CHECK (source IN ('alert','policy','gitops','diagnostic','scan','cluster','audit','velero','certmanager','limits','external_secrets'));`. golang-migrate wraps each migration in a transaction by default; the constraint is logically replaced atomically.
+- Create: `backend/internal/store/migrations/000010_extend_nc_source_enum.down.sql` — restores the prior CHECK.
+- Create: `backend/internal/externalsecrets/thresholds.go` — `ResolveESOThresholds(es ExternalSecret, storesByNSName map[string]SecretStore, clusterStoresByName map[string]ClusterSecretStore, logger)` returning resolved values + per-key sources. `ApplyThresholds(ess []ExternalSecret, stores []SecretStore, clusterStores []ClusterSecretStore, logger)` mutator builds the indexes once (O(1) lookup per ES).
+- Create: `backend/internal/externalsecrets/thresholds_test.go` — table-driven chain tests.
+- Modify: `backend/internal/externalsecrets/handler.go` — `fetchAll` runs `ApplyThresholds` after normalize. (Phase A's Unit 2 establishes `fetchAll`; Phase D's Unit 12 extends it. This is an explicit cross-phase modification, not a Phase A change retroactively patched.)
+- Modify: `frontend/islands/NotificationRules.tsx` — group `NOTIF_SOURCES` by category (Infrastructure / Policy / Secrets / Operations) so the 11-entry source selector stays usable.
+
+**Approach:**
+- Resolver chain per key (resource > referenced store > referenced clusterstore > package default), each key independent. Mirrors Phase 13 exactly:
+  ```
+  resolveKey(esVal, esNamespace, ref, storesMap, clusterStoresMap, defaultValue, extract func(Store) *int) (int, ESOThresholdSource)
+  ```
+- `ESOThresholdSource` enum: `default` / `externalsecret` / `secretstore` / `clustersecretstore`. With `Valid()` belt-and-suspenders guard (L3.5).
+- Two annotation keys (R17): `kubecenter.io/eso-stale-after-minutes`, `kubecenter.io/eso-alert-on-recovery`. One opt-in key (R18): `kubecenter.io/eso-alert-on-lifecycle`.
+- Stale-after default per R17: `2 × refreshInterval`, fallback `2h` when refreshInterval is unset. **Minimum floor: 5 minutes** — values below 5 are rejected (logged + fall through to next layer) to prevent self-DoS via aggressive thresholds against the 60s poller cadence.
+- Invalid-value handling (R19): log + silent fall-through; no `thresholdConflict` flag (no warn-vs-crit ordering exists for these annotations).
+- Source attribution stored per key on `ExternalSecret`: `StaleAfterMinutesSource`, `AlertOnRecoverySource`. **`AlertOnLifecycle` does not get per-key source attribution** — the UI only needs "lifecycle alerts on/off" so source provenance has no actionable use.
+- Index map shape: `storesByNSName` keyed by `<namespace>/<name>` (string), `clusterStoresByName` keyed by `<name>`. O(1) lookup per resolution. Matches `internal/certmanager/thresholds.go` index pattern.
+
+**Patterns to follow:**
+- `backend/internal/certmanager/thresholds.go` — `resolveThresholdKey` generic chain walker, `Valid()` guard, `sanitize<Source>` belt-and-suspenders.
+- L3.1 — single source of truth, called from BOTH handler `fetchAll` AND poller fallback path.
+
+**Test scenarios:**
+- *Happy ES annotation only*: ES sets `eso-stale-after-minutes: "5"`, store has none → resolved (5, `externalsecret`).
+- *Happy store annotation only*: ES no annotation, store sets `60` → (60, `secretstore`).
+- *ClusterStore fallback*: ES references ClusterSecretStore with annotation → (..., `clustersecretstore`).
+- *Default*: no annotations anywhere → (`2 × refreshInterval` or `120` if refresh unset, `default`).
+- *Mixed*: ES sets stale-after, store sets alert-on-recovery → per-key sources differ.
+- *Invalid value*: ES sets `eso-stale-after-minutes: "potato"` → falls through to store; no `thresholdConflict`.
+- *Negative value*: `"-5"` → rejected, falls through.
+- *Zero value*: `"0"` → rejected (matches Phase 13), falls through.
+- *Below floor*: `"3"` → rejected (below 5-min floor), falls through with logged warning.
+- *Missing referenced store*: ES references `nonexistent` store → falls through to clusterstore then default.
+- *Source enum migration*: applying 000010 against a DB with extant non-listed sources (e.g., `certmanager` rows already present) does NOT fail — the new constraint must include all currently-used values.
+- *SuppressResourceFields dispatch*: ESO `sync_failed` event with `SuppressResourceFields=true` → Slack body omits `*Resource:*` line; webhook JSON omits `resourceNamespace`/`resourceName`. Comparison: `certmanager` event still includes them (legacy behavior preserved).
+
+**Verification:**
+- `go test ./internal/externalsecrets/...`.
+- Migration round-trip: `migrate up` then `down` clean against PG with rows in `nc_notifications` containing `certmanager` source.
+
+---
+
+### Unit 13: Notification dispatch — failure + recovery + lifecycle
+
+**Goal:** Poller emits Notification Center events for status transitions. Failure / stale / recovery use distinct dedupe keys (L4.1, R16). Lifecycle is opt-in (R18). RBAC-generic message text (L4.4).
+
+**Requirements:** R15, R16, R18
+
+**Dependencies:** Units 10, 12.
+
+**Files:**
+- Modify: `backend/internal/externalsecrets/poller.go` — emit logic. Dedupe map keyed by `(uid, ESOKind)` where `ESOKind` is one of `sync_failed` / `stale` / `unhealthy` / `recovered_synced` / `recovered_unhealthy` / `created` / `deleted` / `first_synced`.
+- Modify: `backend/internal/externalsecrets/poller_test.go` — failure-then-recovery sequence test (AE2 in requirements doc).
+
+**Approach:**
+- Event kinds (R15, R16, R18):
+  - `externalsecret.sync_failed` (failure)
+  - `externalsecret.stale` (stale)
+  - `secretstore.unhealthy` (failure)
+  - `clustersecretstore.unhealthy` (failure)
+  - `externalsecret.recovered` (recovery — separate dedupe)
+  - `secretstore.recovered`, `clustersecretstore.recovered`
+  - `externalsecret.created`, `externalsecret.deleted`, `externalsecret.first_synced` (lifecycle, opt-in via annotation)
+- Dedupe-key separation per L4.1: failure key `(uid, "sync_failed")`, recovery key `(uid, "recovered")` — recovery is NOT suppressed by a recently-cleared failure.
+- Recovery emission: poller tracks "previous bucket". When `prev=Failure`, current=`Synced`, AND `AlertOnRecovery == true` (resolved per Unit 12) → emit recovery, then update prev. AE2 covers this.
+- RBAC-generic title (L4.4): "ExternalSecret sync failed" not "ExternalSecret apps/db-creds sync failed". Namespace + name go in metadata (`resource_namespace`, `resource_name`), not the title body.
+- Lifecycle events default OFF: emit only when resolved `AlertOnLifecycle == true`.
+- DB-level dedupe via `Store.DedupExists(...)` 15-minute window already wires through `NotificationService` — no change needed.
+
+**Test scenarios:**
+- *AE1*: ES transitions `Synced` → `SyncFailed` → emit `sync_failed` once. Subsequent polls with same `Ready=False` → no re-fire (in-memory `(uid, "sync_failed")` dedupe).
+- *AE2*: same ES `SyncFailed` → `Ready=True` → emit `recovered` once. Different dedupe key from `sync_failed` (the prior failure dedupe entry does NOT suppress recovery).
+- *Reason change while still failing*: `Ready=False, reason=AuthFailed` → `Ready=False, reason=PathNotFound` → no re-fire (dedupe is by `(uid, kind)`, NOT reason — AE1 footnote).
+- *Stale + alert-on-recovery=false*: ES annotated `eso-alert-on-recovery: "false"` → no recovery event.
+- *Lifecycle off by default*: ES `created` event → no fire unless `eso-alert-on-lifecycle: "true"` resolved.
+- *Bucket-enum dedupe correctness* (L4.2): bucket transition `Synced` → `Stale` → `Synced` emits one `stale` and one `recovered` — clean clear of dedupe entry.
+
+**Verification:**
+- `go test ./internal/externalsecrets/... -count=10`.
+- Smoke: induce sync failure on a homelab ExternalSecret, observe Notification Center fires once; force recovery, observe recovery fires once.
+
+---
+
+## Phase E — Bulk refresh actions
+
+Force-sync annotation patch via impersonating client. RBAC-scoped fan-out with per-resource outcome reporting and audit-log honesty (L8.1, L8.2).
+
+### Unit 14: Force-sync action + impersonation + audit
+
+**Goal:** Single-resource force-sync POST. Sets the ESO `force-sync` annotation via strategic-merge patch through the impersonating client. Audit-logs the action.
+
+**Requirements:** R22, R24
+
+**Dependencies:** Phase A.
+
+**Files:**
+- Modify: `backend/internal/externalsecrets/handler.go` — add `HandleForceSyncExternalSecret` for `POST /externalsecrets/externalsecrets/{ns}/{name}/force-sync`.
+- Modify: `backend/internal/audit/logger.go` — add `ActionESOForceSync`, `ActionESOBulkRefresh`, `ActionESOBulkRefreshNamespace` constants.
+
+**Approach:**
+- Force-sync annotation per ESO contract: `force-sync: <RFC3339 timestamp>`. Strategic-merge patch (L8.5 — preserves operator-set annotations):
+  ```go
+  patch := []byte(fmt.Sprintf(`{"metadata":{"annotations":{"force-sync":"%s"}}}`, time.Now().UTC().Format(time.RFC3339)))
+  client.Resource(esGVR).Namespace(ns).Patch(ctx, name, types.MergePatchType, patch, metav1.PatchOptions{})
+  ```
+- In-flight detection (L8.4): pre-check `lastRefreshTime` within last 30s (rather than `Ready=Unknown`, which ESO doesn't reliably set during reconcile — `Ready=False/True` flips happen at end of reconcile). When in-flight, return 409 with reason `"already_refreshing"`. Bulk fan-out treats 409 as `skipped`, not `failed`. Document the heuristic limit: a sync that legitimately takes longer than 30s won't show as in-flight.
+- Audit identity sourcing: `requestedBy` reads from `auth.UserFromContext(r.Context())` — the validated session identity. Never from a request-body field.
+- Audit `Entry.Detail` carries `{requestedBy: user, target: {ns, name, uid}, result: "success" | "skipped:already_refreshing" | "failed:<reason>"}` JSON-encoded.
+- CSRF: register handler under `ar.Group` at `routes.go:75` to inherit `middleware.CSRF`; never register POST routes outside the authenticated group.
+- Cache invalidation post-patch: `Handler.InvalidateCache()` so the next list reflects the new annotation.
+
+**Test scenarios:**
+- *Happy*: user with `update externalsecret` perm → patch succeeds, audit row written with `Result=success`.
+- *RBAC denied*: user without perm → impersonated patch returns 403, handler returns 403, audit row with `Result=denied`.
+- *Already refreshing*: `Ready=Unknown` at request time → 409, audit row with `Result=skipped:already_refreshing`.
+- *Patch preserves operator annotations* (L8.5): pre-existing `eso-stale-after-minutes` annotation survives the force-sync patch (verified in test by reading post-patch object).
+
+**Verification:** `go test ./internal/externalsecrets/...`.
+
+---
+
+### Unit 15: Bulk refresh — async job model with scope-pinned execution
+
+**Goal:** Background-job bulk refresh: client `POST` returns 202 with `jobId`; client polls `GET /externalsecrets/bulk-refresh-jobs/{jobId}` for progress + outcome. Scope is pinned at job-creation time (target UIDs), not re-resolved at execution. Two-step confirmation dialog renders the resolved scope before job creation. Audit log records both request scope and post-fan-out outcome.
+
+**Requirements:** R22, R23, R24
+
+**Dependencies:** Unit 14, Phase D's source-enum migration (for the bulk-refresh job's notification on completion if we wire one — optional).
+
+**Files:**
+- Create: `backend/internal/store/migrations/000012_create_eso_bulk_refresh_jobs.up.sql` (and `.down.sql`) — schema for the lightweight job table:
+  ```sql
+  CREATE TABLE eso_bulk_refresh_jobs (
+      id UUID PRIMARY KEY,
+      cluster_id UUID NOT NULL,
+      requested_by TEXT NOT NULL,
+      action TEXT NOT NULL CHECK (action IN ('refresh_store','refresh_cluster_store','refresh_namespace')),
+      scope_target TEXT NOT NULL,       -- "<ns>/<name>" or namespace
+      target_uids TEXT[] NOT NULL,      -- pinned at creation
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      completed_at TIMESTAMPTZ,
+      succeeded TEXT[] NOT NULL DEFAULT '{}',
+      failed JSONB NOT NULL DEFAULT '[]',     -- [{uid, reason}, ...]
+      skipped JSONB NOT NULL DEFAULT '[]'     -- [{uid, reason}, ...]
+  );
+  CREATE INDEX idx_eso_bulk_refresh_jobs_cluster_created ON eso_bulk_refresh_jobs (cluster_id, created_at DESC);
+  ```
+- Modify: `backend/internal/externalsecrets/handler.go` — add `HandleBulkRefreshStore`, `HandleBulkRefreshClusterStore`, `HandleBulkRefreshNamespace` (each returns 202 + `{jobId}`); `HandleGetBulkRefreshJob` for polling; `HandleResolveBulkScope` for the pre-flight scope GET.
+  - Endpoints (explicit per route — no `...` placeholders):
+    - `GET  /externalsecrets/stores/{ns}/{name}/refresh-scope`
+    - `GET  /externalsecrets/clusterstores/{name}/refresh-scope`
+    - `GET  /externalsecrets/refresh-namespace/{ns}/refresh-scope`
+    - `POST /externalsecrets/stores/{ns}/{name}/refresh-all`
+    - `POST /externalsecrets/clusterstores/{name}/refresh-all`
+    - `POST /externalsecrets/refresh-namespace/{ns}`
+    - `GET  /externalsecrets/bulk-refresh-jobs/{jobId}`
+- Create: `backend/internal/externalsecrets/bulk_worker.go` — background goroutine processes jobs from a buffered channel; on shutdown, marks in-flight jobs as `completed_at = now()` with current state (no orphaned IN-PROGRESS rows).
+- Create: `frontend/islands/ESOBulkRefreshDialog.tsx` — the two-step confirmation dialog. Renders: (1) primary count line "47 ExternalSecrets across 6 namespaces"; (2) expandable per-namespace target list (truncated at 10 namespaces with "...M more" — full list available behind expand toggle); (3) RBAC-restriction notice when filtered scope < full scope ("Showing only resources you can refresh; 12 additional ExternalSecrets are out of your visibility"); (4) zero-scope empty state ("No ExternalSecrets to refresh — the scope is empty"); (5) loading state while the scope-resolve GET is in flight.
+- Modify: `frontend/islands/ESOStoreDetail.tsx`, `ESOClusterStoreDetail.tsx` — "Refresh all dependent ExternalSecrets" button opens the dialog.
+- Modify: `frontend/islands/ESOExternalSecretsList.tsx` — namespace bulk-refresh button.
+- Create: `frontend/islands/ESOBulkRefreshProgress.tsx` — progress polling UI (poll `/bulk-refresh-jobs/{jobId}` every 2s; show running counts; final outcome rendered in-place when `completed_at` is non-null). Page navigation away does NOT cancel the job — operator can return to see results.
+
+**Approach:**
+- POST flow: (a) Re-resolve scope via the same logic as `HandleResolveBulkScope` (RBAC-filtered list → target UIDs); (b) request body MAY carry a `targetUIDs []string` array from the prior GET — when present, the resolved scope MUST equal the requested UIDs; mismatch → 409 Conflict with `{reason: "scope_changed", added: [...], removed: [...]}` so the dialog can re-confirm. (c) Insert job row with the pinned `target_uids`; (d) return 202 + jobId; (e) background worker patches each ES one at a time, updating `succeeded`/`failed`/`skipped` arrays incrementally; (f) writes `completed_at` and the audit log row when done.
+- Inter-call delay: 200ms between patches. Rationale: avoids overwhelming the **ESO controller's reconcile queue**, which is bounded by ESO's own `--concurrent` flag (typically 5-10). The k8s API server has plenty of headroom (platform `QPS=50`, `Burst=100` per `internal/k8s/client.go:75-77`); the bottleneck is ESO's controller, not k8s.
+- Concurrency limit: at most one bulk-refresh job in flight per `(cluster_id, scope_target)` — enforced by a `SELECT ... FOR UPDATE` against the jobs table. Concurrent requests for the same scope return 409 with the existing job's id.
+- Maximum target count: 5000 per job. Above that, return 413 with "scope too large; use per-namespace refresh."
+- Audit log honesty (L8.1): single row per job, written at completion time. `Entry.Detail` JSON carries `{jobId, action, scope, succeeded_count, failed: [...], skipped: [...]}`. Audit log read API renders this JSON inline; verify the existing audit-log viewer (`frontend/islands/AuditLogViewer.tsx`) handles a 100KB+ JSON payload without breaking the table layout — add a smoke test in Phase E.
+- Multi-cluster: the job table is cluster-scoped via `cluster_id`. Background worker uses the local cluster's impersonating client only; remote cluster bulk refresh is out of scope for v1 (separate work — remote cluster's job dispatch model differs because there's no informer cache).
+
+**Test scenarios:**
+- *AE5 happy*: SecretStore with 47 dependent ESes across 6 namespaces; tenant operator can list ESes in 2 of those → GET scope returns 2-namespace target list; POST creates job with those UIDs; worker patches all of them; audit-log shows scoped result.
+- *Mixed outcomes*: 5 targets — 3 succeed, 1 already-refreshing (skipped), 1 RBAC-denied (failed) → final job state `{succeeded: 3, failed: 1, skipped: 1}` with per-resource reasons.
+- *Empty scope*: store with no dependents → GET returns empty scope; dialog shows zero-scope empty state; POST is disallowed at the UI layer.
+- *Scope-changed at execution*: client GETs scope at T=0; new ES created at T+30s; POST submits old `targetUIDs` → 409 with `{added: [new-uid]}` so dialog re-confirms.
+- *Concurrent same scope*: two POSTs for the same store within 1s → second returns 409 with the existing job's id.
+- *Optimistic-lock conflict*: target ES updated between scope-pin and patch → recorded as `failed: optimistic_lock`.
+- *Job survives navigation*: client POSTs, navigates away, returns 5 minutes later → polls jobId, sees completed result.
+- *Job survives backend restart*: in-flight job at restart → on startup, `completed_at = now()` with current state (no orphaned in-progress).
+- *Audit log render*: 1000-target job → audit row's Detail JSON renders without breaking the audit viewer's table.
+
+**Verification:**
+- `go test ./internal/externalsecrets/... -count=10`.
+- Smoke: trigger bulk refresh on homelab store with synthetic dependent ESes; verify outcome matches reality, audit log honest.
+
+---
+
+## Phase F — Per-store rate + cost-tier panel
+
+Wires the metrics-config endpoint (Unit 5) to the dashboard. Cost-tier estimate uses static rate cards. Degrades cleanly when Prometheus unavailable.
+
+### Unit 16: Per-store rate panel + cost-tier card
+
+**Goal:** SecretStore detail page surfaces request-rate from ESO Prometheus metrics. Dashboard surfaces aggregate per-provider request-rate + cost-tier estimate cards for paid-tier providers.
+
+**Requirements:** R25, R26, R27
+
+**Dependencies:** Unit 5 (metrics-config), Phase B (dashboard surface).
+
+**Files:**
+- Create: `backend/internal/externalsecrets/cost_tier.go` — Go map literal of rate-card data + metric name constants + `EstimateCost(provider, requestCount, window)` function. NO `rate_cards.json` file; the data lives in a typed Go map for compiler-checked keys, no JSON unmarshal path. Each provider entry includes `LastUpdated time.Time` so the API response carries the rate-card snapshot date.
+- Modify: `backend/internal/externalsecrets/handler.go` — add `HandleGetStoreMetrics` returning rate and cost estimate for a single store (`GET /externalsecrets/stores/{ns}/{name}/metrics`). Internally calls Prometheus through `monitoring.QueryService` with the metric names from `cost_tier.go`. Per-store endpoint (not a direct frontend `monitoring/query` call) is justified because we enforce store-level RBAC: a user who can't see a store via `CanAccessGroupResource` doesn't get its metrics, even if they could compose the PromQL themselves.
+- Create: `frontend/islands/ESOStoreMetricsPanel.tsx` — panel: "Requests in last 24h: X (rate Y/min)" + cost-tier estimate when paid-tier + caveat caption "Rates as of YYYY-MM-DD; not connected to live billing."
+- Modify: `frontend/islands/ESOStoreDetail.tsx`, `ESOClusterStoreDetail.tsx` — embed the metrics panel.
+- Modify: `frontend/islands/ESODashboard.tsx` — add per-provider cost cards row with the same caveat caption.
+
+**Approach:**
+- Rate-card data (Go map literal in `cost_tier.go`):
+  ```go
+  type providerRateCard struct {
+      Operations  map[string]float64  // "get" → $/M requests, etc.
+      Currency    string              // "USD"
+      LastUpdated time.Time           // when cards were last hand-revised
+  }
+  var rateCards = map[string]providerRateCard{
+      "aws-secrets-manager": {Operations: map[string]float64{"get": 0.05, "list": 0.05}, Currency: "USD", LastUpdated: time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC)},
+      "aws-parameter-store-advanced": {Operations: map[string]float64{"get": 0.05}, Currency: "USD", LastUpdated: ...},
+      "gcp-secret-manager": {...},
+      "azure-key-vault": {...},
+  }
+  ```
+- Metric name constants (also in `cost_tier.go`, replacing the deleted Unit 5):
+  ```go
+  const (
+      MetricSyncCallsTotal = "externalsecret_sync_calls_total"
+      MetricSyncCallsError = "externalsecret_sync_calls_error"
+  )
+  ```
+- Coverage: AWS Secrets Manager, AWS Parameter Store (advanced tier), GCP Secret Manager, Azure Key Vault. Self-hosted (Vault, Kubernetes provider) skip cost estimate per R26.
+- Prometheus query patterns:
+  - Per-store request count: `sum(rate(externalsecret_sync_calls_total{store="<name>", namespace="<ns>"}[5m]))`
+  - Per-store error rate: `sum(rate(externalsecret_sync_calls_error{store="<name>", namespace="<ns>"}[5m]))`
+  - 24h window: `sum_over_time(...[24h])`
+- Singleflight wrap (L1.4): the metric fetch and the per-store list fetch share a singleflight key so concurrent dashboard polls don't hammer Prometheus independently.
+- Degradation: when Prometheus query fails or `monitoring.IsAvailable() == false`, response carries `{rate: nil, error: "rate metrics offline"}`. Frontend shows "rate metrics offline" placeholder. Never fabricates zero (per requirements doc R25).
+- API response includes `lastUpdated` from the rate card so the frontend renders the staleness caption inline rather than via tooltip-only.
+
+**Test scenarios:**
+- *Happy paid-tier*: Vault store with metric data → response includes `{rate, costEstimate: nil}` (Vault is self-hosted — no cost). AWS store with same data → `{rate, costEstimate: $X.XX}`.
+- *Prometheus offline*: Prom unreachable → `{rate: nil, error: "rate metrics offline"}` HTTP 200.
+- *No metrics for store*: ESO never synced → `{rate: 0, costEstimate: 0}`.
+- *Rate-card lookup*: provider `aws-secrets-manager` returns hit; provider `pulumi-esc` returns nil (not in cards); response `costEstimate: nil`, no error.
+
+**Verification:**
+- `go test ./internal/externalsecrets/...`.
+- Smoke: dashboard cost cards render with real Prometheus data on homelab; degradation observable when Prometheus stopped.
+
+---
+
+## Phase G — Universal ExternalSecret wizard
+
+Provider-agnostic ExternalSecret creation. Picks any visible Store/ClusterStore. Path-discovery type-ahead opt-in per provider (per Resolve Before Planning).
+
+### Unit 17: ExternalSecret wizard backend + frontend
+
+**Goal:** Generic `ExternalSecretInput` with `Validate()` and `ToYAML()`. Wizard island uses the existing `WizardStepper` shell. Path-discovery via the **Kubernetes provider only** in v1 (no Vault / AWS / GCP / Azure path-discovery — those would require k8sCenter to authenticate against the source store and break the "k8sCenter never holds source-store credentials" scope boundary).
+
+**Requirements:** R12
+
+**Dependencies:** Phase A (visible store list).
+
+**Files:**
+- Create: `backend/internal/wizard/externalsecret.go` — `ExternalSecretInput` struct + `Validate() []FieldError` + `ToYAML() (string, error)`.
+- Create: `backend/internal/wizard/externalsecret_test.go` — table-driven validation tests.
+- Create: `backend/internal/wizard/regex_parity_test.go` — pins Go DNS-label regex against TS regex constant (L7.3).
+- Modify: `backend/internal/server/routes.go` — register `POST /wizards/externalsecret/preview`.
+- Create: `backend/internal/externalsecrets/path_discovery.go` — `Handler.HandleListPaths` for `GET /externalsecrets/stores/{ns}/{name}/paths?prefix=<>`. **Kubernetes provider only**: lists Secrets in the source namespace via the impersonating client (k8s RBAC enforces visibility — no SSRF surface). All other providers return `{supported: false}` and the frontend renders a free-text path field.
+- Create: `frontend/islands/ExternalSecretWizard.tsx` — single island, two steps (Configure / Review). `detailBasePath = "/external-secrets/external-secrets"` so the post-apply success screen links to the detail page correctly.
+- Create: `frontend/components/wizard/ExternalSecretForm.tsx` — form fields with the path-discovery-aware picker (typeahead for kubernetes provider, free-text everywhere else).
+- Create: `frontend/routes/external-secrets/external-secrets/new.tsx`.
+
+**Approach:**
+- `ExternalSecretInput` fields: `Namespace`, `Name`, `StoreRef {Name, Kind}`, `RefreshInterval`, `TargetSecretName`, `Data []DataItem` where `DataItem = {SecretKey, RemoteRef {Key, Property?, Version?}}`. Optional `DataFrom` for full-secret syncs.
+- Validation: namespace + name DNS labels, target Secret name (RFC 1123), refresh-interval Go duration parse (`time.ParseDuration`), `Data` must have at least one item (or `DataFrom` set). Cross-language regex parity test pins Go regex to TS.
+- `ToYAML()` builds via `map[string]any` (L7.1) — no typed ESO Go SDK import. `apiVersion: external-secrets.io/v1`.
+- Path-discovery proxy: Kubernetes provider only. Endpoint `GET /externalsecrets/stores/{ns}/{name}/paths?prefix=<>` calls the impersonating client to list Secrets in the configured source namespace. Other providers: response carries `{supported: false}` and the frontend renders free-text. The "inline hint" for free-text providers is a single-line helper text below the input: *"This provider doesn't expose path discovery. Enter the remote key path manually (e.g. `secret/data/myapp/db`)."* Same component, same wording, applied uniformly.
+- Path-discovery picker states (Kubernetes provider): loading (spinner inline), error ("Couldn't load paths — enter manually" + degrade to free-text), empty result ("No paths found in this namespace"), timeout (5s timeout → degrade to free-text with notice).
+- Touched-flag pattern (L7.5) for path field on store change.
+- ARIA from day one (L7.7): `htmlFor`/`id` pairing, `aria-invalid`, `aria-describedby`.
+- No `useCallback` cargo-cult (L7.6).
+- Debounce 300ms + AbortController on the path-discovery typeahead.
+
+**Patterns to follow:**
+- `backend/internal/wizard/certificate.go` — table-driven `Validate()` shape.
+- `frontend/islands/CertificateWizard.tsx` — `WizardStepper` shell integration.
+- `frontend/components/wizard/WizardReviewStep.tsx` — Monaco preview + apply.
+
+**Test scenarios:**
+- *Happy*: fully-formed input → preview returns valid YAML, apply succeeds.
+- *Validation*: empty `Data` and empty `DataFrom` → 422 with `FieldError` "must specify at least one of data or dataFrom".
+- *Bad refresh-interval*: `"1z"` → 422.
+- *Cross-language regex parity*: `regex_parity_test.go` confirms Go vs TS DNS label regex match.
+- *Path-discovery Kubernetes provider*: store with provider=kubernetes + prefix `apps/` → response lists Secrets in `apps` namespace.
+- *Path-discovery any other provider*: any non-kubernetes store → `{supported: false}`, frontend renders free-text path input with the standard helper text.
+
+**Verification:**
+- `go test ./internal/wizard/... ./internal/externalsecrets/...`.
+- `deno task check`.
+- Smoke: create an ExternalSecret via wizard against a homelab Vault store.
+
+---
+
+## Phase H — Per-provider SecretStore wizards (12 providers)
+
+Per-provider validation + YAML rendering. `StoreScope` discriminator (Store vs ClusterStore — one Go type, two routes — L7.4). Niche providers ship YAML templates only.
+
+### Unit 18: SecretStore wizard scaffold + StoreScope discriminator
+
+**Goal:** Generic `SecretStoreInput` with `Provider` field + `ProviderSpec map[string]any` driven by per-provider validators. Single Go type; `Scope: StoreScopeNamespaced | StoreScopeCluster` discriminator (mirrors `IssuerScope`).
+
+**Requirements:** R13
+
+**Dependencies:** Phase G (wizard pattern established).
+
+**Files:**
+- Create: `backend/internal/wizard/secretstore.go` — `SecretStoreInput` + `Scope` enum + per-provider dispatcher.
+- Create: `backend/internal/wizard/secretstore_test.go` — table-driven tests across providers.
+- Modify: `backend/internal/server/routes.go` — register `POST /wizards/secret-store/preview` (Scope=Namespaced default), `POST /wizards/cluster-secret-store/preview` (Scope=Cluster default).
+- Create: `frontend/islands/SecretStoreWizard.tsx` — single island, prop-driven `scope` switches route + namespace handling. `detailBasePath = "/external-secrets/stores"` for Namespaced; `detailBasePath = "/external-secrets/cluster-stores"` for Cluster — passed via `scope` prop.
+- Create: `frontend/routes/external-secrets/stores/new.tsx`, `cluster-stores/new.tsx`.
+- Create: `frontend/components/wizard/secretstore/` — per-provider form sub-components (one file per provider). All sub-components reference `frontend/components/wizard/IssuerForm.tsx` as the canonical theme-token-compliant template.
+
+**Approach:**
+- Per-provider validator dispatcher: `provider == "vault"` → `validateVaultSpec(spec)`; `"aws"` → `validateAWSSpec(spec)`; etc. One file per provider in `backend/internal/wizard/secretstore_providers/` (or inline in `secretstore.go` until it becomes unwieldy).
+- `ToYAML()` renders `kind: SecretStore` or `ClusterSecretStore` based on `Scope`. `apiVersion: external-secrets.io/v1`.
+- `provider` selector in the wizard drives the form's secondary panel (Vault auth method picker, AWS region picker, etc.). Touched-flag (L7.5) on every dependent field — switching provider clears the spec slate cleanly.
+- L7.2 culling pass: each of the 12 providers is reviewed against "does the wizard add value over a YAML template?" before building. Providers where the value is mostly mandatory-field reminders ship as YAML templates instead. Final list determined in Unit 19; this unit ships the scaffold.
+
+**Patterns to follow:**
+- `backend/internal/wizard/issuer.go` — `IssuerScope` discriminator pattern.
+- L7.4 — single Go type, single frontend island, two routes.
+
+**Verification:**
+- `go test ./internal/wizard/... -count=10`.
+- `deno task check`.
+
+---
+
+### Unit 19: Per-provider validators + form components
+
+**Goal:** Implementation for the 12 provider wizards. Per-provider auth-method panels and validation. After culling per L7.2, the final wizard set is the providers where wizard adds genuine value over YAML.
+
+**Sizing note:** With ~3 auth methods per provider average, the implementation surface is closer to **~36 form variants** across 12 providers. This unit must be split into per-provider sub-PRs (one PR per provider) to stay within the CLAUDE.md "5 files per phase" rule and to surface culling decisions per provider in the PR description rather than at end-of-phase smoke. Each sub-PR also documents whether that provider's wizard ships or whether it falls through to a YAML template (Unit 20). **R13's contract is delivered when each of the 12 listed providers has at least one of {wizard, YAML template} ship; the wizard-vs-template split is documented per-provider in the sub-PR.**
+
+**Requirements:** R13
+
+**Dependencies:** Unit 18.
+
+**Files (per provider — anticipated):**
+- `backend/internal/wizard/secretstore_providers/vault.go` (multiple auth methods)
+- `backend/internal/wizard/secretstore_providers/aws.go`
+- `backend/internal/wizard/secretstore_providers/azure.go`
+- `backend/internal/wizard/secretstore_providers/gcp.go`
+- ... (one per provider that survives culling)
+- `backend/internal/wizard/secretstore_providers/<provider>_test.go` — table-driven per provider.
+- `frontend/components/wizard/secretstore/<Provider>Form.tsx` per provider.
+
+**Approach (provider-by-provider summary):**
+
+| Provider | Auth methods | Path discovery | Notes |
+|---|---|---|---|
+| Vault | token, kubernetes, approle, jwt, cert | yes (`LIST` on KV) | Auth-method picker drives required fields. |
+| AWS Secrets Manager | IAM (workload identity), static keys | yes (`ListSecrets`) | Region picker. |
+| AWS Parameter Store | IAM | yes (`DescribeParameters`) | Region + parameter-tier picker. |
+| Azure Key Vault | managed identity, service principal, workload identity | yes (`KeyClient.GetPropertiesOfKeysAsync`) | Vault URL + tenant picker. |
+| GCP Secret Manager | workload identity, service account key | yes (`projects.secrets.list`) | Project ID picker. |
+| Akeyless | jwt, kubernetes, plain | no | Free-text path. |
+| Doppler | service token | no | Project + config picker via Doppler API (deferred). |
+| 1Password Connect | connect token | yes (`ListItems`) | Vault picker. |
+| Bitwarden Secrets Manager | access token | no | Project picker (deferred). |
+| CyberArk Conjur | apiKey, jwt | no | Free-text path. |
+| Kubernetes provider | service account in source ns | yes (list Secrets) | Cross-namespace picker. |
+| Infisical | universal-auth (machine identity) | no | Project + environment picker. |
+
+- After L7.2 culling pass: providers whose wizard is mostly a "fill the same 4 fields the YAML asks for" likely drop to YAML-template-only. Bitwarden Secrets Manager, Akeyless, CyberArk Conjur, and Infisical are candidates for culling unless smoke testing surfaces wizard-specific value. Final culling decisions made per provider during implementation; document in PR description which providers landed wizards vs templates.
+- Cross-language regex parity test for any provider-specific field (path-component validators) (L7.3).
+
+**Test scenarios:**
+- *Per provider happy*: minimal valid input → YAML preview matches expected golden.
+- *Per provider auth-method switch*: switching from `token` to `kubernetes` clears irrelevant fields (touched flag).
+- *Per provider missing required*: empty required field → 422 with `FieldError`.
+- *Cross-provider unique fields preserved*: switching from Vault to AWS doesn't leak Vault address into the AWS form.
+
+**Verification:**
+- `go test ./internal/wizard/...`.
+- `deno task check`.
+- Smoke per provider: create a SecretStore via each wizard against a homelab provider where feasible.
+
+---
+
+### Unit 20: Niche-provider YAML templates
+
+**Goal:** Niche providers (Pulumi ESC, Passbolt, Keeper, Onboardbase, Oracle Cloud Vault, Alibaba KMS, custom webhook) get pre-filled YAML templates in the editor — no per-provider wizard.
+
+**Requirements:** R14
+
+**Dependencies:** Unit 18 (wizard pattern; the Stores list page links to "Create from template").
+
+**Files:**
+- Create: `frontend/lib/eso-yaml-templates.ts` — TS map `{providerName: templateString}`.
+- Modify: `frontend/islands/ESOStoresList.tsx` — "Create from template" dropdown next to "New" button.
+- Modify: `frontend/routes/security/external-secrets/stores/new-from-template.tsx` — accepts `?template=<provider>` query param, renders Monaco editor pre-filled with the template + an "Apply" button.
+
+**Approach:**
+- Templates are minimal valid SecretStore YAMLs with TODO placeholders for required fields. e.g.:
+  ```yaml
+  apiVersion: external-secrets.io/v1
+  kind: SecretStore
+  metadata:
+    name: TODO-store-name
+    namespace: TODO-namespace
+  spec:
+    provider:
+      pulumi:
+        organization: TODO-org
+        project: TODO-project
+        environment: TODO-environment
+        accessToken:
+          secretRef:
+            name: TODO-token-secret
+            namespace: TODO-namespace
+            key: token
+  ```
+- Apply uses the same `/yaml/apply` endpoint as the wizards.
+
+**Verification:**
+- `deno task check`.
+- Smoke: create a Pulumi ESC SecretStore from template; YAML applies; observatory picks it up.
+
+---
+
+## Phase I — Chain visualization (topology overlay)
+
+Extends Phase 7B topology builder with `?overlay=eso-chain` (L6.1, L6.2). Reuses `EdgeType` enum + `Overlay` enum extension pattern (L6.1).
+
+### Unit 21: Backend — `ESOChainProvider` interface + `applyESOChainOverlay`
+
+**Goal:** Implement the chain overlay analogous to Phase D mesh overlay. New `EdgeType` constants, new `Overlay` enum value, new `applyESOChainOverlay` function in the topology builder. Node-level RBAC. 2000-edge cap with `EdgesTruncated` flag (L6.2).
+
+**Requirements:** R9, R10, R11
+
+**Dependencies:** Phase A (ExternalSecret data source).
+
+**Files:**
+- Modify: `backend/internal/topology/types.go` — add `EdgeESOAuth` (auth Secret → SecretStore), `EdgeESOSync` (Store → ExternalSecret), `EdgeESOConsumer` (ExternalSecret → synced Secret → Pod). Add `OverlayESOChain Overlay = "eso-chain"`.
+- Modify: `backend/internal/topology/builder.go` — `ESOChainProvider` interface (parallel to `MeshRouteProvider`); `applyOverlay` switch gains `case "eso-chain":`; `applyESOChainOverlay` runtime; `maxESOChainEdges = 2000`.
+- Create: `backend/internal/topology/eso_chain_edges.go` — pure `buildESOChainEdges(externalsecrets, stores, clusterStores, secrets, pods, namespace, nameIndex, maxEdges)` with dedup by `(source, target, type)` (L6.5).
+- Create: `backend/internal/topology/eso_chain_edges_test.go`.
+- Create: `backend/internal/externalsecrets/topology_provider.go` — `Provider` impl of `ESOChainProvider`. Uses cached snapshot from the observatory handler; per-CRD-group RBAC fail-closed (L1.1).
+- Modify: `backend/internal/topology/handler.go` — accept `overlay=eso-chain` value; route through `applyOverlay`.
+
+**Approach:**
+- **Default-response invariance** (L6.1): `Graph.Overlay` field already `omitempty`. New overlay value extends the existing pattern; no callers without `overlay=` see any change. Verified by a "default response is byte-identical" test.
+- Edge construction:
+  - For each ExternalSecret in namespace: emit edge `Store → ExternalSecret` (`EdgeESOSync`).
+  - For each ExternalSecret with a referenced auth Secret in the Store's spec: emit edge `Secret(auth) → Store` (`EdgeESOAuth`).
+  - For each ExternalSecret with a synced Secret: emit edge `ExternalSecret → Secret(synced)` (`EdgeESOConsumer`).
+  - Workload edges (Secret(synced) → Pod / Deployment) ALREADY come from the existing builder's mount detection.
+- Edge dedup by `(source, target, type)` — a single ClusterSecretStore referenced by 50 ExternalSecrets does not produce 50 duplicate `EdgeESOAuth` edges (L6.5).
+- Host-form normalization for cross-namespace store references (L6.3): ClusterSecretStore can be referenced from any namespace; the chain builder resolves both `clusterstore-name` and `clusterstore-name.<ns>` forms via the same `.svc.` splitter pattern Phase D inherited.
+- 2000-edge cap separate from node cap (L6.2): when `len(edges) >= maxESOChainEdges`, set `graph.EdgesTruncated = true`, stop emitting. Nodes themselves obey the existing `maxNodes = 2000` cap; that flag stays as `Truncated`.
+- Per-CRD-group RBAC (L1.1): inside `applyESOChainOverlay`, before emitting any ESO-related edge, the caller's `CanAccessGroupResource(ctx, user, groups, "list", "external-secrets.io", "externalsecrets", namespace)` must return true. Fail-closed: deny → emit no edges, no error, no log indicating "you don't have access" (avoid existence-leak via timing).
+
+**Patterns to follow:**
+- `backend/internal/topology/mesh_edges.go` — pure edge-builder shape.
+- `backend/internal/topology/builder.go:355–417` — `applyOverlay` switch + degradation pattern (`OverlayUnavailable` when provider unwired).
+
+**Test scenarios:**
+- *Happy*: 5 ExternalSecrets in `apps`, all referencing `vault-store` in `apps`; vault-store's auth Secret is `apps/vault-token`; one synced Secret per ES, one Pod mounting each → graph has the expected 6 edges.
+- *Cross-namespace ClusterSecretStore*: ES in `apps` references `clustersecretstore-x`; auth Secret in `vault-system`; chain spans both namespaces (when topology endpoint is called with `namespace=apps`, ClusterSecretStore node appears even though it's cluster-scoped).
+- *Default response unchanged*: GET `/topology/apps` (no overlay query) → response byte-identical to pre-Phase-I.
+- *Overlay unavailable*: ESO not installed → response carries `Overlay: "unavailable"` (matches mesh precedent).
+- *Edge cap*: 3000 ExternalSecrets → response includes `edgesTruncated: true`, not silent clip.
+- *RBAC fail-closed*: user without `list externalsecrets` → ESO chain edges silently absent, response otherwise unchanged.
+- *Edge dedup*: 50 ExternalSecrets sharing one ClusterSecretStore → exactly one `EdgeESOAuth` edge.
+- *Host normalization*: store referenced as `vault-store`, `vault-store.apps`, `vault-store.apps.svc.cluster.local` all resolve to the same node.
+
+**Verification:**
+- `go test ./internal/topology/... ./internal/externalsecrets/... -count=10`.
+
+---
+
+### Unit 22: Frontend — chain overlay toggle on topology page + chain tab on detail
+
+**Goal:** Topology page gains a third overlay toggle (after mesh): "ESO chain". Detail pages for SecretStore / ClusterSecretStore / ExternalSecret gain a "Chain" tab embedding the overlay-rendered subgraph. Standalone chain page (Unit 7's `/external-secrets/chain`) wraps the same overlay.
+
+**Requirements:** R9, R10, R11
+
+**Dependencies:** Unit 21.
+
+**Files:**
+- Modify: `frontend/islands/NamespaceTopology.tsx` — add overlay toggle for `eso-chain`. **Overlays are mutually exclusive** — selecting eso-chain deselects mesh, and vice versa. Toggle-group UI (radio-style), not independent checkboxes. Themed edge colors via CSS custom properties: `var(--accent)` for `EdgeESOAuth`, `var(--accent-secondary)` for `EdgeESOSync`, `var(--muted)` for `EdgeESOConsumer`. Disabled state when backend reports `overlay: "unavailable"`. **Prerequisite refactor:** if `NamespaceTopology` does not already accept a `focusedNode` prop for client-side BFS subgraph filtering, extract that capability before adding the chain tabs (the renderer is currently built for full-namespace view; embedded subgraph rendering is new).
+- Modify: `frontend/islands/ESOStoreDetail.tsx`, `ESOClusterStoreDetail.tsx`, `ESOExternalSecretDetail.tsx` — add "Chain" tab embedding the topology view filtered to the chain neighborhood.
+
+**Approach:**
+- Reuses existing `NamespaceTopology` rendering primitives. The chain tab on detail pages fetches `/topology/{ns}?overlay=eso-chain` and filters client-side via BFS to nodes connected to the focal resource.
+- Embedded chain tab spec: minimum panel height 400px; zoom/pan controls preserved; "View in Topology" escape-hatch link in the tab toolbar (opens the standalone topology page with the focal resource's namespace + overlay pre-toggled); empty-chain state ("No chain edges — this resource has no synced consumers yet"); responsive collapse on viewports <768px (controls move to a top toolbar instead of overlaying the SVG).
+- `Overlay: "unavailable"` semantic: when the user requests `?overlay=eso-chain` against a cluster where ESO is not installed, the response is `Overlay: "unavailable"` regardless of whether mesh is installed. The frontend toggle disabled state with hover text "ESO not installed in this cluster" rather than a generic "overlay unavailable."
+- Theme tokens only — no hardcoded edge colors.
+
+**Verification:**
+- `deno task check`.
+- Smoke: topology page chain toggle renders the edges correctly; detail-page chain tab shows the focal-resource neighborhood.
+
+---
+
+## Phase J — Final docs + roadmap flip
+
+### Unit 23: CLAUDE.md, README.md, roadmap, plan flip
+
+**Goal:** Document the integration in CLAUDE.md (new Phase 14 entry), README.md (Security & Governance bullet update), roadmap item #8 → `[x]`, this plan → `status: complete`.
+
+**Requirements:** R30
+
+**Dependencies:** All prior phases shipped.
+
+**Files:**
+- Modify: `CLAUDE.md` — append Phase 14 (External Secrets Operator) to Build Progress; mirror Phase 11A/12 entry shape with the four lenses (history, drift, bulk-refresh, cost-tier) called out. Roadmap item #8 → `[x]`.
+- Modify: `README.md` — Security & Governance feature bullet for ESO observatory; Architecture table gains "External Secrets" row.
+- Modify: `plans/external-secrets-operator-integration.md` (this file) — `status: complete`.
+
+**Approach:**
+- CLAUDE.md entry covers: package paths, endpoint catalog, persistent history table + retention, drift tri-state, annotation chain, bulk refresh, cost-tier static rate cards, chain overlay, wizard set, Helm grant.
+- Mark each completed unit as `[x]` in this plan as the work lands; flip top-level status only when all phases ship.
+
+**Verification:**
+- `make helm-lint` clean.
+- Roadmap item #8 reads `[x]` post-merge.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** New package `internal/externalsecrets/` with handler + poller + thresholds + cost-tier + bulk-worker; new wizard inputs in `internal/wizard/`; new topology overlay provider. `ApplyThresholds` is the single seam consumed by the handler `fetchAll` (L3.1). Notification dispatch gains a `SuppressResourceFields` flag honored by Slack and webhook channels.
+- **Multi-cluster behavior:** X-Cluster-ID routing applies via existing `ClusterRouter`. The poller is local-cluster-only (Phase 11A constraint); remote-cluster ESO is observability-only via the on-demand impersonated handler. The `eso_sync_history` and `eso_bulk_refresh_jobs` tables are cluster-scoped via `cluster_id` (UUID). Notification dedupe key extends to `(cluster_id, uid, kind)` to prevent collision across multi-cluster routing.
+- **Error propagation:** All new endpoints follow the project's error pattern (`{error: {code, message, detail}}`). 5xx avoided when ESO uninstalled (R2). Bulk-action partial failures reported per-resource (L8.1) — no aggregate-success-when-some-failed lies. Force-sync 409 is a first-class outcome, not a generic error (L8.4); bulk-refresh scope-changed is also 409 with `{added, removed}` diff.
+- **State lifecycle risks:**
+  - Sync history table grows unboundedly without retention; mitigated by hourly `DELETE WHERE attempt_at < now() - INTERVAL '90 days'`. Partitioning deferred until steady-state exceeds 10M rows (compliance-snapshots precedent — L5.5).
+  - Bulk-refresh jobs table grows unboundedly without retention; add a 30-day retention sweep alongside the history table.
+  - Notification dedupe map grows unboundedly per UID; mitigated by entry deletion on bucket transition to `synced` (Phase 13 precedent — L4.2). Restart recovery seeds prev-bucket from DB to prevent recovery-event suppression after restart.
+  - Drift detection on detail page does an extra impersonated `Get`; bounded by the existing 30s cache horizon (impersonated calls are not cached cluster-wide; per-request).
+- **API surface parity:** All new endpoints additive. `Graph.Overlay` field stays `omitempty` so default response is byte-identical to today (L6.1). ExternalSecret/Store list and detail endpoints introduce new types but don't modify existing types. `nc_notifications.source` enum extension is additive at the DB layer.
+- **Integration coverage scenarios:**
+  - (a) ESO uninstalled → all endpoints return empty / detected=false; no 5xx. Routes render empty state.
+  - (b) ESO installed, no ExternalSecrets yet → list endpoints return `[]`; dashboard shows "No External Secrets" empty state.
+  - (c) ExternalSecret with ClusterSecretStore reference, tenant operator without ClusterStore visibility → detail page shows "Source: <restricted>" placeholder; chain graph omits the ClusterStore node (L1.1, L2.2).
+  - (d) Bulk refresh against a store with mixed-permission targets → response carries `{succeeded, failed, skipped}` per-target outcomes; audit log captures honest aggregate.
+  - (e) Provider that doesn't populate `syncedResourceVersion` → drift status reports `Unknown`, never silent false-negative (R20 tri-state).
+  - (f) ESO API version drift (cluster on `v1beta1`-only) → dynamic client transparently serves v1beta1 since it's still served (L6 in repo research).
+  - (g) Notification rule routing for new event kinds → existing source_filter array column accepts `external_secrets`; rule UI auto-picks it up (no rule-engine change).
+- **Unchanged invariants:**
+  - Phase 11A package layout, naming, and behavior — ESO is a sibling, not a refactor.
+  - `Graph.Truncated` (node cap) and `Graph.EdgesTruncated` (overlay edge cap) keep their current semantics.
+  - Notification Service `DedupExists` 15-minute window stays at 15 min — ESO uses a separate in-memory `(uid, kind)` dedupe layered on top.
+  - Audit log retention policy unchanged (90 days); ESO bulk-action records use the existing `Detail` JSON field.
+  - User impersonation discipline: every write call uses the impersonating client (L8.3).
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Per-provider Go SDK pull-in via wizard typed structs would explode go.mod (L7.1) | Use `map[string]any` for `ProviderSpec` everywhere. Validators are hand-rolled, not type-checked. |
+| Notification source enum CHECK constraint already drifted (silently includes velero, certmanager, limits without migration) (L4.3) | Migration 000011 fixes the drift while adding `external_secrets`. Dry-run against a migrated DB before merge. |
+| Sync history table volume (~100M rows/year worst case) exceeds flat-table comfort | Monthly partitioning from day one (L5.2). Retention drops empty partitions, not row-by-row DELETEs. |
+| Drift detection on list view would cause N+1 impersonated Gets | List view reports `LastObservedDriftStatus` from cached history snapshot only; live drift check is detail-page-only. Documented in Unit 3. |
+| Bulk-refresh fan-out 200ms inter-call delay on a 1000-target store = 3+ minute fan-out | Frontend shows progress; the action is async-progress-polled rather than synchronous. Audit row written at completion, not per-target. Document in Unit 15 if smoke testing reveals UX issues. |
+| Annotation cache TTL of 30s means edits don't apply immediately | Documented in operator docs (Phase J). Matches Phase 13 precedent. |
+| Path-discovery proxy could be abused as an SSRF surface | Cut to Kubernetes provider only in v1 (k8s-RBAC-mediated, no source-store auth needed). Cross-provider path-discovery deferred to v2 with explicit auth-model design. |
+| 12-provider wizard scope is sprawling; some wizards may add little value (L7.2) | Unit 19 split into per-provider sub-PRs. Each PR documents whether its provider ships as wizard or template (Unit 20). R13's contract is delivered when all 12 providers have at least one creation path; not 12 wizards specifically. |
+| Cluster-scoped ClusterSecretStore references that span namespaces could leak existence via 403 vs 200 timing | Per-CRD-group RBAC fails closed silently (L1.1) — denial returns no data, never 403. |
+| Force-sync detection of in-flight ESO reconcile | Use `lastRefreshTime within 30s` heuristic (rather than `Ready=Unknown`, which ESO doesn't reliably set mid-reconcile). 409 with `already_refreshing`. Heuristic limit: a sync legitimately taking >30s won't show as in-flight — accepted trade-off. |
+| Bulk-refresh scope race between GET and POST | Client passes `targetUIDs` from GET; backend re-resolves at POST and rejects with 409 + diff if scope changed. |
+| Bulk-refresh job lifetime spans backend restarts | Persisted `eso_bulk_refresh_jobs` table. On restart, in-flight jobs marked completed with current state. Operator can resume polling after navigation away. |
+| Phase 7B 2000-node cap could clip a heavily-shared ClusterSecretStore chain silently | `EdgesTruncated` flag separate from `Truncated` (L6.2). Frontend renders "showing N of M" notice (Unit 22). |
+| Notification recovery emission lost on poller restart | Seed prev-bucket map from `nc_notifications` at startup via `Store.RecentBySourceAndKind`. Without this, recovery alerts post-restart are silently suppressed (cert-manager precedent has the same bug; ESO fixes it). |
+| Notification dispatch leaks tenant resource names to Slack/webhook | `SuppressResourceFields` flag on `Notification`; ESO events set true; dispatcher omits `ResourceNS`/`ResourceName` from external payload bodies. |
+| Annotation `eso-stale-after-minutes` enables self-DoS | 5-minute floor enforced in resolver; values below are rejected and fall through. |
+| Helm `core/secrets get` grant expands platform SA privilege | Documented explicitly in Unit 6; operators in stricter environments can remove the grant; diff-key feature degrades but timeline still functions. |
+| Map-iteration-order flakes in tests | All new tests run with `-count=10` per L7.5 / V2. |
+| Helm chart changes not exercised locally before push | `make helm-lint` + `make helm-template` mandatory pre-push checks (V1). |
+| Theme palette extension (`--warning`, `--accent-secondary` may be new) touches all 7 themes | Unit 7 verifies presence in `frontend/static/themes/*.css` before starting; add to all themes if absent. |
+
+## Documentation / Operational Notes
+
+- Operator-facing: a paragraph in CLAUDE.md (Phase J) covers the annotation surface (`kubecenter.io/eso-stale-after-minutes` with 5-minute floor, `kubecenter.io/eso-alert-on-recovery`, `kubecenter.io/eso-alert-on-lifecycle`), the resolution chain (resource > store > clusterstore > default), the 30s cache TTL for annotation edits, and the bulk-refresh RBAC-scoping behavior.
+- Cost-tier rate cards refresh cadence: quarterly hand-update of the Go map literal in `backend/internal/externalsecrets/cost_tier.go`. Each entry's `LastUpdated` field is rendered to the operator inline ("Rates as of YYYY-MM-DD"); drift between rate cards and provider pricing is a known acceptable trade-off (R26).
+- Sync history retention: 90 days, hardcoded in retention goroutine. Future operator-config option deferred.
+- Drift detection coverage: per-provider `syncedResourceVersion` population is enumerated during Phase C smoke testing; populate a "providers that expose drift" table in operator docs as a Phase J follow-up artifact. Drift detection on the **list view** has up to ~90s staleness (60s poller + 30s handler cache); the **detail page** is always fresh (live RV check on every request). Drift detection requires `get secret` on the synced Secret target — users without that perm see `DriftStatus: Unknown` permanently.
+- Path-discovery is Kubernetes-provider-only in v1. All other providers in the wizard render free-text path inputs. Cross-provider path-discovery is deferred to a v2 with an explicit per-provider auth-model design.
+- PushSecret read-only: spec is intentionally surfaced (selector + remoteRef paths visible to anyone with `list pushsecrets`). PushSecret write surface remains deferred to v2 contingent on usage signals; the read-only-only v1 surface may suppress demand signal because operators have no easy creation path. Re-evaluate at the 6-month mark using observed ExternalSecret-vs-PushSecret ratios.
+- The `eso_sync_history` schema is intentionally ESO-specific. If similar polled-state timelines emerge (GitOps revision history, drift events for other observatory packages), consider extracting a shared schema; defer that decision until at least one second use case lands.
+- Notification rule UI: the `frontend/islands/NotificationRules.tsx` source selector groups entries by category in Phase D (Infrastructure / Policy / Secrets / Operations) — keeps the 11-entry checkbox grid usable.
+
+## Sources & References
+
+- Origin requirements: `docs/brainstorms/2026-04-29-external-secrets-operator-requirements.md`.
+- Phase 11A precedent: `backend/internal/certmanager/` (entire package); CLAUDE.md Phase 11A entry.
+- Phase 11B precedent: `backend/internal/wizard/{certificate,issuer,cert_helpers}.go`; `frontend/islands/{Certificate,Issuer}Wizard.tsx`.
+- Phase 13 precedent: `backend/internal/certmanager/thresholds.go`; CLAUDE.md Phase 13 entry; `plans/cert-manager-configurable-expiry-thresholds.md`.
+- Phase 12 precedent: `backend/internal/topology/{builder,mesh_edges,types}.go`; `plans/service-mesh-observability-phase-d1-topology-backend.md`.
+- Notification Center: `backend/internal/notifications/{types,service,store}.go`; migration `000007_create_notification_center.up.sql`.
+- Audit logger: `backend/internal/audit/{logger,postgres_logger,store}.go`; migration `000001_create_audit_logs.up.sql`.
+- Migration framework: `backend/internal/store/migrate.go`; `migrations/000005_create_compliance_snapshots.up.sql` for cluster_id+UID-keyed flat-table precedent; `migrations/000001_create_audit_logs.up.sql` for retention pattern.
+- Helm RBAC: `helm/kubecenter/templates/clusterrole.yaml` (Istio/Linkerd block at lines 123–146 in current chart).
+- Roadmap: `CLAUDE.md` "Future Features" item #8.
+
+## Implementation Units (checklist)
+
+Order is **A → B → D → C → E → F → G → H → I → J**.
+
+### Phase A — Backend observatory + Helm RBAC
+- [ ] Unit 1 — Package skeleton (discovery + types + normalize, Go-TS hash test)
+- [ ] Unit 2 — Handler (singleflight + cache + permissive-read RBAC + list endpoints)
+- [ ] Unit 3 — Detail endpoints + drift resolution (impersonated `get secret`)
+- [ ] Unit 4 — Routes wiring (under authenticated `ar.Group` for CSRF)
+- [ ] ~~Unit 5~~ — DELETED (metric name constants live in `cost_tier.go`)
+- [ ] Unit 6 — Helm ClusterRole grant (ESO list/watch + core/secrets get/list with documented trade-off)
+
+### Phase B — Frontend observatory
+- [ ] Unit 7 — Routes + list islands + new ESO nav-rail domain section + standalone Chain page + per-list empty states
+- [ ] Unit 8 — Detail islands + Dashboard (sync-health hero ring, broken-ESes-with-consumer-counts table)
+
+### Phase D — Alerting + annotation thresholds (lands BEFORE Phase C)
+- [ ] Unit 12 — Migration 000010 (source enum extension via ALTER) + annotation resolver + `SuppressResourceFields` dispatch flag + notification source grouping
+- [ ] Unit 13 — Notification dispatch (failure + recovery + lifecycle, separate dedupe keys)
+
+### Phase C — Persistence + drift
+- [ ] Unit 9 — Migration 000011 (`eso_sync_history` flat table, three text[] diff columns, partition-candidate comment)
+- [ ] Unit 10 — Sync-history persistence in poller (with restart-recovery prev-bucket seeding)
+- [ ] Unit 11 — Drift detection wiring on detail + Revert button + dashboard counts
+
+### Phase E — Bulk refresh actions
+- [ ] Unit 14 — Force-sync action + impersonation + audit (`lastRefreshTime` heuristic for in-flight detection)
+- [ ] Unit 15 — Migration 000012 (`eso_bulk_refresh_jobs`) + async job model + scope-pinned execution + dialog + progress polling
+
+### Phase F — Per-store rate + cost-tier panel
+- [ ] Unit 16 — Per-store rate panel + cost-tier card (Go map literal rate cards with `LastUpdated`)
+
+### Phase G — Universal ExternalSecret wizard
+- [ ] Unit 17 — ExternalSecret wizard (Kubernetes-provider-only path-discovery) + regex parity test
+
+### Phase H — Per-provider SecretStore wizards (split into per-provider sub-PRs)
+- [ ] Unit 18 — SecretStore wizard scaffold + StoreScope discriminator
+- [ ] Unit 19 — Per-provider validators + form components (one sub-PR per provider; ~36 form variants total)
+- [ ] Unit 20 — Niche-provider YAML templates
+
+### Phase I — Chain visualization
+- [ ] Unit 21 — Backend ESOChainProvider + applyESOChainOverlay
+- [ ] Unit 22 — Frontend chain overlay toggle (mutually exclusive with mesh) + chain tab on detail (with `focusedNode` BFS prerequisite refactor)
+
+### Phase J — Final docs flip
+- [ ] Unit 23 — CLAUDE.md (Phase 14 ESO entry), README.md, roadmap (#8 → [x]), plan status → complete

--- a/plans/external-secrets-operator-integration.md
+++ b/plans/external-secrets-operator-integration.md
@@ -247,7 +247,7 @@ Removed during plan review. The metric-name constants live in `cost_tier.go` (Un
 - Modify: `helm/kubecenter/templates/clusterrole.yaml` — append a block after the existing Istio/Linkerd grants (lines 123–146 in current chart per L9 of repo research).
 
 **Approach:**
-- Blocks:
+- Phase A ships ONLY the ESO CRD list/watch grant:
   ```yaml
   - apiGroups: ["external-secrets.io"]
     resources:
@@ -257,12 +257,16 @@ Removed during plan review. The metric-name constants live in `cost_tier.go` (Un
       - clustersecretstores
       - pushsecrets
     verbs: ["list", "watch"]
+  ```
+- The `core/secrets` `get/list` grant is **deferred to Phase C's Unit 10 PR** — that's the unit whose poller actually consumes it. Shipping the grant ahead of its consumer in Phase A would expand the platform SA's cluster-wide privilege without any code that uses it, and would contradict the existing architectural-boundary comment at `clusterrole.yaml:20` ("secrets are fetched on-demand via impersonated client, not cached in informer"). When Unit 10 lands, it adds:
+  ```yaml
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list"]
   ```
-- The `core/secrets` `get/list` grant is required by the poller in Unit 10 to read synced Secret keys for diff-key computation (R21). This is a meaningful expansion of the platform SA's privilege — the SA gains cluster-wide Secret read. Document the trade-off explicitly: a k8sCenter compromise yields cluster-wide synced-Secret read access. Operators in stricter environments can remove this block; the diff feature degrades to "outcome only, no key-set" but the timeline still functions, drift detection still works, and notifications still fire.
-- The existing Helm wildcard catch-all (`apiGroups: ["*"]; verbs: ["list"]`) at `clusterrole.yaml:160-162` already authorizes `list` on every CRD; the explicit ESO block is defense-in-depth documentation, not net-new authorization. The `core/secrets` `get` grant IS net-new (the wildcard is `list`-only).
+  with the same documented trade-off: a k8sCenter compromise yields cluster-wide synced-Secret read access. Operators in stricter environments can remove the block; the diff feature degrades to "outcome only, no key-set" but the timeline still functions, drift detection still works, and notifications still fire.
+- Phase A's drift resolution path (`resolveDriftStatus` in `internal/externalsecrets/handler.go`) uses the impersonated client, so it works without the SA grant.
+- The existing Helm wildcard catch-all (`apiGroups: ["*"]; verbs: ["list"]`) at `clusterrole.yaml` already authorizes `list` on every CRD; the explicit ESO block is defense-in-depth documentation, not net-new authorization. The `core/secrets` `get` grant IS net-new (the wildcard is `list`-only) — that's why it ships in the unit that consumes it.
 - Get verb on ESO CRDs is implicit through the impersonating client for detail endpoints.
 
 **Verification:**
@@ -438,9 +442,16 @@ PostgreSQL migration for `eso_sync_history`. Poller persistence hook. Drift-awar
 - Create: `backend/internal/externalsecrets/poller_test.go` — table-driven attempt-comparison + dedupe tests.
 - Create: `backend/internal/store/eso_history.go` — `Store.AppendESOHistory(ctx, entry)`, `Store.QueryESOHistory(ctx, uid, limit)`, `Store.RunESOHistoryRetention(ctx)`, `Store.EnsureESOHistoryPartitions(ctx)`.
 - Modify: `backend/internal/server/server.go` — start the poller alongside the cert-manager poller; wire the retention goroutine.
+- Modify: `helm/kubecenter/templates/clusterrole.yaml` — add the `core/secrets` `get/list` grant block here (deferred from Phase A's Unit 6 because the poller is its only consumer):
+  ```yaml
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  ```
+  This is the meaningful privilege expansion called out in Unit 6 — Phase C is where it lands.
 
 **Approach:**
-- Diff computation: read the synced k8s Secret's `Data` keys via the platform service account (which has cluster-wide `get/list secrets` per Unit 6's Helm grant addition). The poller has no requesting-user context and cannot impersonate. The Helm grant is documented as a meaningful privilege expansion in Unit 6; operators in stricter environments can remove the grant and the diff feature degrades to "outcome only, no key-set" while the timeline still functions. Compare against the prior history entry's `diff_keys_*` baseline (we store the resolved key-set per attempt; the "baseline" is the prior attempt's resolved key-set). Emit `{added, removed, changed}` arrays of key names. **Values are never stored or logged.**
+- Diff computation: read the synced k8s Secret's `Data` keys via the platform service account (which gains cluster-wide `get/list secrets` in this unit's Helm grant addition). The poller has no requesting-user context and cannot impersonate. The grant is documented as a meaningful privilege expansion; operators in stricter environments can remove it and the diff feature degrades to "outcome only, no key-set" while the timeline still functions. Compare against the prior history entry's `diff_keys_*` baseline (we store the resolved key-set per attempt; the "baseline" is the prior attempt's resolved key-set). Emit `{added, removed, changed}` arrays of key names. **Values are never stored or logged.**
 - `attempt_at` resolution: use `lastRefreshTime` from ESO status when available, else `now()`. Always at second granularity.
 - INSERT pattern: `INSERT INTO eso_sync_history (...) VALUES (...) ON CONFLICT (uid, attempt_at) DO NOTHING` — idempotent under poller restart (L5.3).
 - `cluster_id` provenance: read from the platform's local-cluster registry at poller startup; cached for the poller's lifetime. The poller is local-cluster-only (Phase 11A constraint); cluster_id never changes mid-process.
@@ -1128,7 +1139,7 @@ Order is **A → B → D → C → E → F → G → H → I → J**.
 - [ ] Unit 3 — Detail endpoints + drift resolution (impersonated `get secret`)
 - [ ] Unit 4 — Routes wiring (under authenticated `ar.Group` for CSRF)
 - [ ] ~~Unit 5~~ — DELETED (metric name constants live in `cost_tier.go`)
-- [ ] Unit 6 — Helm ClusterRole grant (ESO list/watch + core/secrets get/list with documented trade-off)
+- [ ] Unit 6 — Helm ClusterRole grant (ESO CRD list/watch only; core/secrets get/list deferred to Unit 10's PR — see Unit 6 body)
 
 ### Phase B — Frontend observatory
 - [ ] Unit 7 — Routes + list islands + new ESO nav-rail domain section + standalone Chain page + per-list empty states


### PR DESCRIPTION
## Summary

Phase A of the External Secrets Operator integration ([roadmap #8](../blob/main/CLAUDE.md#future-features-roadmap), [plan](plans/external-secrets-operator-integration.md)). Mirrors the cert-manager Phase 11A package layout 1:1.

- **New `internal/externalsecrets/` package** — discovery, normalized types for the 5 ESO v1 CRDs (ExternalSecret, ClusterExternalSecret, SecretStore, ClusterSecretStore, PushSecret), handler with singleflight + 30s cache + per-CRD-group RBAC, detail endpoints with drift resolution
- **11 read endpoints** under `/api/v1/externalsecrets/*` (status + 5 list + 5 detail)
- **Helm ClusterRole grants** for ESO CRD `list`/`watch` (consumed by the discoverer's 30s cache)

Phase scope is read-only observatory. Write actions (force-sync, bulk refresh) ship in Phase E; persistence + drift history in Phase C; alerting + annotation thresholds in Phase D; wizards in Phases G/H; chain overlay in Phase I.

## What's in this PR

### Phase A units (per the plan)

- **U1** — Package skeleton: discovery, types, normalize, table-driven tests for 5 CRDs
- **U2** — Handler: singleflight + 30s cache + per-CRD-group RBAC via `CanAccessGroupResource` + 5-CRD concurrent fetch with **per-CRD failure isolation** (one CRD list erroring doesn't blank the others)
- **U3** — Detail endpoints with **drift resolution** via impersonated synced-Secret RV lookup + tri-state DriftStatus + reason codes (`no_synced_rv` / `secret_deleted` / `rbac_denied` / etc.)
- **U4** — Routes wiring under `/api/v1/externalsecrets/*` + ClusterContext middleware
- **U6** — Helm ClusterRole grants for ESO CRDs (kept tight: `core/secrets get/list` deferred to Phase C poller's PR rather than shipping cluster-wide privilege ahead of consumer code)

### Behavior + correctness highlights

- **Cache-poisoning guard** (`fetchAll` re-checks `ctx.Err()` after `g.Wait()`) — a client disconnect mid-fetch no longer blanks the observatory for 30s
- **Per-CRD partial-failure surface** — `cachedData.errors` map exposes which CRDs are degraded; preserves last-known-good slices when one CRD's List call errors
- **Permissive-read on cluster-scoped CRDs** — empty list with HTTP 200 (not 403) when user lacks the grant; avoids existence-leak via timing
- **`Discoverer.Probe`** runs network calls without holding the write lock; `commitStatus` does a double-check before writing to prevent thundering-herd at the staleDuration boundary
- **Singleflight key embeds the cache generation** so future Phase E `InvalidateCache` calls split new request waves cleanly
- **`StaleAfterMinutes`** is `*int` (consistent with SecretStore); `AlertOnLifecycleSource` symmetric with `AlertOnRecoverySource` — Phase D resolver lands cleanly on the existing wire shape

### Code review pass results

Multi-agent `/ce:review` (correctness + testing + maintainability + project-standards + agent-native + learnings + security + performance + api-contract + reliability + adversarial) flagged 27 actionable findings. Best-judgment auto-resolve: **21 applied, 4 deferred with reasons, 5 advisory**. P1 issues (cache poisoning, Helm SA grant) both resolved. Detailed F-ID-by-F-ID outcomes are in the commit body of `71a2183`.

## Test plan

- [x] `cd backend && go vet ./...` — clean
- [x] `cd backend && go test -count=1 ./...` — repo-wide green (32 packages)
- [x] `cd backend && go test -count=10 ./internal/externalsecrets/...` — stable across 10 runs (race-detector requires CGO_ENABLED=1; CI runs it)
- [x] gofmt clean on touched files
- [ ] CI: GitHub Actions go vet/test, deno lint/build, Trivy scan
- [ ] Smoke against homelab: install ESO via Helm, verify `/api/v1/externalsecrets/status` reports detected, list endpoints return real data, detail endpoint resolves drift correctly

## Out of scope (explicitly deferred)

- Frontend islands + routes under `/security/external-secrets/*` — **Phase B**
- Persistent sync history table (`eso_sync_history`) + drift detection on dashboard — **Phase C**
- Notification source enum + annotation resolver chain (`eso-stale-after-minutes`, etc.) — **Phase D**
- Force-sync action + bulk refresh job model + `core/secrets get/list` SA grant — **Phase E**
- Per-store rate + cost-tier panel — **Phase F**
- ExternalSecret + per-provider SecretStore wizards — **Phases G + H**
- Chain visualization (topology overlay) — **Phase I**

🤖 Generated with [Claude Code](https://claude.com/claude-code)