### PR TITLE
feat(eso): Phase H Unit 19 — Vault provider wizard (1/8)

### DIFF
--- a/backend/internal/wizard/secretstore_test.go
+++ b/backend/internal/wizard/secretstore_test.go
@@ -465,11 +465,24 @@ func TestHandleSecretStorePreview_NoValidatorRegistered(t *testing.T) {
 
 func TestHandleSecretStorePreview_ClusterScope(t *testing.T) {
 	h := testHandler()
+	// Use a complete valid Vault spec so the only error is the cluster-scope
+	// namespace rejection. A minimal spec would produce auth-required errors
+	// that could accidentally satisfy the "namespace" substring check.
 	input := map[string]any{
-		"name":        "shared-store",
-		"namespace":   "should-be-ignored", // cluster scope — must be rejected now
-		"provider":    "vault",
-		"providerSpec": map[string]any{"server": "https://vault.example.com"},
+		"name":      "shared-store",
+		"namespace": "should-be-ignored", // cluster scope — must be rejected
+		"provider":  "vault",
+		"providerSpec": map[string]any{
+			"server": "https://vault.example.com",
+			"auth": map[string]any{
+				"token": map[string]any{
+					"tokenSecretRef": map[string]any{
+						"name": "vault-token",
+						"key":  "token",
+					},
+				},
+			},
+		},
 	}
 	body, _ := json.Marshal(input)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/wizards/cluster-secret-store/preview", bytes.NewReader(body))
@@ -487,9 +500,11 @@ func TestHandleSecretStorePreview_ClusterScope(t *testing.T) {
 		t.Fatalf("expected 422 (namespace must be empty for cluster scope), got %d: %s", rr.Code, rr.Body.String())
 	}
 
+	// Assert specifically on the cluster-scope rejection message, not just any
+	// "namespace" string that might appear in an auth error.
 	respBody := rr.Body.String()
-	if !strings.Contains(respBody, "namespace") {
-		t.Errorf("expected error to reference namespace field; got %s", respBody)
+	if !strings.Contains(respBody, "must be empty for cluster scope") {
+		t.Errorf("expected error to contain 'must be empty for cluster scope'; got %s", respBody)
 	}
 }
 

--- a/backend/internal/wizard/secretstore_test.go
+++ b/backend/internal/wizard/secretstore_test.go
@@ -382,15 +382,28 @@ func TestRegisterSecretStoreProvider_OverridesPriorRegistration(t *testing.T) {
 
 // --- HTTP handler tests (#7) ---
 
+// TestHandleSecretStorePreview_NamespacedScope verifies the route factory
+// bakes Scope=Namespaced and the request body cannot override it. Uses Vault
+// (registered in U19) so the preview produces YAML rather than the
+// fall-through error from U18; the absence of an "auth required" error
+// proves the validator dispatched correctly.
 func TestHandleSecretStorePreview_NamespacedScope(t *testing.T) {
 	h := testHandler()
 	input := map[string]any{
-		"name":        "my-store",
-		"namespace":   "apps",
-		"provider":    "vault",
-		"providerSpec": map[string]any{"server": "https://vault.example.com"},
-		// Attempt to override scope via body — must be ignored (scope is
-		// baked in by the route factory, not decoded from the request).
+		"name":      "my-store",
+		"namespace": "apps",
+		"provider":  "vault",
+		"providerSpec": map[string]any{
+			"server": "https://vault.example.com",
+			"auth": map[string]any{
+				"token": map[string]any{
+					"tokenSecretRef": map[string]any{
+						"name": "vault-token",
+						"key":  "token",
+					},
+				},
+			},
+		},
 	}
 	body, _ := json.Marshal(input)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/wizards/secret-store/preview", bytes.NewReader(body))
@@ -403,14 +416,50 @@ func TestHandleSecretStorePreview_NamespacedScope(t *testing.T) {
 		return &SecretStoreInput{Scope: StoreScopeNamespaced}
 	})(rr, req)
 
-	// U18: no provider validator registered → 422 with "not yet implemented".
-	if rr.Code != http.StatusUnprocessableEntity {
-		t.Fatalf("expected 422 (no validator registered), got %d: %s", rr.Code, rr.Body.String())
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 (valid Vault input), got %d: %s", rr.Code, rr.Body.String())
 	}
 
 	respBody := rr.Body.String()
-	if !strings.Contains(respBody, "not yet implemented") {
-		t.Errorf("expected error message to contain 'not yet implemented'; got %s", respBody)
+	if !strings.Contains(respBody, "kind: SecretStore") {
+		t.Errorf("expected YAML to contain SecretStore kind (scope baked from factory); got %s", respBody)
+	}
+	if strings.Contains(respBody, "ClusterSecretStore") {
+		t.Errorf("scope must be Namespaced (factory wins over body), got ClusterSecretStore in response")
+	}
+}
+
+// TestHandleSecretStorePreview_NoValidatorRegistered verifies the dispatcher
+// fall-through path for a recognized provider with no registered validator —
+// the contract that U18 introduced so the wizard surface is honest about
+// what U19 has yet to ship. Uses a synthetic test-only provider key.
+func TestHandleSecretStorePreview_NoValidatorRegistered(t *testing.T) {
+	const syntheticKey SecretStoreProvider = "test-only-fall-through"
+	validSecretStoreProviders[syntheticKey] = true
+	t.Cleanup(func() { delete(validSecretStoreProviders, syntheticKey) })
+
+	h := testHandler()
+	input := map[string]any{
+		"name":         "my-store",
+		"namespace":    "apps",
+		"provider":     string(syntheticKey),
+		"providerSpec": map[string]any{"any": "value"},
+	}
+	body, _ := json.Marshal(input)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/wizards/secret-store/preview", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = addAuthContext(req)
+
+	rr := httptest.NewRecorder()
+	h.HandlePreview(func() WizardInput {
+		return &SecretStoreInput{Scope: StoreScopeNamespaced}
+	})(rr, req)
+
+	if rr.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422 (no validator registered), got %d: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "not yet implemented") {
+		t.Errorf("expected fall-through message to contain 'not yet implemented'; got %s", rr.Body.String())
 	}
 }
 

--- a/backend/internal/wizard/secretstore_vault.go
+++ b/backend/internal/wizard/secretstore_vault.go
@@ -13,17 +13,15 @@ func init() {
 	RegisterSecretStoreProvider(SecretStoreProviderVault, validateVaultSpec)
 }
 
-// validVaultAuthMethods enumerates the auth methods the wizard surface
-// supports in v1. ESO additionally supports userPass, ldap, iam, and gcp on
-// Vault — those are accessible via the YAML editor but not driven by guided
-// fields here (per the plan's L7.2 culling pass).
-var validVaultAuthMethods = map[string]bool{
-	"token":      true,
-	"kubernetes": true,
-	"appRole":    true,
-	"jwt":        true,
-	"cert":       true,
-}
+// orderedVaultAuthMethods is the canonical ordered list of auth methods the
+// wizard surface supports in v1. ESO additionally supports userPass, ldap,
+// iam, and gcp on Vault — those are accessible via the YAML editor but not
+// driven by guided fields here (per the plan's L7.2 culling pass).
+//
+// Ordering matters: pickVaultAuthMethod iterates this slice to build the
+// "present" list so the multi-method error message is deterministic rather
+// than random-map-order.
+var orderedVaultAuthMethods = []string{"token", "kubernetes", "appRole", "jwt", "cert"}
 
 // validVaultKVVersions lists the spec.provider.vault.version values ESO accepts.
 // "v2" is the upstream default; the wizard emits whatever the user picks
@@ -48,12 +46,9 @@ func validateVaultSpec(spec map[string]any) []FieldError {
 	server, _ := spec["server"].(string)
 	if strings.TrimSpace(server) == "" {
 		errs = append(errs, FieldError{Field: "server", Message: "is required"})
-	} else if err := validateHTTPSPublicURL(server); err != nil {
-		// Vault may legitimately run on a non-public address (homelab,
-		// in-cluster), so reject only obviously-malformed URLs and the
-		// non-https scheme. We accept private addresses for Vault since
-		// the credential-handling boundary lives on the cluster, not the
-		// wizard preview.
+	} else {
+		// validateVaultServerURL accepts private and in-cluster addresses —
+		// only non-HTTPS schemes are rejected (homelab Vault is common).
 		errs = append(errs, validateVaultServerURL(server)...)
 	}
 
@@ -121,9 +116,12 @@ func validateVaultServerURL(raw string) []FieldError {
 // pickVaultAuthMethod returns the single auth method present in the auth
 // block. Multiple methods or no method both produce errors so the wizard
 // rejects ambiguity rather than letting the controller pick silently.
+//
+// Iterates orderedVaultAuthMethods (not a map) so the multi-method error
+// message lists methods in a deterministic, readable order.
 func pickVaultAuthMethod(auth map[string]any) (string, []FieldError) {
 	var present []string
-	for method := range validVaultAuthMethods {
+	for _, method := range orderedVaultAuthMethods {
 		if _, ok := auth[method]; ok {
 			present = append(present, method)
 		}
@@ -167,9 +165,8 @@ func validateVaultAuthToken(auth map[string]any) []FieldError {
 	ref, _ := auth["token"].(map[string]any)
 	tokenRef, _ := ref["tokenSecretRef"].(map[string]any)
 	if tokenRef == nil {
-		// Allow flat shape {token: {name, key}} for wizard-friendly input;
-		// ToYAML hooks (Phase H Unit 19 follow-up) will normalize. For now
-		// require the canonical tokenSecretRef nesting.
+		// ESO requires the canonical nesting: auth.token.tokenSecretRef.{name,key}.
+		// Flat shapes ({token: {name, key}}) are not accepted.
 		return []FieldError{{Field: "auth.token.tokenSecretRef", Message: "is required"}}
 	}
 	return validateVaultSecretRef(tokenRef, "auth.token.tokenSecretRef")
@@ -192,6 +189,11 @@ func validateVaultAuthKubernetes(auth map[string]any) []FieldError {
 	return errs
 }
 
+// validateVaultAuthAppRole validates the AppRole auth block.
+//
+// v1 API/UI gap: auth.appRole.roleRef.* is accepted and validated by this
+// function, but the wizard form only surfaces the roleId field. Direct API
+// callers (YAML editor, curl) may use roleRef; the guided form does not.
 func validateVaultAuthAppRole(auth map[string]any) []FieldError {
 	var errs []FieldError
 	ar, _ := auth["appRole"].(map[string]any)
@@ -222,6 +224,12 @@ func validateVaultAuthAppRole(auth map[string]any) []FieldError {
 	return errs
 }
 
+// validateVaultAuthJWT validates the JWT/OIDC auth block.
+//
+// v1 API/UI gap: auth.jwt.kubernetesServiceAccountToken.* is accepted and
+// validated via the hasKsat path, but the wizard form only surfaces the
+// secretRef path. Direct API callers (YAML editor, curl) may use the SA token
+// approach; the guided form does not surface it.
 func validateVaultAuthJWT(auth map[string]any) []FieldError {
 	var errs []FieldError
 	j, _ := auth["jwt"].(map[string]any)

--- a/backend/internal/wizard/secretstore_vault.go
+++ b/backend/internal/wizard/secretstore_vault.go
@@ -1,0 +1,264 @@
+package wizard
+
+import (
+	"fmt"
+	"strings"
+)
+
+// init registers the Vault provider validator with the SecretStore wizard
+// dispatcher. Lives in this file so the validator ships and registers as one
+// unit — adding a provider is a single-file edit + one line in
+// READY_SECRET_STORE_PROVIDERS on the frontend.
+func init() {
+	RegisterSecretStoreProvider(SecretStoreProviderVault, validateVaultSpec)
+}
+
+// validVaultAuthMethods enumerates the auth methods the wizard surface
+// supports in v1. ESO additionally supports userPass, ldap, iam, and gcp on
+// Vault — those are accessible via the YAML editor but not driven by guided
+// fields here (per the plan's L7.2 culling pass).
+var validVaultAuthMethods = map[string]bool{
+	"token":      true,
+	"kubernetes": true,
+	"appRole":    true,
+	"jwt":        true,
+	"cert":       true,
+}
+
+// validVaultKVVersions lists the spec.provider.vault.version values ESO accepts.
+// "v2" is the upstream default; the wizard emits whatever the user picks
+// rather than relying on the controller default so the YAML preview is
+// self-explanatory.
+var validVaultKVVersions = map[string]bool{
+	"v1": true,
+	"v2": true,
+}
+
+// validateVaultSpec validates a SecretStoreInput.ProviderSpec for the Vault
+// provider. The spec mirrors ESO's spec.provider.vault shape — server, path,
+// version, namespace, caBundle/caProvider, plus an auth block with exactly
+// one method populated.
+//
+// Each FieldError's Field is rooted at the provider-spec level (no
+// "providerSpec." prefix) so the dispatcher's caller can prefix uniformly
+// when surfacing errors to the frontend.
+func validateVaultSpec(spec map[string]any) []FieldError {
+	var errs []FieldError
+
+	server, _ := spec["server"].(string)
+	if strings.TrimSpace(server) == "" {
+		errs = append(errs, FieldError{Field: "server", Message: "is required"})
+	} else if err := validateHTTPSPublicURL(server); err != nil {
+		// Vault may legitimately run on a non-public address (homelab,
+		// in-cluster), so reject only obviously-malformed URLs and the
+		// non-https scheme. We accept private addresses for Vault since
+		// the credential-handling boundary lives on the cluster, not the
+		// wizard preview.
+		errs = append(errs, validateVaultServerURL(server)...)
+	}
+
+	if v, ok := spec["version"]; ok {
+		s, _ := v.(string)
+		if !validVaultKVVersions[s] {
+			errs = append(errs, FieldError{Field: "version", Message: "must be v1 or v2"})
+		}
+	}
+
+	if p, ok := spec["path"]; ok {
+		s, _ := p.(string)
+		if s == "" {
+			errs = append(errs, FieldError{Field: "path", Message: "must not be empty when set"})
+		} else if strings.HasPrefix(s, "/") {
+			errs = append(errs, FieldError{Field: "path", Message: "must not start with a slash"})
+		}
+	}
+
+	if ns, ok := spec["namespace"]; ok {
+		s, _ := ns.(string)
+		if s == "" {
+			errs = append(errs, FieldError{Field: "namespace", Message: "must not be empty when set"})
+		}
+	}
+
+	authRaw, hasAuth := spec["auth"].(map[string]any)
+	if !hasAuth {
+		errs = append(errs, FieldError{Field: "auth", Message: "is required (one of token, kubernetes, appRole, jwt, cert)"})
+		return errs
+	}
+
+	method, methodErrs := pickVaultAuthMethod(authRaw)
+	errs = append(errs, methodErrs...)
+	if method == "" {
+		return errs
+	}
+
+	switch method {
+	case "token":
+		errs = append(errs, validateVaultAuthToken(authRaw)...)
+	case "kubernetes":
+		errs = append(errs, validateVaultAuthKubernetes(authRaw)...)
+	case "appRole":
+		errs = append(errs, validateVaultAuthAppRole(authRaw)...)
+	case "jwt":
+		errs = append(errs, validateVaultAuthJWT(authRaw)...)
+	case "cert":
+		errs = append(errs, validateVaultAuthCert(authRaw)...)
+	}
+
+	return errs
+}
+
+// validateVaultServerURL accepts both public and private addresses for
+// Vault (homelab + in-cluster reach are common) but rejects non-HTTPS
+// schemes. Mirrors validateHTTPSPublicURL but without the public-IP gate.
+func validateVaultServerURL(raw string) []FieldError {
+	if !strings.HasPrefix(strings.ToLower(raw), "https://") {
+		return []FieldError{{Field: "server", Message: "must use https scheme"}}
+	}
+	return nil
+}
+
+// pickVaultAuthMethod returns the single auth method present in the auth
+// block. Multiple methods or no method both produce errors so the wizard
+// rejects ambiguity rather than letting the controller pick silently.
+func pickVaultAuthMethod(auth map[string]any) (string, []FieldError) {
+	var present []string
+	for method := range validVaultAuthMethods {
+		if _, ok := auth[method]; ok {
+			present = append(present, method)
+		}
+	}
+	switch len(present) {
+	case 0:
+		return "", []FieldError{{Field: "auth", Message: "exactly one of token, kubernetes, appRole, jwt, cert must be set"}}
+	case 1:
+		return present[0], nil
+	default:
+		return "", []FieldError{{Field: "auth", Message: fmt.Sprintf("only one auth method may be set; got %d (%s)", len(present), strings.Join(present, ", "))}}
+	}
+}
+
+// validateVaultSecretRef validates an ESO secretRef sub-block at the given
+// field prefix. ESO's SecretKeySelector requires `name` and `key`; namespace
+// is optional and only meaningful for ClusterSecretStore.
+func validateVaultSecretRef(spec map[string]any, prefix string) []FieldError {
+	var errs []FieldError
+	if spec == nil {
+		errs = append(errs, FieldError{Field: prefix, Message: "is required"})
+		return errs
+	}
+	if name, _ := spec["name"].(string); name == "" {
+		errs = append(errs, FieldError{Field: prefix + ".name", Message: "is required"})
+	} else if !dnsLabelRegex.MatchString(name) {
+		errs = append(errs, FieldError{Field: prefix + ".name", Message: "must be a valid DNS label"})
+	}
+	if key, _ := spec["key"].(string); key == "" {
+		errs = append(errs, FieldError{Field: prefix + ".key", Message: "is required"})
+	}
+	if ns, ok := spec["namespace"]; ok {
+		if s, _ := ns.(string); s != "" && !dnsLabelRegex.MatchString(s) {
+			errs = append(errs, FieldError{Field: prefix + ".namespace", Message: "must be a valid DNS label"})
+		}
+	}
+	return errs
+}
+
+func validateVaultAuthToken(auth map[string]any) []FieldError {
+	ref, _ := auth["token"].(map[string]any)
+	tokenRef, _ := ref["tokenSecretRef"].(map[string]any)
+	if tokenRef == nil {
+		// Allow flat shape {token: {name, key}} for wizard-friendly input;
+		// ToYAML hooks (Phase H Unit 19 follow-up) will normalize. For now
+		// require the canonical tokenSecretRef nesting.
+		return []FieldError{{Field: "auth.token.tokenSecretRef", Message: "is required"}}
+	}
+	return validateVaultSecretRef(tokenRef, "auth.token.tokenSecretRef")
+}
+
+func validateVaultAuthKubernetes(auth map[string]any) []FieldError {
+	var errs []FieldError
+	k8s, _ := auth["kubernetes"].(map[string]any)
+	if k8s == nil {
+		return []FieldError{{Field: "auth.kubernetes", Message: "is required"}}
+	}
+	if mp, _ := k8s["mountPath"].(string); strings.TrimSpace(mp) == "" {
+		errs = append(errs, FieldError{Field: "auth.kubernetes.mountPath", Message: "is required (e.g. \"kubernetes\")"})
+	}
+	if role, _ := k8s["role"].(string); strings.TrimSpace(role) == "" {
+		errs = append(errs, FieldError{Field: "auth.kubernetes.role", Message: "is required"})
+	}
+	// Either serviceAccountRef OR secretRef is conventional but not strictly
+	// required by ESO (the controller can use its own SA). We don't enforce.
+	return errs
+}
+
+func validateVaultAuthAppRole(auth map[string]any) []FieldError {
+	var errs []FieldError
+	ar, _ := auth["appRole"].(map[string]any)
+	if ar == nil {
+		return []FieldError{{Field: "auth.appRole", Message: "is required"}}
+	}
+	if path, _ := ar["path"].(string); strings.TrimSpace(path) == "" {
+		errs = append(errs, FieldError{Field: "auth.appRole.path", Message: "is required (e.g. \"approle\")"})
+	}
+	// roleId or roleRef must be present.
+	_, hasRoleID := ar["roleId"].(string)
+	_, hasRoleRef := ar["roleRef"].(map[string]any)
+	if !hasRoleID && !hasRoleRef {
+		errs = append(errs, FieldError{Field: "auth.appRole.roleId", Message: "must specify roleId or roleRef"})
+	}
+	if hasRoleID && hasRoleRef {
+		errs = append(errs, FieldError{Field: "auth.appRole.roleId", Message: "must not specify both roleId and roleRef"})
+	}
+	if hasRoleRef {
+		errs = append(errs, validateVaultSecretRef(ar["roleRef"].(map[string]any), "auth.appRole.roleRef")...)
+	}
+	secretRef, _ := ar["secretRef"].(map[string]any)
+	if secretRef == nil {
+		errs = append(errs, FieldError{Field: "auth.appRole.secretRef", Message: "is required"})
+	} else {
+		errs = append(errs, validateVaultSecretRef(secretRef, "auth.appRole.secretRef")...)
+	}
+	return errs
+}
+
+func validateVaultAuthJWT(auth map[string]any) []FieldError {
+	var errs []FieldError
+	j, _ := auth["jwt"].(map[string]any)
+	if j == nil {
+		return []FieldError{{Field: "auth.jwt", Message: "is required"}}
+	}
+	if path, _ := j["path"].(string); strings.TrimSpace(path) == "" {
+		errs = append(errs, FieldError{Field: "auth.jwt.path", Message: "is required (e.g. \"jwt\")"})
+	}
+	// ESO accepts: secretRef OR kubernetesServiceAccountToken. Wizard
+	// requires one source so the YAML preview produces a working ES.
+	_, hasSecretRef := j["secretRef"].(map[string]any)
+	_, hasKsat := j["kubernetesServiceAccountToken"].(map[string]any)
+	if !hasSecretRef && !hasKsat {
+		errs = append(errs, FieldError{Field: "auth.jwt.secretRef", Message: "must specify secretRef or kubernetesServiceAccountToken"})
+	}
+	if hasSecretRef {
+		errs = append(errs, validateVaultSecretRef(j["secretRef"].(map[string]any), "auth.jwt.secretRef")...)
+	}
+	return errs
+}
+
+func validateVaultAuthCert(auth map[string]any) []FieldError {
+	var errs []FieldError
+	c, _ := auth["cert"].(map[string]any)
+	if c == nil {
+		return []FieldError{{Field: "auth.cert", Message: "is required"}}
+	}
+	if cl, _ := c["clientCert"].(map[string]any); cl == nil {
+		errs = append(errs, FieldError{Field: "auth.cert.clientCert", Message: "is required"})
+	} else {
+		errs = append(errs, validateVaultSecretRef(cl, "auth.cert.clientCert")...)
+	}
+	if sr, _ := c["secretRef"].(map[string]any); sr == nil {
+		errs = append(errs, FieldError{Field: "auth.cert.secretRef", Message: "is required"})
+	} else {
+		errs = append(errs, validateVaultSecretRef(sr, "auth.cert.secretRef")...)
+	}
+	return errs
+}

--- a/backend/internal/wizard/secretstore_vault_test.go
+++ b/backend/internal/wizard/secretstore_vault_test.go
@@ -1,0 +1,449 @@
+package wizard
+
+import (
+	"strings"
+	"testing"
+)
+
+// validVaultSpec returns a minimal valid Vault provider spec with token auth
+// — the simplest auth method to construct in tests. Other auth-method tests
+// override the auth block as needed.
+func validVaultSpec() map[string]any {
+	return map[string]any{
+		"server":  "https://vault.example.com",
+		"path":    "secret",
+		"version": "v2",
+		"auth": map[string]any{
+			"token": map[string]any{
+				"tokenSecretRef": map[string]any{
+					"name": "vault-token",
+					"key":  "token",
+				},
+			},
+		},
+	}
+}
+
+func TestValidateVaultSpec_Valid(t *testing.T) {
+	if errs := validateVaultSpec(validVaultSpec()); len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+}
+
+func TestValidateVaultSpec_MissingServer(t *testing.T) {
+	spec := validVaultSpec()
+	delete(spec, "server")
+	if !hasField(validateVaultSpec(spec), "server") {
+		t.Error("expected server required error")
+	}
+}
+
+func TestValidateVaultSpec_BlankServer(t *testing.T) {
+	spec := validVaultSpec()
+	spec["server"] = "   "
+	if !hasField(validateVaultSpec(spec), "server") {
+		t.Error("expected server error for whitespace-only value")
+	}
+}
+
+func TestValidateVaultSpec_NonHTTPSServer(t *testing.T) {
+	spec := validVaultSpec()
+	spec["server"] = "http://vault.example.com"
+	errs := validateVaultSpec(spec)
+	if !hasField(errs, "server") {
+		t.Errorf("expected server error for http scheme; got %v", errs)
+	}
+}
+
+func TestValidateVaultSpec_AcceptsPrivateAddress(t *testing.T) {
+	// Vault may run on a private address (homelab, in-cluster). Unlike ACME
+	// servers, we accept it.
+	spec := validVaultSpec()
+	spec["server"] = "https://vault.vault.svc.cluster.local:8200"
+	if errs := validateVaultSpec(spec); len(errs) != 0 {
+		t.Errorf("expected private https address to validate, got %v", errs)
+	}
+}
+
+func TestValidateVaultSpec_BadVersion(t *testing.T) {
+	spec := validVaultSpec()
+	spec["version"] = "v3"
+	if !hasField(validateVaultSpec(spec), "version") {
+		t.Error("expected version error for v3")
+	}
+}
+
+func TestValidateVaultSpec_PathLeadingSlash(t *testing.T) {
+	spec := validVaultSpec()
+	spec["path"] = "/secret"
+	if !hasField(validateVaultSpec(spec), "path") {
+		t.Error("expected path error for leading slash")
+	}
+}
+
+func TestValidateVaultSpec_EmptyPathRejected(t *testing.T) {
+	spec := validVaultSpec()
+	spec["path"] = ""
+	if !hasField(validateVaultSpec(spec), "path") {
+		t.Error("expected path error for empty when set")
+	}
+}
+
+func TestValidateVaultSpec_EmptyNamespaceRejected(t *testing.T) {
+	spec := validVaultSpec()
+	spec["namespace"] = ""
+	if !hasField(validateVaultSpec(spec), "namespace") {
+		t.Error("expected namespace error for empty when set")
+	}
+}
+
+func TestValidateVaultSpec_NoAuth(t *testing.T) {
+	spec := validVaultSpec()
+	delete(spec, "auth")
+	if !hasField(validateVaultSpec(spec), "auth") {
+		t.Error("expected auth required error")
+	}
+}
+
+func TestValidateVaultSpec_AuthNoMethod(t *testing.T) {
+	spec := validVaultSpec()
+	spec["auth"] = map[string]any{}
+	if !hasField(validateVaultSpec(spec), "auth") {
+		t.Error("expected auth error for empty block")
+	}
+}
+
+func TestValidateVaultSpec_AuthMultipleMethods(t *testing.T) {
+	spec := validVaultSpec()
+	spec["auth"] = map[string]any{
+		"token":   map[string]any{"tokenSecretRef": map[string]any{"name": "t", "key": "token"}},
+		"appRole": map[string]any{},
+	}
+	errs := validateVaultSpec(spec)
+	if !hasField(errs, "auth") {
+		t.Errorf("expected auth error for multiple methods; got %v", errs)
+	}
+	// Verify the message names both methods so users can disambiguate.
+	found := false
+	for _, e := range errs {
+		if e.Field == "auth" && strings.Contains(e.Message, "only one") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected only-one error message, got %v", errs)
+	}
+}
+
+// --- Token auth ---
+
+func TestValidateVaultSpec_TokenAuth_MissingRef(t *testing.T) {
+	spec := validVaultSpec()
+	spec["auth"] = map[string]any{"token": map[string]any{}}
+	if !hasField(validateVaultSpec(spec), "auth.token.tokenSecretRef") {
+		t.Error("expected tokenSecretRef required")
+	}
+}
+
+func TestValidateVaultSpec_TokenAuth_MissingRefKey(t *testing.T) {
+	spec := validVaultSpec()
+	spec["auth"] = map[string]any{
+		"token": map[string]any{
+			"tokenSecretRef": map[string]any{"name": "vault-token"}, // missing key
+		},
+	}
+	if !hasField(validateVaultSpec(spec), "auth.token.tokenSecretRef.key") {
+		t.Error("expected tokenSecretRef.key required")
+	}
+}
+
+func TestValidateVaultSpec_TokenAuth_BadRefName(t *testing.T) {
+	spec := validVaultSpec()
+	spec["auth"] = map[string]any{
+		"token": map[string]any{
+			"tokenSecretRef": map[string]any{"name": "BadName", "key": "token"},
+		},
+	}
+	if !hasField(validateVaultSpec(spec), "auth.token.tokenSecretRef.name") {
+		t.Error("expected tokenSecretRef.name DNS error")
+	}
+}
+
+// --- Kubernetes auth ---
+
+func TestValidateVaultSpec_KubernetesAuth_Valid(t *testing.T) {
+	spec := validVaultSpec()
+	spec["auth"] = map[string]any{
+		"kubernetes": map[string]any{
+			"mountPath": "kubernetes",
+			"role":      "my-role",
+		},
+	}
+	if errs := validateVaultSpec(spec); len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+}
+
+func TestValidateVaultSpec_KubernetesAuth_MissingMountPath(t *testing.T) {
+	spec := validVaultSpec()
+	spec["auth"] = map[string]any{
+		"kubernetes": map[string]any{"role": "my-role"},
+	}
+	if !hasField(validateVaultSpec(spec), "auth.kubernetes.mountPath") {
+		t.Error("expected mountPath required")
+	}
+}
+
+func TestValidateVaultSpec_KubernetesAuth_MissingRole(t *testing.T) {
+	spec := validVaultSpec()
+	spec["auth"] = map[string]any{
+		"kubernetes": map[string]any{"mountPath": "kubernetes"},
+	}
+	if !hasField(validateVaultSpec(spec), "auth.kubernetes.role") {
+		t.Error("expected role required")
+	}
+}
+
+// --- AppRole auth ---
+
+func TestValidateVaultSpec_AppRoleAuth_Valid(t *testing.T) {
+	spec := validVaultSpec()
+	spec["auth"] = map[string]any{
+		"appRole": map[string]any{
+			"path":   "approle",
+			"roleId": "abc-123",
+			"secretRef": map[string]any{
+				"name": "approle-secret",
+				"key":  "secret-id",
+			},
+		},
+	}
+	if errs := validateVaultSpec(spec); len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+}
+
+func TestValidateVaultSpec_AppRoleAuth_RoleRefValid(t *testing.T) {
+	spec := validVaultSpec()
+	spec["auth"] = map[string]any{
+		"appRole": map[string]any{
+			"path": "approle",
+			"roleRef": map[string]any{
+				"name": "approle-role",
+				"key":  "role-id",
+			},
+			"secretRef": map[string]any{
+				"name": "approle-secret",
+				"key":  "secret-id",
+			},
+		},
+	}
+	if errs := validateVaultSpec(spec); len(errs) != 0 {
+		t.Errorf("expected no errors with roleRef; got %v", errs)
+	}
+}
+
+func TestValidateVaultSpec_AppRoleAuth_NeitherRoleIDNorRoleRef(t *testing.T) {
+	spec := validVaultSpec()
+	spec["auth"] = map[string]any{
+		"appRole": map[string]any{
+			"path":      "approle",
+			"secretRef": map[string]any{"name": "s", "key": "k"},
+		},
+	}
+	if !hasField(validateVaultSpec(spec), "auth.appRole.roleId") {
+		t.Error("expected roleId/roleRef required error")
+	}
+}
+
+func TestValidateVaultSpec_AppRoleAuth_BothRoleIDAndRoleRef(t *testing.T) {
+	spec := validVaultSpec()
+	spec["auth"] = map[string]any{
+		"appRole": map[string]any{
+			"path":      "approle",
+			"roleId":    "abc",
+			"roleRef":   map[string]any{"name": "r", "key": "k"},
+			"secretRef": map[string]any{"name": "s", "key": "k"},
+		},
+	}
+	if !hasField(validateVaultSpec(spec), "auth.appRole.roleId") {
+		t.Error("expected mutual-exclusion error for both roleId and roleRef")
+	}
+}
+
+func TestValidateVaultSpec_AppRoleAuth_MissingSecretRef(t *testing.T) {
+	spec := validVaultSpec()
+	spec["auth"] = map[string]any{
+		"appRole": map[string]any{
+			"path":   "approle",
+			"roleId": "abc",
+		},
+	}
+	if !hasField(validateVaultSpec(spec), "auth.appRole.secretRef") {
+		t.Error("expected secretRef required")
+	}
+}
+
+// --- JWT auth ---
+
+func TestValidateVaultSpec_JWTAuth_Valid(t *testing.T) {
+	spec := validVaultSpec()
+	spec["auth"] = map[string]any{
+		"jwt": map[string]any{
+			"path": "jwt",
+			"role": "my-role",
+			"secretRef": map[string]any{
+				"name": "jwt-token",
+				"key":  "jwt",
+			},
+		},
+	}
+	if errs := validateVaultSpec(spec); len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+}
+
+func TestValidateVaultSpec_JWTAuth_KubernetesSAToken(t *testing.T) {
+	spec := validVaultSpec()
+	spec["auth"] = map[string]any{
+		"jwt": map[string]any{
+			"path": "jwt",
+			"kubernetesServiceAccountToken": map[string]any{
+				"serviceAccountRef": map[string]any{"name": "sa"},
+			},
+		},
+	}
+	if errs := validateVaultSpec(spec); len(errs) != 0 {
+		t.Errorf("expected k8s-SA-token path to validate; got %v", errs)
+	}
+}
+
+func TestValidateVaultSpec_JWTAuth_MissingPath(t *testing.T) {
+	spec := validVaultSpec()
+	spec["auth"] = map[string]any{
+		"jwt": map[string]any{
+			"secretRef": map[string]any{"name": "s", "key": "k"},
+		},
+	}
+	if !hasField(validateVaultSpec(spec), "auth.jwt.path") {
+		t.Error("expected path required")
+	}
+}
+
+func TestValidateVaultSpec_JWTAuth_NoSource(t *testing.T) {
+	spec := validVaultSpec()
+	spec["auth"] = map[string]any{
+		"jwt": map[string]any{"path": "jwt"},
+	}
+	if !hasField(validateVaultSpec(spec), "auth.jwt.secretRef") {
+		t.Error("expected secretRef-or-kubernetesServiceAccountToken error")
+	}
+}
+
+// --- Cert auth ---
+
+func TestValidateVaultSpec_CertAuth_Valid(t *testing.T) {
+	spec := validVaultSpec()
+	spec["auth"] = map[string]any{
+		"cert": map[string]any{
+			"clientCert": map[string]any{"name": "cert", "key": "tls.crt"},
+			"secretRef":  map[string]any{"name": "cert-key", "key": "tls.key"},
+		},
+	}
+	if errs := validateVaultSpec(spec); len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+}
+
+func TestValidateVaultSpec_CertAuth_MissingClientCert(t *testing.T) {
+	spec := validVaultSpec()
+	spec["auth"] = map[string]any{
+		"cert": map[string]any{
+			"secretRef": map[string]any{"name": "s", "key": "k"},
+		},
+	}
+	if !hasField(validateVaultSpec(spec), "auth.cert.clientCert") {
+		t.Error("expected clientCert required")
+	}
+}
+
+func TestValidateVaultSpec_CertAuth_MissingSecretRef(t *testing.T) {
+	spec := validVaultSpec()
+	spec["auth"] = map[string]any{
+		"cert": map[string]any{
+			"clientCert": map[string]any{"name": "c", "key": "k"},
+		},
+	}
+	if !hasField(validateVaultSpec(spec), "auth.cert.secretRef") {
+		t.Error("expected secretRef required")
+	}
+}
+
+// --- Dispatcher integration ---
+
+// TestSecretStoreInput_VaultIntegration confirms validateVaultSpec is wired
+// to the dispatcher via the init() RegisterSecretStoreProvider call. A
+// SecretStoreInput with provider=vault should route through validateVaultSpec
+// and surface its errors at the providerSpec level.
+func TestSecretStoreInput_VaultIntegration(t *testing.T) {
+	s := SecretStoreInput{
+		Scope:        StoreScopeNamespaced,
+		Name:         "vault-store",
+		Namespace:    "apps",
+		Provider:     SecretStoreProviderVault,
+		ProviderSpec: validVaultSpec(),
+	}
+	if errs := s.Validate(); len(errs) != 0 {
+		t.Errorf("expected no errors via dispatcher, got %v", errs)
+	}
+}
+
+func TestSecretStoreInput_VaultIntegration_PropagatesProviderError(t *testing.T) {
+	spec := validVaultSpec()
+	delete(spec, "server")
+	s := SecretStoreInput{
+		Scope:        StoreScopeNamespaced,
+		Name:         "vault-store",
+		Namespace:    "apps",
+		Provider:     SecretStoreProviderVault,
+		ProviderSpec: spec,
+	}
+	errs := s.Validate()
+	if !hasField(errs, "server") {
+		t.Errorf("expected provider-level server error, got %v", errs)
+	}
+}
+
+// TestSecretStoreInput_VaultIntegration_ToYAML asserts the wizard preview's
+// emitted YAML places the spec under spec.provider.vault and does not leak
+// the wizard's transport keys (e.g. "auth" stays nested under vault, not at
+// the top of spec).
+func TestSecretStoreInput_VaultIntegration_ToYAML(t *testing.T) {
+	s := SecretStoreInput{
+		Scope:        StoreScopeNamespaced,
+		Name:         "vault-store",
+		Namespace:    "apps",
+		Provider:     SecretStoreProviderVault,
+		ProviderSpec: validVaultSpec(),
+	}
+	y, err := s.ToYAML()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, want := range []string{
+		"apiVersion: external-secrets.io/v1",
+		"kind: SecretStore",
+		"vault:",
+		"server: https://vault.example.com",
+		"tokenSecretRef:",
+	} {
+		if !strings.Contains(y, want) {
+			t.Errorf("expected YAML to contain %q\n%s", want, y)
+		}
+	}
+	if strings.Contains(y, "auth:\n  token:") && !strings.Contains(y, "    vault:") {
+		// Only a coarse smoke check — TestSecretStoreToYAML_Namespaced
+		// does the structural parsing.
+		_ = y
+	}
+}

--- a/backend/internal/wizard/secretstore_vault_test.go
+++ b/backend/internal/wizard/secretstore_vault_test.go
@@ -3,6 +3,8 @@ package wizard
 import (
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 // validVaultSpec returns a minimal valid Vault provider spec with token auth
@@ -430,20 +432,38 @@ func TestSecretStoreInput_VaultIntegration_ToYAML(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	// Cheap substring check for top-level shape markers.
 	for _, want := range []string{
 		"apiVersion: external-secrets.io/v1",
 		"kind: SecretStore",
-		"vault:",
-		"server: https://vault.example.com",
-		"tokenSecretRef:",
 	} {
 		if !strings.Contains(y, want) {
 			t.Errorf("expected YAML to contain %q\n%s", want, y)
 		}
 	}
-	if strings.Contains(y, "auth:\n  token:") && !strings.Contains(y, "    vault:") {
-		// Only a coarse smoke check — TestSecretStoreToYAML_Namespaced
-		// does the structural parsing.
-		_ = y
+
+	// Structural assertion: walk spec.provider.vault.auth.token.tokenSecretRef
+	// and verify the required name+key keys are present.
+	var doc map[string]any
+	if err := yaml.Unmarshal([]byte(y), &doc); err != nil {
+		t.Fatalf("failed to parse YAML: %v\n%s", err, y)
+	}
+	spec, _ := doc["spec"].(map[string]any)
+	provider, _ := spec["provider"].(map[string]any)
+	vaultSpec, _ := provider["vault"].(map[string]any)
+	if vaultSpec == nil {
+		t.Fatalf("expected spec.provider.vault, got provider keys: %v", keys(provider))
+	}
+	auth, _ := vaultSpec["auth"].(map[string]any)
+	token, _ := auth["token"].(map[string]any)
+	tokenSecretRef, _ := token["tokenSecretRef"].(map[string]any)
+	if tokenSecretRef == nil {
+		t.Fatalf("expected spec.provider.vault.auth.token.tokenSecretRef to be non-nil; auth=%v", auth)
+	}
+	if tokenSecretRef["name"] == nil {
+		t.Errorf("expected tokenSecretRef.name to be present; got %v", tokenSecretRef)
+	}
+	if tokenSecretRef["key"] == nil {
+		t.Errorf("expected tokenSecretRef.key to be present; got %v", tokenSecretRef)
 	}
 }

--- a/frontend/components/wizard/secretstore/VaultForm.tsx
+++ b/frontend/components/wizard/secretstore/VaultForm.tsx
@@ -1,0 +1,582 @@
+import { useSignal } from "@preact/signals";
+import { Input } from "@/components/ui/Input.tsx";
+
+/**
+ * Vault provider form for SecretStoreWizard. Writes into the wizard's
+ * `providerSpec: Record<string, unknown>` slot under the shape
+ * `{ server, path?, version?, namespace?, auth: { <method>: {...} } }`.
+ *
+ * v1 supports five auth methods (token / kubernetes / appRole / jwt / cert);
+ * additional methods (userPass, ldap, iam, gcp) are accessible via the YAML
+ * editor but not driven by guided fields here. Switching auth method clears
+ * the previously-entered method so stale fields don't leak into the preview.
+ */
+
+export type VaultAuthMethod =
+  | "token"
+  | "kubernetes"
+  | "appRole"
+  | "jwt"
+  | "cert";
+
+export interface VaultFormProps {
+  spec: Record<string, unknown>;
+  errors: Record<string, string>;
+  onUpdateSpec: (spec: Record<string, unknown>) => void;
+}
+
+interface SecretRef {
+  name?: string;
+  key?: string;
+}
+
+const AUTH_METHODS: {
+  id: VaultAuthMethod;
+  label: string;
+  description: string;
+}[] = [
+  {
+    id: "token",
+    label: "Token",
+    description: "A Vault token loaded from a Kubernetes Secret.",
+  },
+  {
+    id: "kubernetes",
+    label: "Kubernetes",
+    description:
+      "Vault's Kubernetes auth method using the pod's service account JWT.",
+  },
+  {
+    id: "appRole",
+    label: "AppRole",
+    description:
+      "RoleID + SecretID pair, with the SecretID stored in a Secret.",
+  },
+  {
+    id: "jwt",
+    label: "JWT / OIDC",
+    description:
+      "JWT or OIDC token, either from a Secret or a service account.",
+  },
+  {
+    id: "cert",
+    label: "TLS Cert",
+    description: "Mutual-TLS authentication using a client certificate.",
+  },
+];
+
+/** Determine which auth method the spec currently encodes, or "" when none. */
+function detectMethod(spec: Record<string, unknown>): VaultAuthMethod | "" {
+  const auth = spec.auth as Record<string, unknown> | undefined;
+  if (!auth) return "";
+  for (const m of ["token", "kubernetes", "appRole", "jwt", "cert"] as const) {
+    if (m in auth) return m;
+  }
+  return "";
+}
+
+/** Read a top-level string field from the spec. */
+function getStr(spec: Record<string, unknown>, key: string): string {
+  const v = spec[key];
+  return typeof v === "string" ? v : "";
+}
+
+function getAuthBlock(
+  spec: Record<string, unknown>,
+  method: VaultAuthMethod,
+): Record<string, unknown> {
+  const auth = (spec.auth as Record<string, unknown>) ?? {};
+  return (auth[method] as Record<string, unknown>) ?? {};
+}
+
+export function VaultForm({ spec, errors, onUpdateSpec }: VaultFormProps) {
+  // Track which auth method's fields are currently shown. Persisted in the
+  // spec itself (via detectMethod) so the form survives Back/Next navigation.
+  const method = useSignal<VaultAuthMethod | "">(detectMethod(spec));
+
+  function patchTop(field: string, value: string) {
+    const next = { ...spec };
+    if (value === "") delete next[field];
+    else next[field] = value;
+    onUpdateSpec(next);
+  }
+
+  function setMethod(m: VaultAuthMethod) {
+    if (method.value === m) return;
+    method.value = m;
+    // Clear the auth slate; preserve top-level (server/path/version/namespace).
+    onUpdateSpec({
+      ...spec,
+      auth: { [m]: emptyMethodSpec(m) },
+    });
+  }
+
+  function patchAuth(method: VaultAuthMethod, patch: Record<string, unknown>) {
+    const auth = (spec.auth as Record<string, unknown>) ?? {};
+    const block = (auth[method] as Record<string, unknown>) ?? {};
+    onUpdateSpec({
+      ...spec,
+      auth: { ...auth, [method]: { ...block, ...patch } },
+    });
+  }
+
+  function patchSecretRef(
+    method: VaultAuthMethod,
+    refField: string,
+    patch: SecretRef,
+  ) {
+    const block = getAuthBlock(spec, method);
+    const existing = (block[refField] as SecretRef) ?? {};
+    patchAuth(method, { [refField]: { ...existing, ...patch } });
+  }
+
+  return (
+    <div class="space-y-5">
+      <div class="rounded-md border border-border-primary bg-surface/50 p-4 text-sm text-text-muted">
+        Configure the Vault server connection and authentication method.
+        Credentials must already exist as Kubernetes Secrets in this namespace;
+        this wizard only references them — it never holds Vault credentials
+        directly.
+      </div>
+
+      {/* Top-level Vault fields */}
+      <div class="grid grid-cols-2 gap-4">
+        <Input
+          id="vault-server"
+          label="Server URL"
+          required
+          value={getStr(spec, "server")}
+          onInput={(e) =>
+            patchTop("server", (e.target as HTMLInputElement).value)}
+          placeholder="https://vault.example.com:8200"
+          description="Must use https. Private and in-cluster addresses are accepted."
+          error={errors["server"]}
+        />
+        <Input
+          id="vault-path"
+          label="Mount path (optional)"
+          value={getStr(spec, "path")}
+          onInput={(e) =>
+            patchTop("path", (e.target as HTMLInputElement).value)}
+          placeholder="secret"
+          description="KV mount name. Leave blank for ESO default."
+          error={errors["path"]}
+        />
+      </div>
+
+      <div class="grid grid-cols-2 gap-4">
+        <div class="space-y-1">
+          <label
+            for="vault-version"
+            class="block text-sm font-medium text-text-secondary"
+          >
+            KV version
+          </label>
+          <select
+            id="vault-version"
+            class="block w-full rounded-md border border-border-primary bg-surface px-3 py-2 text-sm text-text-primary"
+            value={getStr(spec, "version") || "v2"}
+            onChange={(e) =>
+              patchTop("version", (e.target as HTMLSelectElement).value)}
+          >
+            <option value="v2">v2 (recommended)</option>
+            <option value="v1">v1</option>
+          </select>
+          {errors["version"] && (
+            <p class="text-sm text-danger">{errors["version"]}</p>
+          )}
+        </div>
+        <Input
+          id="vault-namespace"
+          label="Vault namespace (Enterprise)"
+          value={getStr(spec, "namespace")}
+          onInput={(e) =>
+            patchTop("namespace", (e.target as HTMLInputElement).value)}
+          placeholder="admin/dev"
+          description="Vault Enterprise namespaces only. Leave blank for OSS."
+          error={errors["namespace"]}
+        />
+      </div>
+
+      {/* Auth method picker */}
+      <div class="space-y-3">
+        <h3 class="text-sm font-semibold text-text-primary">
+          Authentication method
+          <span aria-hidden="true" class="text-danger ml-0.5">*</span>
+        </h3>
+        <div class="grid gap-2 sm:grid-cols-2 lg:grid-cols-5">
+          {AUTH_METHODS.map((m) => {
+            const active = method.value === m.id;
+            return (
+              <button
+                key={m.id}
+                type="button"
+                onClick={() => setMethod(m.id)}
+                class={`text-left rounded-lg border p-3 transition-colors ${
+                  active
+                    ? "border-brand bg-brand/5"
+                    : "border-border-primary bg-surface hover:border-border-emphasis"
+                }`}
+                aria-pressed={active}
+              >
+                <div class="font-medium text-text-primary">{m.label}</div>
+                <p class="mt-1 text-xs text-text-muted">{m.description}</p>
+              </button>
+            );
+          })}
+        </div>
+        {errors["auth"] && <p class="text-sm text-danger">{errors["auth"]}</p>}
+      </div>
+
+      {/* Auth-method-specific fields */}
+      {method.value === "token" && (
+        <TokenAuthFields
+          block={getAuthBlock(spec, "token")}
+          errors={errors}
+          onPatchRef={(patch) =>
+            patchSecretRef("token", "tokenSecretRef", patch)}
+        />
+      )}
+      {method.value === "kubernetes" && (
+        <KubernetesAuthFields
+          block={getAuthBlock(spec, "kubernetes")}
+          errors={errors}
+          onPatch={(patch) => patchAuth("kubernetes", patch)}
+        />
+      )}
+      {method.value === "appRole" && (
+        <AppRoleAuthFields
+          block={getAuthBlock(spec, "appRole")}
+          errors={errors}
+          onPatch={(patch) => patchAuth("appRole", patch)}
+          onPatchSecretRef={(patch) =>
+            patchSecretRef("appRole", "secretRef", patch)}
+        />
+      )}
+      {method.value === "jwt" && (
+        <JWTAuthFields
+          block={getAuthBlock(spec, "jwt")}
+          errors={errors}
+          onPatch={(patch) => patchAuth("jwt", patch)}
+          onPatchSecretRef={(patch) =>
+            patchSecretRef("jwt", "secretRef", patch)}
+        />
+      )}
+      {method.value === "cert" && (
+        <CertAuthFields
+          block={getAuthBlock(spec, "cert")}
+          errors={errors}
+          onPatchClientCert={(patch) =>
+            patchSecretRef("cert", "clientCert", patch)}
+          onPatchSecretRef={(patch) =>
+            patchSecretRef("cert", "secretRef", patch)}
+        />
+      )}
+    </div>
+  );
+}
+
+/** Initial empty block for a freshly-selected auth method. The wizard's
+ *  validator rejects empty blocks so the user must populate before preview. */
+function emptyMethodSpec(m: VaultAuthMethod): Record<string, unknown> {
+  switch (m) {
+    case "token":
+      return { tokenSecretRef: {} };
+    case "kubernetes":
+      return {};
+    case "appRole":
+      return { secretRef: {} };
+    case "jwt":
+      return { secretRef: {} };
+    case "cert":
+      return { clientCert: {}, secretRef: {} };
+  }
+}
+
+// --- Per-method field components ---------------------------------------
+
+interface TokenAuthFieldsProps {
+  block: Record<string, unknown>;
+  errors: Record<string, string>;
+  onPatchRef: (patch: SecretRef) => void;
+}
+
+function TokenAuthFields({ block, errors, onPatchRef }: TokenAuthFieldsProps) {
+  const ref = (block.tokenSecretRef as SecretRef) ?? {};
+  return (
+    <div class="rounded-md border border-border-primary p-4 space-y-3">
+      <h4 class="text-sm font-medium text-text-primary">
+        Token Secret reference
+      </h4>
+      <div class="grid grid-cols-2 gap-3">
+        <Input
+          id="vault-token-ref-name"
+          label="Secret name"
+          required
+          value={ref.name ?? ""}
+          onInput={(e) =>
+            onPatchRef({ name: (e.target as HTMLInputElement).value })}
+          placeholder="vault-token"
+          error={errors["auth.token.tokenSecretRef.name"]}
+        />
+        <Input
+          id="vault-token-ref-key"
+          label="Key"
+          required
+          value={ref.key ?? ""}
+          onInput={(e) =>
+            onPatchRef({ key: (e.target as HTMLInputElement).value })}
+          placeholder="token"
+          error={errors["auth.token.tokenSecretRef.key"]}
+        />
+      </div>
+    </div>
+  );
+}
+
+interface KubernetesAuthFieldsProps {
+  block: Record<string, unknown>;
+  errors: Record<string, string>;
+  onPatch: (patch: Record<string, unknown>) => void;
+}
+
+function KubernetesAuthFields(
+  { block, errors, onPatch }: KubernetesAuthFieldsProps,
+) {
+  const mountPath = (block.mountPath as string) ?? "";
+  const role = (block.role as string) ?? "";
+  return (
+    <div class="rounded-md border border-border-primary p-4 space-y-3">
+      <h4 class="text-sm font-medium text-text-primary">Kubernetes auth</h4>
+      <div class="grid grid-cols-2 gap-3">
+        <Input
+          id="vault-k8s-mount"
+          label="Mount path"
+          required
+          value={mountPath}
+          onInput={(e) =>
+            onPatch({ mountPath: (e.target as HTMLInputElement).value })}
+          placeholder="kubernetes"
+          description="The Vault auth path where Kubernetes auth is enabled."
+          error={errors["auth.kubernetes.mountPath"]}
+        />
+        <Input
+          id="vault-k8s-role"
+          label="Role"
+          required
+          value={role}
+          onInput={(e) =>
+            onPatch({ role: (e.target as HTMLInputElement).value })}
+          placeholder="my-app"
+          description="Vault role bound to this service account."
+          error={errors["auth.kubernetes.role"]}
+        />
+      </div>
+    </div>
+  );
+}
+
+interface AppRoleAuthFieldsProps {
+  block: Record<string, unknown>;
+  errors: Record<string, string>;
+  onPatch: (patch: Record<string, unknown>) => void;
+  onPatchSecretRef: (patch: SecretRef) => void;
+}
+
+function AppRoleAuthFields(
+  { block, errors, onPatch, onPatchSecretRef }: AppRoleAuthFieldsProps,
+) {
+  const path = (block.path as string) ?? "";
+  const roleId = (block.roleId as string) ?? "";
+  const secretRef = (block.secretRef as SecretRef) ?? {};
+  return (
+    <div class="rounded-md border border-border-primary p-4 space-y-3">
+      <h4 class="text-sm font-medium text-text-primary">AppRole auth</h4>
+      <div class="grid grid-cols-2 gap-3">
+        <Input
+          id="vault-approle-path"
+          label="Auth path"
+          required
+          value={path}
+          onInput={(e) =>
+            onPatch({ path: (e.target as HTMLInputElement).value })}
+          placeholder="approle"
+          error={errors["auth.appRole.path"]}
+        />
+        <Input
+          id="vault-approle-roleid"
+          label="Role ID"
+          required
+          value={roleId}
+          onInput={(e) =>
+            onPatch({ roleId: (e.target as HTMLInputElement).value })}
+          placeholder="abc-123-…"
+          description="The literal RoleID from `vault read auth/approle/role/<name>/role-id`."
+          error={errors["auth.appRole.roleId"]}
+        />
+      </div>
+      <h4 class="text-sm font-medium text-text-primary">
+        SecretID Secret reference
+      </h4>
+      <div class="grid grid-cols-2 gap-3">
+        <Input
+          id="vault-approle-ref-name"
+          label="Secret name"
+          required
+          value={secretRef.name ?? ""}
+          onInput={(e) =>
+            onPatchSecretRef({ name: (e.target as HTMLInputElement).value })}
+          placeholder="approle-secret"
+          error={errors["auth.appRole.secretRef.name"]}
+        />
+        <Input
+          id="vault-approle-ref-key"
+          label="Key"
+          required
+          value={secretRef.key ?? ""}
+          onInput={(e) =>
+            onPatchSecretRef({ key: (e.target as HTMLInputElement).value })}
+          placeholder="secret-id"
+          error={errors["auth.appRole.secretRef.key"]}
+        />
+      </div>
+    </div>
+  );
+}
+
+interface JWTAuthFieldsProps {
+  block: Record<string, unknown>;
+  errors: Record<string, string>;
+  onPatch: (patch: Record<string, unknown>) => void;
+  onPatchSecretRef: (patch: SecretRef) => void;
+}
+
+function JWTAuthFields(
+  { block, errors, onPatch, onPatchSecretRef }: JWTAuthFieldsProps,
+) {
+  const path = (block.path as string) ?? "";
+  const role = (block.role as string) ?? "";
+  const secretRef = (block.secretRef as SecretRef) ?? {};
+  return (
+    <div class="rounded-md border border-border-primary p-4 space-y-3">
+      <h4 class="text-sm font-medium text-text-primary">JWT / OIDC auth</h4>
+      <div class="grid grid-cols-2 gap-3">
+        <Input
+          id="vault-jwt-path"
+          label="Auth path"
+          required
+          value={path}
+          onInput={(e) =>
+            onPatch({ path: (e.target as HTMLInputElement).value })}
+          placeholder="jwt"
+          error={errors["auth.jwt.path"]}
+        />
+        <Input
+          id="vault-jwt-role"
+          label="Role (optional)"
+          value={role}
+          onInput={(e) =>
+            onPatch({ role: (e.target as HTMLInputElement).value })}
+          placeholder="my-role"
+        />
+      </div>
+      <h4 class="text-sm font-medium text-text-primary">
+        JWT Secret reference
+      </h4>
+      <div class="grid grid-cols-2 gap-3">
+        <Input
+          id="vault-jwt-ref-name"
+          label="Secret name"
+          required
+          value={secretRef.name ?? ""}
+          onInput={(e) =>
+            onPatchSecretRef({ name: (e.target as HTMLInputElement).value })}
+          placeholder="jwt-token"
+          error={errors["auth.jwt.secretRef.name"]}
+        />
+        <Input
+          id="vault-jwt-ref-key"
+          label="Key"
+          required
+          value={secretRef.key ?? ""}
+          onInput={(e) =>
+            onPatchSecretRef({ key: (e.target as HTMLInputElement).value })}
+          placeholder="jwt"
+          error={errors["auth.jwt.secretRef.key"]}
+        />
+      </div>
+    </div>
+  );
+}
+
+interface CertAuthFieldsProps {
+  block: Record<string, unknown>;
+  errors: Record<string, string>;
+  onPatchClientCert: (patch: SecretRef) => void;
+  onPatchSecretRef: (patch: SecretRef) => void;
+}
+
+function CertAuthFields(
+  { block, errors, onPatchClientCert, onPatchSecretRef }: CertAuthFieldsProps,
+) {
+  const clientCert = (block.clientCert as SecretRef) ?? {};
+  const secretRef = (block.secretRef as SecretRef) ?? {};
+  return (
+    <div class="rounded-md border border-border-primary p-4 space-y-4">
+      <div>
+        <h4 class="text-sm font-medium text-text-primary mb-2">
+          Client certificate
+        </h4>
+        <div class="grid grid-cols-2 gap-3">
+          <Input
+            id="vault-cert-cert-name"
+            label="Secret name"
+            required
+            value={clientCert.name ?? ""}
+            onInput={(e) =>
+              onPatchClientCert({
+                name: (e.target as HTMLInputElement).value,
+              })}
+            placeholder="vault-client-cert"
+            error={errors["auth.cert.clientCert.name"]}
+          />
+          <Input
+            id="vault-cert-cert-key"
+            label="Key"
+            required
+            value={clientCert.key ?? ""}
+            onInput={(e) =>
+              onPatchClientCert({ key: (e.target as HTMLInputElement).value })}
+            placeholder="tls.crt"
+            error={errors["auth.cert.clientCert.key"]}
+          />
+        </div>
+      </div>
+      <div>
+        <h4 class="text-sm font-medium text-text-primary mb-2">Client key</h4>
+        <div class="grid grid-cols-2 gap-3">
+          <Input
+            id="vault-cert-key-name"
+            label="Secret name"
+            required
+            value={secretRef.name ?? ""}
+            onInput={(e) =>
+              onPatchSecretRef({ name: (e.target as HTMLInputElement).value })}
+            placeholder="vault-client-key"
+            error={errors["auth.cert.secretRef.name"]}
+          />
+          <Input
+            id="vault-cert-key-key"
+            label="Key"
+            required
+            value={secretRef.key ?? ""}
+            onInput={(e) =>
+              onPatchSecretRef({ key: (e.target as HTMLInputElement).value })}
+            placeholder="tls.key"
+            error={errors["auth.cert.secretRef.key"]}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/wizard/secretstore/VaultForm.tsx
+++ b/frontend/components/wizard/secretstore/VaultForm.tsx
@@ -30,6 +30,29 @@ interface SecretRef {
   key?: string;
 }
 
+/** Typed sub-shapes for each Vault auth method block. */
+interface VaultAuthSpec {
+  token?: { tokenSecretRef?: SecretRef };
+  kubernetes?: { mountPath?: string; role?: string };
+  appRole?: {
+    path?: string;
+    roleId?: string;
+    roleRef?: SecretRef;
+    secretRef?: SecretRef;
+  };
+  jwt?: { path?: string; role?: string; secretRef?: SecretRef };
+  cert?: { clientCert?: SecretRef; secretRef?: SecretRef };
+}
+
+/** Typed shape for a Vault provider spec block (spec.provider.vault). */
+interface VaultSpec {
+  server?: string;
+  path?: string;
+  version?: string;
+  namespace?: string;
+  auth?: VaultAuthSpec;
+}
+
 const AUTH_METHODS: {
   id: VaultAuthMethod;
   label: string;
@@ -69,7 +92,8 @@ const AUTH_METHODS: {
 function detectMethod(spec: Record<string, unknown>): VaultAuthMethod | "" {
   const auth = spec.auth as Record<string, unknown> | undefined;
   if (!auth) return "";
-  for (const m of ["token", "kubernetes", "appRole", "jwt", "cert"] as const) {
+  // Iterate AUTH_METHODS (single source of truth) instead of a separate array.
+  for (const m of AUTH_METHODS.map((x) => x.id)) {
     if (m in auth) return m;
   }
   return "";
@@ -90,6 +114,10 @@ function getAuthBlock(
 }
 
 export function VaultForm({ spec, errors, onUpdateSpec }: VaultFormProps) {
+  // VaultSpec / VaultAuthSpec interfaces above document the shape; field
+  // reads go through getStr() and getAuthBlock() helpers which narrow at
+  // each access site rather than via a single top-level cast.
+
   // Track which auth method's fields are currently shown. Persisted in the
   // spec itself (via detectMethod) so the form survives Back/Next navigation.
   const method = useSignal<VaultAuthMethod | "">(detectMethod(spec));
@@ -111,23 +139,26 @@ export function VaultForm({ spec, errors, onUpdateSpec }: VaultFormProps) {
     });
   }
 
-  function patchAuth(method: VaultAuthMethod, patch: Record<string, unknown>) {
+  function patchAuth(
+    authMethod: VaultAuthMethod,
+    patch: Record<string, unknown>,
+  ) {
     const auth = (spec.auth as Record<string, unknown>) ?? {};
-    const block = (auth[method] as Record<string, unknown>) ?? {};
+    const block = (auth[authMethod] as Record<string, unknown>) ?? {};
     onUpdateSpec({
       ...spec,
-      auth: { ...auth, [method]: { ...block, ...patch } },
+      auth: { ...auth, [authMethod]: { ...block, ...patch } },
     });
   }
 
   function patchSecretRef(
-    method: VaultAuthMethod,
+    authMethod: VaultAuthMethod,
     refField: string,
     patch: SecretRef,
   ) {
-    const block = getAuthBlock(spec, method);
+    const block = getAuthBlock(spec, authMethod);
     const existing = (block[refField] as SecretRef) ?? {};
-    patchAuth(method, { [refField]: { ...existing, ...patch } });
+    patchAuth(authMethod, { [refField]: { ...existing, ...patch } });
   }
 
   return (

--- a/frontend/islands/SecretStoreWizard.tsx
+++ b/frontend/islands/SecretStoreWizard.tsx
@@ -1,6 +1,7 @@
 import { useSignal } from "@preact/signals";
 import { IS_BROWSER } from "fresh/runtime";
-import { apiPost } from "@/lib/api.ts";
+import type { ComponentType } from "preact";
+import { ApiError, apiPost } from "@/lib/api.ts";
 import { useDirtyGuard } from "@/lib/hooks/use-dirty-guard.ts";
 import { useNamespaces } from "@/lib/hooks/use-namespaces.ts";
 import { initialNamespace } from "@/lib/namespace.ts";
@@ -9,6 +10,7 @@ import { WizardStepper } from "@/components/wizard/WizardStepper.tsx";
 import { WizardReviewStep } from "@/components/wizard/WizardReviewStep.tsx";
 import { SecretStoreProviderPickerStep } from "@/components/wizard/secretstore/SecretStoreProviderPickerStep.tsx";
 import { VaultForm } from "@/components/wizard/secretstore/VaultForm.tsx";
+import type { VaultFormProps } from "@/components/wizard/secretstore/VaultForm.tsx";
 import { Input } from "@/components/ui/Input.tsx";
 import { NamespaceSelect } from "@/components/ui/NamespaceSelect.tsx";
 import { Button } from "@/components/ui/Button.tsx";
@@ -17,6 +19,18 @@ import {
   READY_SECRET_STORE_PROVIDERS,
   type SecretStoreProvider,
 } from "@/lib/eso-types.ts";
+
+/** Common props contract for all per-provider Configure forms.
+ *  VaultFormProps satisfies this; future provider forms must match. */
+export type ProviderFormProps = VaultFormProps;
+
+/** Registry mapping provider keys to their Configure-step form component.
+ *  Single edit point as U19 sub-PRs ship additional providers. */
+const PROVIDER_FORMS: Partial<
+  Record<SecretStoreProvider, ComponentType<ProviderFormProps>>
+> = {
+  vault: VaultForm,
+};
 
 // Re-export for any downstream consumers that imported from this island.
 export type { SecretStoreProvider };
@@ -135,6 +149,21 @@ export default function SecretStoreWizard({ scope }: SecretStoreWizardProps) {
       errs.provider = "Select a provider";
     }
 
+    // Light client-side gate for the Configure step — only catches obviously
+    // empty inputs. The server-side validator (surfaced via #1's 422 handler)
+    // catches everything else and routes field errors back here on preview.
+    if (step === 2 && f.provider === "vault") {
+      const ps = f.providerSpec;
+      const server = typeof ps.server === "string" ? ps.server.trim() : "";
+      if (!server) {
+        errs.server = "Server URL is required";
+      }
+      const auth = ps.auth as Record<string, unknown> | undefined;
+      if (!auth || Object.keys(auth).length === 0) {
+        errs.auth = "Select an authentication method";
+      }
+    }
+
     errors.value = errs;
     return Object.keys(errs).length === 0;
   }
@@ -163,6 +192,37 @@ export default function SecretStoreWizard({ scope }: SecretStoreWizardProps) {
       previewYaml.value = resp.data.yaml;
     } catch (err) {
       if (seq !== previewSeq.current) return;
+      // On 422 the backend encodes FieldError[] as JSON in error.detail.
+      // Parse it and route field errors back to the Configure step so users
+      // can fix them in context rather than seeing a raw error string.
+      if (err instanceof ApiError && err.status === 422) {
+        const detail = err.body?.error?.detail;
+        if (typeof detail === "string") {
+          try {
+            const fieldErrors = JSON.parse(detail) as Array<
+              { field: string; message: string }
+            >;
+            if (Array.isArray(fieldErrors) && fieldErrors.length > 0) {
+              const errsMap: Record<string, string> = {};
+              for (const fe of fieldErrors) {
+                errsMap[fe.field] = fe.message;
+              }
+              errors.value = errsMap;
+              // Navigate back to Configure step so field errors are visible.
+              const steps = stepsFor(form.value.provider);
+              const configureIdx = steps.findIndex((s) =>
+                s.title === "Configure"
+              );
+              if (configureIdx >= 0) {
+                currentStep.value = configureIdx;
+              }
+              return;
+            }
+          } catch {
+            // detail was not JSON — fall through to generic error display
+          }
+        }
+      }
       previewError.value = err instanceof Error
         ? err.message
         : "Failed to generate preview";
@@ -190,6 +250,10 @@ export default function SecretStoreWizard({ scope }: SecretStoreWizardProps) {
 
   if (!IS_BROWSER) return <div class="p-6">Loading wizard...</div>;
 
+  // Resolve step list once per render; all step-count references use this
+  // local rather than re-calling stepsFor(form.value.provider) six times.
+  const steps = stepsFor(form.value.provider);
+
   const heading = scope === "cluster"
     ? "Create ClusterSecretStore"
     : "Create SecretStore";
@@ -197,6 +261,13 @@ export default function SecretStoreWizard({ scope }: SecretStoreWizardProps) {
   const detailBasePath = scope === "cluster"
     ? "/external-secrets/cluster-stores"
     : "/external-secrets/stores";
+
+  // Resolve the Configure-step form component from the registry (or undefined
+  // when the selected provider has no guided form yet). This is the single
+  // edit point for adding new provider forms — no scattered if/else branches.
+  const ProviderForm = form.value.provider
+    ? PROVIDER_FORMS[form.value.provider]
+    : undefined;
 
   return (
     <div class="p-6 max-w-4xl mx-auto">
@@ -211,7 +282,7 @@ export default function SecretStoreWizard({ scope }: SecretStoreWizardProps) {
       </div>
 
       <WizardStepper
-        steps={stepsFor(form.value.provider)}
+        steps={steps}
         currentStep={currentStep.value}
         onStepClick={(step) => {
           if (step < currentStep.value) currentStep.value = step;
@@ -271,16 +342,15 @@ export default function SecretStoreWizard({ scope }: SecretStoreWizardProps) {
           </div>
         )}
 
-        {currentStep.value === 2 &&
-          form.value.provider === "vault" && (
-          <VaultForm
+        {currentStep.value === 2 && ProviderForm && (
+          <ProviderForm
             spec={form.value.providerSpec}
             errors={errors.value}
             onUpdateSpec={(spec) => update("providerSpec", spec)}
           />
         )}
 
-        {currentStep.value === stepsFor(form.value.provider).length - 1 && (
+        {currentStep.value === steps.length - 1 && (
           <WizardReviewStep
             yaml={previewYaml.value}
             onYamlChange={(v) => {
@@ -293,7 +363,7 @@ export default function SecretStoreWizard({ scope }: SecretStoreWizardProps) {
         )}
       </div>
 
-      {currentStep.value < stepsFor(form.value.provider).length - 1 && (
+      {currentStep.value < steps.length - 1 && (
         <div class="flex justify-between mt-8">
           <Button
             variant="ghost"
@@ -303,14 +373,12 @@ export default function SecretStoreWizard({ scope }: SecretStoreWizardProps) {
             Back
           </Button>
           <Button variant="primary" onClick={goNext}>
-            {currentStep.value === stepsFor(form.value.provider).length - 2
-              ? "Preview YAML"
-              : "Next"}
+            {currentStep.value === steps.length - 2 ? "Preview YAML" : "Next"}
           </Button>
         </div>
       )}
 
-      {currentStep.value === stepsFor(form.value.provider).length - 1 &&
+      {currentStep.value === steps.length - 1 &&
         !previewLoading.value &&
         previewError.value === null && (
         <div class="flex justify-start mt-4">

--- a/frontend/islands/SecretStoreWizard.tsx
+++ b/frontend/islands/SecretStoreWizard.tsx
@@ -8,11 +8,15 @@ import { DNS_LABEL_REGEX } from "@/lib/wizard-constants.ts";
 import { WizardStepper } from "@/components/wizard/WizardStepper.tsx";
 import { WizardReviewStep } from "@/components/wizard/WizardReviewStep.tsx";
 import { SecretStoreProviderPickerStep } from "@/components/wizard/secretstore/SecretStoreProviderPickerStep.tsx";
+import { VaultForm } from "@/components/wizard/secretstore/VaultForm.tsx";
 import { Input } from "@/components/ui/Input.tsx";
 import { NamespaceSelect } from "@/components/ui/NamespaceSelect.tsx";
 import { Button } from "@/components/ui/Button.tsx";
 import { useRef } from "preact/hooks";
-import type { SecretStoreProvider } from "@/lib/eso-types.ts";
+import {
+  READY_SECRET_STORE_PROVIDERS,
+  type SecretStoreProvider,
+} from "@/lib/eso-types.ts";
 
 // Re-export for any downstream consumers that imported from this island.
 export type { SecretStoreProvider };
@@ -32,14 +36,34 @@ export interface SecretStoreWizardProps {
   scope: "namespaced" | "cluster";
 }
 
-// U18: 3-step wizard — Identity / Provider / Review.
-// The Configure step (per-provider forms) re-appears as step 2 in the U19
-// PR that ships the first real provider validator.
-const STEPS = [
+// Steps shown when no per-provider form ships yet (or the user picks a
+// "coming soon" provider). The Configure step is interleaved at index 2
+// only when the selected provider's form is ready.
+const STEPS_WITHOUT_CONFIGURE = [
   { title: "Identity" },
   { title: "Provider" },
   { title: "Review" },
 ];
+
+const STEPS_WITH_CONFIGURE = [
+  { title: "Identity" },
+  { title: "Provider" },
+  { title: "Configure" },
+  { title: "Review" },
+];
+
+/** Resolve the active step list based on the currently-selected provider.
+ *  Provider readiness is the single edit point as U19 sub-PRs ship — adding
+ *  a provider to READY_SECRET_STORE_PROVIDERS in lib/eso-types.ts surfaces
+ *  the Configure step automatically. */
+function stepsFor(
+  provider: SecretStoreProvider | "",
+): typeof STEPS_WITHOUT_CONFIGURE {
+  if (provider && READY_SECRET_STORE_PROVIDERS.has(provider)) {
+    return STEPS_WITH_CONFIGURE;
+  }
+  return STEPS_WITHOUT_CONFIGURE;
+}
 
 function initialForm(scope: "namespaced" | "cluster"): SecretStoreWizardForm {
   return {
@@ -151,8 +175,9 @@ export default function SecretStoreWizard({ scope }: SecretStoreWizardProps) {
 
   async function goNext() {
     if (!validateStep(currentStep.value)) return;
-    if (currentStep.value === STEPS.length - 2) {
-      currentStep.value = STEPS.length - 1;
+    const steps = stepsFor(form.value.provider);
+    if (currentStep.value === steps.length - 2) {
+      currentStep.value = steps.length - 1;
       await fetchPreview();
     } else {
       currentStep.value = currentStep.value + 1;
@@ -186,7 +211,7 @@ export default function SecretStoreWizard({ scope }: SecretStoreWizardProps) {
       </div>
 
       <WizardStepper
-        steps={STEPS}
+        steps={stepsFor(form.value.provider)}
         currentStep={currentStep.value}
         onStepClick={(step) => {
           if (step < currentStep.value) currentStep.value = step;
@@ -246,7 +271,16 @@ export default function SecretStoreWizard({ scope }: SecretStoreWizardProps) {
           </div>
         )}
 
-        {currentStep.value === STEPS.length - 1 && (
+        {currentStep.value === 2 &&
+          form.value.provider === "vault" && (
+          <VaultForm
+            spec={form.value.providerSpec}
+            errors={errors.value}
+            onUpdateSpec={(spec) => update("providerSpec", spec)}
+          />
+        )}
+
+        {currentStep.value === stepsFor(form.value.provider).length - 1 && (
           <WizardReviewStep
             yaml={previewYaml.value}
             onYamlChange={(v) => {
@@ -259,7 +293,7 @@ export default function SecretStoreWizard({ scope }: SecretStoreWizardProps) {
         )}
       </div>
 
-      {currentStep.value < STEPS.length - 1 && (
+      {currentStep.value < stepsFor(form.value.provider).length - 1 && (
         <div class="flex justify-between mt-8">
           <Button
             variant="ghost"
@@ -269,12 +303,15 @@ export default function SecretStoreWizard({ scope }: SecretStoreWizardProps) {
             Back
           </Button>
           <Button variant="primary" onClick={goNext}>
-            {currentStep.value === STEPS.length - 2 ? "Preview YAML" : "Next"}
+            {currentStep.value === stepsFor(form.value.provider).length - 2
+              ? "Preview YAML"
+              : "Next"}
           </Button>
         </div>
       )}
 
-      {currentStep.value === STEPS.length - 1 && !previewLoading.value &&
+      {currentStep.value === stepsFor(form.value.provider).length - 1 &&
+        !previewLoading.value &&
         previewError.value === null && (
         <div class="flex justify-start mt-4">
           <Button variant="ghost" onClick={goBack}>Back</Button>

--- a/frontend/lib/eso-types.ts
+++ b/frontend/lib/eso-types.ts
@@ -234,7 +234,9 @@ export type SecretStoreProvider =
  * Single edit point as Unit 19 sub-PRs ship per-provider forms.
  * A provider NOT in this set is shown as "coming soon" in the picker.
  */
-export const READY_SECRET_STORE_PROVIDERS = new Set<SecretStoreProvider>();
+export const READY_SECRET_STORE_PROVIDERS = new Set<SecretStoreProvider>([
+  "vault",
+]);
 
 // --- Phase G path-discovery types ------------------------------------------
 


### PR DESCRIPTION
## Summary

First per-provider sub-PR for Phase H Unit 19 (R13 in `plans/external-secrets-operator-integration.md`). Vault — the highest-leverage provider, exercising every scaffold path the U18 PR (#216) established.

The remaining 7 wizard providers will follow as their own sub-PRs (one per provider per the plan's mandate): AWS Secrets Manager, AWS Parameter Store, Azure Key Vault, GCP Secret Manager, Kubernetes (cross-namespace), Doppler, 1Password Connect. Akeyless, Bitwarden Secrets Manager, CyberArk Conjur, and Infisical ship as YAML templates in U20 per the plan's L7.2 culling pass.

## What ships

**Backend** (`secretstore_vault.go`):
- `validateVaultSpec` covers all 5 v1 auth methods: token / kubernetes / appRole / jwt / cert.
- Top-level fields validated: server (https-only, private addresses accepted for in-cluster Vault), path (no leading slash), version (v1/v2), namespace (Vault Enterprise).
- `pickVaultAuthMethod` enforces "exactly one of {token, kubernetes, appRole, jwt, cert}" with deterministic-order error message.
- AppRole: roleId XOR roleRef + secretRef required. JWT: secretRef OR kubernetesServiceAccountToken. Cert: clientCert + secretRef.
- `init()` self-registers via `RegisterSecretStoreProvider(SecretStoreProviderVault, validateVaultSpec)`.

**Tests** (`secretstore_vault_test.go`, 27 tests):
- Per-method × happy + per-method missing-required + edge cases.
- Top-level field validation (https-only, KV version, path leading-slash, namespace empty).
- Auth multi-method rejection.
- Dispatcher integration via `SecretStoreInput.Validate()`.
- Structural ToYAML walk to `spec.provider.vault.auth.token.tokenSecretRef`.

**Frontend** (`VaultForm.tsx`, ~530 LoC):
- Auth-method picker + 5 per-method field components.
- Switching auth method clears the auth slate (preserves top-level fields).
- Field-level error keys match the Go validator paths exactly (e.g., \`auth.token.tokenSecretRef.name\`).

**Wizard wiring** (`SecretStoreWizard.tsx`):
- \`PROVIDER_FORMS\` registry replaces hardcoded provider check — adding a provider's form is now a single registry entry, no Configure-step edits required.
- 422 error.detail is parsed; per-field errors populate \`errors.value\` and the wizard navigates back to Configure for in-place correction (the carefully-aligned VaultForm error keys actually fire now).
- Dynamic \`stepsFor(provider)\` returns 4-step (Identity / Provider / Configure / Review) when the selected provider is in \`READY_SECRET_STORE_PROVIDERS\`, 3-step otherwise.

**Types** (`eso-types.ts`):
- Added \`\"vault\"\` to \`READY_SECRET_STORE_PROVIDERS\`. Picker derives readiness from this Set, so Vault is now selectable.

## Pre-push review (`/ce:review`)

9 reviewer personas surfaced 16 findings. Commit \`a058e31\` resolved 15:

**Load-bearing fixes:**
- **Server 422 errors no longer dropped** — fetchPreview parses error.detail into per-field errors and routes the user back to Configure. Without this fix, the careful field-level error wiring in VaultForm was dead code.
- **PROVIDER_FORMS registry replaces hardcoded vault check** — would have silently broken the next provider sub-PR (Configure step would render an empty panel).
- **Cast-heavy reads** consolidated via VaultSpec / VaultAuthSpec typed interfaces.

**Backend hardening:**
- Dropped the structurally-wrong validateHTTPSPublicURL double-call in validateVaultSpec (logic was accidentally correct but maintenance-hazard).
- pickVaultAuthMethod's multi-method error message is now deterministic (was random map-iteration order).
- Removed misleading \"Allow flat shape\" comment that contradicted the code.

**Test polish:**
- TestSecretStoreInput_VaultIntegration_ToYAML now structurally parses the YAML and walks to the auth.token.tokenSecretRef path. Replaces a dead \`if ... { _ = y }\` block.
- TestHandleSecretStorePreview_ClusterScope now uses a complete valid spec so the assertion isolates the scope-check contract.

**Advisory (deferred):**
- Provider override warning (#16) — RegisterSecretStoreProvider silently replaces prior registrations. A meta-test for this is more scaffolding than the risk warrants. Carry forward to U19 last sub-PR or U20.
- Agent-native: no GET /wizards/secret-store/providers endpoint. Agents can't query \"which providers are wizard-ready\". Carry forward to a separate U19 follow-up.

## Verification

- \`go vet ./...\` clean.
- \`go test ./... -count=1\` — 30 packages pass.
- \`go test ./internal/wizard/ -count=10\` — 10 runs, no flakes (matches plan's L7.5 stability requirement).
- \`deno check\` + \`deno lint\` clean on all touched frontend files.

## Test plan

- [ ] CI passes (\`go test\`, \`deno task check\`, Trivy, E2E with kind).
- [ ] Smoke: \`/external-secrets/stores/new\` — pick Vault → 4-step wizard renders. Other providers still show \"coming soon\" and are not selectable.
- [ ] Smoke: leave required fields blank, click Preview YAML — wizard navigates back to Configure with field-level error indicators next to the offending inputs (server, auth.token.tokenSecretRef.name, etc.).
- [ ] Smoke: switch auth method (token → AppRole → token) — auth fields clear cleanly, no stale state.
- [ ] Smoke: complete a Vault SecretStore against a homelab Vault → preview YAML → /yaml/apply → store appears in observatory.
- [ ] CommandPalette: existing \"Create SecretStore\" / \"Create ClusterSecretStore\" entries navigate correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)