### PR TITLE
feat(eso): Phase G — universal ExternalSecret wizard

### DIFF
--- a/backend/internal/externalsecrets/path_discovery.go
+++ b/backend/internal/externalsecrets/path_discovery.go
@@ -18,13 +18,20 @@ import (
 const pathDiscoveryLimit = 200
 
 // pathDiscoveryResponse is the shape returned by the path-discovery endpoint.
-// `Supported` is the contract — when false, the frontend renders a free-text
-// path field instead of typeahead. `Provider` echoes the resolved provider
-// name (e.g. "kubernetes", "vault") so the UI can tailor helper text.
+//
+//   - Supported=false → frontend renders a free-text path field.
+//   - Paths may be nil (RBAC denied, non-Kubernetes provider) or an empty slice
+//     (namespace is empty). Callers must treat nil and [] identically.
+//   - Truncated=true means the result was capped at pathDiscoveryLimit; the
+//     complete list is larger. The user should narrow the prefix.
+//
+// Provider echoes the resolved provider name (e.g. "kubernetes", "vault") so
+// the UI can tailor helper text.
 type pathDiscoveryResponse struct {
 	Supported bool     `json:"supported"`
 	Provider  string   `json:"provider,omitempty"`
 	Paths     []string `json:"paths,omitempty"`
+	Truncated bool     `json:"truncated,omitempty"`
 }
 
 // HandleListPaths discovers candidate remote-key paths for a SecretStore in
@@ -38,9 +45,8 @@ type pathDiscoveryResponse struct {
 //	GET /externalsecrets/stores/{namespace}/{name}/paths?prefix=<>
 //
 // The Kubernetes provider's source namespace is read from
-// `spec.provider.kubernetes.remoteRef.namespace` (the v1 schema), with a
-// fallback to `spec.provider.kubernetes.remoteNamespace` (older stores).
-// Empty / missing → caller's namespace per ESO defaults.
+// `spec.provider.kubernetes.remoteNamespace` (v1 schema). Empty / missing →
+// caller's namespace per ESO defaults.
 func (h *Handler) HandleListPaths(w http.ResponseWriter, r *http.Request) {
 	user, ok := httputil.RequireUser(w, r)
 	if !ok {
@@ -127,7 +133,11 @@ func (h *Handler) HandleListPaths(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	secrets, err := kubeClient.CoreV1().Secrets(sourceNS).List(r.Context(), metav1.ListOptions{})
+	// Use a server-side Limit to avoid pulling huge lists across the wire.
+	// The limit is set higher than pathDiscoveryLimit to give prefix-filtering
+	// headroom. We do not page via Continue because we cap immediately after;
+	// this is a typeahead, not an exhaustive enumeration.
+	secrets, err := kubeClient.CoreV1().Secrets(sourceNS).List(r.Context(), metav1.ListOptions{Limit: 500})
 	if err != nil {
 		if apierrors.IsForbidden(err) {
 			// Apiserver said no — surface as supported-but-empty so the UI
@@ -148,31 +158,33 @@ func (h *Handler) HandleListPaths(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		paths = append(paths, s.Name)
-		if len(paths) >= pathDiscoveryLimit {
-			break
-		}
 	}
+
+	// Sort first so truncation is deterministic (alphabetically earliest set).
 	sort.Strings(paths)
+	truncated := len(paths) > pathDiscoveryLimit
+	if truncated {
+		paths = paths[:pathDiscoveryLimit]
+	}
 
 	httputil.WriteData(w, pathDiscoveryResponse{
 		Supported: true,
 		Provider:  provider,
 		Paths:     paths,
+		Truncated: truncated,
 	})
 }
 
 // kubernetesProviderSourceNamespace reads the source namespace from a
-// kubernetes-provider spec block. The v1 schema places the namespace under
-// `remoteRef.namespace`; older stores use `remoteNamespace`. Empty when
-// neither is present.
+// kubernetes-provider spec block.
+//
+// ESO v1 KubernetesProvider uses `remoteNamespace` at the provider-spec level
+// (`spec.provider.kubernetes.remoteNamespace`). The `remoteRef` key lives on
+// individual ExternalSecret data items, not on the SecretStore provider config,
+// so only `remoteNamespace` is read here. Empty when not present.
 func kubernetesProviderSourceNamespace(providerSpec map[string]any) string {
 	if providerSpec == nil {
 		return ""
-	}
-	if remoteRef, ok := providerSpec["remoteRef"].(map[string]any); ok {
-		if ns, ok := remoteRef["namespace"].(string); ok && ns != "" {
-			return ns
-		}
 	}
 	if ns, ok := providerSpec["remoteNamespace"].(string); ok && ns != "" {
 		return ns

--- a/backend/internal/externalsecrets/path_discovery.go
+++ b/backend/internal/externalsecrets/path_discovery.go
@@ -1,0 +1,181 @@
+package externalsecrets
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubecenter/kubecenter/internal/httputil"
+)
+
+// pathDiscoveryLimit caps the number of paths returned in a single response.
+// Tuned for typeahead UX: enough to be useful, small enough to keep the JSON
+// payload tight and the user's eye scannable.
+const pathDiscoveryLimit = 200
+
+// pathDiscoveryResponse is the shape returned by the path-discovery endpoint.
+// `Supported` is the contract — when false, the frontend renders a free-text
+// path field instead of typeahead. `Provider` echoes the resolved provider
+// name (e.g. "kubernetes", "vault") so the UI can tailor helper text.
+type pathDiscoveryResponse struct {
+	Supported bool     `json:"supported"`
+	Provider  string   `json:"provider,omitempty"`
+	Paths     []string `json:"paths,omitempty"`
+}
+
+// HandleListPaths discovers candidate remote-key paths for a SecretStore in
+// Phase G's ExternalSecret wizard. Kubernetes-provider stores list Secrets in
+// the configured source namespace via the impersonating client; the typeahead
+// shows that namespace's Secret names, prefix-filtered. All other providers
+// return `{supported: false}` — k8sCenter never holds source-store
+// credentials, so authenticating against Vault/AWS/GCP/Azure to enumerate
+// paths is out of scope.
+//
+//	GET /externalsecrets/stores/{namespace}/{name}/paths?prefix=<>
+//
+// The Kubernetes provider's source namespace is read from
+// `spec.provider.kubernetes.remoteRef.namespace` (the v1 schema), with a
+// fallback to `spec.provider.kubernetes.remoteNamespace` (older stores).
+// Empty / missing → caller's namespace per ESO defaults.
+func (h *Handler) HandleListPaths(w http.ResponseWriter, r *http.Request) {
+	user, ok := httputil.RequireUser(w, r)
+	if !ok {
+		return
+	}
+
+	if !h.Discoverer.IsAvailable(r.Context()) {
+		httputil.WriteError(w, http.StatusServiceUnavailable, "ESO not detected", "")
+		return
+	}
+
+	storeNS := chi.URLParam(r, "namespace")
+	storeName := chi.URLParam(r, "name")
+
+	// RBAC: the user must be allowed to read the SecretStore itself before we
+	// reveal its provider config or proxy a Secret list against it.
+	if !h.canAccess(r.Context(), user, "get", "secretstores", storeNS) {
+		httputil.WriteError(w, http.StatusForbidden, "access denied", "")
+		return
+	}
+
+	dynClient, err := h.dynForUser(user.KubernetesUsername, user.KubernetesGroups)
+	if err != nil {
+		h.Logger.Error("create impersonating dynamic client", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "internal error", "")
+		return
+	}
+
+	obj, err := dynClient.Resource(SecretStoreGVR).Namespace(storeNS).Get(r.Context(), storeName, metav1.GetOptions{})
+	if err != nil {
+		switch {
+		case apierrors.IsForbidden(err):
+			httputil.WriteError(w, http.StatusForbidden, "access denied", "")
+		case apierrors.IsNotFound(err):
+			httputil.WriteError(w, http.StatusNotFound, "store not found", "")
+		default:
+			h.Logger.Error("get store for path discovery", "namespace", storeNS, "name", storeName, "error", err)
+			httputil.WriteError(w, http.StatusInternalServerError, "failed to fetch store", "")
+		}
+		return
+	}
+
+	spec, _ := obj.Object["spec"].(map[string]any)
+	provider, providerSpec := detectProvider(spec)
+
+	// Non-Kubernetes providers fall through to free-text input on the
+	// frontend. We still echo the provider name so the UI can tailor helper
+	// text (e.g. "Vault path: secret/data/myapp").
+	if provider != "kubernetes" {
+		httputil.WriteData(w, pathDiscoveryResponse{Supported: false, Provider: provider})
+		return
+	}
+
+	sourceNS := kubernetesProviderSourceNamespace(providerSpec)
+	if sourceNS == "" {
+		// Kubernetes provider without a configured source namespace: ESO
+		// reads the SecretStore's own namespace. Mirror that default.
+		sourceNS = storeNS
+	}
+
+	// RBAC: user must be allowed to list Secrets in the source namespace.
+	// AccessChecker keys on group/resource; "core/secrets" uses empty
+	// group plus resource "secrets".
+	can, accErr := h.AccessChecker.CanAccessGroupResource(
+		r.Context(),
+		user.KubernetesUsername,
+		user.KubernetesGroups,
+		"list",
+		"",
+		"secrets",
+		sourceNS,
+	)
+	if accErr != nil || !can {
+		httputil.WriteData(w, pathDiscoveryResponse{Supported: true, Provider: provider})
+		return
+	}
+
+	// List Secrets via the impersonating typed client. The API server enforces
+	// RBAC again — defense in depth against an AccessChecker stale read.
+	kubeClient, err := h.clientForUser(user.KubernetesUsername, user.KubernetesGroups)
+	if err != nil {
+		h.Logger.Error("create impersonating typed client", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "internal error", "")
+		return
+	}
+
+	secrets, err := kubeClient.CoreV1().Secrets(sourceNS).List(r.Context(), metav1.ListOptions{})
+	if err != nil {
+		if apierrors.IsForbidden(err) {
+			// Apiserver said no — surface as supported-but-empty so the UI
+			// degrades to free-text rather than 403'ing the form.
+			httputil.WriteData(w, pathDiscoveryResponse{Supported: true, Provider: provider})
+			return
+		}
+		h.Logger.Error("list secrets for path discovery",
+			"sourceNamespace", sourceNS, "store", storeName, "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to list paths", "")
+		return
+	}
+
+	prefix := strings.TrimSpace(r.URL.Query().Get("prefix"))
+	paths := make([]string, 0, len(secrets.Items))
+	for _, s := range secrets.Items {
+		if prefix != "" && !strings.HasPrefix(s.Name, prefix) {
+			continue
+		}
+		paths = append(paths, s.Name)
+		if len(paths) >= pathDiscoveryLimit {
+			break
+		}
+	}
+	sort.Strings(paths)
+
+	httputil.WriteData(w, pathDiscoveryResponse{
+		Supported: true,
+		Provider:  provider,
+		Paths:     paths,
+	})
+}
+
+// kubernetesProviderSourceNamespace reads the source namespace from a
+// kubernetes-provider spec block. The v1 schema places the namespace under
+// `remoteRef.namespace`; older stores use `remoteNamespace`. Empty when
+// neither is present.
+func kubernetesProviderSourceNamespace(providerSpec map[string]any) string {
+	if providerSpec == nil {
+		return ""
+	}
+	if remoteRef, ok := providerSpec["remoteRef"].(map[string]any); ok {
+		if ns, ok := remoteRef["namespace"].(string); ok && ns != "" {
+			return ns
+		}
+	}
+	if ns, ok := providerSpec["remoteNamespace"].(string); ok && ns != "" {
+		return ns
+	}
+	return ""
+}

--- a/backend/internal/externalsecrets/path_discovery_test.go
+++ b/backend/internal/externalsecrets/path_discovery_test.go
@@ -1,0 +1,203 @@
+package externalsecrets
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/kubecenter/kubecenter/internal/auth"
+	"github.com/kubecenter/kubecenter/internal/k8s/resources"
+)
+
+// makeKubernetesProviderStore builds a SecretStore configured for the
+// kubernetes provider with the given source namespace.
+func makeKubernetesProviderStore(ns, name, sourceNS string) *unstructured.Unstructured {
+	provider := map[string]any{}
+	if sourceNS != "" {
+		provider["remoteRef"] = map[string]any{"namespace": sourceNS}
+	}
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "external-secrets.io/v1",
+			"kind":       "SecretStore",
+			"metadata":   map[string]any{"name": name, "namespace": ns, "uid": "uid-store"},
+			"spec":       map[string]any{"provider": map[string]any{"kubernetes": provider}},
+			"status": map[string]any{
+				"conditions": []any{map[string]any{"type": "Ready", "status": "True"}},
+			},
+		},
+	}
+}
+
+// pathDiscoveryHandler wires the typed and dynamic fake clients for tests.
+func pathDiscoveryHandler(esObjs []runtime.Object, secrets ...runtime.Object) *Handler {
+	dynFake := newEsoFakeDynClient(esObjs...)
+	var typedFake kubernetes.Interface = kubefake.NewClientset(secrets...)
+	return &Handler{
+		Discoverer:    detectedDiscoverer(),
+		AccessChecker: resources.NewAlwaysAllowAccessChecker(),
+		Logger:        slog.Default(),
+		dynForUserOverride: func(string, []string) (dynamic.Interface, error) {
+			return dynFake, nil
+		},
+		clientForUserOverride: func(string, []string) (kubernetes.Interface, error) {
+			return typedFake, nil
+		},
+	}
+}
+
+func decodePathDiscovery(t *testing.T, w *httptest.ResponseRecorder) pathDiscoveryResponse {
+	t.Helper()
+	var env struct {
+		Data pathDiscoveryResponse `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode: %v\nbody: %s", err, w.Body.String())
+	}
+	return env.Data
+}
+
+func TestHandleListPaths_KubernetesProvider(t *testing.T) {
+	store := makeKubernetesProviderStore("apps", "k8s-store", "source")
+	secrets := []runtime.Object{
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "alpha", Namespace: "source"}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "beta", Namespace: "source"}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "alphabet", Namespace: "source"}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "other", Namespace: "elsewhere"}},
+	}
+	h := pathDiscoveryHandler([]runtime.Object{store}, secrets...)
+
+	w := httptest.NewRecorder()
+	r := withUser(httptest.NewRequest(http.MethodGet, "/?prefix=alph", nil), &auth.User{KubernetesUsername: "u"})
+	r = urlWithChiParams(r, map[string]string{"namespace": "apps", "name": "k8s-store"})
+	h.HandleListPaths(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; body = %s", w.Code, w.Body.String())
+	}
+	got := decodePathDiscovery(t, w)
+	if !got.Supported || got.Provider != "kubernetes" {
+		t.Errorf("expected supported kubernetes provider, got %+v", got)
+	}
+	if len(got.Paths) != 2 {
+		t.Errorf("expected 2 paths matching prefix 'alph', got %d: %v", len(got.Paths), got.Paths)
+	}
+	// Sorted output
+	if got.Paths[0] != "alpha" || got.Paths[1] != "alphabet" {
+		t.Errorf("expected sorted paths, got %v", got.Paths)
+	}
+}
+
+func TestHandleListPaths_KubernetesProvider_DefaultsToStoreNamespace(t *testing.T) {
+	// Store has no remoteRef.namespace set — falls back to store's own namespace.
+	store := makeKubernetesProviderStore("apps", "k8s-store", "")
+	secrets := []runtime.Object{
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "in-apps", Namespace: "apps"}},
+	}
+	h := pathDiscoveryHandler([]runtime.Object{store}, secrets...)
+
+	w := httptest.NewRecorder()
+	r := withUser(httptest.NewRequest(http.MethodGet, "/", nil), &auth.User{KubernetesUsername: "u"})
+	r = urlWithChiParams(r, map[string]string{"namespace": "apps", "name": "k8s-store"})
+	h.HandleListPaths(w, r)
+
+	got := decodePathDiscovery(t, w)
+	if len(got.Paths) != 1 || got.Paths[0] != "in-apps" {
+		t.Errorf("expected fallback to store namespace, got %+v", got)
+	}
+}
+
+func TestHandleListPaths_NonKubernetesProvider(t *testing.T) {
+	// Vault provider — wizard should fall through to free-text.
+	store := makeStore("apps", "vault-store", "uid-vault")
+	h := pathDiscoveryHandler([]runtime.Object{store})
+
+	w := httptest.NewRecorder()
+	r := withUser(httptest.NewRequest(http.MethodGet, "/", nil), &auth.User{KubernetesUsername: "u"})
+	r = urlWithChiParams(r, map[string]string{"namespace": "apps", "name": "vault-store"})
+	h.HandleListPaths(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; body = %s", w.Code, w.Body.String())
+	}
+	got := decodePathDiscovery(t, w)
+	if got.Supported {
+		t.Errorf("expected supported=false for vault provider, got %+v", got)
+	}
+	if got.Provider != "vault" {
+		t.Errorf("expected provider echo 'vault', got %q", got.Provider)
+	}
+}
+
+func TestHandleListPaths_StoreNotFound(t *testing.T) {
+	h := pathDiscoveryHandler(nil)
+	w := httptest.NewRecorder()
+	r := withUser(httptest.NewRequest(http.MethodGet, "/", nil), &auth.User{KubernetesUsername: "u"})
+	r = urlWithChiParams(r, map[string]string{"namespace": "apps", "name": "missing"})
+	h.HandleListPaths(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestHandleListPaths_RBACDeniedOnStore(t *testing.T) {
+	store := makeKubernetesProviderStore("apps", "k8s-store", "source")
+	h := pathDiscoveryHandler([]runtime.Object{store})
+	h.AccessChecker = resources.NewAlwaysDenyAccessChecker()
+
+	w := httptest.NewRecorder()
+	r := withUser(httptest.NewRequest(http.MethodGet, "/", nil), &auth.User{KubernetesUsername: "u"})
+	r = urlWithChiParams(r, map[string]string{"namespace": "apps", "name": "k8s-store"})
+	h.HandleListPaths(w, r)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+func TestKubernetesProviderSourceNamespace(t *testing.T) {
+	cases := []struct {
+		name string
+		spec map[string]any
+		want string
+	}{
+		{"nil", nil, ""},
+		{"empty", map[string]any{}, ""},
+		{
+			"remoteRef.namespace",
+			map[string]any{"remoteRef": map[string]any{"namespace": "apps"}},
+			"apps",
+		},
+		{
+			"legacy remoteNamespace",
+			map[string]any{"remoteNamespace": "legacy"},
+			"legacy",
+		},
+		{
+			"remoteRef wins over legacy",
+			map[string]any{
+				"remoteRef":       map[string]any{"namespace": "new"},
+				"remoteNamespace": "old",
+			},
+			"new",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := kubernetesProviderSourceNamespace(c.spec); got != c.want {
+				t.Errorf("got %q; want %q", got, c.want)
+			}
+		})
+	}
+}

--- a/backend/internal/externalsecrets/path_discovery_test.go
+++ b/backend/internal/externalsecrets/path_discovery_test.go
@@ -2,6 +2,7 @@ package externalsecrets
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -21,10 +22,11 @@ import (
 
 // makeKubernetesProviderStore builds a SecretStore configured for the
 // kubernetes provider with the given source namespace.
+// ESO v1 KubernetesProvider uses `remoteNamespace` at the provider-spec level.
 func makeKubernetesProviderStore(ns, name, sourceNS string) *unstructured.Unstructured {
 	provider := map[string]any{}
 	if sourceNS != "" {
-		provider["remoteRef"] = map[string]any{"namespace": sourceNS}
+		provider["remoteNamespace"] = sourceNS
 	}
 	return &unstructured.Unstructured{
 		Object: map[string]any{
@@ -166,7 +168,71 @@ func TestHandleListPaths_RBACDeniedOnStore(t *testing.T) {
 	}
 }
 
+// TestHandleListPaths_PartialRBACDeny verifies that when the user can read the
+// SecretStore (get secretstores) but is denied listing Secrets, the endpoint
+// returns HTTP 200 with supported=true and an empty path list — the UI degrades
+// to free-text rather than surfacing a 403.
+func TestHandleListPaths_PartialRBACDeny(t *testing.T) {
+	store := makeKubernetesProviderStore("apps", "k8s-store", "source")
+	h := pathDiscoveryHandler([]runtime.Object{store})
+	// Allow `get secretstores` but deny `list secrets` (and everything else).
+	h.AccessChecker = resources.NewPredicateAccessChecker(func(verb, _, resource, _ string) bool {
+		return verb == "get" && resource == "secretstores"
+	})
+
+	w := httptest.NewRecorder()
+	r := withUser(httptest.NewRequest(http.MethodGet, "/", nil), &auth.User{KubernetesUsername: "u"})
+	r = urlWithChiParams(r, map[string]string{"namespace": "apps", "name": "k8s-store"})
+	h.HandleListPaths(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	got := decodePathDiscovery(t, w)
+	if !got.Supported {
+		t.Error("expected supported=true (kubernetes provider recognised)")
+	}
+	if len(got.Paths) != 0 {
+		t.Errorf("expected empty paths on RBAC deny, got %v", got.Paths)
+	}
+}
+
+// TestHandleListPaths_LimitCap verifies that when the source namespace contains
+// more than pathDiscoveryLimit Secrets the response is capped and Truncated=true.
+func TestHandleListPaths_LimitCap(t *testing.T) {
+	store := makeKubernetesProviderStore("apps", "k8s-store", "source")
+	secrets := make([]runtime.Object, pathDiscoveryLimit+5)
+	for i := range secrets {
+		secrets[i] = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("secret-%04d", i),
+				Namespace: "source",
+			},
+		}
+	}
+	h := pathDiscoveryHandler([]runtime.Object{store}, secrets...)
+
+	w := httptest.NewRecorder()
+	r := withUser(httptest.NewRequest(http.MethodGet, "/", nil), &auth.User{KubernetesUsername: "u"})
+	r = urlWithChiParams(r, map[string]string{"namespace": "apps", "name": "k8s-store"})
+	h.HandleListPaths(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	got := decodePathDiscovery(t, w)
+	if len(got.Paths) != pathDiscoveryLimit {
+		t.Errorf("expected %d paths (cap), got %d", pathDiscoveryLimit, len(got.Paths))
+	}
+	if !got.Truncated {
+		t.Error("expected truncated=true when result exceeds cap")
+	}
+}
+
 func TestKubernetesProviderSourceNamespace(t *testing.T) {
+	// ESO v1 KubernetesProvider only supports `remoteNamespace` at the
+	// provider-spec level. The `remoteRef` key lives on ExternalSecret data
+	// items, not on the SecretStore provider config.
 	cases := []struct {
 		name string
 		spec map[string]any
@@ -175,22 +241,14 @@ func TestKubernetesProviderSourceNamespace(t *testing.T) {
 		{"nil", nil, ""},
 		{"empty", map[string]any{}, ""},
 		{
-			"remoteRef.namespace",
-			map[string]any{"remoteRef": map[string]any{"namespace": "apps"}},
+			"remoteNamespace",
+			map[string]any{"remoteNamespace": "apps"},
 			"apps",
 		},
 		{
-			"legacy remoteNamespace",
-			map[string]any{"remoteNamespace": "legacy"},
-			"legacy",
-		},
-		{
-			"remoteRef wins over legacy",
-			map[string]any{
-				"remoteRef":       map[string]any{"namespace": "new"},
-				"remoteNamespace": "old",
-			},
-			"new",
+			"remoteRef.namespace ignored (not a valid KubernetesProvider field)",
+			map[string]any{"remoteRef": map[string]any{"namespace": "apps"}},
+			"",
 		},
 	}
 	for _, c := range cases {

--- a/backend/internal/server/routes.go
+++ b/backend/internal/server/routes.go
@@ -305,7 +305,7 @@ func (s *Server) registerWizardRoutes(ar chi.Router) {
 		wr.Post("/cluster-issuer/preview", h.HandlePreview(func() wizard.WizardInput {
 			return &wizard.IssuerInput{Scope: wizard.IssuerScopeCluster}
 		}))
-		wr.Post("/externalsecret/preview", h.HandlePreview(func() wizard.WizardInput { return &wizard.ExternalSecretInput{} }))
+		wr.Post("/external-secret/preview", h.HandlePreview(func() wizard.WizardInput { return &wizard.ExternalSecretInput{} }))
 	})
 }
 

--- a/backend/internal/server/routes.go
+++ b/backend/internal/server/routes.go
@@ -305,6 +305,7 @@ func (s *Server) registerWizardRoutes(ar chi.Router) {
 		wr.Post("/cluster-issuer/preview", h.HandlePreview(func() wizard.WizardInput {
 			return &wizard.IssuerInput{Scope: wizard.IssuerScopeCluster}
 		}))
+		wr.Post("/externalsecret/preview", h.HandlePreview(func() wizard.WizardInput { return &wizard.ExternalSecretInput{} }))
 	})
 }
 
@@ -666,6 +667,13 @@ func (s *Server) registerExternalSecretsRoutes(ar chi.Router) {
 		er.Get("/stores", h.HandleListStores)
 		er.With(resources.ValidateURLParams).
 			Get("/stores/{namespace}/{name}", h.HandleGetStore)
+
+		// Path-discovery for ExternalSecret wizard (Phase G Unit 17).
+		// Kubernetes-provider stores list Secrets in their source namespace
+		// via the impersonating client; other providers respond with
+		// `{supported: false}` so the wizard renders a free-text path field.
+		er.With(resources.ValidateURLParams).
+			Get("/stores/{namespace}/{name}/paths", h.HandleListPaths)
 
 		// Per-store rate + cost-tier metrics (Phase F Unit 16). Returns
 		// `{rate, last24h, cost, error}`; degrades to `{error: "rate

--- a/backend/internal/wizard/externalsecret.go
+++ b/backend/internal/wizard/externalsecret.go
@@ -31,9 +31,10 @@ type ExternalSecretDataItemInput struct {
 }
 
 // ExternalSecretDataFromInput pulls every key from a single remote path
-// into the target Secret. Either Extract or Find may be set; Extract takes
-// the verbatim remote object and copies its keys, Find performs a name
-// match against the source store.
+// into the target Secret. Exactly one of Extract or Find must be set —
+// having both or neither is a validation error returned by Validate().
+// Extract takes the verbatim remote object and copies its keys; Find
+// performs a name match against the source store.
 type ExternalSecretDataFromInput struct {
 	Extract *ExternalSecretRemoteRefInput `json:"extract,omitempty"`
 	Find    *ExternalSecretFindInput      `json:"find,omitempty"`

--- a/backend/internal/wizard/externalsecret.go
+++ b/backend/internal/wizard/externalsecret.go
@@ -1,0 +1,248 @@
+package wizard
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	sigsyaml "sigs.k8s.io/yaml"
+)
+
+// ExternalSecretStoreRefInput identifies the SecretStore or ClusterSecretStore
+// the ExternalSecret reads from.
+type ExternalSecretStoreRefInput struct {
+	Name string `json:"name"`
+	Kind string `json:"kind"` // "SecretStore" or "ClusterSecretStore"
+}
+
+// ExternalSecretRemoteRefInput is the source-store coordinate for a single
+// data entry. Property and Version are optional and only emitted when set.
+type ExternalSecretRemoteRefInput struct {
+	Key      string `json:"key"`
+	Property string `json:"property,omitempty"`
+	Version  string `json:"version,omitempty"`
+}
+
+// ExternalSecretDataItemInput maps one source-store ref to a key in the
+// target Kubernetes Secret.
+type ExternalSecretDataItemInput struct {
+	SecretKey string                       `json:"secretKey"`
+	RemoteRef ExternalSecretRemoteRefInput `json:"remoteRef"`
+}
+
+// ExternalSecretDataFromInput pulls every key from a single remote path
+// into the target Secret. Either Extract or Find may be set; Extract takes
+// the verbatim remote object and copies its keys, Find performs a name
+// match against the source store.
+type ExternalSecretDataFromInput struct {
+	Extract *ExternalSecretRemoteRefInput `json:"extract,omitempty"`
+	Find    *ExternalSecretFindInput      `json:"find,omitempty"`
+}
+
+// ExternalSecretFindInput is the v1 dataFrom.find shape. Only Name.RegExp is
+// supported in the wizard surface; tags and path are deferred to the YAML
+// editor (most users want a single regex match).
+type ExternalSecretFindInput struct {
+	Path string                 `json:"path,omitempty"`
+	Name *ExternalSecretFindBy  `json:"name,omitempty"`
+	Tags map[string]string      `json:"tags,omitempty"`
+}
+
+// ExternalSecretFindBy holds a single regex used by dataFrom.find.name.
+type ExternalSecretFindBy struct {
+	RegExp string `json:"regexp"`
+}
+
+// ExternalSecretInput represents the wizard form data for creating an
+// external-secrets.io/v1 ExternalSecret.
+type ExternalSecretInput struct {
+	Name             string                        `json:"name"`
+	Namespace        string                        `json:"namespace"`
+	StoreRef         ExternalSecretStoreRefInput   `json:"storeRef"`
+	RefreshInterval  string                        `json:"refreshInterval,omitempty"`
+	TargetSecretName string                        `json:"targetSecretName,omitempty"`
+	Data             []ExternalSecretDataItemInput `json:"data,omitempty"`
+	DataFrom         []ExternalSecretDataFromInput `json:"dataFrom,omitempty"`
+}
+
+// Validate checks the ExternalSecretInput and returns field-level errors.
+func (e *ExternalSecretInput) Validate() []FieldError {
+	var errs []FieldError
+
+	if !dnsLabelRegex.MatchString(e.Name) {
+		errs = append(errs, FieldError{Field: "name", Message: "must be a valid DNS label (lowercase alphanumeric and hyphens, 1-63 chars)"})
+	}
+	if e.Namespace == "" {
+		errs = append(errs, FieldError{Field: "namespace", Message: "is required"})
+	} else if !dnsLabelRegex.MatchString(e.Namespace) {
+		errs = append(errs, FieldError{Field: "namespace", Message: "must be a valid DNS label"})
+	}
+
+	// storeRef
+	if e.StoreRef.Kind != "SecretStore" && e.StoreRef.Kind != "ClusterSecretStore" {
+		errs = append(errs, FieldError{Field: "storeRef.kind", Message: "must be SecretStore or ClusterSecretStore"})
+	}
+	if e.StoreRef.Name == "" {
+		errs = append(errs, FieldError{Field: "storeRef.name", Message: "is required"})
+	} else if !dnsLabelRegex.MatchString(e.StoreRef.Name) {
+		errs = append(errs, FieldError{Field: "storeRef.name", Message: "must be a valid DNS label"})
+	}
+
+	// targetSecretName: required so the wizard always renders a deterministic
+	// target Secret name in the preview (ESO defaults to ExternalSecret.name
+	// when omitted, but exposing the default explicitly avoids surprise).
+	if e.TargetSecretName == "" {
+		errs = append(errs, FieldError{Field: "targetSecretName", Message: "is required"})
+	} else if !dnsLabelRegex.MatchString(e.TargetSecretName) {
+		errs = append(errs, FieldError{Field: "targetSecretName", Message: "must be a valid DNS label"})
+	}
+
+	// refreshInterval — optional; when set must parse as a non-negative Go
+	// duration. ESO accepts "0" to disable polling, so we allow zero.
+	if e.RefreshInterval != "" {
+		d, err := time.ParseDuration(e.RefreshInterval)
+		if err != nil {
+			errs = append(errs, FieldError{Field: "refreshInterval", Message: "must be a valid Go duration (e.g. 1h)"})
+		} else if d < 0 {
+			errs = append(errs, FieldError{Field: "refreshInterval", Message: "must not be negative"})
+		}
+	}
+
+	// At least one of data or dataFrom is required.
+	if len(e.Data) == 0 && len(e.DataFrom) == 0 {
+		errs = append(errs, FieldError{Field: "data", Message: "must specify at least one of data or dataFrom"})
+	}
+
+	// Per-item data validation.
+	seenSecretKeys := map[string]bool{}
+	for i, item := range e.Data {
+		if item.SecretKey == "" {
+			errs = append(errs, FieldError{Field: fmt.Sprintf("data[%d].secretKey", i), Message: "is required"})
+		} else if seenSecretKeys[item.SecretKey] {
+			errs = append(errs, FieldError{Field: fmt.Sprintf("data[%d].secretKey", i), Message: "duplicate secretKey"})
+		} else {
+			seenSecretKeys[item.SecretKey] = true
+		}
+		if strings.TrimSpace(item.RemoteRef.Key) == "" {
+			errs = append(errs, FieldError{Field: fmt.Sprintf("data[%d].remoteRef.key", i), Message: "is required"})
+		}
+	}
+
+	// Per-item dataFrom validation. Each entry must specify exactly one of
+	// extract or find. Find regex must compile.
+	for i, df := range e.DataFrom {
+		hasExtract := df.Extract != nil
+		hasFind := df.Find != nil
+		switch {
+		case !hasExtract && !hasFind:
+			errs = append(errs, FieldError{Field: fmt.Sprintf("dataFrom[%d]", i), Message: "must specify either extract or find"})
+		case hasExtract && hasFind:
+			errs = append(errs, FieldError{Field: fmt.Sprintf("dataFrom[%d]", i), Message: "must specify only one of extract or find"})
+		case hasExtract:
+			if strings.TrimSpace(df.Extract.Key) == "" {
+				errs = append(errs, FieldError{Field: fmt.Sprintf("dataFrom[%d].extract.key", i), Message: "is required"})
+			}
+		case hasFind:
+			if df.Find.Name == nil || strings.TrimSpace(df.Find.Name.RegExp) == "" {
+				errs = append(errs, FieldError{Field: fmt.Sprintf("dataFrom[%d].find.name.regexp", i), Message: "is required"})
+			}
+		}
+	}
+
+	return errs
+}
+
+// ToExternalSecret returns a map representation suitable for YAML marshaling.
+// Built as map[string]any (per L7.1) so the wizard does not pull the ESO Go
+// SDK into go.mod just for type-checking the spec.
+func (e *ExternalSecretInput) ToExternalSecret() map[string]any {
+	storeRef := map[string]any{
+		"name": e.StoreRef.Name,
+		"kind": e.StoreRef.Kind,
+	}
+
+	target := map[string]any{
+		"name": e.TargetSecretName,
+	}
+
+	spec := map[string]any{
+		"secretStoreRef": storeRef,
+		"target":         target,
+	}
+	if e.RefreshInterval != "" {
+		spec["refreshInterval"] = e.RefreshInterval
+	}
+
+	if len(e.Data) > 0 {
+		data := make([]map[string]any, 0, len(e.Data))
+		for _, item := range e.Data {
+			ref := map[string]any{"key": item.RemoteRef.Key}
+			if item.RemoteRef.Property != "" {
+				ref["property"] = item.RemoteRef.Property
+			}
+			if item.RemoteRef.Version != "" {
+				ref["version"] = item.RemoteRef.Version
+			}
+			data = append(data, map[string]any{
+				"secretKey": item.SecretKey,
+				"remoteRef": ref,
+			})
+		}
+		spec["data"] = data
+	}
+
+	if len(e.DataFrom) > 0 {
+		dataFrom := make([]map[string]any, 0, len(e.DataFrom))
+		for _, df := range e.DataFrom {
+			entry := map[string]any{}
+			if df.Extract != nil {
+				ex := map[string]any{"key": df.Extract.Key}
+				if df.Extract.Property != "" {
+					ex["property"] = df.Extract.Property
+				}
+				if df.Extract.Version != "" {
+					ex["version"] = df.Extract.Version
+				}
+				entry["extract"] = ex
+			}
+			if df.Find != nil {
+				find := map[string]any{}
+				if df.Find.Path != "" {
+					find["path"] = df.Find.Path
+				}
+				if df.Find.Name != nil {
+					find["name"] = map[string]any{"regexp": df.Find.Name.RegExp}
+				}
+				if len(df.Find.Tags) > 0 {
+					tags := map[string]any{}
+					for k, v := range df.Find.Tags {
+						tags[k] = v
+					}
+					find["tags"] = tags
+				}
+				entry["find"] = find
+			}
+			dataFrom = append(dataFrom, entry)
+		}
+		spec["dataFrom"] = dataFrom
+	}
+
+	return map[string]any{
+		"apiVersion": "external-secrets.io/v1",
+		"kind":       "ExternalSecret",
+		"metadata": map[string]any{
+			"name":      e.Name,
+			"namespace": e.Namespace,
+		},
+		"spec": spec,
+	}
+}
+
+// ToYAML implements WizardInput.
+func (e *ExternalSecretInput) ToYAML() (string, error) {
+	y, err := sigsyaml.Marshal(e.ToExternalSecret())
+	if err != nil {
+		return "", err
+	}
+	return string(y), nil
+}

--- a/backend/internal/wizard/externalsecret_test.go
+++ b/backend/internal/wizard/externalsecret_test.go
@@ -235,6 +235,80 @@ func TestExternalSecretToYAML_OmitsZeroFields(t *testing.T) {
 	}
 }
 
+func TestExternalSecretToYAML_DataFromFind(t *testing.T) {
+	e := validExternalSecretInput()
+	e.Data = nil
+	e.DataFrom = []ExternalSecretDataFromInput{
+		{Find: &ExternalSecretFindInput{Name: &ExternalSecretFindBy{RegExp: "^db-"}}},
+	}
+	y, err := e.ToYAML()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, want := range []string{"dataFrom:", "find:", "regexp: ^db-"} {
+		if !strings.Contains(y, want) {
+			t.Errorf("expected YAML to contain %q\n%s", want, y)
+		}
+	}
+	if strings.Contains(y, "extract:") {
+		t.Errorf("expected extract absent in find-only YAML\n%s", y)
+	}
+}
+
+func TestExternalSecretToYAML_OmitsEmptyProperty(t *testing.T) {
+	e := validExternalSecretInput()
+	// Property is empty (zero value) — must be omitted from the rendered YAML.
+	e.Data = []ExternalSecretDataItemInput{
+		{SecretKey: "DB_PASSWORD", RemoteRef: ExternalSecretRemoteRefInput{Key: "secret/data/myapp", Property: ""}},
+	}
+	y, err := e.ToYAML()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(y, "property:") {
+		t.Errorf("expected property omitted when empty\n%s", y)
+	}
+}
+
+func TestExternalSecretToYAML_DataAndDataFromCoexist(t *testing.T) {
+	e := validExternalSecretInput()
+	e.DataFrom = []ExternalSecretDataFromInput{
+		{Extract: &ExternalSecretRemoteRefInput{Key: "secret/data/common"}},
+	}
+	y, err := e.ToYAML()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(y, "data:") {
+		t.Errorf("expected data section present\n%s", y)
+	}
+	if !strings.Contains(y, "dataFrom:") {
+		t.Errorf("expected dataFrom section present\n%s", y)
+	}
+}
+
+func TestExternalSecretValidate_DataItemMissingFields_FieldChecks(t *testing.T) {
+	e := validExternalSecretInput()
+	e.Data = []ExternalSecretDataItemInput{
+		{},                                                        // missing secretKey + remoteRef.key
+		{SecretKey: "ok"},                                         // missing remoteRef.key
+		{RemoteRef: ExternalSecretRemoteRefInput{Key: "k"}},       // missing secretKey
+	}
+	errs := e.Validate()
+	if !hasField(errs, "data[0].secretKey") {
+		t.Error("expected data[0].secretKey error")
+	}
+	if !hasField(errs, "data[0].remoteRef.key") {
+		t.Error("expected data[0].remoteRef.key error")
+	}
+	if !hasField(errs, "data[1].remoteRef.key") {
+		t.Error("expected data[1].remoteRef.key error")
+	}
+	if !hasField(errs, "data[2].secretKey") {
+		t.Error("expected data[2].secretKey error")
+	}
+}
+
 func hasField(errs []FieldError, field string) bool {
 	for _, e := range errs {
 		if e.Field == field {

--- a/backend/internal/wizard/externalsecret_test.go
+++ b/backend/internal/wizard/externalsecret_test.go
@@ -1,0 +1,245 @@
+package wizard
+
+import (
+	"strings"
+	"testing"
+)
+
+func validExternalSecretInput() ExternalSecretInput {
+	return ExternalSecretInput{
+		Name:             "my-app-config",
+		Namespace:        "apps",
+		StoreRef:         ExternalSecretStoreRefInput{Name: "vault-store", Kind: "SecretStore"},
+		RefreshInterval:  "1h",
+		TargetSecretName: "my-app-config",
+		Data: []ExternalSecretDataItemInput{
+			{SecretKey: "DB_PASSWORD", RemoteRef: ExternalSecretRemoteRefInput{Key: "secret/data/myapp", Property: "db_password"}},
+		},
+	}
+}
+
+func TestExternalSecretValidate_Valid(t *testing.T) {
+	e := validExternalSecretInput()
+	if errs := e.Validate(); len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+}
+
+func TestExternalSecretValidate_InvalidName(t *testing.T) {
+	cases := []string{"", "MyApp", "-bad", "bad-", "has space", strings.Repeat("a", 64)}
+	for _, n := range cases {
+		e := validExternalSecretInput()
+		e.Name = n
+		errs := e.Validate()
+		if !hasField(errs, "name") {
+			t.Errorf("expected name error for %q, got %v", n, errs)
+		}
+	}
+}
+
+func TestExternalSecretValidate_MissingNamespace(t *testing.T) {
+	e := validExternalSecretInput()
+	e.Namespace = ""
+	if !hasField(e.Validate(), "namespace") {
+		t.Error("expected namespace error")
+	}
+}
+
+func TestExternalSecretValidate_StoreRefKind(t *testing.T) {
+	cases := []string{"", "BadKind", "secretstore"}
+	for _, k := range cases {
+		e := validExternalSecretInput()
+		e.StoreRef.Kind = k
+		if !hasField(e.Validate(), "storeRef.kind") {
+			t.Errorf("expected storeRef.kind error for %q", k)
+		}
+	}
+}
+
+func TestExternalSecretValidate_ClusterStoreKind_Valid(t *testing.T) {
+	e := validExternalSecretInput()
+	e.StoreRef.Kind = "ClusterSecretStore"
+	if errs := e.Validate(); len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+}
+
+func TestExternalSecretValidate_StoreRefName(t *testing.T) {
+	e := validExternalSecretInput()
+	e.StoreRef.Name = ""
+	if !hasField(e.Validate(), "storeRef.name") {
+		t.Error("expected storeRef.name error")
+	}
+	e.StoreRef.Name = "BadName"
+	if !hasField(e.Validate(), "storeRef.name") {
+		t.Error("expected storeRef.name DNS error")
+	}
+}
+
+func TestExternalSecretValidate_TargetSecretName(t *testing.T) {
+	e := validExternalSecretInput()
+	e.TargetSecretName = ""
+	if !hasField(e.Validate(), "targetSecretName") {
+		t.Error("expected targetSecretName required")
+	}
+	e.TargetSecretName = "BadName"
+	if !hasField(e.Validate(), "targetSecretName") {
+		t.Error("expected targetSecretName DNS error")
+	}
+}
+
+func TestExternalSecretValidate_BadRefreshInterval(t *testing.T) {
+	e := validExternalSecretInput()
+	e.RefreshInterval = "1z"
+	if !hasField(e.Validate(), "refreshInterval") {
+		t.Error("expected refreshInterval error")
+	}
+	e.RefreshInterval = "-5s"
+	if !hasField(e.Validate(), "refreshInterval") {
+		t.Error("expected negative refreshInterval error")
+	}
+}
+
+func TestExternalSecretValidate_RefreshIntervalZero(t *testing.T) {
+	e := validExternalSecretInput()
+	e.RefreshInterval = "0"
+	if errs := e.Validate(); len(errs) != 0 {
+		t.Errorf("expected no errors for zero refresh, got %v", errs)
+	}
+}
+
+func TestExternalSecretValidate_NoDataAndNoDataFrom(t *testing.T) {
+	e := validExternalSecretInput()
+	e.Data = nil
+	if !hasField(e.Validate(), "data") {
+		t.Error("expected error when both data and dataFrom are empty")
+	}
+}
+
+func TestExternalSecretValidate_DataFromOnly_Extract(t *testing.T) {
+	e := validExternalSecretInput()
+	e.Data = nil
+	e.DataFrom = []ExternalSecretDataFromInput{
+		{Extract: &ExternalSecretRemoteRefInput{Key: "secret/data/myapp"}},
+	}
+	if errs := e.Validate(); len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+}
+
+func TestExternalSecretValidate_DataFromBothExtractAndFind(t *testing.T) {
+	e := validExternalSecretInput()
+	e.Data = nil
+	e.DataFrom = []ExternalSecretDataFromInput{{
+		Extract: &ExternalSecretRemoteRefInput{Key: "k"},
+		Find:    &ExternalSecretFindInput{Name: &ExternalSecretFindBy{RegExp: "^x$"}},
+	}}
+	errs := e.Validate()
+	if !hasField(errs, "dataFrom[0]") {
+		t.Errorf("expected mutual-exclusion error, got %v", errs)
+	}
+}
+
+func TestExternalSecretValidate_DataFromExtractMissingKey(t *testing.T) {
+	e := validExternalSecretInput()
+	e.Data = nil
+	e.DataFrom = []ExternalSecretDataFromInput{{Extract: &ExternalSecretRemoteRefInput{}}}
+	if !hasField(e.Validate(), "dataFrom[0].extract.key") {
+		t.Error("expected extract.key error")
+	}
+}
+
+func TestExternalSecretValidate_DataFromFindMissingRegex(t *testing.T) {
+	e := validExternalSecretInput()
+	e.Data = nil
+	e.DataFrom = []ExternalSecretDataFromInput{{Find: &ExternalSecretFindInput{}}}
+	if !hasField(e.Validate(), "dataFrom[0].find.name.regexp") {
+		t.Error("expected find regex required error")
+	}
+}
+
+func TestExternalSecretValidate_DataItemMissingFields(t *testing.T) {
+	e := validExternalSecretInput()
+	e.Data = []ExternalSecretDataItemInput{
+		{},                                         // missing both
+		{SecretKey: "ok"},                          // missing remoteRef.key
+		{RemoteRef: ExternalSecretRemoteRefInput{Key: "k"}}, // missing secretKey
+	}
+	errs := e.Validate()
+	// At least three field errors expected.
+	if len(errs) < 3 {
+		t.Errorf("expected at least 3 errors, got %d: %v", len(errs), errs)
+	}
+}
+
+func TestExternalSecretValidate_DuplicateSecretKey(t *testing.T) {
+	e := validExternalSecretInput()
+	e.Data = []ExternalSecretDataItemInput{
+		{SecretKey: "DUP", RemoteRef: ExternalSecretRemoteRefInput{Key: "k1"}},
+		{SecretKey: "DUP", RemoteRef: ExternalSecretRemoteRefInput{Key: "k2"}},
+	}
+	if !hasField(e.Validate(), "data[1].secretKey") {
+		t.Error("expected duplicate secretKey error")
+	}
+}
+
+func TestExternalSecretToYAML_BasicShape(t *testing.T) {
+	e := validExternalSecretInput()
+	y, err := e.ToYAML()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, want := range []string{
+		"apiVersion: external-secrets.io/v1",
+		"kind: ExternalSecret",
+		"name: my-app-config",
+		"namespace: apps",
+		"refreshInterval: 1h",
+		"secretStoreRef:",
+		"kind: SecretStore",
+		"target:",
+		"data:",
+		"DB_PASSWORD",
+		"property: db_password",
+	} {
+		if !strings.Contains(y, want) {
+			t.Errorf("expected YAML to contain %q\n%s", want, y)
+		}
+	}
+}
+
+func TestExternalSecretToYAML_DataFromExtract(t *testing.T) {
+	e := validExternalSecretInput()
+	e.Data = nil
+	e.DataFrom = []ExternalSecretDataFromInput{
+		{Extract: &ExternalSecretRemoteRefInput{Key: "secret/data/myapp"}},
+	}
+	y, err := e.ToYAML()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(y, "dataFrom:") || !strings.Contains(y, "extract:") {
+		t.Errorf("expected dataFrom + extract, got\n%s", y)
+	}
+}
+
+func TestExternalSecretToYAML_OmitsZeroFields(t *testing.T) {
+	e := validExternalSecretInput()
+	e.RefreshInterval = ""
+	y, err := e.ToYAML()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(y, "refreshInterval") {
+		t.Errorf("expected refreshInterval omitted, got\n%s", y)
+	}
+}
+
+func hasField(errs []FieldError, field string) bool {
+	for _, e := range errs {
+		if e.Field == field {
+			return true
+		}
+	}
+	return false
+}

--- a/frontend/components/wizard/ExternalSecretForm.tsx
+++ b/frontend/components/wizard/ExternalSecretForm.tsx
@@ -1,0 +1,428 @@
+import { useEffect, useRef, useState } from "preact/hooks";
+import { Input } from "@/components/ui/Input.tsx";
+import { NamespaceSelect } from "@/components/ui/NamespaceSelect.tsx";
+import { Button } from "@/components/ui/Button.tsx";
+import { esoApi } from "@/lib/eso-api.ts";
+import type {
+  ExternalSecretWizardForm,
+  ExternalSecretWizardStoreOption,
+} from "@/islands/ExternalSecretWizard.tsx";
+
+interface ExternalSecretFormProps {
+  form: ExternalSecretWizardForm;
+  errors: Record<string, string>;
+  namespaces: string[];
+  stores: ExternalSecretWizardStoreOption[];
+  storesLoading: boolean;
+  onUpdate: (field: keyof ExternalSecretWizardForm, value: unknown) => void;
+  onUpdateData: (
+    index: number,
+    field: "secretKey" | "key" | "property",
+    value: string,
+  ) => void;
+  onAddDataItem: () => void;
+  onRemoveDataItem: (index: number) => void;
+  onPathFieldTouched: (index: number) => void;
+}
+
+const PATH_DEBOUNCE_MS = 300;
+
+interface PathDiscoveryState {
+  supported: boolean;
+  provider: string;
+  paths: string[];
+  loading: boolean;
+  error: string | null;
+}
+
+/** Helper text shown below the path field when path-discovery is unsupported. */
+const FREE_TEXT_HELPER =
+  "This provider doesn't expose path discovery. Enter the remote key path manually (e.g. `secret/data/myapp/db`).";
+
+export function ExternalSecretForm({
+  form,
+  errors,
+  namespaces,
+  stores,
+  storesLoading,
+  onUpdate,
+  onUpdateData,
+  onAddDataItem,
+  onRemoveDataItem,
+  onPathFieldTouched,
+}: ExternalSecretFormProps) {
+  // Path-discovery state — keyed by data-item index. The Kubernetes provider
+  // typeahead populates `paths`; other providers leave `supported` false so
+  // the row renders a free-text input with helper text.
+  const [discovery, setDiscovery] = useState<PathDiscoveryState>({
+    supported: false,
+    provider: "",
+    paths: [],
+    loading: false,
+    error: null,
+  });
+
+  // Resolve the selected store (by name + kind) to surface its provider so the
+  // form can decide whether to enable typeahead.
+  const selectedStore = stores.find(
+    (s) => s.name === form.storeRefName && s.kind === form.storeRefKind,
+  );
+
+  // Track the latest fetch sequence so a stale response cannot overwrite a
+  // newer one. AbortController cancels in-flight fetches when the user keeps
+  // typing.
+  const fetchSeq = useRef(0);
+  const abortRef = useRef<AbortController | null>(null);
+  const debounceHandle = useRef<number | null>(null);
+
+  // Probe path-discovery support whenever the selected store changes. A
+  // kubernetes-provider store flips `supported=true` and seeds an initial
+  // (prefix-empty) listing; other providers report `supported=false`.
+  useEffect(() => {
+    if (!selectedStore || selectedStore.kind !== "SecretStore") {
+      // ClusterSecretStore + missing store: typeahead off until the user picks
+      // a namespaced store. ClusterSecretStores can't be probed by this
+      // endpoint (it requires a namespace).
+      setDiscovery({
+        supported: false,
+        provider: selectedStore?.provider ?? "",
+        paths: [],
+        loading: false,
+        error: null,
+      });
+      return;
+    }
+    let cancelled = false;
+    setDiscovery((d) => ({ ...d, loading: true, error: null }));
+    esoApi
+      .listStorePaths(selectedStore.namespace ?? "", selectedStore.name)
+      .then((resp) => {
+        if (cancelled) return;
+        setDiscovery({
+          supported: !!resp.data.supported,
+          provider: resp.data.provider ?? "",
+          paths: resp.data.paths ?? [],
+          loading: false,
+          error: null,
+        });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        // Degrade to free-text on error — surface a notice so the user knows
+        // why the typeahead isn't kicking in.
+        setDiscovery({
+          supported: false,
+          provider: selectedStore.provider,
+          paths: [],
+          loading: false,
+          error: "Couldn't load paths — enter manually",
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedStore?.name, selectedStore?.namespace, selectedStore?.kind]);
+
+  // Re-fetch with a debounced prefix when the user types in any data-item
+  // path field on a Kubernetes-provider store.
+  function handlePathInput(index: number, value: string) {
+    onUpdateData(index, "key", value);
+    onPathFieldTouched(index);
+
+    if (
+      !discovery.supported || !selectedStore ||
+      selectedStore.kind !== "SecretStore"
+    ) {
+      return;
+    }
+
+    if (debounceHandle.current !== null) {
+      clearTimeout(debounceHandle.current);
+    }
+    debounceHandle.current = setTimeout(() => {
+      debounceHandle.current = null;
+
+      // Cancel previous in-flight fetch.
+      if (abortRef.current) abortRef.current.abort();
+      abortRef.current = new AbortController();
+      const seq = ++fetchSeq.current;
+
+      setDiscovery((d) => ({ ...d, loading: true, error: null }));
+      esoApi
+        .listStorePaths(
+          selectedStore.namespace ?? "",
+          selectedStore.name,
+          value,
+        )
+        .then((resp) => {
+          if (seq !== fetchSeq.current) return;
+          setDiscovery({
+            supported: !!resp.data.supported,
+            provider: resp.data.provider ?? "",
+            paths: resp.data.paths ?? [],
+            loading: false,
+            error: null,
+          });
+        })
+        .catch(() => {
+          if (seq !== fetchSeq.current) return;
+          setDiscovery({
+            supported: false,
+            provider: selectedStore.provider,
+            paths: [],
+            loading: false,
+            error: "Couldn't load paths — enter manually",
+          });
+        });
+    }, PATH_DEBOUNCE_MS);
+  }
+
+  // Cleanup pending timer + abort controller on unmount.
+  useEffect(() => {
+    return () => {
+      if (debounceHandle.current !== null) clearTimeout(debounceHandle.current);
+      if (abortRef.current) abortRef.current.abort();
+    };
+  }, []);
+
+  // Auto-derive targetSecretName from name until user touches it.
+  function handleNameChange(value: string) {
+    onUpdate("name", value);
+    if (!form.targetSecretNameTouched) {
+      onUpdate("targetSecretName", value);
+    }
+  }
+
+  return (
+    <div class="space-y-5">
+      <div class="grid grid-cols-2 gap-4">
+        <Input
+          id="es-name"
+          label="Name"
+          required
+          value={form.name}
+          onInput={(e) =>
+            handleNameChange((e.target as HTMLInputElement).value)}
+          placeholder="my-app-config"
+          error={errors.name}
+        />
+        <NamespaceSelect
+          value={form.namespace}
+          namespaces={namespaces}
+          error={errors.namespace}
+          onChange={(ns) => onUpdate("namespace", ns)}
+        />
+      </div>
+
+      <div class="grid grid-cols-2 gap-4">
+        <div class="space-y-1">
+          <label
+            for="es-store-kind"
+            class="block text-sm font-medium text-text-secondary"
+          >
+            Store kind
+          </label>
+          <select
+            id="es-store-kind"
+            class="block w-full rounded-md border border-border-primary bg-surface px-3 py-2 text-sm text-text-primary"
+            value={form.storeRefKind}
+            onChange={(e) =>
+              onUpdate(
+                "storeRefKind",
+                (e.target as HTMLSelectElement).value as
+                  | "SecretStore"
+                  | "ClusterSecretStore",
+              )}
+          >
+            <option value="SecretStore">SecretStore</option>
+            <option value="ClusterSecretStore">ClusterSecretStore</option>
+          </select>
+        </div>
+
+        <div class="space-y-1">
+          <label
+            for="es-store-name"
+            class="block text-sm font-medium text-text-secondary"
+          >
+            Store
+            <span aria-hidden="true" class="text-danger ml-0.5">*</span>
+          </label>
+          <select
+            id="es-store-name"
+            class="block w-full rounded-md border border-border-primary bg-surface px-3 py-2 text-sm text-text-primary"
+            value={form.storeRefName}
+            onChange={(e) =>
+              onUpdate("storeRefName", (e.target as HTMLSelectElement).value)}
+            aria-invalid={errors["storeRef.name"] ? "true" : undefined}
+            aria-describedby={errors["storeRef.name"]
+              ? "es-store-name-error"
+              : undefined}
+            disabled={storesLoading}
+          >
+            <option value="">
+              {storesLoading ? "Loading…" : "Select a store"}
+            </option>
+            {stores
+              .filter((s) => s.kind === form.storeRefKind)
+              .map((s) => (
+                <option
+                  key={`${s.kind}:${s.namespace ?? ""}:${s.name}`}
+                  value={s.name}
+                >
+                  {s.name}
+                  {s.namespace ? ` (${s.namespace})` : ""}
+                  {s.provider ? ` — ${s.provider}` : ""}
+                </option>
+              ))}
+          </select>
+          {errors["storeRef.name"] && (
+            <p id="es-store-name-error" class="text-sm text-danger">
+              {errors["storeRef.name"]}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div class="grid grid-cols-2 gap-4">
+        <Input
+          id="es-target"
+          label="Target Secret name"
+          required
+          value={form.targetSecretName}
+          onInput={(e) => {
+            onUpdate(
+              "targetSecretName",
+              (e.target as HTMLInputElement).value,
+            );
+            onUpdate("targetSecretNameTouched", true);
+          }}
+          placeholder={form.name || "my-app-config"}
+          description="The Kubernetes Secret ESO will create or update."
+          error={errors.targetSecretName}
+        />
+        <Input
+          id="es-refresh"
+          label="Refresh interval"
+          value={form.refreshInterval}
+          onInput={(e) =>
+            onUpdate(
+              "refreshInterval",
+              (e.target as HTMLInputElement).value,
+            )}
+          placeholder="1h"
+          description="Go duration. Leave blank to use ESO's default. Use `0` to disable polling."
+          error={errors.refreshInterval}
+        />
+      </div>
+
+      <div class="space-y-3">
+        <div class="flex items-center justify-between">
+          <h3 class="text-sm font-semibold text-text-primary">Data items</h3>
+          <Button variant="ghost" onClick={onAddDataItem}>
+            + Add data item
+          </Button>
+        </div>
+        {errors.data && <p class="text-sm text-danger">{errors.data}</p>}
+
+        {form.data.map((item, idx) => (
+          <div
+            key={idx}
+            class="rounded-md border border-border-primary p-4 space-y-3"
+          >
+            <div class="flex items-center justify-between">
+              <span class="text-xs uppercase tracking-wide text-text-muted">
+                Data item {idx + 1}
+              </span>
+              {form.data.length > 1 && (
+                <button
+                  type="button"
+                  class="text-xs text-text-muted hover:text-danger"
+                  onClick={() => onRemoveDataItem(idx)}
+                >
+                  Remove
+                </button>
+              )}
+            </div>
+            <div class="grid grid-cols-2 gap-3">
+              <Input
+                id={`es-data-${idx}-secretkey`}
+                label="Secret key"
+                required
+                value={item.secretKey}
+                onInput={(e) =>
+                  onUpdateData(
+                    idx,
+                    "secretKey",
+                    (e.target as HTMLInputElement).value,
+                  )}
+                placeholder="DB_PASSWORD"
+                error={errors[`data[${idx}].secretKey`]}
+              />
+              <Input
+                id={`es-data-${idx}-property`}
+                label="Property (optional)"
+                value={item.property}
+                onInput={(e) =>
+                  onUpdateData(
+                    idx,
+                    "property",
+                    (e.target as HTMLInputElement).value,
+                  )}
+                placeholder="db_password"
+                description="Sub-key inside the remote object. Leave blank to use the whole value."
+              />
+            </div>
+            <div class="space-y-1">
+              <label
+                for={`es-data-${idx}-key`}
+                class="block text-sm font-medium text-text-secondary"
+              >
+                Remote key
+                <span aria-hidden="true" class="text-danger ml-0.5">*</span>
+              </label>
+              <input
+                id={`es-data-${idx}-key`}
+                type="text"
+                list={discovery.supported ? `es-data-${idx}-paths` : undefined}
+                value={item.key}
+                onInput={(e) =>
+                  handlePathInput(idx, (e.target as HTMLInputElement).value)}
+                placeholder={discovery.supported
+                  ? "Start typing to search…"
+                  : "secret/data/myapp"}
+                class="block w-full rounded-md border border-border-primary bg-surface px-3 py-2 text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-brand/50"
+                aria-invalid={errors[`data[${idx}].remoteRef.key`]
+                  ? "true"
+                  : undefined}
+                aria-describedby={`es-data-${idx}-hint`}
+              />
+              {discovery.supported && (
+                <datalist id={`es-data-${idx}-paths`}>
+                  {discovery.paths.map((p) => <option key={p} value={p} />)}
+                </datalist>
+              )}
+              <p id={`es-data-${idx}-hint`} class="text-xs text-text-muted">
+                {discovery.loading
+                  ? "Loading paths…"
+                  : discovery.error
+                  ? discovery.error
+                  : discovery.supported
+                  ? discovery.paths.length === 0
+                    ? "No paths found in this namespace"
+                    : `${discovery.paths.length} path${
+                      discovery.paths.length === 1 ? "" : "s"
+                    } available`
+                  : FREE_TEXT_HELPER}
+              </p>
+              {errors[`data[${idx}].remoteRef.key`] && (
+                <p class="text-sm text-danger">
+                  {errors[`data[${idx}].remoteRef.key`]}
+                </p>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/wizard/ExternalSecretForm.tsx
+++ b/frontend/components/wizard/ExternalSecretForm.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState } from "preact/hooks";
+import { useSignal } from "@preact/signals";
+import { useEffect, useRef } from "preact/hooks";
 import { Input } from "@/components/ui/Input.tsx";
 import { NamespaceSelect } from "@/components/ui/NamespaceSelect.tsx";
 import { Button } from "@/components/ui/Button.tsx";
@@ -51,10 +52,11 @@ export function ExternalSecretForm({
   onRemoveDataItem,
   onPathFieldTouched,
 }: ExternalSecretFormProps) {
-  // Path-discovery state — keyed by data-item index. The Kubernetes provider
-  // typeahead populates `paths`; other providers leave `supported` false so
-  // the row renders a free-text input with helper text.
-  const [discovery, setDiscovery] = useState<PathDiscoveryState>({
+  // Path-discovery state. The Kubernetes provider typeahead populates `paths`;
+  // other providers leave `supported` false so the row renders a free-text
+  // input with helper text. Signal avoids re-rendering the whole form on every
+  // loading-state tick.
+  const discovery = useSignal<PathDiscoveryState>({
     supported: false,
     provider: "",
     paths: [],
@@ -75,6 +77,49 @@ export function ExternalSecretForm({
   const abortRef = useRef<AbortController | null>(null);
   const debounceHandle = useRef<number | null>(null);
 
+  // Shared fetch helper used by both the store-change probe and the debounced
+  // typeahead. Cancels any in-flight request via abortRef, increments fetchSeq
+  // for stale-response guards, and always drives the same discovery state.
+  function fetchPaths(prefix?: string) {
+    if (!selectedStore || selectedStore.kind !== "SecretStore") return;
+
+    if (abortRef.current) abortRef.current.abort();
+    abortRef.current = new AbortController();
+    const seq = ++fetchSeq.current;
+    const signal = abortRef.current.signal;
+
+    discovery.value = { ...discovery.value, loading: true, error: null };
+    esoApi
+      .listStorePaths(
+        selectedStore.namespace ?? "",
+        selectedStore.name,
+        prefix,
+        signal,
+      )
+      .then((resp) => {
+        if (seq !== fetchSeq.current) return;
+        discovery.value = {
+          supported: !!resp.data.supported,
+          provider: resp.data.provider ?? "",
+          paths: resp.data.paths ?? [],
+          loading: false,
+          error: null,
+        };
+      })
+      .catch((err) => {
+        if (seq !== fetchSeq.current) return;
+        // Ignore abort errors — they're caused by our own cancellation.
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        discovery.value = {
+          supported: false,
+          provider: selectedStore.provider,
+          paths: [],
+          loading: false,
+          error: "Couldn't load paths — enter manually",
+        };
+      });
+  }
+
   // Probe path-discovery support whenever the selected store changes. A
   // kubernetes-provider store flips `supported=true` and seeds an initial
   // (prefix-empty) listing; other providers report `supported=false`.
@@ -83,43 +128,19 @@ export function ExternalSecretForm({
       // ClusterSecretStore + missing store: typeahead off until the user picks
       // a namespaced store. ClusterSecretStores can't be probed by this
       // endpoint (it requires a namespace).
-      setDiscovery({
+      discovery.value = {
         supported: false,
         provider: selectedStore?.provider ?? "",
         paths: [],
         loading: false,
         error: null,
-      });
+      };
       return;
     }
-    let cancelled = false;
-    setDiscovery((d) => ({ ...d, loading: true, error: null }));
-    esoApi
-      .listStorePaths(selectedStore.namespace ?? "", selectedStore.name)
-      .then((resp) => {
-        if (cancelled) return;
-        setDiscovery({
-          supported: !!resp.data.supported,
-          provider: resp.data.provider ?? "",
-          paths: resp.data.paths ?? [],
-          loading: false,
-          error: null,
-        });
-      })
-      .catch(() => {
-        if (cancelled) return;
-        // Degrade to free-text on error — surface a notice so the user knows
-        // why the typeahead isn't kicking in.
-        setDiscovery({
-          supported: false,
-          provider: selectedStore.provider,
-          paths: [],
-          loading: false,
-          error: "Couldn't load paths — enter manually",
-        });
-      });
+    fetchPaths();
     return () => {
-      cancelled = true;
+      // Cancel in-flight store probe on cleanup (store change or unmount).
+      if (abortRef.current) abortRef.current.abort();
     };
   }, [selectedStore?.name, selectedStore?.namespace, selectedStore?.kind]);
 
@@ -130,7 +151,7 @@ export function ExternalSecretForm({
     onPathFieldTouched(index);
 
     if (
-      !discovery.supported || !selectedStore ||
+      !discovery.value.supported || !selectedStore ||
       selectedStore.kind !== "SecretStore"
     ) {
       return;
@@ -141,39 +162,7 @@ export function ExternalSecretForm({
     }
     debounceHandle.current = setTimeout(() => {
       debounceHandle.current = null;
-
-      // Cancel previous in-flight fetch.
-      if (abortRef.current) abortRef.current.abort();
-      abortRef.current = new AbortController();
-      const seq = ++fetchSeq.current;
-
-      setDiscovery((d) => ({ ...d, loading: true, error: null }));
-      esoApi
-        .listStorePaths(
-          selectedStore.namespace ?? "",
-          selectedStore.name,
-          value,
-        )
-        .then((resp) => {
-          if (seq !== fetchSeq.current) return;
-          setDiscovery({
-            supported: !!resp.data.supported,
-            provider: resp.data.provider ?? "",
-            paths: resp.data.paths ?? [],
-            loading: false,
-            error: null,
-          });
-        })
-        .catch(() => {
-          if (seq !== fetchSeq.current) return;
-          setDiscovery({
-            supported: false,
-            provider: selectedStore.provider,
-            paths: [],
-            loading: false,
-            error: "Couldn't load paths — enter manually",
-          });
-        });
+      fetchPaths(value);
     }, PATH_DEBOUNCE_MS);
   }
 
@@ -383,11 +372,13 @@ export function ExternalSecretForm({
               <input
                 id={`es-data-${idx}-key`}
                 type="text"
-                list={discovery.supported ? `es-data-${idx}-paths` : undefined}
+                list={discovery.value.supported
+                  ? `es-data-${idx}-paths`
+                  : undefined}
                 value={item.key}
                 onInput={(e) =>
                   handlePathInput(idx, (e.target as HTMLInputElement).value)}
-                placeholder={discovery.supported
+                placeholder={discovery.value.supported
                   ? "Start typing to search…"
                   : "secret/data/myapp"}
                 class="block w-full rounded-md border border-border-primary bg-surface px-3 py-2 text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-brand/50"
@@ -396,21 +387,23 @@ export function ExternalSecretForm({
                   : undefined}
                 aria-describedby={`es-data-${idx}-hint`}
               />
-              {discovery.supported && (
+              {discovery.value.supported && (
                 <datalist id={`es-data-${idx}-paths`}>
-                  {discovery.paths.map((p) => <option key={p} value={p} />)}
+                  {discovery.value.paths.map((p) => (
+                    <option key={p} value={p} />
+                  ))}
                 </datalist>
               )}
               <p id={`es-data-${idx}-hint`} class="text-xs text-text-muted">
-                {discovery.loading
+                {discovery.value.loading
                   ? "Loading paths…"
-                  : discovery.error
-                  ? discovery.error
-                  : discovery.supported
-                  ? discovery.paths.length === 0
+                  : discovery.value.error
+                  ? discovery.value.error
+                  : discovery.value.supported
+                  ? discovery.value.paths.length === 0
                     ? "No paths found in this namespace"
-                    : `${discovery.paths.length} path${
-                      discovery.paths.length === 1 ? "" : "s"
+                    : `${discovery.value.paths.length} path${
+                      discovery.value.paths.length === 1 ? "" : "s"
                     } available`
                   : FREE_TEXT_HELPER}
               </p>

--- a/frontend/islands/CommandPalette.tsx
+++ b/frontend/islands/CommandPalette.tsx
@@ -106,6 +106,10 @@ function buildSearchIndex(): SearchItem[] {
       href: "/external-secrets/external-secrets",
     },
     {
+      label: "Create ExternalSecret",
+      href: "/external-secrets/external-secrets/new",
+    },
+    {
       label: "View SecretStores",
       href: "/external-secrets/stores",
     },

--- a/frontend/islands/ESOExternalSecretsList.tsx
+++ b/frontend/islands/ESOExternalSecretsList.tsx
@@ -108,15 +108,23 @@ export default function ESOExternalSecretsList() {
     <div class="p-6">
       <div class="flex items-start justify-between mb-1">
         <h1 class="text-2xl font-bold text-text-primary">ExternalSecrets</h1>
-        {namespace.value.trim() !== "" && (
-          <button
-            type="button"
-            onClick={() => (showRefreshDialog.value = true)}
-            class="px-3 py-1.5 text-sm rounded border border-border-primary text-text-primary hover:bg-base"
+        <div class="flex items-center gap-2">
+          {namespace.value.trim() !== "" && (
+            <button
+              type="button"
+              onClick={() => (showRefreshDialog.value = true)}
+              class="px-3 py-1.5 text-sm rounded border border-border-primary text-text-primary hover:bg-base"
+            >
+              Refresh namespace
+            </button>
+          )}
+          <a
+            href="/external-secrets/external-secrets/new"
+            class="px-3 py-1.5 text-sm rounded border border-brand text-brand hover:bg-brand/10"
           >
-            Refresh namespace
-          </button>
-        )}
+            + New ExternalSecret
+          </a>
+        </div>
       </div>
 
       {showRefreshDialog.value && (
@@ -273,10 +281,16 @@ export default function ESOExternalSecretsList() {
 
       {!loading.value && !error.value && items.value.length === 0 && (
         <div class="text-center py-12 rounded-lg border border-border-primary bg-elevated">
-          <p class="text-text-muted">
+          <p class="text-text-muted mb-3">
             No ExternalSecrets in this namespace. Create one to start syncing
             secrets from a SecretStore.
           </p>
+          <a
+            href="/external-secrets/external-secrets/new"
+            class="inline-block px-4 py-2 text-sm rounded border border-brand text-brand hover:bg-brand/10"
+          >
+            New ExternalSecret
+          </a>
         </div>
       )}
     </div>

--- a/frontend/islands/ExternalSecretWizard.tsx
+++ b/frontend/islands/ExternalSecretWizard.tsx
@@ -1,6 +1,6 @@
 import { useSignal } from "@preact/signals";
 import { IS_BROWSER } from "fresh/runtime";
-import { useEffect } from "preact/hooks";
+import { useEffect, useRef } from "preact/hooks";
 import { useDirtyGuard } from "@/lib/hooks/use-dirty-guard.ts";
 import { useNamespaces } from "@/lib/hooks/use-namespaces.ts";
 import { initialNamespace } from "@/lib/namespace.ts";
@@ -74,39 +74,52 @@ export default function ExternalSecretWizard() {
   const previewYaml = useSignal("");
   const previewLoading = useSignal(false);
   const previewError = useSignal<string | null>(null);
+  const previewSeq = useRef(0);
 
   useDirtyGuard(dirty);
 
   // Load both Namespaced and Cluster stores once so the dropdown can switch
-  // between them without an extra round-trip.
+  // between them without an extra round-trip. allSettled ensures a single
+  // failure (e.g. user lacks ClusterSecretStore permission) doesn't discard
+  // the other slice.
   useEffect(() => {
     if (!IS_BROWSER) return;
-    Promise.all([esoApi.listStores(), esoApi.listClusterStores()])
-      .then(([nsResp, clResp]) => {
+    let cancelled = false;
+    Promise.allSettled([esoApi.listStores(), esoApi.listClusterStores()])
+      .then(([nsResult, clResult]) => {
+        if (cancelled) return;
         const list: ExternalSecretWizardStoreOption[] = [];
-        for (const s of nsResp.data ?? []) {
-          list.push({
-            name: s.name,
-            namespace: s.namespace ?? "",
-            kind: "SecretStore",
-            provider: s.provider ?? "",
-          });
+        if (nsResult.status === "fulfilled") {
+          for (const s of nsResult.value.data ?? []) {
+            list.push({
+              name: s.name,
+              namespace: s.namespace ?? "",
+              kind: "SecretStore",
+              provider: s.provider ?? "",
+            });
+          }
+        } else {
+          console.warn("Failed to load SecretStores:", nsResult.reason);
         }
-        for (const s of clResp.data ?? []) {
-          list.push({
-            name: s.name,
-            kind: "ClusterSecretStore",
-            provider: s.provider ?? "",
-          });
+        if (clResult.status === "fulfilled") {
+          for (const s of clResult.value.data ?? []) {
+            list.push({
+              name: s.name,
+              kind: "ClusterSecretStore",
+              provider: s.provider ?? "",
+            });
+          }
+        } else {
+          console.warn("Failed to load ClusterSecretStores:", clResult.reason);
         }
         stores.value = list;
       })
-      .catch(() => {
-        stores.value = [];
-      })
       .finally(() => {
-        storesLoading.value = false;
+        if (!cancelled) storesLoading.value = false;
       });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   function updateField(field: keyof ExternalSecretWizardForm, value: unknown) {
@@ -177,9 +190,9 @@ export default function ExternalSecretWizard() {
     }
     if (
       f.refreshInterval &&
-      !/^[0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h)?$/i.test(f.refreshInterval)
+      !/^(0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+)$/i.test(f.refreshInterval)
     ) {
-      errs.refreshInterval = "Must be a Go duration (e.g. 1h, 30m)";
+      errs.refreshInterval = "Must be a Go duration (e.g. 1h, 30m, 1h30m)";
     }
     if (!f.data.length) {
       errs.data = "At least one data item is required";
@@ -198,6 +211,7 @@ export default function ExternalSecretWizard() {
   }
 
   async function fetchPreview() {
+    const seq = ++previewSeq.current;
     previewLoading.value = true;
     previewError.value = null;
     const f = form.value;
@@ -222,13 +236,15 @@ export default function ExternalSecretWizard() {
 
     try {
       const resp = await esoApi.previewExternalSecret(payload);
+      if (seq !== previewSeq.current) return;
       previewYaml.value = resp.data.yaml;
     } catch (err) {
+      if (seq !== previewSeq.current) return;
       previewError.value = err instanceof Error
         ? err.message
         : "Failed to generate preview";
     } finally {
-      previewLoading.value = false;
+      if (seq === previewSeq.current) previewLoading.value = false;
     }
   }
 

--- a/frontend/islands/ExternalSecretWizard.tsx
+++ b/frontend/islands/ExternalSecretWizard.tsx
@@ -1,0 +1,323 @@
+import { useSignal } from "@preact/signals";
+import { IS_BROWSER } from "fresh/runtime";
+import { useEffect } from "preact/hooks";
+import { useDirtyGuard } from "@/lib/hooks/use-dirty-guard.ts";
+import { useNamespaces } from "@/lib/hooks/use-namespaces.ts";
+import { initialNamespace } from "@/lib/namespace.ts";
+import { DNS_LABEL_REGEX } from "@/lib/wizard-constants.ts";
+import { esoApi } from "@/lib/eso-api.ts";
+import { WizardStepper } from "@/components/wizard/WizardStepper.tsx";
+import { WizardReviewStep } from "@/components/wizard/WizardReviewStep.tsx";
+import { ExternalSecretForm } from "@/components/wizard/ExternalSecretForm.tsx";
+import { Button } from "@/components/ui/Button.tsx";
+
+export interface ExternalSecretWizardDataItem {
+  secretKey: string;
+  key: string;
+  property: string;
+  /** True once the user has typed in this row's path field. */
+  pathTouched: boolean;
+}
+
+export interface ExternalSecretWizardForm {
+  name: string;
+  namespace: string;
+  storeRefName: string;
+  storeRefKind: "SecretStore" | "ClusterSecretStore";
+  refreshInterval: string;
+  targetSecretName: string;
+  /** True once the user explicitly edited targetSecretName themselves. */
+  targetSecretNameTouched: boolean;
+  data: ExternalSecretWizardDataItem[];
+}
+
+export interface ExternalSecretWizardStoreOption {
+  name: string;
+  /** Empty string for ClusterSecretStore. */
+  namespace?: string;
+  kind: "SecretStore" | "ClusterSecretStore";
+  provider: string;
+}
+
+const STEPS = [
+  { title: "Configure" },
+  { title: "Review" },
+];
+
+function newDataItem(): ExternalSecretWizardDataItem {
+  return { secretKey: "", key: "", property: "", pathTouched: false };
+}
+
+function initialForm(): ExternalSecretWizardForm {
+  return {
+    name: "",
+    namespace: initialNamespace(),
+    storeRefName: "",
+    storeRefKind: "SecretStore",
+    refreshInterval: "1h",
+    targetSecretName: "",
+    targetSecretNameTouched: false,
+    data: [newDataItem()],
+  };
+}
+
+export default function ExternalSecretWizard() {
+  const currentStep = useSignal(0);
+  const form = useSignal<ExternalSecretWizardForm>(initialForm());
+  const errors = useSignal<Record<string, string>>({});
+  const dirty = useSignal(false);
+  const namespaces = useNamespaces();
+
+  const stores = useSignal<ExternalSecretWizardStoreOption[]>([]);
+  const storesLoading = useSignal(true);
+
+  const previewYaml = useSignal("");
+  const previewLoading = useSignal(false);
+  const previewError = useSignal<string | null>(null);
+
+  useDirtyGuard(dirty);
+
+  // Load both Namespaced and Cluster stores once so the dropdown can switch
+  // between them without an extra round-trip.
+  useEffect(() => {
+    if (!IS_BROWSER) return;
+    Promise.all([esoApi.listStores(), esoApi.listClusterStores()])
+      .then(([nsResp, clResp]) => {
+        const list: ExternalSecretWizardStoreOption[] = [];
+        for (const s of nsResp.data ?? []) {
+          list.push({
+            name: s.name,
+            namespace: s.namespace ?? "",
+            kind: "SecretStore",
+            provider: s.provider ?? "",
+          });
+        }
+        for (const s of clResp.data ?? []) {
+          list.push({
+            name: s.name,
+            kind: "ClusterSecretStore",
+            provider: s.provider ?? "",
+          });
+        }
+        stores.value = list;
+      })
+      .catch(() => {
+        stores.value = [];
+      })
+      .finally(() => {
+        storesLoading.value = false;
+      });
+  }, []);
+
+  function updateField(field: keyof ExternalSecretWizardForm, value: unknown) {
+    dirty.value = true;
+    // Switching kind clears the selected store so a stale selection doesn't
+    // bleed into the new kind's option list.
+    if (field === "storeRefKind") {
+      form.value = {
+        ...form.value,
+        storeRefKind: value as "SecretStore" | "ClusterSecretStore",
+        storeRefName: "",
+      };
+      return;
+    }
+    form.value = { ...form.value, [field]: value } as ExternalSecretWizardForm;
+  }
+
+  function updateData(
+    index: number,
+    field: "secretKey" | "key" | "property",
+    value: string,
+  ) {
+    dirty.value = true;
+    const next = form.value.data.map((item, i) =>
+      i === index ? { ...item, [field]: value } : item
+    );
+    form.value = { ...form.value, data: next };
+  }
+
+  function markPathTouched(index: number) {
+    if (form.value.data[index].pathTouched) return;
+    const next = form.value.data.map((item, i) =>
+      i === index ? { ...item, pathTouched: true } : item
+    );
+    form.value = { ...form.value, data: next };
+  }
+
+  function addDataItem() {
+    dirty.value = true;
+    form.value = { ...form.value, data: [...form.value.data, newDataItem()] };
+  }
+
+  function removeDataItem(index: number) {
+    dirty.value = true;
+    form.value = {
+      ...form.value,
+      data: form.value.data.filter((_, i) => i !== index),
+    };
+  }
+
+  function validate(): boolean {
+    const f = form.value;
+    const errs: Record<string, string> = {};
+
+    if (!f.name || !DNS_LABEL_REGEX.test(f.name)) {
+      errs.name = "Must be a valid DNS label";
+    }
+    if (!f.namespace || !DNS_LABEL_REGEX.test(f.namespace)) {
+      errs.namespace = "Must be a valid DNS label";
+    }
+    if (!f.storeRefName) {
+      errs["storeRef.name"] = "Select a store";
+    } else if (!DNS_LABEL_REGEX.test(f.storeRefName)) {
+      errs["storeRef.name"] = "Store name must be a valid DNS label";
+    }
+    if (!f.targetSecretName || !DNS_LABEL_REGEX.test(f.targetSecretName)) {
+      errs.targetSecretName = "Must be a valid DNS label";
+    }
+    if (
+      f.refreshInterval &&
+      !/^[0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h)?$/i.test(f.refreshInterval)
+    ) {
+      errs.refreshInterval = "Must be a Go duration (e.g. 1h, 30m)";
+    }
+    if (!f.data.length) {
+      errs.data = "At least one data item is required";
+    }
+    f.data.forEach((item, i) => {
+      if (!item.secretKey) {
+        errs[`data[${i}].secretKey`] = "Required";
+      }
+      if (!item.key.trim()) {
+        errs[`data[${i}].remoteRef.key`] = "Required";
+      }
+    });
+
+    errors.value = errs;
+    return Object.keys(errs).length === 0;
+  }
+
+  async function fetchPreview() {
+    previewLoading.value = true;
+    previewError.value = null;
+    const f = form.value;
+
+    const payload = {
+      name: f.name,
+      namespace: f.namespace,
+      storeRef: {
+        name: f.storeRefName,
+        kind: f.storeRefKind,
+      },
+      refreshInterval: f.refreshInterval || undefined,
+      targetSecretName: f.targetSecretName,
+      data: f.data.map((d) => ({
+        secretKey: d.secretKey,
+        remoteRef: {
+          key: d.key,
+          property: d.property || undefined,
+        },
+      })),
+    };
+
+    try {
+      const resp = await esoApi.previewExternalSecret(payload);
+      previewYaml.value = resp.data.yaml;
+    } catch (err) {
+      previewError.value = err instanceof Error
+        ? err.message
+        : "Failed to generate preview";
+    } finally {
+      previewLoading.value = false;
+    }
+  }
+
+  async function goNext() {
+    if (currentStep.value === 0) {
+      if (!validate()) return;
+      currentStep.value = 1;
+      await fetchPreview();
+    }
+  }
+
+  function goBack() {
+    if (currentStep.value > 0) currentStep.value = currentStep.value - 1;
+  }
+
+  if (!IS_BROWSER) return <div class="p-6">Loading wizard...</div>;
+
+  return (
+    <div class="p-6 max-w-4xl mx-auto">
+      <div class="flex items-center justify-between mb-6">
+        <h1 class="text-2xl font-bold text-text-primary">
+          Create ExternalSecret
+        </h1>
+        <a
+          href="/external-secrets/external-secrets"
+          class="text-sm text-text-muted hover:text-text-primary"
+        >
+          Cancel
+        </a>
+      </div>
+
+      <WizardStepper
+        steps={STEPS}
+        currentStep={currentStep.value}
+        onStepClick={(step) => {
+          if (step < currentStep.value) currentStep.value = step;
+        }}
+      />
+
+      <div class="mt-6">
+        {currentStep.value === 0 && (
+          <ExternalSecretForm
+            form={form.value}
+            errors={errors.value}
+            namespaces={namespaces.value}
+            stores={stores.value}
+            storesLoading={storesLoading.value}
+            onUpdate={updateField}
+            onUpdateData={updateData}
+            onAddDataItem={addDataItem}
+            onRemoveDataItem={removeDataItem}
+            onPathFieldTouched={markPathTouched}
+          />
+        )}
+
+        {currentStep.value === 1 && (
+          <WizardReviewStep
+            yaml={previewYaml.value}
+            onYamlChange={(v) => {
+              previewYaml.value = v;
+            }}
+            loading={previewLoading.value}
+            error={previewError.value}
+            detailBasePath="/external-secrets/external-secrets"
+          />
+        )}
+      </div>
+
+      {currentStep.value < 1 && (
+        <div class="flex justify-between mt-8">
+          <Button
+            variant="ghost"
+            onClick={goBack}
+            disabled={currentStep.value === 0}
+          >
+            Back
+          </Button>
+          <Button variant="primary" onClick={goNext}>
+            Preview YAML
+          </Button>
+        </div>
+      )}
+
+      {currentStep.value === 1 && !previewLoading.value &&
+        previewError.value === null && (
+        <div class="flex justify-start mt-4">
+          <Button variant="ghost" onClick={goBack}>Back</Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -127,10 +127,12 @@ async function refreshAccessToken(): Promise<boolean> {
  * - Injects Bearer token and X-Cluster-ID header
  * - Auto-refreshes on 401 (single concurrent refresh, replays queued requests)
  * - Parses error responses into ApiError
+ * - Accepts an optional `signal` for cooperative cancellation; pass
+ *   `AbortController.signal` from the caller to cancel in-flight requests.
  */
 export async function api<T>(
   path: string,
-  options: RequestInit = {},
+  options: RequestInit & { signal?: AbortSignal } = {},
 ): Promise<APIResponse<T>> {
   const doFetch = (): Promise<Response> => {
     const headers = new Headers(options.headers);
@@ -150,6 +152,7 @@ export async function api<T>(
       ...options,
       headers,
       credentials: "include",
+      signal: options.signal,
     });
   };
 
@@ -205,7 +208,8 @@ export async function api<T>(
 }
 
 /** Convenience methods. */
-export const apiGet = <T>(path: string) => api<T>(path, { method: "GET" });
+export const apiGet = <T>(path: string, signal?: AbortSignal) =>
+  api<T>(path, { method: "GET", signal });
 
 export const apiPost = <T>(path: string, body?: unknown) =>
   api<T>(path, {

--- a/frontend/lib/eso-api.ts
+++ b/frontend/lib/eso-api.ts
@@ -15,6 +15,7 @@ import type {
   ClusterExternalSecret,
   ESOStatus,
   ExternalSecret,
+  PathDiscoveryResponse,
   PushSecret,
   SecretStore,
   StoreMetrics,
@@ -185,21 +186,25 @@ export const esoApi = {
 
   /** Discover candidate remote-key paths for a SecretStore. Kubernetes
    *  provider returns Secret names from the source namespace; other providers
-   *  return `{supported: false}` so the UI degrades to a free-text input. */
-  listStorePaths: (namespace: string, name: string, prefix?: string) => {
+   *  return `{supported: false}` so the UI degrades to a free-text input.
+   *  Pass `signal` to cancel the in-flight request (e.g. on store change or
+   *  component unmount). */
+  listStorePaths: (
+    namespace: string,
+    name: string,
+    prefix?: string,
+    signal?: AbortSignal,
+  ) => {
     const qs = prefix ? `?prefix=${encodeURIComponent(prefix)}` : "";
-    return apiGet<{
-      supported: boolean;
-      provider?: string;
-      paths?: string[];
-    }>(
+    return apiGet<PathDiscoveryResponse>(
       `/v1/externalsecrets/stores/${pathParam(namespace)}/${
         pathParam(name)
       }/paths${qs}`,
+      signal,
     );
   },
 
   /** ExternalSecret wizard preview — returns rendered YAML. */
   previewExternalSecret: (input: unknown) =>
-    apiPost<{ yaml: string }>("/v1/wizards/externalsecret/preview", input),
+    apiPost<{ yaml: string }>("/v1/wizards/external-secret/preview", input),
 };

--- a/frontend/lib/eso-api.ts
+++ b/frontend/lib/eso-api.ts
@@ -180,4 +180,26 @@ export const esoApi = {
     apiGet<StoreMetrics>(
       `/v1/externalsecrets/clusterstores/${pathParam(name)}/metrics`,
     ),
+
+  // --- Phase G ExternalSecret wizard --------------------------------------
+
+  /** Discover candidate remote-key paths for a SecretStore. Kubernetes
+   *  provider returns Secret names from the source namespace; other providers
+   *  return `{supported: false}` so the UI degrades to a free-text input. */
+  listStorePaths: (namespace: string, name: string, prefix?: string) => {
+    const qs = prefix ? `?prefix=${encodeURIComponent(prefix)}` : "";
+    return apiGet<{
+      supported: boolean;
+      provider?: string;
+      paths?: string[];
+    }>(
+      `/v1/externalsecrets/stores/${pathParam(namespace)}/${
+        pathParam(name)
+      }/paths${qs}`,
+    );
+  },
+
+  /** ExternalSecret wizard preview — returns rendered YAML. */
+  previewExternalSecret: (input: unknown) =>
+    apiPost<{ yaml: string }>("/v1/wizards/externalsecret/preview", input),
 };

--- a/frontend/lib/eso-types.ts
+++ b/frontend/lib/eso-types.ts
@@ -201,6 +201,23 @@ export interface StoreMetrics {
   windowEnd?: string;
 }
 
+// --- Phase G path-discovery types ------------------------------------------
+
+/**
+ * Response shape for GET /externalsecrets/stores/{ns}/{name}/paths.
+ * - `supported=false` → frontend renders a free-text path field.
+ * - `paths` may be absent (RBAC denied) or empty (namespace has no Secrets).
+ *   Callers must treat absent and [] identically.
+ * - `truncated=true` → result capped at the server-side limit; user should
+ *   narrow the prefix to see more results.
+ */
+export interface PathDiscoveryResponse {
+  supported: boolean;
+  provider?: string;
+  paths?: string[];
+  truncated?: boolean;
+}
+
 /** GET /externalsecrets/bulk-refresh-jobs/{jobId} payload. */
 export interface BulkRefreshJob {
   jobId: string;

--- a/frontend/routes/external-secrets/external-secrets/new.tsx
+++ b/frontend/routes/external-secrets/external-secrets/new.tsx
@@ -1,0 +1,18 @@
+import { define } from "@/utils.ts";
+import SubNav from "@/islands/SubNav.tsx";
+import { DOMAIN_SECTIONS } from "@/lib/constants.ts";
+import ExternalSecretWizard from "@/islands/ExternalSecretWizard.tsx";
+
+const section = DOMAIN_SECTIONS.find((s) => s.id === "external-secrets")!;
+
+export default define.page(function ExternalSecretNewPage() {
+  return (
+    <>
+      <SubNav
+        tabs={section.tabs ?? []}
+        currentPath="/external-secrets/external-secrets"
+      />
+      <ExternalSecretWizard />
+    </>
+  );
+});


### PR DESCRIPTION
## Summary

Phase G / Unit 17 of the External Secrets Operator integration (R12 in `plans/external-secrets-operator-integration.md`). Provider-agnostic ExternalSecret creation backed by a typed wizard input and an opt-in path-discovery typeahead.

- Backend `ExternalSecretInput` with table-driven `Validate()` + `ToYAML()` via `map[string]any` (no ESO Go SDK import).
- Kubernetes-provider-only path discovery at `GET /externalsecrets/stores/{ns}/{name}/paths`. Other providers respond `{supported:false}` so the wizard degrades to free-text — k8sCenter never holds source-store credentials.
- Wizard preview at `POST /wizards/external-secret/preview`.
- Frontend wizard island + form component + new route, with debounced typeahead, real `AbortSignal`-driven cancellation, and a `fetchSeq` race guard.
- `+ New ExternalSecret` CTA on the list page + CommandPalette quick action.

## Scope boundaries (per plan)

- Path discovery is Kubernetes-provider only. Vault/AWS/GCP/Azure remain free-text in v1 — adding source-store auth would break the credential boundary.
- ClusterSecretStore path discovery deferred (the discovery endpoint is namespaced).
- `dataFrom` is modeled and validated server-side but the v1 UI surfaces only `data` items. Agents posting `dataFrom` to the preview endpoint get full coverage.

## Pre-push review (`/ce:review`)

11 reviewer personas (correctness, security, adversarial, testing, maintainability, project-standards, api-contract, kieran-typescript, julik-frontend-races, agent-native, learnings) surfaced 12 actionable + 6 advisory findings. Commit \`84d7e74\` resolved 16:

**Backend hardening:**
- Dropped a fictional \`remoteRef.namespace\` lookup in \`kubernetesProviderSourceNamespace\` (ESO v1 KubernetesProvider only exposes \`remoteNamespace\` at the provider-spec level).
- Added \`metav1.ListOptions{Limit:500}\` to the Secrets list call.
- Sort before truncating to \`pathDiscoveryLimit\`; added a \`Truncated\` flag to the response.
- Renamed wizard route to \`/wizards/external-secret/preview\` to match kebab-case siblings.

**Frontend race fixes:**
- Threaded \`AbortSignal\` through \`api()\` → \`apiGet()\` → \`listStorePaths()\` so the AbortController actually cancels in-flight fetches (was decorative; only \`fetchSeq\` was guarding state).
- Consolidated the store-change probe and debounced typeahead into a single \`fetchPaths()\` helper sharing one \`abortRef\` + \`fetchSeq\`.
- \`Promise.all\` → \`Promise.allSettled\` on stores mount so a failed clusterstores call doesn't discard the namespaced slice.
- Added unmount cleanup on stores fetch; \`previewSeq\` race guard on \`fetchPreview\`.
- Loosened the client-side refresh-interval regex to accept compound durations (\`1h30m\`).

**Test coverage:**
- Added \`TestHandleListPaths_PartialRBACDeny\` (user can read store but not list secrets — degrades to \`{supported:true, paths:[]}\` not 403).
- Added \`TestHandleListPaths_LimitCap\` (>200 secrets → cap fires, \`truncated=true\`).
- Added \`TestExternalSecretToYAML_DataFromFind\`, \`_OmitsEmptyProperty\`, \`_DataAndDataFromCoexist\`; replaced a count-only assertion with explicit field checks.

**Deferred (advisory, surfaced for separate cleanup):**
- TS \`unknown\`-typing on \`updateField\`/\`onUpdate\` — cross-wizard pattern; calls for a single typing pass across all wizards.
- Form imports types from its owning island — established convention across 4 prior wizards.
- \`targetSecretNameTouched\`/\`pathTouched\` on form state — cosmetic; payload builder already filters them.
- \`detectProvider\` map iteration ordering — pre-existing in \`normalize.go\` (Phase A).

## Verification

- \`go vet ./...\` clean.
- \`go test ./...\` — 30 packages pass.
- \`deno check\` clean on all touched frontend files.
- Local CRLF/LF noise from \`deno fmt --check\` is a pre-existing Windows working-copy artifact (479 files mismatched on \`main\` alone); CI green there confirms it's harmless.

## Test plan

- [ ] CI passes (\`go test\`, \`deno task check\`, Trivy, E2E with kind).
- [ ] Smoke: create an ExternalSecret via the wizard against a homelab Vault store (free-text path field).
- [ ] Smoke: create an ExternalSecret via the wizard against a homelab Kubernetes-provider store (typeahead populates from source namespace, narrows on prefix, degrades cleanly when source namespace is empty).
- [ ] Verify YAML preview round-trips through Monaco edit + \`/yaml/apply\`.
- [ ] Verify the \`+ New ExternalSecret\` CTA appears on both the populated list and the empty state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)