### PR TITLE
feat(eso): Phase B — frontend observatory (Units 7 & 8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,9 @@ e2e/test-results/
 .claude/scheduled_tasks.lock
 .claude/scheduled_tasks.json
 
+# Claude Code per-subagent isolated worktrees
+.claude/worktrees/
+
 # Claude Code per-user local settings
 .claude/settings.local.json
 

--- a/frontend/components/eso/ESOBadges.tsx
+++ b/frontend/components/eso/ESOBadges.tsx
@@ -1,0 +1,77 @@
+import type {
+  DriftStatus,
+  Status,
+  ThresholdSource,
+} from "@/lib/eso-types.ts";
+import { ColorBadge } from "@/components/ui/ColorBadge.tsx";
+
+/** Status enum → CSS custom property color. Six values cover the lifecycle:
+ * Synced (success), SyncFailed (danger), Refreshing (accent), Stale (warning),
+ * Drifted (accent-secondary — distinct from failure red), Unknown (muted). */
+const STATUS_COLORS: Record<Status, string> = {
+  Synced: "var(--success)",
+  SyncFailed: "var(--danger)",
+  Refreshing: "var(--accent)",
+  Stale: "var(--warning)",
+  Drifted: "var(--accent-secondary)",
+  Unknown: "var(--text-muted)",
+};
+
+const DRIFT_COLORS: Record<DriftStatus, string> = {
+  InSync: "var(--success)",
+  Drifted: "var(--accent-secondary)",
+  Unknown: "var(--text-muted)",
+};
+
+const SOURCE_LABELS: Record<ThresholdSource, string> = {
+  default: "Default",
+  externalsecret: "ExternalSecret",
+  secretstore: "Store",
+  clustersecretstore: "ClusterStore",
+};
+
+/** Renders a pill badge for ExternalSecret status. */
+export function StatusBadge({ status }: { status: Status }) {
+  return (
+    <ColorBadge
+      label={status}
+      color={STATUS_COLORS[status] ?? "var(--text-muted)"}
+    />
+  );
+}
+
+/** Renders a pill badge for the tri-state drift indicator. Used inline on
+ * detail pages alongside the status badge. List rows rely on the Status
+ * badge alone (DriftStatus = "Drifted" is overlaid into Status by
+ * DeriveStatus on the detail endpoint). */
+export function DriftBadge({ status }: { status: DriftStatus }) {
+  return (
+    <ColorBadge
+      label={status}
+      color={DRIFT_COLORS[status] ?? "var(--text-muted)"}
+    />
+  );
+}
+
+/** Threshold source attribution badge — Phase D resolver populates these per
+ * key (StaleAfterMinutesSource, AlertOnRecoverySource, etc.). Phase A response
+ * shape carries the field but always omits the value, so renders nothing. */
+export function SourceBadge({ source }: { source?: ThresholdSource }) {
+  if (!source) return null;
+  return (
+    <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[11px] font-normal text-text-muted bg-bg-base border border-border-subtle">
+      {SOURCE_LABELS[source] ?? source}
+    </span>
+  );
+}
+
+/** Provider family badge (vault, aws, gcp, azurekv, kubernetes, ...).
+ * Uses muted styling — provider is informational, not status-driven. */
+export function ProviderBadge({ provider }: { provider: string }) {
+  if (!provider) {
+    return <span class="text-xs text-text-muted">&mdash;</span>;
+  }
+  return (
+    <ColorBadge label={provider} color="var(--accent)" />
+  );
+}

--- a/frontend/components/eso/ESOBadges.tsx
+++ b/frontend/components/eso/ESOBadges.tsx
@@ -1,8 +1,4 @@
-import type {
-  DriftStatus,
-  Status,
-  ThresholdSource,
-} from "@/lib/eso-types.ts";
+import type { DriftStatus, Status, ThresholdSource } from "@/lib/eso-types.ts";
 import { ColorBadge } from "@/components/ui/ColorBadge.tsx";
 
 /** Status enum → CSS custom property color. Six values cover the lifecycle:
@@ -59,7 +55,7 @@ export function DriftBadge({ status }: { status: DriftStatus }) {
 export function SourceBadge({ source }: { source?: ThresholdSource }) {
   if (!source) return null;
   return (
-    <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[11px] font-normal text-text-muted bg-bg-base border border-border-subtle">
+    <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[11px] font-normal text-text-muted bg-base border border-border-subtle">
       {SOURCE_LABELS[source] ?? source}
     </span>
   );
@@ -71,7 +67,5 @@ export function ProviderBadge({ provider }: { provider: string }) {
   if (!provider) {
     return <span class="text-xs text-text-muted">&mdash;</span>;
   }
-  return (
-    <ColorBadge label={provider} color="var(--accent)" />
-  );
+  return <ColorBadge label={provider} color="var(--accent)" />;
 }

--- a/frontend/components/eso/ESODriftIndicator.tsx
+++ b/frontend/components/eso/ESODriftIndicator.tsx
@@ -1,0 +1,76 @@
+import type { DriftStatus, DriftUnknownReason } from "@/lib/eso-types.ts";
+import { DriftBadge } from "@/components/eso/ESOBadges.tsx";
+
+/** Per-reason hint text rendered next to the badge. The reason field is
+ * populated only on the detail endpoint; list rows leave driftStatus as
+ * Unknown without a reason. */
+const REASON_HINTS: Record<DriftUnknownReason, string> = {
+  no_synced_rv:
+    "Provider does not expose syncedResourceVersion — drift cannot be determined.",
+  no_target_name:
+    "ExternalSecret has no target Secret name — nothing to compare against.",
+  secret_deleted:
+    "The synced Secret has been deleted. ESO should recreate it on the next reconcile.",
+  rbac_denied:
+    "Drift requires `get secret` on the target namespace. Your role does not include that permission.",
+  transient_error:
+    "Drift check failed transiently — retry the page.",
+  client_error: "Internal error creating the impersonated client.",
+};
+
+interface ESODriftIndicatorProps {
+  status: DriftStatus;
+  reason?: DriftUnknownReason;
+  /** When provided, the Drifted state renders a "Revert" button stub. The
+   * actual force-sync action lands in Phase E (Unit 14); this Phase B
+   * variant is non-functional and shows an inline note. */
+  onRevert?: () => void;
+}
+
+/** Tri-state drift indicator for the ExternalSecret detail page. Renders the
+ * coloured badge inline with explanatory text and (when status=Drifted) a
+ * Revert action stub. */
+export function ESODriftIndicator(
+  { status, reason, onRevert }: ESODriftIndicatorProps,
+) {
+  return (
+    <div class="flex flex-col gap-1.5">
+      <div class="flex items-center gap-2">
+        <DriftBadge status={status} />
+        {status === "Drifted" && (
+          <span class="text-xs text-text-muted">
+            The synced Secret has been edited since ESO last reconciled it.
+          </span>
+        )}
+        {status === "Unknown" && reason && (
+          <span class="text-xs text-text-muted">
+            {REASON_HINTS[reason] ??
+              "Drift state is currently unknown."}
+          </span>
+        )}
+        {status === "InSync" && (
+          <span class="text-xs text-text-muted">
+            Synced Secret matches the resource version ESO recorded.
+          </span>
+        )}
+      </div>
+      {status === "Drifted" && onRevert && (
+        <div class="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onRevert}
+            class="text-xs px-2 py-1 rounded border border-border-primary text-text-muted hover:text-text-primary hover:bg-bg-base transition-colors"
+            disabled
+            aria-disabled="true"
+            title="Force-sync ships in Phase E"
+          >
+            Revert drift
+          </button>
+          <span class="text-[11px] text-text-muted">
+            Force-sync action available in Phase&nbsp;E.
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/eso/ESODriftIndicator.tsx
+++ b/frontend/components/eso/ESODriftIndicator.tsx
@@ -13,25 +13,21 @@ const REASON_HINTS: Record<DriftUnknownReason, string> = {
     "The synced Secret has been deleted. ESO should recreate it on the next reconcile.",
   rbac_denied:
     "Drift requires `get secret` on the target namespace. Your role does not include that permission.",
-  transient_error:
-    "Drift check failed transiently — retry the page.",
+  transient_error: "Drift check failed transiently — retry the page.",
   client_error: "Internal error creating the impersonated client.",
 };
 
 interface ESODriftIndicatorProps {
   status: DriftStatus;
   reason?: DriftUnknownReason;
-  /** When provided, the Drifted state renders a "Revert" button stub. The
-   * actual force-sync action lands in Phase E (Unit 14); this Phase B
-   * variant is non-functional and shows an inline note. */
-  onRevert?: () => void;
 }
 
 /** Tri-state drift indicator for the ExternalSecret detail page. Renders the
- * coloured badge inline with explanatory text and (when status=Drifted) a
- * Revert action stub. */
+ * coloured badge inline with explanatory text. When status=Drifted, also
+ * renders a disabled "Revert" stub — Phase E (Unit 14) will replace the stub
+ * with a real force-sync handler. */
 export function ESODriftIndicator(
-  { status, reason, onRevert }: ESODriftIndicatorProps,
+  { status, reason }: ESODriftIndicatorProps,
 ) {
   return (
     <div class="flex flex-col gap-1.5">
@@ -54,12 +50,11 @@ export function ESODriftIndicator(
           </span>
         )}
       </div>
-      {status === "Drifted" && onRevert && (
+      {status === "Drifted" && (
         <div class="flex items-center gap-2">
           <button
             type="button"
-            onClick={onRevert}
-            class="text-xs px-2 py-1 rounded border border-border-primary text-text-muted hover:text-text-primary hover:bg-bg-base transition-colors"
+            class="text-xs px-2 py-1 rounded border border-border-primary text-text-muted hover:text-text-primary hover:bg-base transition-colors"
             disabled
             aria-disabled="true"
             title="Force-sync ships in Phase E"

--- a/frontend/components/eso/ESONotDetected.tsx
+++ b/frontend/components/eso/ESONotDetected.tsx
@@ -1,0 +1,26 @@
+/** "ESO not installed" tile shared between the dashboard and list islands.
+ *
+ * Backend Phase A returns `{detected: false}` from `/externalsecrets/status`
+ * when no ESO CRDs are present. Per plan R2 every list/index surface should
+ * surface that as an install prompt rather than the empty-list copy. */
+export function ESONotDetected() {
+  return (
+    <div class="rounded-lg border border-border-primary p-8 text-center bg-elevated">
+      <p class="text-lg font-medium text-text-primary mb-2">
+        External Secrets Operator is not installed in this cluster.
+      </p>
+      <p class="text-sm text-text-muted">
+        Install via the{" "}
+        <a
+          class="text-brand hover:underline"
+          href="https://external-secrets.io/latest/introduction/getting-started/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          ESO Helm chart
+        </a>{" "}
+        to start managing secrets across stores.
+      </p>
+    </div>
+  );
+}

--- a/frontend/islands/CommandPalette.tsx
+++ b/frontend/islands/CommandPalette.tsx
@@ -97,6 +97,26 @@ function buildSearchIndex(): SearchItem[] {
       label: "Create ClusterIssuer",
       href: "/security/certificates/cluster-issuers/new",
     },
+    {
+      label: "External Secrets Dashboard",
+      href: "/external-secrets/dashboard",
+    },
+    {
+      label: "View ExternalSecrets",
+      href: "/external-secrets/external-secrets",
+    },
+    {
+      label: "View SecretStores",
+      href: "/external-secrets/stores",
+    },
+    {
+      label: "View ClusterSecretStores",
+      href: "/external-secrets/cluster-stores",
+    },
+    {
+      label: "View ExternalSecrets Chain",
+      href: "/external-secrets/chain",
+    },
     { label: "View Gateway API", href: "/networking/gateway-api" },
     { label: "View Service Mesh", href: "/networking/mesh" },
     { label: "View Mesh Routing", href: "/networking/mesh/routing" },

--- a/frontend/islands/ESOChainPage.tsx
+++ b/frontend/islands/ESOChainPage.tsx
@@ -1,0 +1,86 @@
+import { useSignal } from "@preact/signals";
+import { IS_BROWSER } from "fresh/runtime";
+
+/** Chain page (Phase B placeholder).
+ *
+ * The cross-resource overlay (ExternalSecret → SecretStore → target Secret →
+ * consuming Pods) ships in Phase I as a `?overlay=eso-chain` query on the
+ * existing `/observability/topology` view. Until then this page exists so the
+ * "Chain" tab in the External Secrets nav has a real landing surface and a
+ * one-click jump into the namespaced topology view. */
+export default function ESOChainPage() {
+  const namespace = useSignal("");
+
+  if (!IS_BROWSER) return null;
+
+  const ns = namespace.value.trim();
+
+  return (
+    <div class="p-6">
+      <div class="flex items-start justify-between mb-1">
+        <h1 class="text-2xl font-bold text-text-primary">ESO Chain</h1>
+      </div>
+      <p class="text-sm text-text-muted mb-6">
+        Visualize the path from a SecretStore through ExternalSecrets to the
+        Pods consuming the resulting Secret.
+      </p>
+
+      <div class="rounded-lg border border-border-primary bg-bg-elevated p-6 max-w-2xl">
+        <h2 class="text-base font-semibold text-text-primary mb-2">
+          Chain overlay coming in Phase I
+        </h2>
+        <p class="text-sm text-text-muted mb-4">
+          The dedicated overlay is part of a later phase. In the meantime, the
+          existing namespace topology view shows the same resources — pick a
+          namespace below to jump into it.
+        </p>
+
+        <div class="flex items-center gap-3 mb-4">
+          <label
+            class="text-sm font-medium text-text-secondary shrink-0"
+            htmlFor="eso-chain-ns"
+          >
+            Namespace
+          </label>
+          <input
+            id="eso-chain-ns"
+            type="text"
+            class="flex-1 rounded border border-border-primary px-3 py-1.5 text-sm bg-bg-base text-text-primary"
+            placeholder="e.g. payments-prod"
+            value={namespace.value}
+            aria-describedby="eso-chain-ns-hint"
+            onInput={(e) => {
+              namespace.value = (e.target as HTMLInputElement).value;
+            }}
+          />
+        </div>
+        <p id="eso-chain-ns-hint" class="text-xs text-text-muted mb-4">
+          Type a namespace, then click "Open in Topology" to view its
+          ExternalSecrets in context.
+        </p>
+
+        {ns
+          ? (
+            <a
+              href={`/observability/topology?namespace=${
+                encodeURIComponent(ns)
+              }`}
+              class="inline-flex items-center gap-2 rounded-md bg-brand px-3 py-1.5 text-sm font-medium text-white hover:bg-brand/90"
+            >
+              Open in Topology →
+            </a>
+          )
+          : (
+            <button
+              type="button"
+              class="inline-flex items-center gap-2 rounded-md border border-border-primary px-3 py-1.5 text-sm font-medium text-text-muted cursor-not-allowed opacity-60"
+              disabled
+              aria-disabled="true"
+            >
+              Select a namespace
+            </button>
+          )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/islands/ESOChainPage.tsx
+++ b/frontend/islands/ESOChainPage.tsx
@@ -25,7 +25,7 @@ export default function ESOChainPage() {
         Pods consuming the resulting Secret.
       </p>
 
-      <div class="rounded-lg border border-border-primary bg-bg-elevated p-6 max-w-2xl">
+      <div class="rounded-lg border border-border-primary bg-elevated p-6 max-w-2xl">
         <h2 class="text-base font-semibold text-text-primary mb-2">
           Chain overlay coming in Phase I
         </h2>
@@ -45,7 +45,7 @@ export default function ESOChainPage() {
           <input
             id="eso-chain-ns"
             type="text"
-            class="flex-1 rounded border border-border-primary px-3 py-1.5 text-sm bg-bg-base text-text-primary"
+            class="flex-1 rounded border border-border-primary px-3 py-1.5 text-sm bg-base text-text-primary"
             placeholder="e.g. payments-prod"
             value={namespace.value}
             aria-describedby="eso-chain-ns-hint"

--- a/frontend/islands/ESOClusterExternalSecretDetail.tsx
+++ b/frontend/islands/ESOClusterExternalSecretDetail.tsx
@@ -111,7 +111,7 @@ export default function ESOClusterExternalSecretDetail({ name }: Props) {
 
       {activeTab.value === "overview" && (
         <div role="tabpanel" class="space-y-4">
-          <div class="rounded-lg border border-border-primary bg-bg-elevated p-5">
+          <div class="rounded-lg border border-border-primary bg-elevated p-5">
             <h2 class="text-sm font-semibold text-text-primary mb-4">
               Details
             </h2>
@@ -169,7 +169,7 @@ export default function ESOClusterExternalSecretDetail({ name }: Props) {
           </div>
 
           {/* Namespace selectors */}
-          <div class="rounded-lg border border-border-primary bg-bg-elevated p-5">
+          <div class="rounded-lg border border-border-primary bg-elevated p-5">
             <h2 class="text-sm font-semibold text-text-primary mb-3">
               Namespace selectors
             </h2>
@@ -179,7 +179,7 @@ export default function ESOClusterExternalSecretDetail({ name }: Props) {
                   {ces.namespaceSelectors.map((s) => (
                     <span
                       key={s}
-                      class="inline-flex items-center px-2 py-0.5 rounded text-xs font-mono text-text-primary bg-bg-base border border-border-subtle"
+                      class="inline-flex items-center px-2 py-0.5 rounded text-xs font-mono text-text-primary bg-base border border-border-subtle"
                     >
                       {s}
                     </span>
@@ -205,7 +205,7 @@ export default function ESOClusterExternalSecretDetail({ name }: Props) {
 
           {/* Provisioned / failed namespaces */}
           <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div class="rounded-lg border border-border-primary bg-bg-elevated p-5">
+            <div class="rounded-lg border border-border-primary bg-elevated p-5">
               <h2 class="text-sm font-semibold text-text-primary mb-3">
                 Provisioned namespaces ({(ces.provisionedNamespaces ?? [])
                   .length})
@@ -220,7 +220,7 @@ export default function ESOClusterExternalSecretDetail({ name }: Props) {
                 )
                 : <p class="text-sm text-text-muted">None.</p>}
             </div>
-            <div class="rounded-lg border border-border-primary bg-bg-elevated p-5">
+            <div class="rounded-lg border border-border-primary bg-elevated p-5">
               <h2 class="text-sm font-semibold text-text-primary mb-3">
                 Failed namespaces ({(ces.failedNamespaces ?? []).length})
               </h2>
@@ -239,7 +239,7 @@ export default function ESOClusterExternalSecretDetail({ name }: Props) {
       {activeTab.value === "yaml" && (
         <div
           role="tabpanel"
-          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+          class="rounded-lg border border-border-primary bg-elevated p-5 text-sm text-text-muted"
         >
           YAML editor coming in Phase&nbsp;B.
         </div>
@@ -248,7 +248,7 @@ export default function ESOClusterExternalSecretDetail({ name }: Props) {
       {activeTab.value === "events" && (
         <div
           role="tabpanel"
-          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+          class="rounded-lg border border-border-primary bg-elevated p-5 text-sm text-text-muted"
         >
           Events feed coming in Phase&nbsp;B.
         </div>
@@ -257,7 +257,7 @@ export default function ESOClusterExternalSecretDetail({ name }: Props) {
       {activeTab.value === "history" && (
         <div
           role="tabpanel"
-          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+          class="rounded-lg border border-border-primary bg-elevated p-5 text-sm text-text-muted"
         >
           History timeline coming in Phase&nbsp;C.
         </div>
@@ -266,7 +266,7 @@ export default function ESOClusterExternalSecretDetail({ name }: Props) {
       {activeTab.value === "chain" && (
         <div
           role="tabpanel"
-          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+          class="rounded-lg border border-border-primary bg-elevated p-5 text-sm text-text-muted"
         >
           Chain visualization coming in Phase&nbsp;I.
         </div>

--- a/frontend/islands/ESOClusterExternalSecretDetail.tsx
+++ b/frontend/islands/ESOClusterExternalSecretDetail.tsx
@@ -1,0 +1,276 @@
+import { useSignal } from "@preact/signals";
+import { IS_BROWSER } from "fresh/runtime";
+import { useEffect } from "preact/hooks";
+import { Spinner } from "@/components/ui/Spinner.tsx";
+import { StatusBadge } from "@/components/eso/ESOBadges.tsx";
+import { esoApi } from "@/lib/eso-api.ts";
+import type { ClusterExternalSecret } from "@/lib/eso-types.ts";
+
+interface Props {
+  name: string;
+}
+
+type TabKey = "overview" | "yaml" | "events" | "history" | "chain";
+
+const EM_DASH = "—";
+
+function storeHref(kind: string, name: string): string {
+  if (kind === "ClusterSecretStore") {
+    return `/external-secrets/cluster-stores/${encodeURIComponent(name)}`;
+  }
+  // Namespaced store referenced from a cluster-scoped resource — link to
+  // the list view since we don't know the namespace at this point.
+  return "/external-secrets/stores";
+}
+
+export default function ESOClusterExternalSecretDetail({ name }: Props) {
+  const loading = useSignal(true);
+  const error = useSignal<string | null>(null);
+  const data = useSignal<ClusterExternalSecret | null>(null);
+  const activeTab = useSignal<TabKey>("overview");
+
+  useEffect(() => {
+    if (!IS_BROWSER) return;
+    let cancelled = false;
+    (async () => {
+      loading.value = true;
+      error.value = null;
+      try {
+        const res = await esoApi.getClusterExternalSecret(name);
+        if (!cancelled) data.value = res.data ?? null;
+      } catch {
+        if (!cancelled) error.value = "Failed to load ClusterExternalSecret";
+      } finally {
+        if (!cancelled) loading.value = false;
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [name]);
+
+  if (!IS_BROWSER) return null;
+
+  if (loading.value) {
+    return (
+      <div class="flex justify-center py-12">
+        <Spinner class="text-brand" />
+      </div>
+    );
+  }
+
+  if (error.value) {
+    return <p class="text-sm text-danger p-6">{error.value}</p>;
+  }
+
+  if (!data.value) return null;
+
+  const ces = data.value;
+  const showMessage = ces.status === "SyncFailed" ||
+    (ces.readyMessage && ces.readyMessage.length > 0);
+
+  return (
+    <div class="p-6 space-y-6">
+      {/* Header */}
+      <div class="flex flex-wrap items-center gap-3">
+        <h1 class="text-2xl font-bold text-text-primary">{ces.name}</h1>
+        <StatusBadge status={ces.status} />
+        <span class="text-xs text-text-muted">Cluster-scoped</span>
+      </div>
+
+      {/* Tab strip */}
+      <div role="tablist" class="flex gap-1 border-b border-border-primary">
+        {(
+          [
+            ["overview", "Overview"],
+            ["yaml", "YAML"],
+            ["events", "Events"],
+            ["history", "History"],
+            ["chain", "Chain"],
+          ] as Array<[TabKey, string]>
+        ).map(([key, label]) => {
+          const active = activeTab.value === key;
+          return (
+            <button
+              key={key}
+              type="button"
+              role="tab"
+              aria-selected={active}
+              onClick={() => (activeTab.value = key)}
+              class={`px-3 py-2 text-sm border-b-2 -mb-px transition-colors ${
+                active
+                  ? "border-brand text-text-primary"
+                  : "border-transparent text-text-muted hover:text-text-primary"
+              }`}
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+
+      {activeTab.value === "overview" && (
+        <div role="tabpanel" class="space-y-4">
+          <div class="rounded-lg border border-border-primary bg-bg-elevated p-5">
+            <h2 class="text-sm font-semibold text-text-primary mb-4">
+              Details
+            </h2>
+            <dl class="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-3 text-sm">
+              <div>
+                <dt class="text-text-muted">Name</dt>
+                <dd class="text-text-primary">{ces.name}</dd>
+              </div>
+              <div class="sm:col-span-2">
+                <dt class="text-text-muted">UID</dt>
+                <dd class="text-text-primary font-mono text-xs">{ces.uid}</dd>
+              </div>
+              <div>
+                <dt class="text-text-muted">Store</dt>
+                <dd>
+                  <a
+                    href={storeHref(ces.storeRef.kind, ces.storeRef.name)}
+                    class="text-brand hover:underline"
+                  >
+                    {ces.storeRef.kind}/{ces.storeRef.name}
+                  </a>
+                </dd>
+              </div>
+              <div>
+                <dt class="text-text-muted">Target Secret</dt>
+                <dd class="text-text-primary">
+                  {ces.targetSecretName || EM_DASH}
+                </dd>
+              </div>
+              <div>
+                <dt class="text-text-muted">Refresh Interval</dt>
+                <dd class="text-text-primary">
+                  {ces.refreshInterval || EM_DASH}
+                </dd>
+              </div>
+              <div>
+                <dt class="text-text-muted">External Secret Base Name</dt>
+                <dd class="text-text-primary">
+                  {ces.externalSecretBaseName || EM_DASH}
+                </dd>
+              </div>
+              {ces.readyReason && (
+                <div class="sm:col-span-2">
+                  <dt class="text-text-muted">Ready Reason</dt>
+                  <dd class="text-text-primary">{ces.readyReason}</dd>
+                </div>
+              )}
+              {showMessage && (
+                <div class="sm:col-span-2">
+                  <dt class="text-text-muted">Message</dt>
+                  <dd class="text-text-secondary">{ces.readyMessage}</dd>
+                </div>
+              )}
+            </dl>
+          </div>
+
+          {/* Namespace selectors */}
+          <div class="rounded-lg border border-border-primary bg-bg-elevated p-5">
+            <h2 class="text-sm font-semibold text-text-primary mb-3">
+              Namespace selectors
+            </h2>
+            {ces.namespaceSelectors && ces.namespaceSelectors.length > 0
+              ? (
+                <div class="flex flex-wrap gap-1.5">
+                  {ces.namespaceSelectors.map((s) => (
+                    <span
+                      key={s}
+                      class="inline-flex items-center px-2 py-0.5 rounded text-xs font-mono text-text-primary bg-bg-base border border-border-subtle"
+                    >
+                      {s}
+                    </span>
+                  ))}
+                </div>
+              )
+              : (
+                <p class="text-sm text-text-muted">
+                  No selectors set — using static namespace list.
+                </p>
+              )}
+            {ces.namespaces && ces.namespaces.length > 0 && (
+              <div class="mt-4">
+                <h3 class="text-xs font-semibold text-text-muted mb-2">
+                  Static namespace list
+                </h3>
+                <ul class="text-sm text-text-primary list-disc list-inside space-y-0.5">
+                  {ces.namespaces.map((ns) => <li key={ns}>{ns}</li>)}
+                </ul>
+              </div>
+            )}
+          </div>
+
+          {/* Provisioned / failed namespaces */}
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div class="rounded-lg border border-border-primary bg-bg-elevated p-5">
+              <h2 class="text-sm font-semibold text-text-primary mb-3">
+                Provisioned namespaces ({(ces.provisionedNamespaces ?? [])
+                  .length})
+              </h2>
+              {ces.provisionedNamespaces && ces.provisionedNamespaces.length > 0
+                ? (
+                  <ul class="text-sm text-text-primary list-disc list-inside space-y-0.5">
+                    {ces.provisionedNamespaces.map((ns) => (
+                      <li key={ns}>{ns}</li>
+                    ))}
+                  </ul>
+                )
+                : <p class="text-sm text-text-muted">None.</p>}
+            </div>
+            <div class="rounded-lg border border-border-primary bg-bg-elevated p-5">
+              <h2 class="text-sm font-semibold text-text-primary mb-3">
+                Failed namespaces ({(ces.failedNamespaces ?? []).length})
+              </h2>
+              {ces.failedNamespaces && ces.failedNamespaces.length > 0
+                ? (
+                  <ul class="text-sm text-danger list-disc list-inside space-y-0.5">
+                    {ces.failedNamespaces.map((ns) => <li key={ns}>{ns}</li>)}
+                  </ul>
+                )
+                : <p class="text-sm text-text-muted">None.</p>}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {activeTab.value === "yaml" && (
+        <div
+          role="tabpanel"
+          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+        >
+          YAML editor coming in Phase&nbsp;B.
+        </div>
+      )}
+
+      {activeTab.value === "events" && (
+        <div
+          role="tabpanel"
+          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+        >
+          Events feed coming in Phase&nbsp;B.
+        </div>
+      )}
+
+      {activeTab.value === "history" && (
+        <div
+          role="tabpanel"
+          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+        >
+          History timeline coming in Phase&nbsp;C.
+        </div>
+      )}
+
+      {activeTab.value === "chain" && (
+        <div
+          role="tabpanel"
+          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+        >
+          Chain visualization coming in Phase&nbsp;I.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/islands/ESOClusterExternalSecretsList.tsx
+++ b/frontend/islands/ESOClusterExternalSecretsList.tsx
@@ -3,6 +3,7 @@ import { IS_BROWSER } from "fresh/runtime";
 import { useEffect } from "preact/hooks";
 import { esoApi } from "@/lib/eso-api.ts";
 import { StatusBadge } from "@/components/eso/ESOBadges.tsx";
+import { ESONotDetected } from "@/components/eso/ESONotDetected.tsx";
 import { Spinner } from "@/components/ui/Spinner.tsx";
 import type { ClusterExternalSecret } from "@/lib/eso-types.ts";
 
@@ -11,6 +12,7 @@ export default function ESOClusterExternalSecretsList() {
   const loading = useSignal(true);
   const error = useSignal<string | null>(null);
   const search = useSignal("");
+  const detected = useSignal<boolean | null>(null);
 
   async function fetchData() {
     try {
@@ -24,12 +26,33 @@ export default function ESOClusterExternalSecretsList() {
 
   useEffect(() => {
     if (!IS_BROWSER) return;
-    fetchData().then(() => {
-      loading.value = false;
-    });
+    (async () => {
+      try {
+        const statusRes = await esoApi.status();
+        const present = statusRes.data?.detected !== false;
+        detected.value = present;
+        if (present) await fetchData();
+      } catch {
+        detected.value = true;
+        await fetchData();
+      } finally {
+        loading.value = false;
+      }
+    })();
   }, []);
 
   if (!IS_BROWSER) return null;
+
+  if (!loading.value && detected.value === false) {
+    return (
+      <div class="p-6">
+        <h1 class="text-2xl font-bold text-text-primary mb-6">
+          ClusterExternalSecrets
+        </h1>
+        <ESONotDetected />
+      </div>
+    );
+  }
 
   const filtered = items.value.filter((ces) => {
     if (!search.value) return true;
@@ -65,7 +88,7 @@ export default function ESOClusterExternalSecretsList() {
           <input
             id="eso-ces-search"
             type="text"
-            class="rounded border border-border-primary px-3 py-1.5 text-sm bg-bg-base text-text-primary max-w-xs"
+            class="rounded border border-border-primary px-3 py-1.5 text-sm bg-base text-text-primary max-w-xs"
             placeholder="name, store, target..."
             value={search.value}
             onInput={(e) => {
@@ -136,7 +159,9 @@ export default function ESOClusterExternalSecretsList() {
                 <tr key={ces.uid} class="hover:bg-hover/30">
                   <td class="px-3 py-2">
                     <a
-                      href={`/external-secrets/cluster-external-secrets/${ces.name}`}
+                      href={`/external-secrets/cluster-external-secrets/${
+                        encodeURIComponent(ces.name)
+                      }`}
                       class="font-medium text-brand hover:underline"
                     >
                       {ces.name}
@@ -166,7 +191,7 @@ export default function ESOClusterExternalSecretsList() {
 
       {!loading.value && !error.value && filtered.length === 0 &&
         items.value.length > 0 && (
-        <div class="text-center py-12 rounded-lg border border-border-primary bg-bg-elevated">
+        <div class="text-center py-12 rounded-lg border border-border-primary bg-elevated">
           <p class="text-text-muted">
             No ClusterExternalSecrets match your filters.
           </p>
@@ -174,7 +199,7 @@ export default function ESOClusterExternalSecretsList() {
       )}
 
       {!loading.value && !error.value && items.value.length === 0 && (
-        <div class="text-center py-12 rounded-lg border border-border-primary bg-bg-elevated">
+        <div class="text-center py-12 rounded-lg border border-border-primary bg-elevated">
           <p class="text-text-muted">
             No ClusterExternalSecrets visible. These sync the same Secret to
             multiple namespaces.

--- a/frontend/islands/ESOClusterExternalSecretsList.tsx
+++ b/frontend/islands/ESOClusterExternalSecretsList.tsx
@@ -1,0 +1,186 @@
+import { useSignal } from "@preact/signals";
+import { IS_BROWSER } from "fresh/runtime";
+import { useEffect } from "preact/hooks";
+import { esoApi } from "@/lib/eso-api.ts";
+import { StatusBadge } from "@/components/eso/ESOBadges.tsx";
+import { Spinner } from "@/components/ui/Spinner.tsx";
+import type { ClusterExternalSecret } from "@/lib/eso-types.ts";
+
+export default function ESOClusterExternalSecretsList() {
+  const items = useSignal<ClusterExternalSecret[]>([]);
+  const loading = useSignal(true);
+  const error = useSignal<string | null>(null);
+  const search = useSignal("");
+
+  async function fetchData() {
+    try {
+      const res = await esoApi.listClusterExternalSecrets();
+      items.value = Array.isArray(res.data) ? res.data : [];
+      error.value = null;
+    } catch {
+      error.value = "Failed to load ClusterExternalSecrets";
+    }
+  }
+
+  useEffect(() => {
+    if (!IS_BROWSER) return;
+    fetchData().then(() => {
+      loading.value = false;
+    });
+  }, []);
+
+  if (!IS_BROWSER) return null;
+
+  const filtered = items.value.filter((ces) => {
+    if (!search.value) return true;
+    const q = search.value.toLowerCase();
+    return (
+      ces.name.toLowerCase().includes(q) ||
+      ces.storeRef.name.toLowerCase().includes(q) ||
+      (ces.targetSecretName ?? "").toLowerCase().includes(q)
+    );
+  });
+
+  return (
+    <div class="p-6">
+      <div class="flex items-start justify-between mb-1">
+        <h1 class="text-2xl font-bold text-text-primary">
+          ClusterExternalSecrets
+        </h1>
+      </div>
+      <p class="text-sm text-text-muted mb-6">
+        Cluster-scoped resources that fan out the same Secret to multiple
+        namespaces.
+      </p>
+
+      {/* Filters */}
+      <div class="mb-4 flex flex-wrap items-center gap-4">
+        <div class="flex items-center gap-2">
+          <label
+            class="text-sm font-medium text-text-secondary"
+            htmlFor="eso-ces-search"
+          >
+            Search
+          </label>
+          <input
+            id="eso-ces-search"
+            type="text"
+            class="rounded border border-border-primary px-3 py-1.5 text-sm bg-bg-base text-text-primary max-w-xs"
+            placeholder="name, store, target..."
+            value={search.value}
+            onInput={(e) => {
+              search.value = (e.target as HTMLInputElement).value;
+            }}
+          />
+        </div>
+        <span class="text-xs text-text-muted">
+          {filtered.length} of {items.value.length} ClusterExternalSecrets
+        </span>
+      </div>
+
+      {loading.value && (
+        <div class="flex justify-center py-12">
+          <Spinner class="text-brand" />
+        </div>
+      )}
+
+      {!loading.value && error.value && (
+        <p class="text-sm text-danger py-4">{error.value}</p>
+      )}
+
+      {!loading.value && !error.value && filtered.length > 0 && (
+        <div class="overflow-x-auto rounded-lg border border-border-primary">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="border-b border-border-primary bg-surface">
+                <th
+                  scope="col"
+                  class="px-3 py-2 text-left text-xs font-medium text-text-muted"
+                >
+                  Name
+                </th>
+                <th
+                  scope="col"
+                  class="px-3 py-2 text-left text-xs font-medium text-text-muted"
+                >
+                  Status
+                </th>
+                <th
+                  scope="col"
+                  class="px-3 py-2 text-left text-xs font-medium text-text-muted"
+                >
+                  Store
+                </th>
+                <th
+                  scope="col"
+                  class="px-3 py-2 text-left text-xs font-medium text-text-muted"
+                >
+                  Target
+                </th>
+                <th
+                  scope="col"
+                  class="px-3 py-2 text-right text-xs font-medium text-text-muted"
+                >
+                  Provisioned
+                </th>
+                <th
+                  scope="col"
+                  class="px-3 py-2 text-right text-xs font-medium text-text-muted"
+                >
+                  Failed
+                </th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-border-subtle">
+              {filtered.map((ces) => (
+                <tr key={ces.uid} class="hover:bg-hover/30">
+                  <td class="px-3 py-2">
+                    <a
+                      href={`/external-secrets/cluster-external-secrets/${ces.name}`}
+                      class="font-medium text-brand hover:underline"
+                    >
+                      {ces.name}
+                    </a>
+                  </td>
+                  <td class="px-3 py-2">
+                    <StatusBadge status={ces.status} />
+                  </td>
+                  <td class="px-3 py-2 text-text-secondary">
+                    {ces.storeRef.name}
+                  </td>
+                  <td class="px-3 py-2 text-text-secondary">
+                    {ces.targetSecretName ?? "—"}
+                  </td>
+                  <td class="px-3 py-2 text-right text-text-secondary tabular-nums">
+                    {(ces.provisionedNamespaces ?? []).length}
+                  </td>
+                  <td class="px-3 py-2 text-right text-text-secondary tabular-nums">
+                    {(ces.failedNamespaces ?? []).length}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {!loading.value && !error.value && filtered.length === 0 &&
+        items.value.length > 0 && (
+        <div class="text-center py-12 rounded-lg border border-border-primary bg-bg-elevated">
+          <p class="text-text-muted">
+            No ClusterExternalSecrets match your filters.
+          </p>
+        </div>
+      )}
+
+      {!loading.value && !error.value && items.value.length === 0 && (
+        <div class="text-center py-12 rounded-lg border border-border-primary bg-bg-elevated">
+          <p class="text-text-muted">
+            No ClusterExternalSecrets visible. These sync the same Secret to
+            multiple namespaces.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/islands/ESOClusterStoreDetail.tsx
+++ b/frontend/islands/ESOClusterStoreDetail.tsx
@@ -99,7 +99,7 @@ export default function ESOClusterStoreDetail({ name }: Props) {
 
       {activeTab.value === "overview" && (
         <div role="tabpanel" class="space-y-4">
-          <div class="rounded-lg border border-border-primary bg-bg-elevated p-5">
+          <div class="rounded-lg border border-border-primary bg-elevated p-5">
             <h2 class="text-sm font-semibold text-text-primary mb-4">
               Details
             </h2>
@@ -152,14 +152,14 @@ export default function ESOClusterStoreDetail({ name }: Props) {
           </div>
 
           {store.providerSpec && Object.keys(store.providerSpec).length > 0 && (
-            <div class="rounded-lg border border-border-primary bg-bg-elevated p-5">
+            <div class="rounded-lg border border-border-primary bg-elevated p-5">
               <h2 class="text-sm font-semibold text-text-primary mb-1">
                 Provider spec
               </h2>
               <p class="text-xs text-text-muted mb-3">
                 Read-only infrastructure addressing — never credentials.
               </p>
-              <pre class="text-xs font-mono text-text-primary bg-bg-base border border-border-subtle rounded p-3 overflow-x-auto">
+              <pre class="text-xs font-mono text-text-primary bg-base border border-border-subtle rounded p-3 overflow-x-auto">
 {JSON.stringify(store.providerSpec, null, 2)}
               </pre>
             </div>
@@ -170,7 +170,7 @@ export default function ESOClusterStoreDetail({ name }: Props) {
       {activeTab.value === "yaml" && (
         <div
           role="tabpanel"
-          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+          class="rounded-lg border border-border-primary bg-elevated p-5 text-sm text-text-muted"
         >
           YAML editor coming in Phase&nbsp;B.
         </div>
@@ -179,7 +179,7 @@ export default function ESOClusterStoreDetail({ name }: Props) {
       {activeTab.value === "events" && (
         <div
           role="tabpanel"
-          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+          class="rounded-lg border border-border-primary bg-elevated p-5 text-sm text-text-muted"
         >
           Events feed coming in Phase&nbsp;B.
         </div>
@@ -188,7 +188,7 @@ export default function ESOClusterStoreDetail({ name }: Props) {
       {activeTab.value === "history" && (
         <div
           role="tabpanel"
-          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+          class="rounded-lg border border-border-primary bg-elevated p-5 text-sm text-text-muted"
         >
           History timeline coming in Phase&nbsp;C.
         </div>
@@ -197,7 +197,7 @@ export default function ESOClusterStoreDetail({ name }: Props) {
       {activeTab.value === "chain" && (
         <div
           role="tabpanel"
-          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+          class="rounded-lg border border-border-primary bg-elevated p-5 text-sm text-text-muted"
         >
           Chain visualization coming in Phase&nbsp;I.
         </div>

--- a/frontend/islands/ESOClusterStoreDetail.tsx
+++ b/frontend/islands/ESOClusterStoreDetail.tsx
@@ -1,0 +1,207 @@
+import { useSignal } from "@preact/signals";
+import { IS_BROWSER } from "fresh/runtime";
+import { useEffect } from "preact/hooks";
+import { Spinner } from "@/components/ui/Spinner.tsx";
+import { ProviderBadge, StatusBadge } from "@/components/eso/ESOBadges.tsx";
+import { esoApi } from "@/lib/eso-api.ts";
+import type { SecretStore } from "@/lib/eso-types.ts";
+
+interface Props {
+  name: string;
+}
+
+type TabKey = "overview" | "yaml" | "events" | "history" | "chain";
+
+const EM_DASH = "—";
+
+export default function ESOClusterStoreDetail({ name }: Props) {
+  const loading = useSignal(true);
+  const error = useSignal<string | null>(null);
+  const data = useSignal<SecretStore | null>(null);
+  const activeTab = useSignal<TabKey>("overview");
+
+  useEffect(() => {
+    if (!IS_BROWSER) return;
+    let cancelled = false;
+    (async () => {
+      loading.value = true;
+      error.value = null;
+      try {
+        const res = await esoApi.getClusterStore(name);
+        if (!cancelled) data.value = res.data ?? null;
+      } catch {
+        if (!cancelled) error.value = "Failed to load ClusterSecretStore";
+      } finally {
+        if (!cancelled) loading.value = false;
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [name]);
+
+  if (!IS_BROWSER) return null;
+
+  if (loading.value) {
+    return (
+      <div class="flex justify-center py-12">
+        <Spinner class="text-brand" />
+      </div>
+    );
+  }
+
+  if (error.value) {
+    return <p class="text-sm text-danger p-6">{error.value}</p>;
+  }
+
+  if (!data.value) return null;
+
+  const store = data.value;
+
+  return (
+    <div class="p-6 space-y-6">
+      <div class="flex flex-wrap items-center gap-3">
+        <h1 class="text-2xl font-bold text-text-primary">{store.name}</h1>
+        <StatusBadge status={store.status} />
+        <ProviderBadge provider={store.provider} />
+        <span class="text-xs text-text-muted">Cluster-scoped</span>
+      </div>
+
+      <div role="tablist" class="flex gap-1 border-b border-border-primary">
+        {(
+          [
+            ["overview", "Overview"],
+            ["yaml", "YAML"],
+            ["events", "Events"],
+            ["history", "History"],
+            ["chain", "Chain"],
+          ] as Array<[TabKey, string]>
+        ).map(([key, label]) => {
+          const active = activeTab.value === key;
+          return (
+            <button
+              key={key}
+              type="button"
+              role="tab"
+              aria-selected={active}
+              onClick={() => (activeTab.value = key)}
+              class={`px-3 py-2 text-sm border-b-2 -mb-px transition-colors ${
+                active
+                  ? "border-brand text-text-primary"
+                  : "border-transparent text-text-muted hover:text-text-primary"
+              }`}
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+
+      {activeTab.value === "overview" && (
+        <div role="tabpanel" class="space-y-4">
+          <div class="rounded-lg border border-border-primary bg-bg-elevated p-5">
+            <h2 class="text-sm font-semibold text-text-primary mb-4">
+              Details
+            </h2>
+            <dl class="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-3 text-sm">
+              <div>
+                <dt class="text-text-muted">Namespace</dt>
+                <dd class="text-text-muted">{EM_DASH}</dd>
+              </div>
+              <div>
+                <dt class="text-text-muted">Name</dt>
+                <dd class="text-text-primary">{store.name}</dd>
+              </div>
+              <div class="sm:col-span-2">
+                <dt class="text-text-muted">UID</dt>
+                <dd class="text-text-primary font-mono text-xs">{store.uid}</dd>
+              </div>
+              <div>
+                <dt class="text-text-muted">Status</dt>
+                <dd>
+                  <StatusBadge status={store.status} />
+                </dd>
+              </div>
+              <div>
+                <dt class="text-text-muted">Ready</dt>
+                <dd class="text-text-primary">{store.ready ? "Yes" : "No"}</dd>
+              </div>
+              <div>
+                <dt class="text-text-muted">Provider</dt>
+                <dd>
+                  <ProviderBadge provider={store.provider} />
+                </dd>
+              </div>
+              <div>
+                <dt class="text-text-muted">Scope</dt>
+                <dd class="text-text-primary">{store.scope}</dd>
+              </div>
+              {store.readyReason && (
+                <div class="sm:col-span-2">
+                  <dt class="text-text-muted">Ready Reason</dt>
+                  <dd class="text-text-primary">{store.readyReason}</dd>
+                </div>
+              )}
+              {store.readyMessage && (
+                <div class="sm:col-span-2">
+                  <dt class="text-text-muted">Ready Message</dt>
+                  <dd class="text-text-secondary">{store.readyMessage}</dd>
+                </div>
+              )}
+            </dl>
+          </div>
+
+          {store.providerSpec && Object.keys(store.providerSpec).length > 0 && (
+            <div class="rounded-lg border border-border-primary bg-bg-elevated p-5">
+              <h2 class="text-sm font-semibold text-text-primary mb-1">
+                Provider spec
+              </h2>
+              <p class="text-xs text-text-muted mb-3">
+                Read-only infrastructure addressing — never credentials.
+              </p>
+              <pre class="text-xs font-mono text-text-primary bg-bg-base border border-border-subtle rounded p-3 overflow-x-auto">
+{JSON.stringify(store.providerSpec, null, 2)}
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+
+      {activeTab.value === "yaml" && (
+        <div
+          role="tabpanel"
+          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+        >
+          YAML editor coming in Phase&nbsp;B.
+        </div>
+      )}
+
+      {activeTab.value === "events" && (
+        <div
+          role="tabpanel"
+          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+        >
+          Events feed coming in Phase&nbsp;B.
+        </div>
+      )}
+
+      {activeTab.value === "history" && (
+        <div
+          role="tabpanel"
+          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+        >
+          History timeline coming in Phase&nbsp;C.
+        </div>
+      )}
+
+      {activeTab.value === "chain" && (
+        <div
+          role="tabpanel"
+          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+        >
+          Chain visualization coming in Phase&nbsp;I.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/islands/ESOClusterStoresList.tsx
+++ b/frontend/islands/ESOClusterStoresList.tsx
@@ -1,0 +1,177 @@
+import { useSignal } from "@preact/signals";
+import { IS_BROWSER } from "fresh/runtime";
+import { useEffect } from "preact/hooks";
+import { esoApi } from "@/lib/eso-api.ts";
+import { ProviderBadge, StatusBadge } from "@/components/eso/ESOBadges.tsx";
+import { Spinner } from "@/components/ui/Spinner.tsx";
+import type { SecretStore } from "@/lib/eso-types.ts";
+
+export default function ESOClusterStoresList() {
+  const items = useSignal<SecretStore[]>([]);
+  const loading = useSignal(true);
+  const error = useSignal<string | null>(null);
+  const search = useSignal("");
+
+  async function fetchData() {
+    try {
+      const res = await esoApi.listClusterStores();
+      items.value = Array.isArray(res.data) ? res.data : [];
+      error.value = null;
+    } catch {
+      error.value = "Failed to load ClusterSecretStores";
+    }
+  }
+
+  useEffect(() => {
+    if (!IS_BROWSER) return;
+    fetchData().then(() => {
+      loading.value = false;
+    });
+  }, []);
+
+  if (!IS_BROWSER) return null;
+
+  const filtered = items.value.filter((s) => {
+    if (!search.value) return true;
+    const q = search.value.toLowerCase();
+    return (
+      s.name.toLowerCase().includes(q) ||
+      (s.provider ?? "").toLowerCase().includes(q)
+    );
+  });
+
+  return (
+    <div class="p-6">
+      <div class="flex items-start justify-between mb-1">
+        <h1 class="text-2xl font-bold text-text-primary">
+          ClusterSecretStores
+        </h1>
+      </div>
+      <p class="text-sm text-text-muted mb-6">
+        Cluster-scoped SecretStores accessible to ExternalSecrets in any
+        namespace.
+      </p>
+
+      {/* Filters */}
+      <div class="mb-4 flex flex-wrap items-center gap-4">
+        <div class="flex items-center gap-2">
+          <label
+            class="text-sm font-medium text-text-secondary"
+            htmlFor="eso-cstores-search"
+          >
+            Search
+          </label>
+          <input
+            id="eso-cstores-search"
+            type="text"
+            class="rounded border border-border-primary px-3 py-1.5 text-sm bg-bg-base text-text-primary max-w-xs"
+            placeholder="name, provider..."
+            value={search.value}
+            onInput={(e) => {
+              search.value = (e.target as HTMLInputElement).value;
+            }}
+          />
+        </div>
+        <span class="text-xs text-text-muted">
+          {filtered.length} of {items.value.length} ClusterSecretStores
+        </span>
+      </div>
+
+      {loading.value && (
+        <div class="flex justify-center py-12">
+          <Spinner class="text-brand" />
+        </div>
+      )}
+
+      {!loading.value && error.value && (
+        <p class="text-sm text-danger py-4">{error.value}</p>
+      )}
+
+      {!loading.value && !error.value && filtered.length > 0 && (
+        <div class="overflow-x-auto rounded-lg border border-border-primary">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="border-b border-border-primary bg-surface">
+                <th
+                  scope="col"
+                  class="px-3 py-2 text-left text-xs font-medium text-text-muted"
+                >
+                  Name
+                </th>
+                <th
+                  scope="col"
+                  class="px-3 py-2 text-left text-xs font-medium text-text-muted"
+                >
+                  Status
+                </th>
+                <th
+                  scope="col"
+                  class="px-3 py-2 text-left text-xs font-medium text-text-muted"
+                >
+                  Provider
+                </th>
+                <th
+                  scope="col"
+                  class="px-3 py-2 text-left text-xs font-medium text-text-muted"
+                >
+                  Ready
+                </th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-border-subtle">
+              {filtered.map((s) => (
+                <tr key={s.uid} class="hover:bg-hover/30">
+                  <td class="px-3 py-2">
+                    <a
+                      href={`/external-secrets/cluster-stores/${s.name}`}
+                      class="font-medium text-brand hover:underline"
+                    >
+                      {s.name}
+                    </a>
+                  </td>
+                  <td class="px-3 py-2">
+                    <StatusBadge status={s.status} />
+                  </td>
+                  <td class="px-3 py-2">
+                    <ProviderBadge provider={s.provider} />
+                  </td>
+                  <td class="px-3 py-2">
+                    {s.ready
+                      ? (
+                        <span class="text-success text-xs font-medium">
+                          Ready
+                        </span>
+                      )
+                      : (
+                        <span class="text-danger text-xs font-medium">
+                          Not Ready
+                        </span>
+                      )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {!loading.value && !error.value && filtered.length === 0 &&
+        items.value.length > 0 && (
+        <div class="text-center py-12 rounded-lg border border-border-primary bg-bg-elevated">
+          <p class="text-text-muted">
+            No ClusterSecretStores match your filters.
+          </p>
+        </div>
+      )}
+
+      {!loading.value && !error.value && items.value.length === 0 && (
+        <div class="text-center py-12 rounded-lg border border-border-primary bg-bg-elevated">
+          <p class="text-text-muted">
+            No ClusterSecretStores visible. Your permissions may restrict
+            visibility, or no ClusterSecretStores exist.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/islands/ESOClusterStoresList.tsx
+++ b/frontend/islands/ESOClusterStoresList.tsx
@@ -3,6 +3,7 @@ import { IS_BROWSER } from "fresh/runtime";
 import { useEffect } from "preact/hooks";
 import { esoApi } from "@/lib/eso-api.ts";
 import { ProviderBadge, StatusBadge } from "@/components/eso/ESOBadges.tsx";
+import { ESONotDetected } from "@/components/eso/ESONotDetected.tsx";
 import { Spinner } from "@/components/ui/Spinner.tsx";
 import type { SecretStore } from "@/lib/eso-types.ts";
 
@@ -11,6 +12,7 @@ export default function ESOClusterStoresList() {
   const loading = useSignal(true);
   const error = useSignal<string | null>(null);
   const search = useSignal("");
+  const detected = useSignal<boolean | null>(null);
 
   async function fetchData() {
     try {
@@ -24,12 +26,33 @@ export default function ESOClusterStoresList() {
 
   useEffect(() => {
     if (!IS_BROWSER) return;
-    fetchData().then(() => {
-      loading.value = false;
-    });
+    (async () => {
+      try {
+        const statusRes = await esoApi.status();
+        const present = statusRes.data?.detected !== false;
+        detected.value = present;
+        if (present) await fetchData();
+      } catch {
+        detected.value = true;
+        await fetchData();
+      } finally {
+        loading.value = false;
+      }
+    })();
   }, []);
 
   if (!IS_BROWSER) return null;
+
+  if (!loading.value && detected.value === false) {
+    return (
+      <div class="p-6">
+        <h1 class="text-2xl font-bold text-text-primary mb-6">
+          ClusterSecretStores
+        </h1>
+        <ESONotDetected />
+      </div>
+    );
+  }
 
   const filtered = items.value.filter((s) => {
     if (!search.value) return true;
@@ -64,7 +87,7 @@ export default function ESOClusterStoresList() {
           <input
             id="eso-cstores-search"
             type="text"
-            class="rounded border border-border-primary px-3 py-1.5 text-sm bg-bg-base text-text-primary max-w-xs"
+            class="rounded border border-border-primary px-3 py-1.5 text-sm bg-base text-text-primary max-w-xs"
             placeholder="name, provider..."
             value={search.value}
             onInput={(e) => {
@@ -123,7 +146,9 @@ export default function ESOClusterStoresList() {
                 <tr key={s.uid} class="hover:bg-hover/30">
                   <td class="px-3 py-2">
                     <a
-                      href={`/external-secrets/cluster-stores/${s.name}`}
+                      href={`/external-secrets/cluster-stores/${
+                        encodeURIComponent(s.name)
+                      }`}
                       class="font-medium text-brand hover:underline"
                     >
                       {s.name}
@@ -157,7 +182,7 @@ export default function ESOClusterStoresList() {
 
       {!loading.value && !error.value && filtered.length === 0 &&
         items.value.length > 0 && (
-        <div class="text-center py-12 rounded-lg border border-border-primary bg-bg-elevated">
+        <div class="text-center py-12 rounded-lg border border-border-primary bg-elevated">
           <p class="text-text-muted">
             No ClusterSecretStores match your filters.
           </p>
@@ -165,7 +190,7 @@ export default function ESOClusterStoresList() {
       )}
 
       {!loading.value && !error.value && items.value.length === 0 && (
-        <div class="text-center py-12 rounded-lg border border-border-primary bg-bg-elevated">
+        <div class="text-center py-12 rounded-lg border border-border-primary bg-elevated">
           <p class="text-text-muted">
             No ClusterSecretStores visible. Your permissions may restrict
             visibility, or no ClusterSecretStores exist.

--- a/frontend/islands/ESODashboard.tsx
+++ b/frontend/islands/ESODashboard.tsx
@@ -20,6 +20,7 @@ import { useEffect } from "preact/hooks";
 import { Spinner } from "@/components/ui/Spinner.tsx";
 import { Button } from "@/components/ui/Button.tsx";
 import { ProviderBadge, StatusBadge } from "@/components/eso/ESOBadges.tsx";
+import { ESONotDetected } from "@/components/eso/ESONotDetected.tsx";
 import { esoApi } from "@/lib/eso-api.ts";
 import { timeAgo } from "@/lib/timeAgo.ts";
 import type {
@@ -121,7 +122,7 @@ function SecondaryCard(
 ) {
   const inner = (
     <div
-      class="rounded-lg border border-border-primary p-4 bg-bg-elevated h-full flex flex-col"
+      class="rounded-lg border border-border-primary p-4 bg-elevated h-full flex flex-col"
       aria-label={`${label}: ${count}`}
     >
       <div class="flex items-center justify-between mb-2">
@@ -268,39 +269,22 @@ export default function ESODashboard() {
 
       {error.value && <p class="text-sm text-danger py-4">{error.value}</p>}
 
-      {!loading.value && !error.value && !detected && (
-        <div class="rounded-lg border border-border-primary p-8 text-center bg-bg-elevated">
-          <p class="text-lg font-medium text-text-primary mb-2">
-            External Secrets Operator is not installed in this cluster.
-          </p>
-          <p class="text-sm text-text-muted">
-            Install via the{" "}
-            <a
-              class="text-brand hover:underline"
-              href="https://external-secrets.io/latest/introduction/getting-started/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              ESO Helm chart
-            </a>{" "}
-            to start managing secrets across stores.
-          </p>
-        </div>
-      )}
+      {!loading.value && !error.value && !detected && <ESONotDetected />}
 
       {!loading.value && !error.value && detected && (
         <>
-          {/* Hero — sync health ring */}
-          <div class="rounded-lg border border-border-primary p-6 bg-bg-elevated mb-6 flex flex-col items-center">
-            {total === 0
-              ? (
-                <div class="py-8 text-center">
-                  <p class="text-text-muted">
-                    No ExternalSecrets visible.
-                  </p>
-                </div>
-              )
-              : <SyncHealthRing synced={counts.Synced} total={total} />}
+          {
+            /* Hero — sync health ring. Renders 0/0 when no ExternalSecrets are
+           * visible so the dashboard's vertical rhythm doesn't shift the moment
+           * the first ES appears. */
+          }
+          <div class="rounded-lg border border-border-primary p-6 bg-elevated mb-6 flex flex-col items-center">
+            <SyncHealthRing synced={counts.Synced} total={total} />
+            {total === 0 && (
+              <p class="text-xs text-text-muted mt-3">
+                No ExternalSecrets visible yet.
+              </p>
+            )}
           </div>
 
           {/* Secondary cards row */}
@@ -335,7 +319,7 @@ export default function ESODashboard() {
           {/* Tertiary row — providers + cost stub */}
           <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-6">
             <div
-              class="rounded-lg border border-border-primary p-4 bg-bg-elevated"
+              class="rounded-lg border border-border-primary p-4 bg-elevated"
               aria-label="Stores by provider"
             >
               <h2 class="text-sm font-medium text-text-primary mb-3">
@@ -365,7 +349,7 @@ export default function ESODashboard() {
             </div>
 
             <div
-              class="rounded-lg border border-border-primary p-4 bg-bg-elevated"
+              class="rounded-lg border border-border-primary p-4 bg-elevated"
               aria-label="Cost estimate"
             >
               <h2 class="text-sm font-medium text-text-primary mb-3">
@@ -393,7 +377,7 @@ export default function ESODashboard() {
           </div>
           {broken.length === 0
             ? (
-              <div class="text-center py-8 rounded-lg border border-border-primary bg-bg-elevated">
+              <div class="text-center py-8 rounded-lg border border-border-primary bg-elevated">
                 <p class="text-text-muted">
                   No broken ExternalSecrets — everything synced!
                 </p>

--- a/frontend/islands/ESODashboard.tsx
+++ b/frontend/islands/ESODashboard.tsx
@@ -1,0 +1,495 @@
+/** External Secrets Operator dashboard — Phase B Unit 8b.
+ *
+ * Surfaces sync health at a glance:
+ *   - Hero gauge ring: synced / total ExternalSecrets
+ *   - Secondary cards: SyncFailed / Stale / Drifted / Unknown counts
+ *   - Tertiary row: stores by provider + cost-tier stub (Phase F)
+ *   - Failure table: ExternalSecrets in non-Synced/non-Refreshing state
+ *
+ * Data sources (loaded concurrently via Promise.all):
+ *   - esoApi.status() — ESO discovery
+ *   - esoApi.listExternalSecrets() — primary inventory
+ *   - esoApi.listStores() / listClusterStores() — store provider breakdown
+ *
+ * Theme tokens only — no hardcoded color classes.
+ */
+
+import { useSignal } from "@preact/signals";
+import { IS_BROWSER } from "fresh/runtime";
+import { useEffect } from "preact/hooks";
+import { Spinner } from "@/components/ui/Spinner.tsx";
+import { Button } from "@/components/ui/Button.tsx";
+import { ProviderBadge, StatusBadge } from "@/components/eso/ESOBadges.tsx";
+import { esoApi } from "@/lib/eso-api.ts";
+import { timeAgo } from "@/lib/timeAgo.ts";
+import type {
+  ESOStatus,
+  ExternalSecret,
+  SecretStore,
+  Status,
+} from "@/lib/eso-types.ts";
+
+const FAILURE_TABLE_LIMIT = 50;
+
+/** Severity ordering for the broken-ES table. Synced/Refreshing rows are
+ * filtered out before sort. Drifted falls below Stale because Drifted is
+ * "config out of band" while Stale is "controller hasn't synced in too long". */
+const FAILURE_SEVERITY: Record<Status, number> = {
+  SyncFailed: 0,
+  Stale: 1,
+  Drifted: 2,
+  Unknown: 3,
+  Refreshing: 4,
+  Synced: 5,
+};
+
+/** Hero gauge — synced / total. Renders the SVG ring inline (no external
+ * chart lib) using `var(--success)` for the synced arc and the standard
+ * GaugeRing primitive isn't reused here because we want a fraction display
+ * (`X / Y`) rather than the percentage label GaugeRing emits. */
+function SyncHealthRing(
+  { synced, total }: { synced: number; total: number },
+) {
+  const size = 200;
+  const strokeWidth = 12;
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const fraction = total > 0 ? synced / total : 0;
+  const offset = circumference - fraction * circumference;
+  const center = size / 2;
+
+  return (
+    <div
+      class="relative inline-flex items-center justify-center"
+      role="img"
+      aria-label={`${synced} of ${total} synced`}
+      style={{ width: `${size}px`, height: `${size}px` }}
+    >
+      <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+        <circle
+          cx={center}
+          cy={center}
+          r={radius}
+          fill="none"
+          stroke="var(--bg-elevated)"
+          stroke-width={strokeWidth}
+        />
+        <circle
+          cx={center}
+          cy={center}
+          r={radius}
+          fill="none"
+          stroke="var(--success)"
+          stroke-width={strokeWidth}
+          stroke-linecap="round"
+          stroke-dasharray={circumference}
+          stroke-dashoffset={offset}
+          transform={`rotate(-90 ${center} ${center})`}
+          style={{
+            transition: "stroke-dashoffset 1s cubic-bezier(0.16, 1, 0.3, 1)",
+          }}
+        />
+      </svg>
+      <div class="absolute inset-0 flex flex-col items-center justify-center">
+        <span
+          class="font-bold text-text-primary"
+          style={{
+            fontSize: "32px",
+            fontFamily: "var(--font-mono, monospace)",
+          }}
+        >
+          {synced} / {total}
+        </span>
+        <span class="text-xs text-text-muted mt-1">
+          ExternalSecrets synced
+        </span>
+      </div>
+    </div>
+  );
+}
+
+interface SecondaryCardProps {
+  label: string;
+  count: number;
+  color: string;
+  subText: string;
+  href?: string;
+}
+
+function SecondaryCard(
+  { label, count, color, subText, href }: SecondaryCardProps,
+) {
+  const inner = (
+    <div
+      class="rounded-lg border border-border-primary p-4 bg-bg-elevated h-full flex flex-col"
+      aria-label={`${label}: ${count}`}
+    >
+      <div class="flex items-center justify-between mb-2">
+        <span class="text-xs font-medium uppercase tracking-wide text-text-muted">
+          {label}
+        </span>
+      </div>
+      <span
+        class="font-bold"
+        style={{
+          color,
+          fontSize: "28px",
+          fontFamily: "var(--font-mono, monospace)",
+          lineHeight: 1.1,
+        }}
+      >
+        {count}
+      </span>
+      <p class="text-xs text-text-muted mt-2 leading-snug">{subText}</p>
+    </div>
+  );
+  if (href && count > 0) {
+    return (
+      <a href={href} class="block hover:opacity-90 transition-opacity">
+        {inner}
+      </a>
+    );
+  }
+  return inner;
+}
+
+/** Aggregate provider counts across Namespaced + Cluster stores.
+ * Empty/unset providers fold into the "(none)" bucket. */
+function aggregateProviders(stores: SecretStore[]): Array<[string, number]> {
+  const counts = new Map<string, number>();
+  for (const s of stores) {
+    const key = s.provider || "(none)";
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return [...counts.entries()].sort((a, b) => b[1] - a[1]);
+}
+
+export default function ESODashboard() {
+  const status = useSignal<ESOStatus | null>(null);
+  const externalSecrets = useSignal<ExternalSecret[]>([]);
+  const stores = useSignal<SecretStore[]>([]);
+  const clusterStores = useSignal<SecretStore[]>([]);
+  const loading = useSignal(true);
+  const error = useSignal<string | null>(null);
+  const refreshing = useSignal(false);
+
+  async function fetchData() {
+    try {
+      const [statusRes, esRes, storesRes, clusterStoresRes] = await Promise
+        .all([
+          esoApi.status(),
+          esoApi.listExternalSecrets(),
+          esoApi.listStores(),
+          esoApi.listClusterStores(),
+        ]);
+      status.value = statusRes.data;
+      externalSecrets.value = Array.isArray(esRes.data) ? esRes.data : [];
+      stores.value = Array.isArray(storesRes.data) ? storesRes.data : [];
+      clusterStores.value = Array.isArray(clusterStoresRes.data)
+        ? clusterStoresRes.data
+        : [];
+      error.value = null;
+    } catch {
+      error.value = "Failed to load ESO dashboard data";
+    }
+  }
+
+  useEffect(() => {
+    if (!IS_BROWSER) return;
+    fetchData().then(() => {
+      loading.value = false;
+    });
+  }, []);
+
+  async function handleRefresh() {
+    refreshing.value = true;
+    await fetchData();
+    refreshing.value = false;
+  }
+
+  if (!IS_BROWSER) return null;
+
+  // Aggregate counts client-side. Backend already RBAC-filters.
+  const items = externalSecrets.value;
+  const total = items.length;
+  const counts = {
+    Synced: 0,
+    SyncFailed: 0,
+    Refreshing: 0,
+    Stale: 0,
+    Drifted: 0,
+    Unknown: 0,
+  } satisfies Record<Status, number>;
+  for (const it of items) counts[it.status]++;
+
+  const allStores = [...stores.value, ...clusterStores.value];
+  const providerCounts = aggregateProviders(allStores);
+
+  // Failure table — non-Synced / non-Refreshing only.
+  const broken = items
+    .filter((i) => i.status !== "Synced" && i.status !== "Refreshing")
+    .sort((a, b) => {
+      const sev = FAILURE_SEVERITY[a.status] - FAILURE_SEVERITY[b.status];
+      if (sev !== 0) return sev;
+      return `${a.namespace}/${a.name}`.localeCompare(
+        `${b.namespace}/${b.name}`,
+      );
+    });
+  const brokenDisplayed = broken.slice(0, FAILURE_TABLE_LIMIT);
+  const brokenOverflow = broken.length - brokenDisplayed.length;
+
+  const detected = status.value?.detected === true;
+
+  return (
+    <div class="p-6">
+      <div class="flex items-center justify-between mb-1">
+        <h1 class="text-2xl font-bold text-text-primary">External Secrets</h1>
+        {!loading.value && (
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={handleRefresh}
+            disabled={refreshing.value}
+          >
+            {refreshing.value ? "Refreshing..." : "Refresh"}
+          </Button>
+        )}
+      </div>
+      <p class="text-sm text-text-muted mb-6">
+        Sync health across ExternalSecret resources, source stores by provider,
+        and currently broken syncs.
+      </p>
+
+      {loading.value && (
+        <div class="flex justify-center py-12">
+          <Spinner class="text-brand" />
+        </div>
+      )}
+
+      {error.value && <p class="text-sm text-danger py-4">{error.value}</p>}
+
+      {!loading.value && !error.value && !detected && (
+        <div class="rounded-lg border border-border-primary p-8 text-center bg-bg-elevated">
+          <p class="text-lg font-medium text-text-primary mb-2">
+            External Secrets Operator is not installed in this cluster.
+          </p>
+          <p class="text-sm text-text-muted">
+            Install via the{" "}
+            <a
+              class="text-brand hover:underline"
+              href="https://external-secrets.io/latest/introduction/getting-started/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              ESO Helm chart
+            </a>{" "}
+            to start managing secrets across stores.
+          </p>
+        </div>
+      )}
+
+      {!loading.value && !error.value && detected && (
+        <>
+          {/* Hero — sync health ring */}
+          <div class="rounded-lg border border-border-primary p-6 bg-bg-elevated mb-6 flex flex-col items-center">
+            {total === 0
+              ? (
+                <div class="py-8 text-center">
+                  <p class="text-text-muted">
+                    No ExternalSecrets visible.
+                  </p>
+                </div>
+              )
+              : <SyncHealthRing synced={counts.Synced} total={total} />}
+          </div>
+
+          {/* Secondary cards row */}
+          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+            <SecondaryCard
+              label="Sync Failed"
+              count={counts.SyncFailed}
+              color="var(--danger)"
+              subText="ExternalSecrets the controller could not reconcile."
+              href="/external-secrets/external-secrets?status=SyncFailed"
+            />
+            <SecondaryCard
+              label="Stale"
+              count={counts.Stale}
+              color="var(--warning)"
+              subText="Phase D resolves stale thresholds — count is 0 until that ships."
+            />
+            <SecondaryCard
+              label="Drifted"
+              count={counts.Drifted}
+              color="var(--accent-secondary)"
+              subText="Drift only resolves on detail pages."
+            />
+            <SecondaryCard
+              label="Unknown"
+              count={counts.Unknown}
+              color="var(--text-muted)"
+              subText="Brand-new ExternalSecrets the controller hasn't reconciled yet."
+            />
+          </div>
+
+          {/* Tertiary row — providers + cost stub */}
+          <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-6">
+            <div
+              class="rounded-lg border border-border-primary p-4 bg-bg-elevated"
+              aria-label="Stores by provider"
+            >
+              <h2 class="text-sm font-medium text-text-primary mb-3">
+                Stores by provider
+              </h2>
+              {providerCounts.length === 0
+                ? (
+                  <p class="text-xs text-text-muted">
+                    No SecretStores or ClusterSecretStores visible.
+                  </p>
+                )
+                : (
+                  <ul class="space-y-2">
+                    {providerCounts.map(([provider, n]) => (
+                      <li
+                        key={provider}
+                        class="flex items-center justify-between gap-3"
+                      >
+                        <ProviderBadge provider={provider} />
+                        <span class="text-xs font-mono text-text-secondary">
+                          {n} {n === 1 ? "store" : "stores"}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+            </div>
+
+            <div
+              class="rounded-lg border border-border-primary p-4 bg-bg-elevated"
+              aria-label="Cost estimate"
+            >
+              <h2 class="text-sm font-medium text-text-primary mb-3">
+                Per-provider cost estimate
+              </h2>
+              <p class="text-xs text-text-muted">
+                Per-provider cost estimates ship in Phase F.
+              </p>
+              <p class="text-xs text-text-muted mt-2">
+                Rate-card snapshot date:{" "}
+                <span class="font-mono">— pending —</span>
+              </p>
+            </div>
+          </div>
+
+          {/* Failure table */}
+          <div class="mb-1">
+            <h2 class="text-lg font-semibold text-text-primary">
+              Broken ExternalSecrets right now
+            </h2>
+            <p class="text-sm text-text-muted mb-3">
+              ExternalSecrets currently in SyncFailed, Stale, Drifted, or
+              Unknown state.
+            </p>
+          </div>
+          {broken.length === 0
+            ? (
+              <div class="text-center py-8 rounded-lg border border-border-primary bg-bg-elevated">
+                <p class="text-text-muted">
+                  No broken ExternalSecrets — everything synced!
+                </p>
+              </div>
+            )
+            : (
+              <div class="overflow-x-auto rounded-lg border border-border-primary">
+                <table class="w-full text-sm">
+                  <thead>
+                    <tr class="border-b border-border-primary bg-surface">
+                      <th
+                        scope="col"
+                        class="px-3 py-2 text-left text-xs font-medium text-text-muted"
+                      >
+                        Namespace
+                      </th>
+                      <th
+                        scope="col"
+                        class="px-3 py-2 text-left text-xs font-medium text-text-muted"
+                      >
+                        Name
+                      </th>
+                      <th
+                        scope="col"
+                        class="px-3 py-2 text-left text-xs font-medium text-text-muted"
+                      >
+                        Status
+                      </th>
+                      <th
+                        scope="col"
+                        class="px-3 py-2 text-left text-xs font-medium text-text-muted"
+                      >
+                        Reason
+                      </th>
+                      <th
+                        scope="col"
+                        class="px-3 py-2 text-left text-xs font-medium text-text-muted"
+                      >
+                        Last Sync
+                      </th>
+                      <th
+                        scope="col"
+                        class="px-3 py-2 text-left text-xs font-medium text-text-muted"
+                        title="Affected workload counts ship in Phase I (chain visualization)."
+                      >
+                        Affected workloads
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody class="divide-y divide-border-subtle">
+                    {brokenDisplayed.map((es) => {
+                      const href = `/external-secrets/external-secrets/${
+                        encodeURIComponent(es.namespace)
+                      }/${encodeURIComponent(es.name)}`;
+                      return (
+                        <tr key={es.uid} class="hover:bg-hover/30">
+                          <td class="px-3 py-2 text-text-secondary">
+                            {es.namespace}
+                          </td>
+                          <td class="px-3 py-2">
+                            <a
+                              href={href}
+                              class="text-brand hover:underline font-medium"
+                            >
+                              {es.name}
+                            </a>
+                          </td>
+                          <td class="px-3 py-2">
+                            <StatusBadge status={es.status} />
+                          </td>
+                          <td class="px-3 py-2 text-text-secondary text-xs">
+                            {es.readyReason ?? "—"}
+                          </td>
+                          <td class="px-3 py-2 text-text-secondary text-xs">
+                            {es.lastSyncTime ? timeAgo(es.lastSyncTime) : "—"}
+                          </td>
+                          <td
+                            class="px-3 py-2 text-text-muted text-xs"
+                            title="Affected workload counts ship in Phase I (chain visualization)."
+                          >
+                            —
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+                {brokenOverflow > 0 && (
+                  <div class="px-3 py-2 border-t border-border-primary bg-surface text-xs text-text-muted text-center">
+                    +{brokenOverflow} more
+                  </div>
+                )}
+              </div>
+            )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/islands/ESOExternalSecretDetail.tsx
+++ b/frontend/islands/ESOExternalSecretDetail.tsx
@@ -6,6 +6,7 @@ import { StatusBadge } from "@/components/eso/ESOBadges.tsx";
 import { ESODriftIndicator } from "@/components/eso/ESODriftIndicator.tsx";
 import { esoApi } from "@/lib/eso-api.ts";
 import { resourceHref } from "@/lib/k8s-links.ts";
+import { timeAgo } from "@/lib/timeAgo.ts";
 import type { ExternalSecret } from "@/lib/eso-types.ts";
 
 interface Props {
@@ -16,21 +17,6 @@ interface Props {
 type TabKey = "overview" | "yaml" | "events" | "history" | "chain";
 
 const EM_DASH = "—";
-
-function formatRelative(iso?: string): string {
-  if (!iso) return EM_DASH;
-  const ts = new Date(iso).getTime();
-  if (Number.isNaN(ts)) return iso;
-  const now = Date.now();
-  const seconds = Math.round((now - ts) / 1000);
-  if (Math.abs(seconds) < 60) return `${seconds}s ago`;
-  const minutes = Math.round(seconds / 60);
-  if (Math.abs(minutes) < 60) return `${minutes}m ago`;
-  const hours = Math.round(minutes / 60);
-  if (Math.abs(hours) < 24) return `${hours}h ago`;
-  const days = Math.round(hours / 24);
-  return `${days}d ago`;
-}
 
 function storeHref(kind: string, namespace: string, name: string): string {
   if (kind === "ClusterSecretStore") {
@@ -100,7 +86,6 @@ export default function ESOExternalSecretDetail({ namespace, name }: Props) {
           <ESODriftIndicator
             status={es.driftStatus}
             reason={es.driftUnknownReason}
-            onRevert={() => {}}
           />
         )}
       </div>
@@ -139,7 +124,7 @@ export default function ESOExternalSecretDetail({ namespace, name }: Props) {
       {/* Tab panels */}
       {activeTab.value === "overview" && (
         <div role="tabpanel" class="space-y-4">
-          <div class="rounded-lg border border-border-primary bg-bg-elevated p-5">
+          <div class="rounded-lg border border-border-primary bg-elevated p-5">
             <h2 class="text-sm font-semibold text-text-primary mb-4">
               Details
             </h2>
@@ -204,7 +189,7 @@ export default function ESOExternalSecretDetail({ namespace, name }: Props) {
                   class="text-text-primary"
                   title={es.lastSyncTime ?? ""}
                 >
-                  {formatRelative(es.lastSyncTime)}
+                  {es.lastSyncTime ? timeAgo(es.lastSyncTime) : EM_DASH}
                 </dd>
               </div>
               <div class="sm:col-span-2">
@@ -233,7 +218,7 @@ export default function ESOExternalSecretDetail({ namespace, name }: Props) {
       {activeTab.value === "yaml" && (
         <div
           role="tabpanel"
-          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+          class="rounded-lg border border-border-primary bg-elevated p-5 text-sm text-text-muted"
         >
           YAML editor coming in Phase&nbsp;B.
         </div>
@@ -242,7 +227,7 @@ export default function ESOExternalSecretDetail({ namespace, name }: Props) {
       {activeTab.value === "events" && (
         <div
           role="tabpanel"
-          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+          class="rounded-lg border border-border-primary bg-elevated p-5 text-sm text-text-muted"
         >
           Events feed coming in Phase&nbsp;B.
         </div>
@@ -251,7 +236,7 @@ export default function ESOExternalSecretDetail({ namespace, name }: Props) {
       {activeTab.value === "history" && (
         <div
           role="tabpanel"
-          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+          class="rounded-lg border border-border-primary bg-elevated p-5 text-sm text-text-muted"
         >
           History timeline coming in Phase&nbsp;C.
         </div>
@@ -260,7 +245,7 @@ export default function ESOExternalSecretDetail({ namespace, name }: Props) {
       {activeTab.value === "chain" && (
         <div
           role="tabpanel"
-          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+          class="rounded-lg border border-border-primary bg-elevated p-5 text-sm text-text-muted"
         >
           Chain visualization coming in Phase&nbsp;I.
         </div>

--- a/frontend/islands/ESOExternalSecretDetail.tsx
+++ b/frontend/islands/ESOExternalSecretDetail.tsx
@@ -1,0 +1,270 @@
+import { useSignal } from "@preact/signals";
+import { IS_BROWSER } from "fresh/runtime";
+import { useEffect } from "preact/hooks";
+import { Spinner } from "@/components/ui/Spinner.tsx";
+import { StatusBadge } from "@/components/eso/ESOBadges.tsx";
+import { ESODriftIndicator } from "@/components/eso/ESODriftIndicator.tsx";
+import { esoApi } from "@/lib/eso-api.ts";
+import { resourceHref } from "@/lib/k8s-links.ts";
+import type { ExternalSecret } from "@/lib/eso-types.ts";
+
+interface Props {
+  namespace: string;
+  name: string;
+}
+
+type TabKey = "overview" | "yaml" | "events" | "history" | "chain";
+
+const EM_DASH = "—";
+
+function formatRelative(iso?: string): string {
+  if (!iso) return EM_DASH;
+  const ts = new Date(iso).getTime();
+  if (Number.isNaN(ts)) return iso;
+  const now = Date.now();
+  const seconds = Math.round((now - ts) / 1000);
+  if (Math.abs(seconds) < 60) return `${seconds}s ago`;
+  const minutes = Math.round(seconds / 60);
+  if (Math.abs(minutes) < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (Math.abs(hours) < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  return `${days}d ago`;
+}
+
+function storeHref(kind: string, namespace: string, name: string): string {
+  if (kind === "ClusterSecretStore") {
+    return `/external-secrets/cluster-stores/${encodeURIComponent(name)}`;
+  }
+  return `/external-secrets/stores/${encodeURIComponent(namespace)}/${
+    encodeURIComponent(name)
+  }`;
+}
+
+export default function ESOExternalSecretDetail({ namespace, name }: Props) {
+  const loading = useSignal(true);
+  const error = useSignal<string | null>(null);
+  const data = useSignal<ExternalSecret | null>(null);
+  const activeTab = useSignal<TabKey>("overview");
+
+  useEffect(() => {
+    if (!IS_BROWSER) return;
+    let cancelled = false;
+    (async () => {
+      loading.value = true;
+      error.value = null;
+      try {
+        const res = await esoApi.getExternalSecret(namespace, name);
+        if (!cancelled) data.value = res.data ?? null;
+      } catch {
+        if (!cancelled) error.value = "Failed to load ExternalSecret";
+      } finally {
+        if (!cancelled) loading.value = false;
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [namespace, name]);
+
+  if (!IS_BROWSER) return null;
+
+  if (loading.value) {
+    return (
+      <div class="flex justify-center py-12">
+        <Spinner class="text-brand" />
+      </div>
+    );
+  }
+
+  if (error.value) {
+    return <p class="text-sm text-danger p-6">{error.value}</p>;
+  }
+
+  if (!data.value) return null;
+
+  const es = data.value;
+  const showMessage = es.status === "SyncFailed" ||
+    (es.readyMessage && es.readyMessage.length > 0);
+  const targetSecretLink = es.targetSecretName
+    ? resourceHref("secret", es.namespace, es.targetSecretName)
+    : null;
+
+  return (
+    <div class="p-6 space-y-6">
+      {/* Header */}
+      <div class="flex flex-wrap items-center gap-3">
+        <h1 class="text-2xl font-bold text-text-primary">{es.name}</h1>
+        <StatusBadge status={es.status} />
+        {es.driftStatus && (
+          <ESODriftIndicator
+            status={es.driftStatus}
+            reason={es.driftUnknownReason}
+            onRevert={() => {}}
+          />
+        )}
+      </div>
+
+      {/* Tab strip */}
+      <div role="tablist" class="flex gap-1 border-b border-border-primary">
+        {(
+          [
+            ["overview", "Overview"],
+            ["yaml", "YAML"],
+            ["events", "Events"],
+            ["history", "History"],
+            ["chain", "Chain"],
+          ] as Array<[TabKey, string]>
+        ).map(([key, label]) => {
+          const active = activeTab.value === key;
+          return (
+            <button
+              key={key}
+              type="button"
+              role="tab"
+              aria-selected={active}
+              onClick={() => (activeTab.value = key)}
+              class={`px-3 py-2 text-sm border-b-2 -mb-px transition-colors ${
+                active
+                  ? "border-brand text-text-primary"
+                  : "border-transparent text-text-muted hover:text-text-primary"
+              }`}
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Tab panels */}
+      {activeTab.value === "overview" && (
+        <div role="tabpanel" class="space-y-4">
+          <div class="rounded-lg border border-border-primary bg-bg-elevated p-5">
+            <h2 class="text-sm font-semibold text-text-primary mb-4">
+              Details
+            </h2>
+            <dl class="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-3 text-sm">
+              <div>
+                <dt class="text-text-muted">Namespace</dt>
+                <dd class="text-text-primary">{es.namespace}</dd>
+              </div>
+              <div>
+                <dt class="text-text-muted">Name</dt>
+                <dd class="text-text-primary">{es.name}</dd>
+              </div>
+              <div class="sm:col-span-2">
+                <dt class="text-text-muted">UID</dt>
+                <dd class="text-text-primary font-mono text-xs">{es.uid}</dd>
+              </div>
+              <div>
+                <dt class="text-text-muted">Store</dt>
+                <dd>
+                  <a
+                    href={storeHref(
+                      es.storeRef.kind,
+                      es.namespace,
+                      es.storeRef.name,
+                    )}
+                    class="text-brand hover:underline"
+                  >
+                    {es.storeRef.kind}/{es.storeRef.name}
+                  </a>
+                </dd>
+              </div>
+              <div>
+                <dt class="text-text-muted">Target Secret</dt>
+                <dd>
+                  {es.targetSecretName
+                    ? (targetSecretLink
+                      ? (
+                        <a
+                          href={targetSecretLink}
+                          class="text-brand hover:underline"
+                        >
+                          {es.targetSecretName}
+                        </a>
+                      )
+                      : (
+                        <span class="text-text-primary">
+                          {es.targetSecretName}
+                        </span>
+                      ))
+                    : <span class="text-text-muted">{EM_DASH}</span>}
+                </dd>
+              </div>
+              <div>
+                <dt class="text-text-muted">Refresh Interval</dt>
+                <dd class="text-text-primary">
+                  {es.refreshInterval || EM_DASH}
+                </dd>
+              </div>
+              <div>
+                <dt class="text-text-muted">Last Sync</dt>
+                <dd
+                  class="text-text-primary"
+                  title={es.lastSyncTime ?? ""}
+                >
+                  {formatRelative(es.lastSyncTime)}
+                </dd>
+              </div>
+              <div class="sm:col-span-2">
+                <dt class="text-text-muted">Synced ResourceVersion</dt>
+                <dd class="text-text-primary font-mono text-xs">
+                  {es.syncedResourceVersion || EM_DASH}
+                </dd>
+              </div>
+              {es.readyReason && (
+                <div class="sm:col-span-2">
+                  <dt class="text-text-muted">Ready Reason</dt>
+                  <dd class="text-text-primary">{es.readyReason}</dd>
+                </div>
+              )}
+              {showMessage && (
+                <div class="sm:col-span-2">
+                  <dt class="text-text-muted">Message</dt>
+                  <dd class="text-text-secondary">{es.readyMessage}</dd>
+                </div>
+              )}
+            </dl>
+          </div>
+        </div>
+      )}
+
+      {activeTab.value === "yaml" && (
+        <div
+          role="tabpanel"
+          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+        >
+          YAML editor coming in Phase&nbsp;B.
+        </div>
+      )}
+
+      {activeTab.value === "events" && (
+        <div
+          role="tabpanel"
+          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+        >
+          Events feed coming in Phase&nbsp;B.
+        </div>
+      )}
+
+      {activeTab.value === "history" && (
+        <div
+          role="tabpanel"
+          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+        >
+          History timeline coming in Phase&nbsp;C.
+        </div>
+      )}
+
+      {activeTab.value === "chain" && (
+        <div
+          role="tabpanel"
+          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+        >
+          Chain visualization coming in Phase&nbsp;I.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/islands/ESOExternalSecretsList.tsx
+++ b/frontend/islands/ESOExternalSecretsList.tsx
@@ -3,6 +3,7 @@ import { IS_BROWSER } from "fresh/runtime";
 import { useEffect, useRef } from "preact/hooks";
 import { esoApi } from "@/lib/eso-api.ts";
 import { StatusBadge } from "@/components/eso/ESOBadges.tsx";
+import { ESONotDetected } from "@/components/eso/ESONotDetected.tsx";
 import { Spinner } from "@/components/ui/Spinner.tsx";
 import { timeAgo } from "@/lib/timeAgo.ts";
 import type { ExternalSecret } from "@/lib/eso-types.ts";
@@ -17,6 +18,8 @@ export default function ESOExternalSecretsList() {
   const error = useSignal<string | null>(null);
   const namespace = useSignal("");
   const search = useSignal("");
+  // null = unknown (still loading), true = ESO present, false = render install prompt.
+  const detected = useSignal<boolean | null>(null);
 
   // Sequence counter: every fetch captures a token; a response is applied
   // only if its token is still the latest. Stops slow earlier responses
@@ -41,9 +44,21 @@ export default function ESOExternalSecretsList() {
 
   useEffect(() => {
     if (!IS_BROWSER) return;
-    fetchData().then(() => {
-      loading.value = false;
-    });
+    (async () => {
+      try {
+        const statusRes = await esoApi.status();
+        const present = statusRes.data?.detected !== false;
+        detected.value = present;
+        if (present) await fetchData();
+      } catch {
+        // Status probe failed — assume present and let fetchData surface the
+        // real error rather than masking it as "ESO not installed".
+        detected.value = true;
+        await fetchData();
+      } finally {
+        loading.value = false;
+      }
+    })();
     return () => {
       if (debounceHandle.current !== null) {
         clearTimeout(debounceHandle.current);
@@ -64,6 +79,17 @@ export default function ESOExternalSecretsList() {
   }
 
   if (!IS_BROWSER) return null;
+
+  if (!loading.value && detected.value === false) {
+    return (
+      <div class="p-6">
+        <h1 class="text-2xl font-bold text-text-primary mb-6">
+          ExternalSecrets
+        </h1>
+        <ESONotDetected />
+      </div>
+    );
+  }
 
   const filtered = items.value.filter((es) => {
     if (!search.value) return true;
@@ -97,7 +123,7 @@ export default function ESOExternalSecretsList() {
           <input
             id="eso-es-ns"
             type="text"
-            class="rounded border border-border-primary px-3 py-1.5 text-sm bg-bg-base text-text-primary max-w-xs"
+            class="rounded border border-border-primary px-3 py-1.5 text-sm bg-base text-text-primary max-w-xs"
             placeholder="All namespaces"
             value={namespace.value}
             aria-describedby="eso-es-ns-hint"
@@ -118,7 +144,7 @@ export default function ESOExternalSecretsList() {
           <input
             id="eso-es-search"
             type="text"
-            class="rounded border border-border-primary px-3 py-1.5 text-sm bg-bg-base text-text-primary max-w-xs"
+            class="rounded border border-border-primary px-3 py-1.5 text-sm bg-base text-text-primary max-w-xs"
             placeholder="name, store, target..."
             value={search.value}
             onInput={(e) => {
@@ -189,7 +215,9 @@ export default function ESOExternalSecretsList() {
                 <tr key={es.uid} class="hover:bg-hover/30">
                   <td class="px-3 py-2">
                     <a
-                      href={`/external-secrets/external-secrets/${es.namespace}/${es.name}`}
+                      href={`/external-secrets/external-secrets/${
+                        encodeURIComponent(es.namespace)
+                      }/${encodeURIComponent(es.name)}`}
                       class="font-medium text-brand hover:underline"
                     >
                       {es.name}
@@ -217,7 +245,7 @@ export default function ESOExternalSecretsList() {
 
       {!loading.value && !error.value && filtered.length === 0 &&
         items.value.length > 0 && (
-        <div class="text-center py-12 rounded-lg border border-border-primary bg-bg-elevated">
+        <div class="text-center py-12 rounded-lg border border-border-primary bg-elevated">
           <p class="text-text-muted">
             No ExternalSecrets match your filters.
           </p>
@@ -225,7 +253,7 @@ export default function ESOExternalSecretsList() {
       )}
 
       {!loading.value && !error.value && items.value.length === 0 && (
-        <div class="text-center py-12 rounded-lg border border-border-primary bg-bg-elevated">
+        <div class="text-center py-12 rounded-lg border border-border-primary bg-elevated">
           <p class="text-text-muted">
             No ExternalSecrets in this namespace. Create one to start syncing
             secrets from a SecretStore.

--- a/frontend/islands/ESOExternalSecretsList.tsx
+++ b/frontend/islands/ESOExternalSecretsList.tsx
@@ -1,0 +1,237 @@
+import { useSignal } from "@preact/signals";
+import { IS_BROWSER } from "fresh/runtime";
+import { useEffect, useRef } from "preact/hooks";
+import { esoApi } from "@/lib/eso-api.ts";
+import { StatusBadge } from "@/components/eso/ESOBadges.tsx";
+import { Spinner } from "@/components/ui/Spinner.tsx";
+import { timeAgo } from "@/lib/timeAgo.ts";
+import type { ExternalSecret } from "@/lib/eso-types.ts";
+
+/** Debounce window (ms) for namespace input → re-fetch. Long enough to
+ *  coalesce typing, short enough to feel responsive once the user stops. */
+const NAMESPACE_DEBOUNCE_MS = 300;
+
+export default function ESOExternalSecretsList() {
+  const items = useSignal<ExternalSecret[]>([]);
+  const loading = useSignal(true);
+  const error = useSignal<string | null>(null);
+  const namespace = useSignal("");
+  const search = useSignal("");
+
+  // Sequence counter: every fetch captures a token; a response is applied
+  // only if its token is still the latest. Stops slow earlier responses
+  // from overwriting state from later, faster ones (`apiGet` does not
+  // expose an AbortSignal, so the sequence guard is the canonical guard).
+  const fetchSeq = useRef(0);
+  const debounceHandle = useRef<number | null>(null);
+
+  async function fetchData() {
+    const seq = ++fetchSeq.current;
+    try {
+      const ns = namespace.value.trim() || undefined;
+      const res = await esoApi.listExternalSecrets(ns);
+      if (seq !== fetchSeq.current) return; // stale — drop
+      items.value = Array.isArray(res.data) ? res.data : [];
+      error.value = null;
+    } catch {
+      if (seq !== fetchSeq.current) return;
+      error.value = "Failed to load ExternalSecrets";
+    }
+  }
+
+  useEffect(() => {
+    if (!IS_BROWSER) return;
+    fetchData().then(() => {
+      loading.value = false;
+    });
+    return () => {
+      if (debounceHandle.current !== null) {
+        clearTimeout(debounceHandle.current);
+        debounceHandle.current = null;
+      }
+    };
+  }, []);
+
+  function handleNamespaceChange(value: string) {
+    namespace.value = value;
+    if (debounceHandle.current !== null) {
+      clearTimeout(debounceHandle.current);
+    }
+    debounceHandle.current = setTimeout(() => {
+      debounceHandle.current = null;
+      fetchData();
+    }, NAMESPACE_DEBOUNCE_MS);
+  }
+
+  if (!IS_BROWSER) return null;
+
+  const filtered = items.value.filter((es) => {
+    if (!search.value) return true;
+    const q = search.value.toLowerCase();
+    return (
+      es.name.toLowerCase().includes(q) ||
+      es.namespace.toLowerCase().includes(q) ||
+      es.storeRef.name.toLowerCase().includes(q) ||
+      (es.targetSecretName ?? "").toLowerCase().includes(q)
+    );
+  });
+
+  return (
+    <div class="p-6">
+      <div class="flex items-start justify-between mb-1">
+        <h1 class="text-2xl font-bold text-text-primary">ExternalSecrets</h1>
+      </div>
+      <p class="text-sm text-text-muted mb-6">
+        ExternalSecrets sync data from a SecretStore into a Kubernetes Secret.
+      </p>
+
+      {/* Filters */}
+      <div class="mb-4 flex flex-wrap items-center gap-4">
+        <div class="flex items-center gap-2">
+          <label
+            class="text-sm font-medium text-text-secondary"
+            htmlFor="eso-es-ns"
+          >
+            Namespace
+          </label>
+          <input
+            id="eso-es-ns"
+            type="text"
+            class="rounded border border-border-primary px-3 py-1.5 text-sm bg-bg-base text-text-primary max-w-xs"
+            placeholder="All namespaces"
+            value={namespace.value}
+            aria-describedby="eso-es-ns-hint"
+            onInput={(e) =>
+              handleNamespaceChange((e.target as HTMLInputElement).value)}
+          />
+          <span id="eso-es-ns-hint" class="sr-only">
+            Filter ExternalSecrets by namespace; updates after a brief pause.
+          </span>
+        </div>
+        <div class="flex items-center gap-2">
+          <label
+            class="text-sm font-medium text-text-secondary"
+            htmlFor="eso-es-search"
+          >
+            Search
+          </label>
+          <input
+            id="eso-es-search"
+            type="text"
+            class="rounded border border-border-primary px-3 py-1.5 text-sm bg-bg-base text-text-primary max-w-xs"
+            placeholder="name, store, target..."
+            value={search.value}
+            onInput={(e) => {
+              search.value = (e.target as HTMLInputElement).value;
+            }}
+          />
+        </div>
+        <span class="text-xs text-text-muted">
+          {filtered.length} of {items.value.length} ExternalSecrets
+        </span>
+      </div>
+
+      {loading.value && (
+        <div class="flex justify-center py-12">
+          <Spinner class="text-brand" />
+        </div>
+      )}
+
+      {!loading.value && error.value && (
+        <p class="text-sm text-danger py-4">{error.value}</p>
+      )}
+
+      {!loading.value && !error.value && filtered.length > 0 && (
+        <div class="overflow-x-auto rounded-lg border border-border-primary">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="border-b border-border-primary bg-surface">
+                <th
+                  scope="col"
+                  class="px-3 py-2 text-left text-xs font-medium text-text-muted"
+                >
+                  Name
+                </th>
+                <th
+                  scope="col"
+                  class="px-3 py-2 text-left text-xs font-medium text-text-muted"
+                >
+                  Namespace
+                </th>
+                <th
+                  scope="col"
+                  class="px-3 py-2 text-left text-xs font-medium text-text-muted"
+                >
+                  Status
+                </th>
+                <th
+                  scope="col"
+                  class="px-3 py-2 text-left text-xs font-medium text-text-muted"
+                >
+                  Store
+                </th>
+                <th
+                  scope="col"
+                  class="px-3 py-2 text-left text-xs font-medium text-text-muted"
+                >
+                  Target Secret
+                </th>
+                <th
+                  scope="col"
+                  class="px-3 py-2 text-left text-xs font-medium text-text-muted"
+                >
+                  Last Sync
+                </th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-border-subtle">
+              {filtered.map((es) => (
+                <tr key={es.uid} class="hover:bg-hover/30">
+                  <td class="px-3 py-2">
+                    <a
+                      href={`/external-secrets/external-secrets/${es.namespace}/${es.name}`}
+                      class="font-medium text-brand hover:underline"
+                    >
+                      {es.name}
+                    </a>
+                  </td>
+                  <td class="px-3 py-2 text-text-secondary">{es.namespace}</td>
+                  <td class="px-3 py-2">
+                    <StatusBadge status={es.status} />
+                  </td>
+                  <td class="px-3 py-2 text-text-secondary">
+                    {es.storeRef.name}
+                  </td>
+                  <td class="px-3 py-2 text-text-secondary">
+                    {es.targetSecretName ?? "—"}
+                  </td>
+                  <td class="px-3 py-2 text-text-secondary text-xs">
+                    {es.lastSyncTime ? timeAgo(es.lastSyncTime) : "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {!loading.value && !error.value && filtered.length === 0 &&
+        items.value.length > 0 && (
+        <div class="text-center py-12 rounded-lg border border-border-primary bg-bg-elevated">
+          <p class="text-text-muted">
+            No ExternalSecrets match your filters.
+          </p>
+        </div>
+      )}
+
+      {!loading.value && !error.value && items.value.length === 0 && (
+        <div class="text-center py-12 rounded-lg border border-border-primary bg-bg-elevated">
+          <p class="text-text-muted">
+            No ExternalSecrets in this namespace. Create one to start syncing
+            secrets from a SecretStore.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/islands/ESOPushSecretDetail.tsx
+++ b/frontend/islands/ESOPushSecretDetail.tsx
@@ -5,6 +5,7 @@ import { Spinner } from "@/components/ui/Spinner.tsx";
 import { StatusBadge } from "@/components/eso/ESOBadges.tsx";
 import { esoApi } from "@/lib/eso-api.ts";
 import { resourceHref } from "@/lib/k8s-links.ts";
+import { timeAgo } from "@/lib/timeAgo.ts";
 import type { PushSecret } from "@/lib/eso-types.ts";
 
 interface Props {
@@ -15,21 +16,6 @@ interface Props {
 type TabKey = "overview" | "yaml" | "events" | "history" | "chain";
 
 const EM_DASH = "—";
-
-function formatRelative(iso?: string): string {
-  if (!iso) return EM_DASH;
-  const ts = new Date(iso).getTime();
-  if (Number.isNaN(ts)) return iso;
-  const now = Date.now();
-  const seconds = Math.round((now - ts) / 1000);
-  if (Math.abs(seconds) < 60) return `${seconds}s ago`;
-  const minutes = Math.round(seconds / 60);
-  if (Math.abs(minutes) < 60) return `${minutes}m ago`;
-  const hours = Math.round(minutes / 60);
-  if (Math.abs(hours) < 24) return `${hours}h ago`;
-  const days = Math.round(hours / 24);
-  return `${days}d ago`;
-}
 
 function storeHref(kind: string, namespace: string, name: string): string {
   if (kind === "ClusterSecretStore") {
@@ -128,7 +114,7 @@ export default function ESOPushSecretDetail({ namespace, name }: Props) {
 
       {activeTab.value === "overview" && (
         <div role="tabpanel" class="space-y-4">
-          <div class="rounded-lg border border-border-primary bg-bg-elevated p-5">
+          <div class="rounded-lg border border-border-primary bg-elevated p-5">
             <h2 class="text-sm font-semibold text-text-primary mb-4">
               Details
             </h2>
@@ -178,7 +164,7 @@ export default function ESOPushSecretDetail({ namespace, name }: Props) {
                   class="text-text-primary"
                   title={ps.lastSyncTime ?? ""}
                 >
-                  {formatRelative(ps.lastSyncTime)}
+                  {ps.lastSyncTime ? timeAgo(ps.lastSyncTime) : EM_DASH}
                 </dd>
               </div>
               {ps.readyReason && (
@@ -196,7 +182,7 @@ export default function ESOPushSecretDetail({ namespace, name }: Props) {
             </dl>
           </div>
 
-          <div class="rounded-lg border border-border-primary bg-bg-elevated p-5">
+          <div class="rounded-lg border border-border-primary bg-elevated p-5">
             <h2 class="text-sm font-semibold text-text-primary mb-3">
               Push targets ({(ps.storeRefs ?? []).length})
             </h2>
@@ -223,7 +209,7 @@ export default function ESOPushSecretDetail({ namespace, name }: Props) {
       {activeTab.value === "yaml" && (
         <div
           role="tabpanel"
-          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+          class="rounded-lg border border-border-primary bg-elevated p-5 text-sm text-text-muted"
         >
           YAML editor coming in Phase&nbsp;B.
         </div>
@@ -232,7 +218,7 @@ export default function ESOPushSecretDetail({ namespace, name }: Props) {
       {activeTab.value === "events" && (
         <div
           role="tabpanel"
-          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+          class="rounded-lg border border-border-primary bg-elevated p-5 text-sm text-text-muted"
         >
           Events feed coming in Phase&nbsp;B.
         </div>
@@ -241,7 +227,7 @@ export default function ESOPushSecretDetail({ namespace, name }: Props) {
       {activeTab.value === "history" && (
         <div
           role="tabpanel"
-          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+          class="rounded-lg border border-border-primary bg-elevated p-5 text-sm text-text-muted"
         >
           History timeline coming in Phase&nbsp;C.
         </div>
@@ -250,7 +236,7 @@ export default function ESOPushSecretDetail({ namespace, name }: Props) {
       {activeTab.value === "chain" && (
         <div
           role="tabpanel"
-          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+          class="rounded-lg border border-border-primary bg-elevated p-5 text-sm text-text-muted"
         >
           Chain visualization coming in Phase&nbsp;I.
         </div>

--- a/frontend/islands/ESOPushSecretDetail.tsx
+++ b/frontend/islands/ESOPushSecretDetail.tsx
@@ -1,0 +1,260 @@
+import { useSignal } from "@preact/signals";
+import { IS_BROWSER } from "fresh/runtime";
+import { useEffect } from "preact/hooks";
+import { Spinner } from "@/components/ui/Spinner.tsx";
+import { StatusBadge } from "@/components/eso/ESOBadges.tsx";
+import { esoApi } from "@/lib/eso-api.ts";
+import { resourceHref } from "@/lib/k8s-links.ts";
+import type { PushSecret } from "@/lib/eso-types.ts";
+
+interface Props {
+  namespace: string;
+  name: string;
+}
+
+type TabKey = "overview" | "yaml" | "events" | "history" | "chain";
+
+const EM_DASH = "—";
+
+function formatRelative(iso?: string): string {
+  if (!iso) return EM_DASH;
+  const ts = new Date(iso).getTime();
+  if (Number.isNaN(ts)) return iso;
+  const now = Date.now();
+  const seconds = Math.round((now - ts) / 1000);
+  if (Math.abs(seconds) < 60) return `${seconds}s ago`;
+  const minutes = Math.round(seconds / 60);
+  if (Math.abs(minutes) < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (Math.abs(hours) < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  return `${days}d ago`;
+}
+
+function storeHref(kind: string, namespace: string, name: string): string {
+  if (kind === "ClusterSecretStore") {
+    return `/external-secrets/cluster-stores/${encodeURIComponent(name)}`;
+  }
+  return `/external-secrets/stores/${encodeURIComponent(namespace)}/${
+    encodeURIComponent(name)
+  }`;
+}
+
+export default function ESOPushSecretDetail({ namespace, name }: Props) {
+  const loading = useSignal(true);
+  const error = useSignal<string | null>(null);
+  const data = useSignal<PushSecret | null>(null);
+  const activeTab = useSignal<TabKey>("overview");
+
+  useEffect(() => {
+    if (!IS_BROWSER) return;
+    let cancelled = false;
+    (async () => {
+      loading.value = true;
+      error.value = null;
+      try {
+        const res = await esoApi.getPushSecret(namespace, name);
+        if (!cancelled) data.value = res.data ?? null;
+      } catch {
+        if (!cancelled) error.value = "Failed to load PushSecret";
+      } finally {
+        if (!cancelled) loading.value = false;
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [namespace, name]);
+
+  if (!IS_BROWSER) return null;
+
+  if (loading.value) {
+    return (
+      <div class="flex justify-center py-12">
+        <Spinner class="text-brand" />
+      </div>
+    );
+  }
+
+  if (error.value) {
+    return <p class="text-sm text-danger p-6">{error.value}</p>;
+  }
+
+  if (!data.value) return null;
+
+  const ps = data.value;
+  const showMessage = ps.status === "SyncFailed" ||
+    (ps.readyMessage && ps.readyMessage.length > 0);
+  const sourceSecretLink = ps.sourceSecretName
+    ? resourceHref("secret", ps.namespace, ps.sourceSecretName)
+    : null;
+
+  return (
+    <div class="p-6 space-y-6">
+      <div class="flex flex-wrap items-center gap-3">
+        <h1 class="text-2xl font-bold text-text-primary">{ps.name}</h1>
+        <StatusBadge status={ps.status} />
+      </div>
+
+      <div role="tablist" class="flex gap-1 border-b border-border-primary">
+        {(
+          [
+            ["overview", "Overview"],
+            ["yaml", "YAML"],
+            ["events", "Events"],
+            ["history", "History"],
+            ["chain", "Chain"],
+          ] as Array<[TabKey, string]>
+        ).map(([key, label]) => {
+          const active = activeTab.value === key;
+          return (
+            <button
+              key={key}
+              type="button"
+              role="tab"
+              aria-selected={active}
+              onClick={() => (activeTab.value = key)}
+              class={`px-3 py-2 text-sm border-b-2 -mb-px transition-colors ${
+                active
+                  ? "border-brand text-text-primary"
+                  : "border-transparent text-text-muted hover:text-text-primary"
+              }`}
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+
+      {activeTab.value === "overview" && (
+        <div role="tabpanel" class="space-y-4">
+          <div class="rounded-lg border border-border-primary bg-bg-elevated p-5">
+            <h2 class="text-sm font-semibold text-text-primary mb-4">
+              Details
+            </h2>
+            <dl class="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-3 text-sm">
+              <div>
+                <dt class="text-text-muted">Namespace</dt>
+                <dd class="text-text-primary">{ps.namespace}</dd>
+              </div>
+              <div>
+                <dt class="text-text-muted">Name</dt>
+                <dd class="text-text-primary">{ps.name}</dd>
+              </div>
+              <div class="sm:col-span-2">
+                <dt class="text-text-muted">UID</dt>
+                <dd class="text-text-primary font-mono text-xs">{ps.uid}</dd>
+              </div>
+              <div>
+                <dt class="text-text-muted">Source Secret</dt>
+                <dd>
+                  {ps.sourceSecretName
+                    ? (sourceSecretLink
+                      ? (
+                        <a
+                          href={sourceSecretLink}
+                          class="text-brand hover:underline"
+                        >
+                          {ps.sourceSecretName}
+                        </a>
+                      )
+                      : (
+                        <span class="text-text-primary">
+                          {ps.sourceSecretName}
+                        </span>
+                      ))
+                    : <span class="text-text-muted">{EM_DASH}</span>}
+                </dd>
+              </div>
+              <div>
+                <dt class="text-text-muted">Refresh Interval</dt>
+                <dd class="text-text-primary">
+                  {ps.refreshInterval || EM_DASH}
+                </dd>
+              </div>
+              <div>
+                <dt class="text-text-muted">Last Sync</dt>
+                <dd
+                  class="text-text-primary"
+                  title={ps.lastSyncTime ?? ""}
+                >
+                  {formatRelative(ps.lastSyncTime)}
+                </dd>
+              </div>
+              {ps.readyReason && (
+                <div class="sm:col-span-2">
+                  <dt class="text-text-muted">Ready Reason</dt>
+                  <dd class="text-text-primary">{ps.readyReason}</dd>
+                </div>
+              )}
+              {showMessage && (
+                <div class="sm:col-span-2">
+                  <dt class="text-text-muted">Message</dt>
+                  <dd class="text-text-secondary">{ps.readyMessage}</dd>
+                </div>
+              )}
+            </dl>
+          </div>
+
+          <div class="rounded-lg border border-border-primary bg-bg-elevated p-5">
+            <h2 class="text-sm font-semibold text-text-primary mb-3">
+              Push targets ({(ps.storeRefs ?? []).length})
+            </h2>
+            {ps.storeRefs && ps.storeRefs.length > 0
+              ? (
+                <ul class="text-sm space-y-1">
+                  {ps.storeRefs.map((s) => (
+                    <li key={`${s.kind}/${s.name}`}>
+                      <a
+                        href={storeHref(s.kind, ps.namespace, s.name)}
+                        class="text-brand hover:underline"
+                      >
+                        {s.kind}/{s.name}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              )
+              : <p class="text-sm text-text-muted">No store references.</p>}
+          </div>
+        </div>
+      )}
+
+      {activeTab.value === "yaml" && (
+        <div
+          role="tabpanel"
+          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+        >
+          YAML editor coming in Phase&nbsp;B.
+        </div>
+      )}
+
+      {activeTab.value === "events" && (
+        <div
+          role="tabpanel"
+          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+        >
+          Events feed coming in Phase&nbsp;B.
+        </div>
+      )}
+
+      {activeTab.value === "history" && (
+        <div
+          role="tabpanel"
+          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+        >
+          History timeline coming in Phase&nbsp;C.
+        </div>
+      )}
+
+      {activeTab.value === "chain" && (
+        <div
+          role="tabpanel"
+          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+        >
+          Chain visualization coming in Phase&nbsp;I.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/islands/ESOPushSecretsList.tsx
+++ b/frontend/islands/ESOPushSecretsList.tsx
@@ -3,6 +3,7 @@ import { IS_BROWSER } from "fresh/runtime";
 import { useEffect, useRef } from "preact/hooks";
 import { esoApi } from "@/lib/eso-api.ts";
 import { StatusBadge } from "@/components/eso/ESOBadges.tsx";
+import { ESONotDetected } from "@/components/eso/ESONotDetected.tsx";
 import { Spinner } from "@/components/ui/Spinner.tsx";
 import type { PushSecret } from "@/lib/eso-types.ts";
 
@@ -14,6 +15,7 @@ export default function ESOPushSecretsList() {
   const error = useSignal<string | null>(null);
   const namespace = useSignal("");
   const search = useSignal("");
+  const detected = useSignal<boolean | null>(null);
 
   const fetchSeq = useRef(0);
   const debounceHandle = useRef<number | null>(null);
@@ -34,9 +36,19 @@ export default function ESOPushSecretsList() {
 
   useEffect(() => {
     if (!IS_BROWSER) return;
-    fetchData().then(() => {
-      loading.value = false;
-    });
+    (async () => {
+      try {
+        const statusRes = await esoApi.status();
+        const present = statusRes.data?.detected !== false;
+        detected.value = present;
+        if (present) await fetchData();
+      } catch {
+        detected.value = true;
+        await fetchData();
+      } finally {
+        loading.value = false;
+      }
+    })();
     return () => {
       if (debounceHandle.current !== null) {
         clearTimeout(debounceHandle.current);
@@ -57,6 +69,15 @@ export default function ESOPushSecretsList() {
   }
 
   if (!IS_BROWSER) return null;
+
+  if (!loading.value && detected.value === false) {
+    return (
+      <div class="p-6">
+        <h1 class="text-2xl font-bold text-text-primary mb-6">PushSecrets</h1>
+        <ESONotDetected />
+      </div>
+    );
+  }
 
   const filtered = items.value.filter((p) => {
     if (!search.value) return true;
@@ -90,7 +111,7 @@ export default function ESOPushSecretsList() {
           <input
             id="eso-ps-ns"
             type="text"
-            class="rounded border border-border-primary px-3 py-1.5 text-sm bg-bg-base text-text-primary max-w-xs"
+            class="rounded border border-border-primary px-3 py-1.5 text-sm bg-base text-text-primary max-w-xs"
             placeholder="All namespaces"
             value={namespace.value}
             aria-describedby="eso-ps-ns-hint"
@@ -111,7 +132,7 @@ export default function ESOPushSecretsList() {
           <input
             id="eso-ps-search"
             type="text"
-            class="rounded border border-border-primary px-3 py-1.5 text-sm bg-bg-base text-text-primary max-w-xs"
+            class="rounded border border-border-primary px-3 py-1.5 text-sm bg-base text-text-primary max-w-xs"
             placeholder="name, source..."
             value={search.value}
             onInput={(e) => {
@@ -176,7 +197,9 @@ export default function ESOPushSecretsList() {
                 <tr key={p.uid} class="hover:bg-hover/30">
                   <td class="px-3 py-2">
                     <a
-                      href={`/external-secrets/push-secrets/${p.namespace}/${p.name}`}
+                      href={`/external-secrets/push-secrets/${
+                        encodeURIComponent(p.namespace)
+                      }/${encodeURIComponent(p.name)}`}
                       class="font-medium text-brand hover:underline"
                     >
                       {p.name}
@@ -201,13 +224,13 @@ export default function ESOPushSecretsList() {
 
       {!loading.value && !error.value && filtered.length === 0 &&
         items.value.length > 0 && (
-        <div class="text-center py-12 rounded-lg border border-border-primary bg-bg-elevated">
+        <div class="text-center py-12 rounded-lg border border-border-primary bg-elevated">
           <p class="text-text-muted">No PushSecrets match your filters.</p>
         </div>
       )}
 
       {!loading.value && !error.value && items.value.length === 0 && (
-        <div class="text-center py-12 rounded-lg border border-border-primary bg-bg-elevated">
+        <div class="text-center py-12 rounded-lg border border-border-primary bg-elevated">
           <p class="text-text-muted">
             No PushSecrets in this namespace. PushSecrets push Kubernetes
             Secrets back out to a source store (uncommon).

--- a/frontend/islands/ESOPushSecretsList.tsx
+++ b/frontend/islands/ESOPushSecretsList.tsx
@@ -1,0 +1,219 @@
+import { useSignal } from "@preact/signals";
+import { IS_BROWSER } from "fresh/runtime";
+import { useEffect, useRef } from "preact/hooks";
+import { esoApi } from "@/lib/eso-api.ts";
+import { StatusBadge } from "@/components/eso/ESOBadges.tsx";
+import { Spinner } from "@/components/ui/Spinner.tsx";
+import type { PushSecret } from "@/lib/eso-types.ts";
+
+const NAMESPACE_DEBOUNCE_MS = 300;
+
+export default function ESOPushSecretsList() {
+  const items = useSignal<PushSecret[]>([]);
+  const loading = useSignal(true);
+  const error = useSignal<string | null>(null);
+  const namespace = useSignal("");
+  const search = useSignal("");
+
+  const fetchSeq = useRef(0);
+  const debounceHandle = useRef<number | null>(null);
+
+  async function fetchData() {
+    const seq = ++fetchSeq.current;
+    try {
+      const ns = namespace.value.trim() || undefined;
+      const res = await esoApi.listPushSecrets(ns);
+      if (seq !== fetchSeq.current) return;
+      items.value = Array.isArray(res.data) ? res.data : [];
+      error.value = null;
+    } catch {
+      if (seq !== fetchSeq.current) return;
+      error.value = "Failed to load PushSecrets";
+    }
+  }
+
+  useEffect(() => {
+    if (!IS_BROWSER) return;
+    fetchData().then(() => {
+      loading.value = false;
+    });
+    return () => {
+      if (debounceHandle.current !== null) {
+        clearTimeout(debounceHandle.current);
+        debounceHandle.current = null;
+      }
+    };
+  }, []);
+
+  function handleNamespaceChange(value: string) {
+    namespace.value = value;
+    if (debounceHandle.current !== null) {
+      clearTimeout(debounceHandle.current);
+    }
+    debounceHandle.current = setTimeout(() => {
+      debounceHandle.current = null;
+      fetchData();
+    }, NAMESPACE_DEBOUNCE_MS);
+  }
+
+  if (!IS_BROWSER) return null;
+
+  const filtered = items.value.filter((p) => {
+    if (!search.value) return true;
+    const q = search.value.toLowerCase();
+    return (
+      p.name.toLowerCase().includes(q) ||
+      p.namespace.toLowerCase().includes(q) ||
+      (p.sourceSecretName ?? "").toLowerCase().includes(q)
+    );
+  });
+
+  return (
+    <div class="p-6">
+      <div class="flex items-start justify-between mb-1">
+        <h1 class="text-2xl font-bold text-text-primary">PushSecrets</h1>
+      </div>
+      <p class="text-sm text-text-muted mb-6">
+        PushSecrets push Kubernetes Secrets out to a remote backend (the reverse
+        direction of ExternalSecrets).
+      </p>
+
+      {/* Filters */}
+      <div class="mb-4 flex flex-wrap items-center gap-4">
+        <div class="flex items-center gap-2">
+          <label
+            class="text-sm font-medium text-text-secondary"
+            htmlFor="eso-ps-ns"
+          >
+            Namespace
+          </label>
+          <input
+            id="eso-ps-ns"
+            type="text"
+            class="rounded border border-border-primary px-3 py-1.5 text-sm bg-bg-base text-text-primary max-w-xs"
+            placeholder="All namespaces"
+            value={namespace.value}
+            aria-describedby="eso-ps-ns-hint"
+            onInput={(e) =>
+              handleNamespaceChange((e.target as HTMLInputElement).value)}
+          />
+          <span id="eso-ps-ns-hint" class="sr-only">
+            Filter PushSecrets by namespace; updates after a brief pause.
+          </span>
+        </div>
+        <div class="flex items-center gap-2">
+          <label
+            class="text-sm font-medium text-text-secondary"
+            htmlFor="eso-ps-search"
+          >
+            Search
+          </label>
+          <input
+            id="eso-ps-search"
+            type="text"
+            class="rounded border border-border-primary px-3 py-1.5 text-sm bg-bg-base text-text-primary max-w-xs"
+            placeholder="name, source..."
+            value={search.value}
+            onInput={(e) => {
+              search.value = (e.target as HTMLInputElement).value;
+            }}
+          />
+        </div>
+        <span class="text-xs text-text-muted">
+          {filtered.length} of {items.value.length} PushSecrets
+        </span>
+      </div>
+
+      {loading.value && (
+        <div class="flex justify-center py-12">
+          <Spinner class="text-brand" />
+        </div>
+      )}
+
+      {!loading.value && error.value && (
+        <p class="text-sm text-danger py-4">{error.value}</p>
+      )}
+
+      {!loading.value && !error.value && filtered.length > 0 && (
+        <div class="overflow-x-auto rounded-lg border border-border-primary">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="border-b border-border-primary bg-surface">
+                <th
+                  scope="col"
+                  class="px-3 py-2 text-left text-xs font-medium text-text-muted"
+                >
+                  Name
+                </th>
+                <th
+                  scope="col"
+                  class="px-3 py-2 text-left text-xs font-medium text-text-muted"
+                >
+                  Namespace
+                </th>
+                <th
+                  scope="col"
+                  class="px-3 py-2 text-left text-xs font-medium text-text-muted"
+                >
+                  Status
+                </th>
+                <th
+                  scope="col"
+                  class="px-3 py-2 text-left text-xs font-medium text-text-muted"
+                >
+                  Source Secret
+                </th>
+                <th
+                  scope="col"
+                  class="px-3 py-2 text-right text-xs font-medium text-text-muted"
+                >
+                  Stores
+                </th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-border-subtle">
+              {filtered.map((p) => (
+                <tr key={p.uid} class="hover:bg-hover/30">
+                  <td class="px-3 py-2">
+                    <a
+                      href={`/external-secrets/push-secrets/${p.namespace}/${p.name}`}
+                      class="font-medium text-brand hover:underline"
+                    >
+                      {p.name}
+                    </a>
+                  </td>
+                  <td class="px-3 py-2 text-text-secondary">{p.namespace}</td>
+                  <td class="px-3 py-2">
+                    <StatusBadge status={p.status} />
+                  </td>
+                  <td class="px-3 py-2 text-text-secondary">
+                    {p.sourceSecretName ?? "—"}
+                  </td>
+                  <td class="px-3 py-2 text-right text-text-secondary tabular-nums">
+                    {(p.storeRefs ?? []).length}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {!loading.value && !error.value && filtered.length === 0 &&
+        items.value.length > 0 && (
+        <div class="text-center py-12 rounded-lg border border-border-primary bg-bg-elevated">
+          <p class="text-text-muted">No PushSecrets match your filters.</p>
+        </div>
+      )}
+
+      {!loading.value && !error.value && items.value.length === 0 && (
+        <div class="text-center py-12 rounded-lg border border-border-primary bg-bg-elevated">
+          <p class="text-text-muted">
+            No PushSecrets in this namespace. PushSecrets push Kubernetes
+            Secrets back out to a source store (uncommon).
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/islands/ESOStoreDetail.tsx
+++ b/frontend/islands/ESOStoreDetail.tsx
@@ -99,7 +99,7 @@ export default function ESOStoreDetail({ namespace, name }: Props) {
 
       {activeTab.value === "overview" && (
         <div role="tabpanel" class="space-y-4">
-          <div class="rounded-lg border border-border-primary bg-bg-elevated p-5">
+          <div class="rounded-lg border border-border-primary bg-elevated p-5">
             <h2 class="text-sm font-semibold text-text-primary mb-4">
               Details
             </h2>
@@ -152,14 +152,14 @@ export default function ESOStoreDetail({ namespace, name }: Props) {
           </div>
 
           {store.providerSpec && Object.keys(store.providerSpec).length > 0 && (
-            <div class="rounded-lg border border-border-primary bg-bg-elevated p-5">
+            <div class="rounded-lg border border-border-primary bg-elevated p-5">
               <h2 class="text-sm font-semibold text-text-primary mb-1">
                 Provider spec
               </h2>
               <p class="text-xs text-text-muted mb-3">
                 Read-only infrastructure addressing — never credentials.
               </p>
-              <pre class="text-xs font-mono text-text-primary bg-bg-base border border-border-subtle rounded p-3 overflow-x-auto">
+              <pre class="text-xs font-mono text-text-primary bg-base border border-border-subtle rounded p-3 overflow-x-auto">
 {JSON.stringify(store.providerSpec, null, 2)}
               </pre>
             </div>
@@ -170,7 +170,7 @@ export default function ESOStoreDetail({ namespace, name }: Props) {
       {activeTab.value === "yaml" && (
         <div
           role="tabpanel"
-          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+          class="rounded-lg border border-border-primary bg-elevated p-5 text-sm text-text-muted"
         >
           YAML editor coming in Phase&nbsp;B.
         </div>
@@ -179,7 +179,7 @@ export default function ESOStoreDetail({ namespace, name }: Props) {
       {activeTab.value === "events" && (
         <div
           role="tabpanel"
-          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+          class="rounded-lg border border-border-primary bg-elevated p-5 text-sm text-text-muted"
         >
           Events feed coming in Phase&nbsp;B.
         </div>
@@ -188,7 +188,7 @@ export default function ESOStoreDetail({ namespace, name }: Props) {
       {activeTab.value === "history" && (
         <div
           role="tabpanel"
-          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+          class="rounded-lg border border-border-primary bg-elevated p-5 text-sm text-text-muted"
         >
           History timeline coming in Phase&nbsp;C.
         </div>
@@ -197,7 +197,7 @@ export default function ESOStoreDetail({ namespace, name }: Props) {
       {activeTab.value === "chain" && (
         <div
           role="tabpanel"
-          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+          class="rounded-lg border border-border-primary bg-elevated p-5 text-sm text-text-muted"
         >
           Chain visualization coming in Phase&nbsp;I.
         </div>

--- a/frontend/islands/ESOStoreDetail.tsx
+++ b/frontend/islands/ESOStoreDetail.tsx
@@ -1,0 +1,207 @@
+import { useSignal } from "@preact/signals";
+import { IS_BROWSER } from "fresh/runtime";
+import { useEffect } from "preact/hooks";
+import { Spinner } from "@/components/ui/Spinner.tsx";
+import { ProviderBadge, StatusBadge } from "@/components/eso/ESOBadges.tsx";
+import { esoApi } from "@/lib/eso-api.ts";
+import type { SecretStore } from "@/lib/eso-types.ts";
+
+interface Props {
+  namespace: string;
+  name: string;
+}
+
+type TabKey = "overview" | "yaml" | "events" | "history" | "chain";
+
+const EM_DASH = "—";
+
+export default function ESOStoreDetail({ namespace, name }: Props) {
+  const loading = useSignal(true);
+  const error = useSignal<string | null>(null);
+  const data = useSignal<SecretStore | null>(null);
+  const activeTab = useSignal<TabKey>("overview");
+
+  useEffect(() => {
+    if (!IS_BROWSER) return;
+    let cancelled = false;
+    (async () => {
+      loading.value = true;
+      error.value = null;
+      try {
+        const res = await esoApi.getStore(namespace, name);
+        if (!cancelled) data.value = res.data ?? null;
+      } catch {
+        if (!cancelled) error.value = "Failed to load SecretStore";
+      } finally {
+        if (!cancelled) loading.value = false;
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [namespace, name]);
+
+  if (!IS_BROWSER) return null;
+
+  if (loading.value) {
+    return (
+      <div class="flex justify-center py-12">
+        <Spinner class="text-brand" />
+      </div>
+    );
+  }
+
+  if (error.value) {
+    return <p class="text-sm text-danger p-6">{error.value}</p>;
+  }
+
+  if (!data.value) return null;
+
+  const store = data.value;
+
+  return (
+    <div class="p-6 space-y-6">
+      <div class="flex flex-wrap items-center gap-3">
+        <h1 class="text-2xl font-bold text-text-primary">{store.name}</h1>
+        <StatusBadge status={store.status} />
+        <ProviderBadge provider={store.provider} />
+      </div>
+
+      <div role="tablist" class="flex gap-1 border-b border-border-primary">
+        {(
+          [
+            ["overview", "Overview"],
+            ["yaml", "YAML"],
+            ["events", "Events"],
+            ["history", "History"],
+            ["chain", "Chain"],
+          ] as Array<[TabKey, string]>
+        ).map(([key, label]) => {
+          const active = activeTab.value === key;
+          return (
+            <button
+              key={key}
+              type="button"
+              role="tab"
+              aria-selected={active}
+              onClick={() => (activeTab.value = key)}
+              class={`px-3 py-2 text-sm border-b-2 -mb-px transition-colors ${
+                active
+                  ? "border-brand text-text-primary"
+                  : "border-transparent text-text-muted hover:text-text-primary"
+              }`}
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+
+      {activeTab.value === "overview" && (
+        <div role="tabpanel" class="space-y-4">
+          <div class="rounded-lg border border-border-primary bg-bg-elevated p-5">
+            <h2 class="text-sm font-semibold text-text-primary mb-4">
+              Details
+            </h2>
+            <dl class="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-3 text-sm">
+              <div>
+                <dt class="text-text-muted">Namespace</dt>
+                <dd class="text-text-primary">{store.namespace || EM_DASH}</dd>
+              </div>
+              <div>
+                <dt class="text-text-muted">Name</dt>
+                <dd class="text-text-primary">{store.name}</dd>
+              </div>
+              <div class="sm:col-span-2">
+                <dt class="text-text-muted">UID</dt>
+                <dd class="text-text-primary font-mono text-xs">{store.uid}</dd>
+              </div>
+              <div>
+                <dt class="text-text-muted">Status</dt>
+                <dd>
+                  <StatusBadge status={store.status} />
+                </dd>
+              </div>
+              <div>
+                <dt class="text-text-muted">Ready</dt>
+                <dd class="text-text-primary">{store.ready ? "Yes" : "No"}</dd>
+              </div>
+              <div>
+                <dt class="text-text-muted">Provider</dt>
+                <dd>
+                  <ProviderBadge provider={store.provider} />
+                </dd>
+              </div>
+              <div>
+                <dt class="text-text-muted">Scope</dt>
+                <dd class="text-text-primary">{store.scope}</dd>
+              </div>
+              {store.readyReason && (
+                <div class="sm:col-span-2">
+                  <dt class="text-text-muted">Ready Reason</dt>
+                  <dd class="text-text-primary">{store.readyReason}</dd>
+                </div>
+              )}
+              {store.readyMessage && (
+                <div class="sm:col-span-2">
+                  <dt class="text-text-muted">Ready Message</dt>
+                  <dd class="text-text-secondary">{store.readyMessage}</dd>
+                </div>
+              )}
+            </dl>
+          </div>
+
+          {store.providerSpec && Object.keys(store.providerSpec).length > 0 && (
+            <div class="rounded-lg border border-border-primary bg-bg-elevated p-5">
+              <h2 class="text-sm font-semibold text-text-primary mb-1">
+                Provider spec
+              </h2>
+              <p class="text-xs text-text-muted mb-3">
+                Read-only infrastructure addressing — never credentials.
+              </p>
+              <pre class="text-xs font-mono text-text-primary bg-bg-base border border-border-subtle rounded p-3 overflow-x-auto">
+{JSON.stringify(store.providerSpec, null, 2)}
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+
+      {activeTab.value === "yaml" && (
+        <div
+          role="tabpanel"
+          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+        >
+          YAML editor coming in Phase&nbsp;B.
+        </div>
+      )}
+
+      {activeTab.value === "events" && (
+        <div
+          role="tabpanel"
+          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+        >
+          Events feed coming in Phase&nbsp;B.
+        </div>
+      )}
+
+      {activeTab.value === "history" && (
+        <div
+          role="tabpanel"
+          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+        >
+          History timeline coming in Phase&nbsp;C.
+        </div>
+      )}
+
+      {activeTab.value === "chain" && (
+        <div
+          role="tabpanel"
+          class="rounded-lg border border-border-primary bg-bg-elevated p-5 text-sm text-text-muted"
+        >
+          Chain visualization coming in Phase&nbsp;I.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/islands/ESOStoresList.tsx
+++ b/frontend/islands/ESOStoresList.tsx
@@ -3,6 +3,7 @@ import { IS_BROWSER } from "fresh/runtime";
 import { useEffect, useRef } from "preact/hooks";
 import { esoApi } from "@/lib/eso-api.ts";
 import { ProviderBadge, StatusBadge } from "@/components/eso/ESOBadges.tsx";
+import { ESONotDetected } from "@/components/eso/ESONotDetected.tsx";
 import { Spinner } from "@/components/ui/Spinner.tsx";
 import type { SecretStore } from "@/lib/eso-types.ts";
 
@@ -14,6 +15,7 @@ export default function ESOStoresList() {
   const error = useSignal<string | null>(null);
   const namespace = useSignal("");
   const search = useSignal("");
+  const detected = useSignal<boolean | null>(null);
 
   const fetchSeq = useRef(0);
   const debounceHandle = useRef<number | null>(null);
@@ -34,9 +36,19 @@ export default function ESOStoresList() {
 
   useEffect(() => {
     if (!IS_BROWSER) return;
-    fetchData().then(() => {
-      loading.value = false;
-    });
+    (async () => {
+      try {
+        const statusRes = await esoApi.status();
+        const present = statusRes.data?.detected !== false;
+        detected.value = present;
+        if (present) await fetchData();
+      } catch {
+        detected.value = true;
+        await fetchData();
+      } finally {
+        loading.value = false;
+      }
+    })();
     return () => {
       if (debounceHandle.current !== null) {
         clearTimeout(debounceHandle.current);
@@ -57,6 +69,15 @@ export default function ESOStoresList() {
   }
 
   if (!IS_BROWSER) return null;
+
+  if (!loading.value && detected.value === false) {
+    return (
+      <div class="p-6">
+        <h1 class="text-2xl font-bold text-text-primary mb-6">SecretStores</h1>
+        <ESONotDetected />
+      </div>
+    );
+  }
 
   const filtered = items.value.filter((s) => {
     if (!search.value) return true;
@@ -89,7 +110,7 @@ export default function ESOStoresList() {
           <input
             id="eso-stores-ns"
             type="text"
-            class="rounded border border-border-primary px-3 py-1.5 text-sm bg-bg-base text-text-primary max-w-xs"
+            class="rounded border border-border-primary px-3 py-1.5 text-sm bg-base text-text-primary max-w-xs"
             placeholder="All namespaces"
             value={namespace.value}
             aria-describedby="eso-stores-ns-hint"
@@ -110,7 +131,7 @@ export default function ESOStoresList() {
           <input
             id="eso-stores-search"
             type="text"
-            class="rounded border border-border-primary px-3 py-1.5 text-sm bg-bg-base text-text-primary max-w-xs"
+            class="rounded border border-border-primary px-3 py-1.5 text-sm bg-base text-text-primary max-w-xs"
             placeholder="name, provider..."
             value={search.value}
             onInput={(e) => {
@@ -174,14 +195,25 @@ export default function ESOStoresList() {
               {filtered.map((s) => (
                 <tr key={s.uid} class="hover:bg-hover/30">
                   <td class="px-3 py-2">
-                    <a
-                      href={`/external-secrets/stores/${
-                        s.namespace ?? ""
-                      }/${s.name}`}
-                      class="font-medium text-brand hover:underline"
-                    >
-                      {s.name}
-                    </a>
+                    {s.namespace
+                      ? (
+                        <a
+                          href={`/external-secrets/stores/${
+                            encodeURIComponent(s.namespace)
+                          }/${encodeURIComponent(s.name)}`}
+                          class="font-medium text-brand hover:underline"
+                        >
+                          {s.name}
+                        </a>
+                      )
+                      : (
+                        // Namespaced list shouldn't return scope=Cluster, but
+                        // type allows it. Render plain text rather than a link
+                        // to a route that requires a namespace segment.
+                        <span class="font-medium text-text-primary">
+                          {s.name}
+                        </span>
+                      )}
                   </td>
                   <td class="px-3 py-2 text-text-secondary">
                     {s.namespace ?? "—"}
@@ -214,13 +246,13 @@ export default function ESOStoresList() {
 
       {!loading.value && !error.value && filtered.length === 0 &&
         items.value.length > 0 && (
-        <div class="text-center py-12 rounded-lg border border-border-primary bg-bg-elevated">
+        <div class="text-center py-12 rounded-lg border border-border-primary bg-elevated">
           <p class="text-text-muted">No SecretStores match your filters.</p>
         </div>
       )}
 
       {!loading.value && !error.value && items.value.length === 0 && (
-        <div class="text-center py-12 rounded-lg border border-border-primary bg-bg-elevated">
+        <div class="text-center py-12 rounded-lg border border-border-primary bg-elevated">
           <p class="text-text-muted">
             No SecretStores in this namespace. ExternalSecrets require a
             SecretStore to function.

--- a/frontend/islands/ESOStoresList.tsx
+++ b/frontend/islands/ESOStoresList.tsx
@@ -1,0 +1,232 @@
+import { useSignal } from "@preact/signals";
+import { IS_BROWSER } from "fresh/runtime";
+import { useEffect, useRef } from "preact/hooks";
+import { esoApi } from "@/lib/eso-api.ts";
+import { ProviderBadge, StatusBadge } from "@/components/eso/ESOBadges.tsx";
+import { Spinner } from "@/components/ui/Spinner.tsx";
+import type { SecretStore } from "@/lib/eso-types.ts";
+
+const NAMESPACE_DEBOUNCE_MS = 300;
+
+export default function ESOStoresList() {
+  const items = useSignal<SecretStore[]>([]);
+  const loading = useSignal(true);
+  const error = useSignal<string | null>(null);
+  const namespace = useSignal("");
+  const search = useSignal("");
+
+  const fetchSeq = useRef(0);
+  const debounceHandle = useRef<number | null>(null);
+
+  async function fetchData() {
+    const seq = ++fetchSeq.current;
+    try {
+      const ns = namespace.value.trim() || undefined;
+      const res = await esoApi.listStores(ns);
+      if (seq !== fetchSeq.current) return;
+      items.value = Array.isArray(res.data) ? res.data : [];
+      error.value = null;
+    } catch {
+      if (seq !== fetchSeq.current) return;
+      error.value = "Failed to load SecretStores";
+    }
+  }
+
+  useEffect(() => {
+    if (!IS_BROWSER) return;
+    fetchData().then(() => {
+      loading.value = false;
+    });
+    return () => {
+      if (debounceHandle.current !== null) {
+        clearTimeout(debounceHandle.current);
+        debounceHandle.current = null;
+      }
+    };
+  }, []);
+
+  function handleNamespaceChange(value: string) {
+    namespace.value = value;
+    if (debounceHandle.current !== null) {
+      clearTimeout(debounceHandle.current);
+    }
+    debounceHandle.current = setTimeout(() => {
+      debounceHandle.current = null;
+      fetchData();
+    }, NAMESPACE_DEBOUNCE_MS);
+  }
+
+  if (!IS_BROWSER) return null;
+
+  const filtered = items.value.filter((s) => {
+    if (!search.value) return true;
+    const q = search.value.toLowerCase();
+    return (
+      s.name.toLowerCase().includes(q) ||
+      (s.namespace ?? "").toLowerCase().includes(q) ||
+      (s.provider ?? "").toLowerCase().includes(q)
+    );
+  });
+
+  return (
+    <div class="p-6">
+      <div class="flex items-start justify-between mb-1">
+        <h1 class="text-2xl font-bold text-text-primary">SecretStores</h1>
+      </div>
+      <p class="text-sm text-text-muted mb-6">
+        Namespaced SecretStores describe how ESO talks to a secret backend.
+      </p>
+
+      {/* Filters */}
+      <div class="mb-4 flex flex-wrap items-center gap-4">
+        <div class="flex items-center gap-2">
+          <label
+            class="text-sm font-medium text-text-secondary"
+            htmlFor="eso-stores-ns"
+          >
+            Namespace
+          </label>
+          <input
+            id="eso-stores-ns"
+            type="text"
+            class="rounded border border-border-primary px-3 py-1.5 text-sm bg-bg-base text-text-primary max-w-xs"
+            placeholder="All namespaces"
+            value={namespace.value}
+            aria-describedby="eso-stores-ns-hint"
+            onInput={(e) =>
+              handleNamespaceChange((e.target as HTMLInputElement).value)}
+          />
+          <span id="eso-stores-ns-hint" class="sr-only">
+            Filter SecretStores by namespace; updates after a brief pause.
+          </span>
+        </div>
+        <div class="flex items-center gap-2">
+          <label
+            class="text-sm font-medium text-text-secondary"
+            htmlFor="eso-stores-search"
+          >
+            Search
+          </label>
+          <input
+            id="eso-stores-search"
+            type="text"
+            class="rounded border border-border-primary px-3 py-1.5 text-sm bg-bg-base text-text-primary max-w-xs"
+            placeholder="name, provider..."
+            value={search.value}
+            onInput={(e) => {
+              search.value = (e.target as HTMLInputElement).value;
+            }}
+          />
+        </div>
+        <span class="text-xs text-text-muted">
+          {filtered.length} of {items.value.length} SecretStores
+        </span>
+      </div>
+
+      {loading.value && (
+        <div class="flex justify-center py-12">
+          <Spinner class="text-brand" />
+        </div>
+      )}
+
+      {!loading.value && error.value && (
+        <p class="text-sm text-danger py-4">{error.value}</p>
+      )}
+
+      {!loading.value && !error.value && filtered.length > 0 && (
+        <div class="overflow-x-auto rounded-lg border border-border-primary">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="border-b border-border-primary bg-surface">
+                <th
+                  scope="col"
+                  class="px-3 py-2 text-left text-xs font-medium text-text-muted"
+                >
+                  Name
+                </th>
+                <th
+                  scope="col"
+                  class="px-3 py-2 text-left text-xs font-medium text-text-muted"
+                >
+                  Namespace
+                </th>
+                <th
+                  scope="col"
+                  class="px-3 py-2 text-left text-xs font-medium text-text-muted"
+                >
+                  Status
+                </th>
+                <th
+                  scope="col"
+                  class="px-3 py-2 text-left text-xs font-medium text-text-muted"
+                >
+                  Provider
+                </th>
+                <th
+                  scope="col"
+                  class="px-3 py-2 text-left text-xs font-medium text-text-muted"
+                >
+                  Ready
+                </th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-border-subtle">
+              {filtered.map((s) => (
+                <tr key={s.uid} class="hover:bg-hover/30">
+                  <td class="px-3 py-2">
+                    <a
+                      href={`/external-secrets/stores/${
+                        s.namespace ?? ""
+                      }/${s.name}`}
+                      class="font-medium text-brand hover:underline"
+                    >
+                      {s.name}
+                    </a>
+                  </td>
+                  <td class="px-3 py-2 text-text-secondary">
+                    {s.namespace ?? "—"}
+                  </td>
+                  <td class="px-3 py-2">
+                    <StatusBadge status={s.status} />
+                  </td>
+                  <td class="px-3 py-2">
+                    <ProviderBadge provider={s.provider} />
+                  </td>
+                  <td class="px-3 py-2">
+                    {s.ready
+                      ? (
+                        <span class="text-success text-xs font-medium">
+                          Ready
+                        </span>
+                      )
+                      : (
+                        <span class="text-danger text-xs font-medium">
+                          Not Ready
+                        </span>
+                      )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {!loading.value && !error.value && filtered.length === 0 &&
+        items.value.length > 0 && (
+        <div class="text-center py-12 rounded-lg border border-border-primary bg-bg-elevated">
+          <p class="text-text-muted">No SecretStores match your filters.</p>
+        </div>
+      )}
+
+      {!loading.value && !error.value && items.value.length === 0 && (
+        <div class="text-center py-12 rounded-lg border border-border-primary bg-bg-elevated">
+          <p class="text-text-muted">
+            No SecretStores in this namespace. ExternalSecrets require a
+            SecretStore to function.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/islands/IconRail.tsx
+++ b/frontend/islands/IconRail.tsx
@@ -29,6 +29,8 @@ const ICONS: Record<string, string> = {
     '<line x1="7" y1="7" x2="7" y2="17"/><circle cx="7" cy="5" r="2"/><circle cx="13" cy="7" r="2"/><path d="M7 7c0 3 6 3 6 0"/>',
   archive:
     '<rect x="3" y="7" width="14" height="10" rx="1"/><path d="M3 10h14"/><path d="M5 4h10v3H5z"/><rect x="8" y="12" width="4" height="2" rx="0.5"/>',
+  key:
+    '<circle cx="6" cy="14" r="3"/><path d="M8 12l9-9M13 7l3 3M15 5l3 3"/>',
   settings:
     '<circle cx="10" cy="10" r="7"/><circle cx="10" cy="10" r="3"/><path d="M13 10h4M3 10h4M10 3v4M10 13v4"/>',
 };

--- a/frontend/islands/IconRail.tsx
+++ b/frontend/islands/IconRail.tsx
@@ -29,8 +29,7 @@ const ICONS: Record<string, string> = {
     '<line x1="7" y1="7" x2="7" y2="17"/><circle cx="7" cy="5" r="2"/><circle cx="13" cy="7" r="2"/><path d="M7 7c0 3 6 3 6 0"/>',
   archive:
     '<rect x="3" y="7" width="14" height="10" rx="1"/><path d="M3 10h14"/><path d="M5 4h10v3H5z"/><rect x="8" y="12" width="4" height="2" rx="0.5"/>',
-  key:
-    '<circle cx="6" cy="14" r="3"/><path d="M8 12l9-9M13 7l3 3M15 5l3 3"/>',
+  key: '<circle cx="6" cy="14" r="3"/><path d="M8 12l9-9M13 7l3 3M15 5l3 3"/>',
   settings:
     '<circle cx="10" cy="10" r="7"/><circle cx="10" cy="10" r="3"/><path d="M13 10h4M3 10h4M10 3v4M10 13v4"/>',
 };

--- a/frontend/lib/constants.ts
+++ b/frontend/lib/constants.ts
@@ -579,6 +579,30 @@ export const DOMAIN_SECTIONS: DomainSection[] = [
     ],
   },
   {
+    id: "external-secrets",
+    label: "External Secrets",
+    icon: "key",
+    href: "/external-secrets",
+    tabs: [
+      { label: "Dashboard", href: "/external-secrets/dashboard" },
+      {
+        label: "ExternalSecrets",
+        href: "/external-secrets/external-secrets",
+      },
+      {
+        label: "ClusterExternalSecrets",
+        href: "/external-secrets/cluster-external-secrets",
+      },
+      { label: "Stores", href: "/external-secrets/stores" },
+      {
+        label: "ClusterStores",
+        href: "/external-secrets/cluster-stores",
+      },
+      { label: "PushSecrets", href: "/external-secrets/push-secrets" },
+      { label: "Chain", href: "/external-secrets/chain" },
+    ],
+  },
+  {
     id: "backup",
     label: "Backup",
     icon: "archive",

--- a/frontend/lib/eso-api.ts
+++ b/frontend/lib/eso-api.ts
@@ -1,0 +1,93 @@
+/** Typed API client for External Secrets Operator endpoints (Phase A backend).
+ *
+ * Imports only from `lib/api.ts` (the underlying HTTP helpers). All endpoints
+ * return enveloped responses (`{ data: T }`) per the project's API convention.
+ *
+ * Phase A surface: 11 read endpoints. Force-sync, bulk refresh, and other
+ * write actions land in Phase E.
+ */
+
+import { apiGet } from "@/lib/api.ts";
+import type {
+  ClusterExternalSecret,
+  ESOStatus,
+  ExternalSecret,
+  PushSecret,
+  SecretStore,
+} from "@/lib/eso-types.ts";
+
+function nsQueryString(namespace?: string): string {
+  if (!namespace) return "";
+  return `?namespace=${encodeURIComponent(namespace)}`;
+}
+
+function pathParam(s: string): string {
+  return encodeURIComponent(s);
+}
+
+export const esoApi = {
+  /** ESO discovery status — detected / namespace / version / lastChecked. */
+  status: () => apiGet<ESOStatus>("/v1/externalsecrets/status"),
+
+  /** ExternalSecrets across all visible namespaces; optional ?namespace= filter. */
+  listExternalSecrets: (namespace?: string) =>
+    apiGet<ExternalSecret[]>(
+      `/v1/externalsecrets/externalsecrets${nsQueryString(namespace)}`,
+    ),
+
+  /** Single ExternalSecret with drift resolution. */
+  getExternalSecret: (namespace: string, name: string) =>
+    apiGet<ExternalSecret>(
+      `/v1/externalsecrets/externalsecrets/${pathParam(namespace)}/${
+        pathParam(name)
+      }`,
+    ),
+
+  /** ClusterExternalSecrets — cluster-scoped, permissive-read RBAC. */
+  listClusterExternalSecrets: () =>
+    apiGet<ClusterExternalSecret[]>(
+      "/v1/externalsecrets/clusterexternalsecrets",
+    ),
+
+  /** Single ClusterExternalSecret. */
+  getClusterExternalSecret: (name: string) =>
+    apiGet<ClusterExternalSecret>(
+      `/v1/externalsecrets/clusterexternalsecrets/${pathParam(name)}`,
+    ),
+
+  /** Namespaced SecretStores. */
+  listStores: (namespace?: string) =>
+    apiGet<SecretStore[]>(
+      `/v1/externalsecrets/stores${nsQueryString(namespace)}`,
+    ),
+
+  /** Single SecretStore. */
+  getStore: (namespace: string, name: string) =>
+    apiGet<SecretStore>(
+      `/v1/externalsecrets/stores/${pathParam(namespace)}/${pathParam(name)}`,
+    ),
+
+  /** ClusterSecretStores — cluster-scoped, permissive-read RBAC. */
+  listClusterStores: () =>
+    apiGet<SecretStore[]>("/v1/externalsecrets/clusterstores"),
+
+  /** Single ClusterSecretStore. */
+  getClusterStore: (name: string) =>
+    apiGet<SecretStore>(
+      `/v1/externalsecrets/clusterstores/${pathParam(name)}`,
+    ),
+
+  /** PushSecrets — read-only in v1. */
+  listPushSecrets: (namespace?: string) =>
+    apiGet<PushSecret[]>(
+      `/v1/externalsecrets/pushsecrets${nsQueryString(namespace)}`,
+    ),
+
+  /** Single PushSecret. */
+  getPushSecret: (namespace: string, name: string) =>
+    apiGet<PushSecret>(
+      `/v1/externalsecrets/pushsecrets/${pathParam(namespace)}/${
+        pathParam(name)
+      }`,
+    ),
+};

--- a/frontend/lib/eso-types.ts
+++ b/frontend/lib/eso-types.ts
@@ -1,0 +1,132 @@
+/**
+ * External Secrets Operator (ESO) types — mirrors backend/internal/externalsecrets/types.go.
+ *
+ * The Phase A Go-side hash test (`types_hash_test.go`) pins the exported field
+ * shape of each backend type. Any drift between these TS interfaces and that
+ * pinned hash means one side needs to be updated.
+ *
+ * Phase A surface is read-only observatory. Phase D will populate the
+ * threshold-resolved fields (StaleAfterMinutes, AlertOnRecovery, etc.); they
+ * are typed as optional / nullable here so the wire shape is final from day
+ * one.
+ */
+
+export type Status =
+  | "Synced"
+  | "SyncFailed"
+  | "Refreshing"
+  | "Stale"
+  | "Drifted"
+  | "Unknown";
+
+export type DriftStatus = "InSync" | "Drifted" | "Unknown";
+
+/** Reason codes accompanying DriftStatus="Unknown" on detail responses.
+ * Operationally distinct states the drift resolver collapses into Unknown:
+ * the synced Secret has no resourceVersion (provider didn't populate it),
+ * the Secret was deleted, the user lacks `get secret` perm, etc. */
+export type DriftUnknownReason =
+  | "no_synced_rv"
+  | "no_target_name"
+  | "secret_deleted"
+  | "rbac_denied"
+  | "transient_error"
+  | "client_error";
+
+/** Layer of the resolution chain that supplied an annotation-resolved value.
+ * Phase D's resolver populates these per-key on the ExternalSecret. */
+export type ThresholdSource =
+  | "default"
+  | "externalsecret"
+  | "secretstore"
+  | "clustersecretstore";
+
+export interface ESOStatus {
+  detected: boolean;
+  namespace?: string;
+  version?: string;
+  lastChecked: string;
+}
+
+export interface StoreRef {
+  name: string;
+  /** "SecretStore" or "ClusterSecretStore". */
+  kind: string;
+}
+
+export interface ExternalSecret {
+  namespace: string;
+  name: string;
+  uid: string;
+  status: Status;
+  driftStatus?: DriftStatus;
+  /** Reason when driftStatus is "Unknown". Detail endpoint only. */
+  driftUnknownReason?: DriftUnknownReason;
+  readyReason?: string;
+  readyMessage?: string;
+  storeRef: StoreRef;
+  targetSecretName?: string;
+  /** Duration string, e.g. "1h", "30m". */
+  refreshInterval?: string;
+  lastSyncTime?: string;
+  syncedResourceVersion?: string;
+  /** Phase D fields — undefined / null in Phase A responses. */
+  staleAfterMinutes?: number | null;
+  staleAfterMinutesSource?: ThresholdSource;
+  alertOnRecovery?: boolean | null;
+  alertOnRecoverySource?: ThresholdSource;
+  alertOnLifecycle?: boolean | null;
+  alertOnLifecycleSource?: ThresholdSource;
+}
+
+export interface ClusterExternalSecret {
+  name: string;
+  uid: string;
+  status: Status;
+  readyReason?: string;
+  readyMessage?: string;
+  storeRef: StoreRef;
+  targetSecretName?: string;
+  refreshInterval?: string;
+  /** Selector clauses rendered as "k=v" strings. */
+  namespaceSelectors?: string[];
+  /** Static namespace list (alternative to selector). */
+  namespaces?: string[];
+  provisionedNamespaces?: string[];
+  failedNamespaces?: string[];
+  externalSecretBaseName?: string;
+}
+
+export interface SecretStore {
+  /** Empty for ClusterSecretStore. */
+  namespace?: string;
+  name: string;
+  uid: string;
+  scope: "Namespaced" | "Cluster";
+  status: Status;
+  ready: boolean;
+  readyReason?: string;
+  readyMessage?: string;
+  /** Provider family ("vault", "aws", "gcp", "azurekv", "kubernetes", etc.) — empty when no provider key is set. */
+  provider: string;
+  /** Raw spec.provider.<provider> sub-object, surfaced verbatim. Treat as
+   * read-only infrastructure addressing info, not credentials. */
+  providerSpec?: Record<string, unknown>;
+  /** Phase D — annotation-set thresholds inherited by ESes referencing this store. */
+  staleAfterMinutes?: number | null;
+  alertOnRecovery?: boolean | null;
+  alertOnLifecycle?: boolean | null;
+}
+
+export interface PushSecret {
+  namespace: string;
+  name: string;
+  uid: string;
+  status: Status;
+  readyReason?: string;
+  readyMessage?: string;
+  storeRefs: StoreRef[];
+  sourceSecretName?: string;
+  refreshInterval?: string;
+  lastSyncTime?: string;
+}

--- a/frontend/routes/external-secrets/chain.tsx
+++ b/frontend/routes/external-secrets/chain.tsx
@@ -1,0 +1,15 @@
+import { define } from "@/utils.ts";
+import SubNav from "@/islands/SubNav.tsx";
+import { DOMAIN_SECTIONS } from "@/lib/constants.ts";
+import ESOChainPage from "@/islands/ESOChainPage.tsx";
+
+const section = DOMAIN_SECTIONS.find((s) => s.id === "external-secrets")!;
+
+export default define.page(function ChainPage(ctx) {
+  return (
+    <>
+      <SubNav tabs={section.tabs ?? []} currentPath={ctx.url.pathname} />
+      <ESOChainPage />
+    </>
+  );
+});

--- a/frontend/routes/external-secrets/cluster-external-secrets.tsx
+++ b/frontend/routes/external-secrets/cluster-external-secrets.tsx
@@ -1,0 +1,15 @@
+import { define } from "@/utils.ts";
+import SubNav from "@/islands/SubNav.tsx";
+import { DOMAIN_SECTIONS } from "@/lib/constants.ts";
+import ESOClusterExternalSecretsList from "@/islands/ESOClusterExternalSecretsList.tsx";
+
+const section = DOMAIN_SECTIONS.find((s) => s.id === "external-secrets")!;
+
+export default define.page(function ClusterExternalSecretsPage(ctx) {
+  return (
+    <>
+      <SubNav tabs={section.tabs ?? []} currentPath={ctx.url.pathname} />
+      <ESOClusterExternalSecretsList />
+    </>
+  );
+});

--- a/frontend/routes/external-secrets/cluster-external-secrets/[name].tsx
+++ b/frontend/routes/external-secrets/cluster-external-secrets/[name].tsx
@@ -1,0 +1,19 @@
+import { define } from "@/utils.ts";
+import SubNav from "@/islands/SubNav.tsx";
+import { DOMAIN_SECTIONS } from "@/lib/constants.ts";
+import ESOClusterExternalSecretDetail from "@/islands/ESOClusterExternalSecretDetail.tsx";
+
+const section = DOMAIN_SECTIONS.find((s) => s.id === "external-secrets")!;
+
+export default define.page(function ESClusterExternalSecretDetailPage(ctx) {
+  const { name } = ctx.params;
+  return (
+    <>
+      <SubNav
+        tabs={section.tabs ?? []}
+        currentPath="/external-secrets/cluster-external-secrets"
+      />
+      <ESOClusterExternalSecretDetail name={name} />
+    </>
+  );
+});

--- a/frontend/routes/external-secrets/cluster-stores.tsx
+++ b/frontend/routes/external-secrets/cluster-stores.tsx
@@ -1,0 +1,15 @@
+import { define } from "@/utils.ts";
+import SubNav from "@/islands/SubNav.tsx";
+import { DOMAIN_SECTIONS } from "@/lib/constants.ts";
+import ESOClusterStoresList from "@/islands/ESOClusterStoresList.tsx";
+
+const section = DOMAIN_SECTIONS.find((s) => s.id === "external-secrets")!;
+
+export default define.page(function ClusterStoresPage(ctx) {
+  return (
+    <>
+      <SubNav tabs={section.tabs ?? []} currentPath={ctx.url.pathname} />
+      <ESOClusterStoresList />
+    </>
+  );
+});

--- a/frontend/routes/external-secrets/cluster-stores/[name].tsx
+++ b/frontend/routes/external-secrets/cluster-stores/[name].tsx
@@ -1,0 +1,19 @@
+import { define } from "@/utils.ts";
+import SubNav from "@/islands/SubNav.tsx";
+import { DOMAIN_SECTIONS } from "@/lib/constants.ts";
+import ESOClusterStoreDetail from "@/islands/ESOClusterStoreDetail.tsx";
+
+const section = DOMAIN_SECTIONS.find((s) => s.id === "external-secrets")!;
+
+export default define.page(function ESClusterStoreDetailPage(ctx) {
+  const { name } = ctx.params;
+  return (
+    <>
+      <SubNav
+        tabs={section.tabs ?? []}
+        currentPath="/external-secrets/cluster-stores"
+      />
+      <ESOClusterStoreDetail name={name} />
+    </>
+  );
+});

--- a/frontend/routes/external-secrets/dashboard.tsx
+++ b/frontend/routes/external-secrets/dashboard.tsx
@@ -1,0 +1,15 @@
+import { define } from "@/utils.ts";
+import SubNav from "@/islands/SubNav.tsx";
+import { DOMAIN_SECTIONS } from "@/lib/constants.ts";
+import ESODashboard from "@/islands/ESODashboard.tsx";
+
+const section = DOMAIN_SECTIONS.find((s) => s.id === "external-secrets")!;
+
+export default define.page(function ESODashboardPage(ctx) {
+  return (
+    <>
+      <SubNav tabs={section.tabs ?? []} currentPath={ctx.url.pathname} />
+      <ESODashboard />
+    </>
+  );
+});

--- a/frontend/routes/external-secrets/external-secrets.tsx
+++ b/frontend/routes/external-secrets/external-secrets.tsx
@@ -1,0 +1,15 @@
+import { define } from "@/utils.ts";
+import SubNav from "@/islands/SubNav.tsx";
+import { DOMAIN_SECTIONS } from "@/lib/constants.ts";
+import ESOExternalSecretsList from "@/islands/ESOExternalSecretsList.tsx";
+
+const section = DOMAIN_SECTIONS.find((s) => s.id === "external-secrets")!;
+
+export default define.page(function ExternalSecretsPage(ctx) {
+  return (
+    <>
+      <SubNav tabs={section.tabs ?? []} currentPath={ctx.url.pathname} />
+      <ESOExternalSecretsList />
+    </>
+  );
+});

--- a/frontend/routes/external-secrets/external-secrets/[namespace]/[name].tsx
+++ b/frontend/routes/external-secrets/external-secrets/[namespace]/[name].tsx
@@ -1,0 +1,19 @@
+import { define } from "@/utils.ts";
+import SubNav from "@/islands/SubNav.tsx";
+import { DOMAIN_SECTIONS } from "@/lib/constants.ts";
+import ESOExternalSecretDetail from "@/islands/ESOExternalSecretDetail.tsx";
+
+const section = DOMAIN_SECTIONS.find((s) => s.id === "external-secrets")!;
+
+export default define.page(function ESExternalSecretDetailPage(ctx) {
+  const { namespace, name } = ctx.params;
+  return (
+    <>
+      <SubNav
+        tabs={section.tabs ?? []}
+        currentPath="/external-secrets/external-secrets"
+      />
+      <ESOExternalSecretDetail namespace={namespace} name={name} />
+    </>
+  );
+});

--- a/frontend/routes/external-secrets/index.tsx
+++ b/frontend/routes/external-secrets/index.tsx
@@ -1,0 +1,10 @@
+import { define } from "@/utils.ts";
+
+export const handler = define.handlers({
+  GET(_ctx) {
+    return new Response(null, {
+      status: 302,
+      headers: { Location: "/external-secrets/dashboard" },
+    });
+  },
+});

--- a/frontend/routes/external-secrets/push-secrets.tsx
+++ b/frontend/routes/external-secrets/push-secrets.tsx
@@ -1,0 +1,15 @@
+import { define } from "@/utils.ts";
+import SubNav from "@/islands/SubNav.tsx";
+import { DOMAIN_SECTIONS } from "@/lib/constants.ts";
+import ESOPushSecretsList from "@/islands/ESOPushSecretsList.tsx";
+
+const section = DOMAIN_SECTIONS.find((s) => s.id === "external-secrets")!;
+
+export default define.page(function PushSecretsPage(ctx) {
+  return (
+    <>
+      <SubNav tabs={section.tabs ?? []} currentPath={ctx.url.pathname} />
+      <ESOPushSecretsList />
+    </>
+  );
+});

--- a/frontend/routes/external-secrets/push-secrets/[namespace]/[name].tsx
+++ b/frontend/routes/external-secrets/push-secrets/[namespace]/[name].tsx
@@ -1,0 +1,19 @@
+import { define } from "@/utils.ts";
+import SubNav from "@/islands/SubNav.tsx";
+import { DOMAIN_SECTIONS } from "@/lib/constants.ts";
+import ESOPushSecretDetail from "@/islands/ESOPushSecretDetail.tsx";
+
+const section = DOMAIN_SECTIONS.find((s) => s.id === "external-secrets")!;
+
+export default define.page(function ESPushSecretDetailPage(ctx) {
+  const { namespace, name } = ctx.params;
+  return (
+    <>
+      <SubNav
+        tabs={section.tabs ?? []}
+        currentPath="/external-secrets/push-secrets"
+      />
+      <ESOPushSecretDetail namespace={namespace} name={name} />
+    </>
+  );
+});

--- a/frontend/routes/external-secrets/stores.tsx
+++ b/frontend/routes/external-secrets/stores.tsx
@@ -1,0 +1,15 @@
+import { define } from "@/utils.ts";
+import SubNav from "@/islands/SubNav.tsx";
+import { DOMAIN_SECTIONS } from "@/lib/constants.ts";
+import ESOStoresList from "@/islands/ESOStoresList.tsx";
+
+const section = DOMAIN_SECTIONS.find((s) => s.id === "external-secrets")!;
+
+export default define.page(function StoresPage(ctx) {
+  return (
+    <>
+      <SubNav tabs={section.tabs ?? []} currentPath={ctx.url.pathname} />
+      <ESOStoresList />
+    </>
+  );
+});

--- a/frontend/routes/external-secrets/stores/[namespace]/[name].tsx
+++ b/frontend/routes/external-secrets/stores/[namespace]/[name].tsx
@@ -1,0 +1,19 @@
+import { define } from "@/utils.ts";
+import SubNav from "@/islands/SubNav.tsx";
+import { DOMAIN_SECTIONS } from "@/lib/constants.ts";
+import ESOStoreDetail from "@/islands/ESOStoreDetail.tsx";
+
+const section = DOMAIN_SECTIONS.find((s) => s.id === "external-secrets")!;
+
+export default define.page(function ESStoreDetailPage(ctx) {
+  const { namespace, name } = ctx.params;
+  return (
+    <>
+      <SubNav
+        tabs={section.tabs ?? []}
+        currentPath="/external-secrets/stores"
+      />
+      <ESOStoreDetail namespace={namespace} name={name} />
+    </>
+  );
+});


### PR DESCRIPTION
## Summary

Phase B of the External Secrets Operator integration ([plan](plans/external-secrets-operator-integration.md)). Frontend observatory layer over the Phase A backend — read-only views, no write actions (deferred to Phase E).

- **Units 7a/7b**: TS types + typed API client + nav-rail entry + status / drift / provider badges
- **Unit 7c**: 6 list islands (ExternalSecrets, ClusterExternalSecrets, Stores, ClusterStores, PushSecrets) + Chain page placeholder + routes
- **Unit 8a**: 4 detail islands with Overview / YAML / Events / History / Chain tab strip (Phase C–I tabs are placeholders today)
- **Unit 8b**: Dashboard — sync-health hero ring, secondary cards (SyncFailed/Stale/Drifted/Unknown), provider donut, broken-ES failure table
- Command Palette quick actions for the new domain

## Requirements covered

| Req | How |
|---|---|
| R2 — empty state when CRDs missing | Dashboard + every list island gate on `esoApi.status()` and render the shared `ESONotDetected` install-prompt tile |
| R5 — status surfaced | `StatusBadge` + condition reasons throughout |
| R9 — standalone Chain page | `/external-secrets/chain` placeholder with namespace selector → topology jump |
| R20 — drift surfaced on detail | `ESODriftIndicator` tri-state with reason hints |
| R27 — dashboard | Sync-health ring + broken-ES table + provider breakdown |
| R28 — RBAC scoped | Lists render whatever the backend RBAC-filtered response returns |

## Code review

`/ce:review` was run against the branch before push. All P1 and P2 findings addressed in `b71e228`:

- `deno fmt` failures fixed
- `bg-bg-*` invalid Tailwind classes swept (62 occurrences) — prevented transparent-background regression
- `ESONotDetected` tile wired into list islands (R2 contract)
- `encodeURIComponent` on every list-link interpolation; missing-namespace guard in `ESOStoresList`
- Duplicated `formatRelative` replaced with shared `lib/timeAgo`
- No-op `onRevert` prop dropped from `ESODriftIndicator`
- Gauge ring renders 0/0 instead of vanishing on empty inventory

## Verification

- `cd frontend && deno fmt --check ./components/eso/ ./islands/ESO*.tsx ./lib/eso-types.ts ./lib/eso-api.ts ./routes/external-secrets/` — clean (30 files)
- `deno lint` — clean
- `deno check` — clean

## Out of scope

Phase B explicitly excludes write actions (force-sync, bulk refresh — Phase E), persistence (history table — Phase C), threshold annotations (Phase D), per-store metrics (Phase F), wizards (Phase G/H), and the chain overlay itself (Phase I). Tab strips on detail pages render placeholders for these.

## Test plan

- [ ] `cd frontend && deno task check` passes locally
- [ ] Manual smoke against homelab: dashboard renders sync-ring + provider breakdown with cluster data
- [ ] Each list page loads and namespace filter debounces without race jitter
- [ ] Detail pages load via list-link click; drift indicator shows correct tri-state
- [ ] Visit `/external-secrets/external-secrets` on a cluster without ESO installed → "ESO not installed" tile renders (not the "Create one to start syncing" copy)
- [ ] Command palette `Cmd+K` lists all 5 ESO entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)