### PR TITLE
feat(eso): Phase H Unit 19 — AWS Secrets Manager provider wizard (2/8)

### DIFF
--- a/backend/internal/wizard/secretstore_aws.go
+++ b/backend/internal/wizard/secretstore_aws.go
@@ -1,0 +1,176 @@
+package wizard
+
+import (
+	"fmt"
+	"strings"
+)
+
+// init registers the AWS Secrets Manager provider validator with the
+// SecretStore wizard dispatcher. The same validator handles both
+// SecretStoreProviderAWS (Secrets Manager) and the synthetic AWSPS key after
+// the ToSecretStore remap injects service: ParameterStore. We only register
+// for SecretStoreProviderAWS here; AWSPS validation lands in its own sub-PR.
+func init() {
+	RegisterSecretStoreProvider(SecretStoreProviderAWS, validateAWSSpec)
+}
+
+// orderedAWSAuthMethods is the canonical ordered list of auth methods the
+// wizard surface supports for AWS in v1. The ESO AWS provider also accepts
+// implicit SDK-default credentials (no auth block), but the wizard requires
+// an explicit choice so the YAML preview is self-documenting.
+//
+// Ordering matters: pickAWSAuthMethod iterates this slice to build the
+// "present" list so the multi-method error message is deterministic rather
+// than random-map-order.
+var orderedAWSAuthMethods = []string{"jwt", "secretRef"}
+
+// validateAWSSpec validates a SecretStoreInput.ProviderSpec for the AWS
+// Secrets Manager provider. The spec mirrors ESO's spec.provider.aws shape —
+// region (required), role (optional assume-role ARN), and an auth block
+// with exactly one method populated.
+//
+// service is intentionally not surfaced here: when the wizard sends provider
+// "aws" (Secrets Manager), ESO defaults to SecretsManager when service is
+// absent. The "awsps" UX key injects service: ParameterStore upstream in
+// ToSecretStore; it will have its own validator sub-PR.
+//
+// Each FieldError's Field is rooted at the provider-spec level (no
+// "providerSpec." prefix) so the dispatcher's caller can prefix uniformly
+// when surfacing errors to the frontend.
+func validateAWSSpec(spec map[string]any) []FieldError {
+	var errs []FieldError
+
+	region, _ := spec["region"].(string)
+	if strings.TrimSpace(region) == "" {
+		errs = append(errs, FieldError{Field: "region", Message: "is required (e.g. \"us-east-1\")"})
+	}
+
+	// role is optional — an assume-role ARN. ESO controller validates the
+	// ARN format at runtime; we only reject obviously empty strings when set.
+	if v, ok := spec["role"]; ok {
+		if s, _ := v.(string); strings.TrimSpace(s) == "" {
+			errs = append(errs, FieldError{Field: "role", Message: "must not be empty when set"})
+		}
+	}
+
+	authRaw, hasAuth := spec["auth"].(map[string]any)
+	if !hasAuth {
+		errs = append(errs, FieldError{Field: "auth", Message: "is required (one of jwt, secretRef)"})
+		return errs
+	}
+
+	method, methodErrs := pickAWSAuthMethod(authRaw)
+	errs = append(errs, methodErrs...)
+	if method == "" {
+		return errs
+	}
+
+	switch method {
+	case "jwt":
+		errs = append(errs, validateAWSAuthJWT(authRaw)...)
+	case "secretRef":
+		errs = append(errs, validateAWSAuthSecretRef(authRaw)...)
+	}
+
+	return errs
+}
+
+// pickAWSAuthMethod returns the single auth method present in the auth block.
+// Multiple methods or no method both produce errors so the wizard rejects
+// ambiguity rather than letting the controller pick silently.
+//
+// Iterates orderedAWSAuthMethods (not a map) so the multi-method error
+// message lists methods in a deterministic, readable order.
+func pickAWSAuthMethod(auth map[string]any) (string, []FieldError) {
+	var present []string
+	for _, method := range orderedAWSAuthMethods {
+		if _, ok := auth[method]; ok {
+			present = append(present, method)
+		}
+	}
+	switch len(present) {
+	case 0:
+		return "", []FieldError{{Field: "auth", Message: "exactly one of jwt, secretRef must be set"}}
+	case 1:
+		return present[0], nil
+	default:
+		return "", []FieldError{{Field: "auth", Message: fmt.Sprintf("only one auth method may be set; got %d (%s)", len(present), strings.Join(present, ", "))}}
+	}
+}
+
+// validateAWSSecretKeyRef validates an ESO SecretKeySelector sub-block at the
+// given field prefix. Requires name and key; namespace is optional (only
+// meaningful for ClusterSecretStore).
+func validateAWSSecretKeyRef(spec map[string]any, prefix string) []FieldError {
+	var errs []FieldError
+	if spec == nil {
+		errs = append(errs, FieldError{Field: prefix, Message: "is required"})
+		return errs
+	}
+	if name, _ := spec["name"].(string); name == "" {
+		errs = append(errs, FieldError{Field: prefix + ".name", Message: "is required"})
+	} else if !dnsLabelRegex.MatchString(name) {
+		errs = append(errs, FieldError{Field: prefix + ".name", Message: "must be a valid DNS label"})
+	}
+	if key, _ := spec["key"].(string); key == "" {
+		errs = append(errs, FieldError{Field: prefix + ".key", Message: "is required"})
+	}
+	if ns, ok := spec["namespace"]; ok {
+		if s, _ := ns.(string); s != "" && !dnsLabelRegex.MatchString(s) {
+			errs = append(errs, FieldError{Field: prefix + ".namespace", Message: "must be a valid DNS label"})
+		}
+	}
+	return errs
+}
+
+// validateAWSAuthJWT validates the IAM workload-identity auth block.
+// ESO maps this to spec.provider.aws.auth.jwt.serviceAccountRef.
+//
+// The wizard surfaces only the serviceAccountRef path (the most common
+// in-cluster pattern). Direct API callers may pass additional JWT fields
+// via the YAML editor.
+func validateAWSAuthJWT(auth map[string]any) []FieldError {
+	j, _ := auth["jwt"].(map[string]any)
+	if j == nil {
+		return []FieldError{{Field: "auth.jwt", Message: "is required"}}
+	}
+	saRef, _ := j["serviceAccountRef"].(map[string]any)
+	if saRef == nil {
+		return []FieldError{{Field: "auth.jwt.serviceAccountRef", Message: "is required"}}
+	}
+	name, _ := saRef["name"].(string)
+	if strings.TrimSpace(name) == "" {
+		return []FieldError{{Field: "auth.jwt.serviceAccountRef.name", Message: "is required"}}
+	}
+	if !dnsLabelRegex.MatchString(name) {
+		return []FieldError{{Field: "auth.jwt.serviceAccountRef.name", Message: "must be a valid DNS label"}}
+	}
+	return nil
+}
+
+// validateAWSAuthSecretRef validates the static-credentials auth block.
+// ESO maps this to spec.provider.aws.auth.secretRef with two sub-keys:
+// accessKeyIDSecretRef and secretAccessKeySecretRef, both required.
+func validateAWSAuthSecretRef(auth map[string]any) []FieldError {
+	var errs []FieldError
+	sr, _ := auth["secretRef"].(map[string]any)
+	if sr == nil {
+		return []FieldError{{Field: "auth.secretRef", Message: "is required"}}
+	}
+
+	akID, _ := sr["accessKeyIDSecretRef"].(map[string]any)
+	if akID == nil {
+		errs = append(errs, FieldError{Field: "auth.secretRef.accessKeyIDSecretRef", Message: "is required"})
+	} else {
+		errs = append(errs, validateAWSSecretKeyRef(akID, "auth.secretRef.accessKeyIDSecretRef")...)
+	}
+
+	sakKey, _ := sr["secretAccessKeySecretRef"].(map[string]any)
+	if sakKey == nil {
+		errs = append(errs, FieldError{Field: "auth.secretRef.secretAccessKeySecretRef", Message: "is required"})
+	} else {
+		errs = append(errs, validateAWSSecretKeyRef(sakKey, "auth.secretRef.secretAccessKeySecretRef")...)
+	}
+
+	return errs
+}

--- a/backend/internal/wizard/secretstore_aws_test.go
+++ b/backend/internal/wizard/secretstore_aws_test.go
@@ -317,6 +317,22 @@ func TestSecretStoreInput_AWSIntegration_PropagatesProviderError(t *testing.T) {
 	}
 }
 
+func TestSecretStoreInput_AWSIntegration_PropagatesRoleWhitespaceError(t *testing.T) {
+	spec := validAWSSpec()
+	spec["role"] = "   "
+	s := SecretStoreInput{
+		Scope:        StoreScopeNamespaced,
+		Name:         "aws-store",
+		Namespace:    "apps",
+		Provider:     SecretStoreProviderAWS,
+		ProviderSpec: spec,
+	}
+	errs := s.Validate()
+	if !hasField(errs, "role") {
+		t.Errorf("expected provider-level role error for whitespace-only value, got %v", errs)
+	}
+}
+
 // TestSecretStoreInput_AWSIntegration_ToYAML asserts the wizard preview's
 // emitted YAML places the spec under spec.provider.aws and does not leak the
 // wizard's transport keys at the wrong nesting level.

--- a/backend/internal/wizard/secretstore_aws_test.go
+++ b/backend/internal/wizard/secretstore_aws_test.go
@@ -1,0 +1,367 @@
+package wizard
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// validAWSSpec returns a minimal valid AWS Secrets Manager provider spec
+// using IAM workload-identity (jwt) auth — the most common in-cluster pattern.
+// Other auth-method tests override the auth block as needed.
+func validAWSSpec() map[string]any {
+	return map[string]any{
+		"region": "us-east-1",
+		"auth": map[string]any{
+			"jwt": map[string]any{
+				"serviceAccountRef": map[string]any{
+					"name": "my-service-account",
+				},
+			},
+		},
+	}
+}
+
+// validAWSSpecStaticCreds returns a minimal valid spec using static credentials.
+func validAWSSpecStaticCreds() map[string]any {
+	return map[string]any{
+		"region": "eu-west-1",
+		"auth": map[string]any{
+			"secretRef": map[string]any{
+				"accessKeyIDSecretRef": map[string]any{
+					"name": "aws-creds",
+					"key":  "access-key-id",
+				},
+				"secretAccessKeySecretRef": map[string]any{
+					"name": "aws-creds",
+					"key":  "secret-access-key",
+				},
+			},
+		},
+	}
+}
+
+// --- Top-level field tests ---
+
+func TestValidateAWSSpec_Valid_JWT(t *testing.T) {
+	if errs := validateAWSSpec(validAWSSpec()); len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+}
+
+func TestValidateAWSSpec_Valid_StaticCreds(t *testing.T) {
+	if errs := validateAWSSpec(validAWSSpecStaticCreds()); len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+}
+
+func TestValidateAWSSpec_Valid_WithOptionalRole(t *testing.T) {
+	spec := validAWSSpec()
+	spec["role"] = "arn:aws:iam::123456789012:role/my-role"
+	if errs := validateAWSSpec(spec); len(errs) != 0 {
+		t.Errorf("expected no errors with role set, got %v", errs)
+	}
+}
+
+func TestValidateAWSSpec_MissingRegion(t *testing.T) {
+	spec := validAWSSpec()
+	delete(spec, "region")
+	if !hasField(validateAWSSpec(spec), "region") {
+		t.Error("expected region required error")
+	}
+}
+
+func TestValidateAWSSpec_BlankRegion(t *testing.T) {
+	spec := validAWSSpec()
+	spec["region"] = "   "
+	if !hasField(validateAWSSpec(spec), "region") {
+		t.Error("expected region error for whitespace-only value")
+	}
+}
+
+func TestValidateAWSSpec_RoleEmptyWhenSet(t *testing.T) {
+	spec := validAWSSpec()
+	spec["role"] = "   "
+	if !hasField(validateAWSSpec(spec), "role") {
+		t.Error("expected role error for whitespace-only value when set")
+	}
+}
+
+func TestValidateAWSSpec_RoleAbsent_NoError(t *testing.T) {
+	// role is optional — absence must not produce an error.
+	spec := validAWSSpec()
+	delete(spec, "role")
+	if errs := validateAWSSpec(spec); len(errs) != 0 {
+		t.Errorf("expected no errors when role absent, got %v", errs)
+	}
+}
+
+// --- Auth block tests ---
+
+func TestValidateAWSSpec_NoAuth(t *testing.T) {
+	spec := validAWSSpec()
+	delete(spec, "auth")
+	if !hasField(validateAWSSpec(spec), "auth") {
+		t.Error("expected auth required error")
+	}
+}
+
+func TestValidateAWSSpec_AuthNoMethod(t *testing.T) {
+	spec := validAWSSpec()
+	spec["auth"] = map[string]any{}
+	if !hasField(validateAWSSpec(spec), "auth") {
+		t.Error("expected auth error for empty block")
+	}
+}
+
+func TestValidateAWSSpec_AuthMultipleMethods(t *testing.T) {
+	spec := validAWSSpec()
+	spec["auth"] = map[string]any{
+		"jwt": map[string]any{
+			"serviceAccountRef": map[string]any{"name": "sa"},
+		},
+		"secretRef": map[string]any{
+			"accessKeyIDSecretRef":     map[string]any{"name": "s", "key": "k"},
+			"secretAccessKeySecretRef": map[string]any{"name": "s", "key": "k"},
+		},
+	}
+	errs := validateAWSSpec(spec)
+	if !hasField(errs, "auth") {
+		t.Errorf("expected auth error for multiple methods; got %v", errs)
+	}
+	// Verify the message names both methods so users can disambiguate.
+	found := false
+	for _, e := range errs {
+		if e.Field == "auth" && strings.Contains(e.Message, "only one") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected only-one error message, got %v", errs)
+	}
+}
+
+// --- JWT auth tests ---
+
+func TestValidateAWSSpec_JWTAuth_Valid(t *testing.T) {
+	spec := validAWSSpec() // already uses jwt
+	if errs := validateAWSSpec(spec); len(errs) != 0 {
+		t.Errorf("expected no errors for jwt auth, got %v", errs)
+	}
+}
+
+func TestValidateAWSSpec_JWTAuth_MissingJWTBlock(t *testing.T) {
+	spec := validAWSSpec()
+	spec["auth"] = map[string]any{"jwt": nil}
+	if !hasField(validateAWSSpec(spec), "auth.jwt") {
+		t.Error("expected auth.jwt required error when block is nil")
+	}
+}
+
+func TestValidateAWSSpec_JWTAuth_MissingServiceAccountRef(t *testing.T) {
+	spec := validAWSSpec()
+	spec["auth"] = map[string]any{
+		"jwt": map[string]any{},
+	}
+	if !hasField(validateAWSSpec(spec), "auth.jwt.serviceAccountRef") {
+		t.Error("expected auth.jwt.serviceAccountRef required error")
+	}
+}
+
+func TestValidateAWSSpec_JWTAuth_MissingServiceAccountRefName(t *testing.T) {
+	spec := validAWSSpec()
+	spec["auth"] = map[string]any{
+		"jwt": map[string]any{
+			"serviceAccountRef": map[string]any{},
+		},
+	}
+	if !hasField(validateAWSSpec(spec), "auth.jwt.serviceAccountRef.name") {
+		t.Error("expected auth.jwt.serviceAccountRef.name required error")
+	}
+}
+
+func TestValidateAWSSpec_JWTAuth_BlankServiceAccountRefName(t *testing.T) {
+	spec := validAWSSpec()
+	spec["auth"] = map[string]any{
+		"jwt": map[string]any{
+			"serviceAccountRef": map[string]any{"name": "   "},
+		},
+	}
+	if !hasField(validateAWSSpec(spec), "auth.jwt.serviceAccountRef.name") {
+		t.Error("expected auth.jwt.serviceAccountRef.name error for whitespace")
+	}
+}
+
+func TestValidateAWSSpec_JWTAuth_BadServiceAccountRefName(t *testing.T) {
+	spec := validAWSSpec()
+	spec["auth"] = map[string]any{
+		"jwt": map[string]any{
+			"serviceAccountRef": map[string]any{"name": "Bad_Name"},
+		},
+	}
+	if !hasField(validateAWSSpec(spec), "auth.jwt.serviceAccountRef.name") {
+		t.Error("expected auth.jwt.serviceAccountRef.name DNS error")
+	}
+}
+
+// --- Static credentials (secretRef) auth tests ---
+
+func TestValidateAWSSpec_SecretRefAuth_Valid(t *testing.T) {
+	if errs := validateAWSSpec(validAWSSpecStaticCreds()); len(errs) != 0 {
+		t.Errorf("expected no errors for secretRef auth, got %v", errs)
+	}
+}
+
+func TestValidateAWSSpec_SecretRefAuth_MissingSecretRefBlock(t *testing.T) {
+	spec := validAWSSpecStaticCreds()
+	spec["auth"] = map[string]any{"secretRef": nil}
+	if !hasField(validateAWSSpec(spec), "auth.secretRef") {
+		t.Error("expected auth.secretRef required error when block is nil")
+	}
+}
+
+func TestValidateAWSSpec_SecretRefAuth_MissingAccessKeyIDRef(t *testing.T) {
+	spec := validAWSSpecStaticCreds()
+	spec["auth"] = map[string]any{
+		"secretRef": map[string]any{
+			"secretAccessKeySecretRef": map[string]any{"name": "aws-creds", "key": "sak"},
+		},
+	}
+	if !hasField(validateAWSSpec(spec), "auth.secretRef.accessKeyIDSecretRef") {
+		t.Error("expected auth.secretRef.accessKeyIDSecretRef required error")
+	}
+}
+
+func TestValidateAWSSpec_SecretRefAuth_MissingSecretAccessKeyRef(t *testing.T) {
+	spec := validAWSSpecStaticCreds()
+	spec["auth"] = map[string]any{
+		"secretRef": map[string]any{
+			"accessKeyIDSecretRef": map[string]any{"name": "aws-creds", "key": "akid"},
+		},
+	}
+	if !hasField(validateAWSSpec(spec), "auth.secretRef.secretAccessKeySecretRef") {
+		t.Error("expected auth.secretRef.secretAccessKeySecretRef required error")
+	}
+}
+
+func TestValidateAWSSpec_SecretRefAuth_AccessKeyIDRefMissingName(t *testing.T) {
+	spec := validAWSSpecStaticCreds()
+	spec["auth"] = map[string]any{
+		"secretRef": map[string]any{
+			"accessKeyIDSecretRef":     map[string]any{"key": "akid"}, // missing name
+			"secretAccessKeySecretRef": map[string]any{"name": "aws-creds", "key": "sak"},
+		},
+	}
+	if !hasField(validateAWSSpec(spec), "auth.secretRef.accessKeyIDSecretRef.name") {
+		t.Error("expected auth.secretRef.accessKeyIDSecretRef.name required error")
+	}
+}
+
+func TestValidateAWSSpec_SecretRefAuth_AccessKeyIDRefMissingKey(t *testing.T) {
+	spec := validAWSSpecStaticCreds()
+	spec["auth"] = map[string]any{
+		"secretRef": map[string]any{
+			"accessKeyIDSecretRef":     map[string]any{"name": "aws-creds"}, // missing key
+			"secretAccessKeySecretRef": map[string]any{"name": "aws-creds", "key": "sak"},
+		},
+	}
+	if !hasField(validateAWSSpec(spec), "auth.secretRef.accessKeyIDSecretRef.key") {
+		t.Error("expected auth.secretRef.accessKeyIDSecretRef.key required error")
+	}
+}
+
+func TestValidateAWSSpec_SecretRefAuth_BadAccessKeyIDRefName(t *testing.T) {
+	spec := validAWSSpecStaticCreds()
+	spec["auth"] = map[string]any{
+		"secretRef": map[string]any{
+			"accessKeyIDSecretRef":     map[string]any{"name": "BadName", "key": "akid"},
+			"secretAccessKeySecretRef": map[string]any{"name": "aws-creds", "key": "sak"},
+		},
+	}
+	if !hasField(validateAWSSpec(spec), "auth.secretRef.accessKeyIDSecretRef.name") {
+		t.Error("expected auth.secretRef.accessKeyIDSecretRef.name DNS error")
+	}
+}
+
+// --- Dispatcher integration tests ---
+
+// TestSecretStoreInput_AWSIntegration confirms validateAWSSpec is wired to the
+// dispatcher via the init() RegisterSecretStoreProvider call.
+func TestSecretStoreInput_AWSIntegration(t *testing.T) {
+	s := SecretStoreInput{
+		Scope:        StoreScopeNamespaced,
+		Name:         "aws-store",
+		Namespace:    "apps",
+		Provider:     SecretStoreProviderAWS,
+		ProviderSpec: validAWSSpec(),
+	}
+	if errs := s.Validate(); len(errs) != 0 {
+		t.Errorf("expected no errors via dispatcher, got %v", errs)
+	}
+}
+
+func TestSecretStoreInput_AWSIntegration_PropagatesProviderError(t *testing.T) {
+	spec := validAWSSpec()
+	delete(spec, "region")
+	s := SecretStoreInput{
+		Scope:        StoreScopeNamespaced,
+		Name:         "aws-store",
+		Namespace:    "apps",
+		Provider:     SecretStoreProviderAWS,
+		ProviderSpec: spec,
+	}
+	errs := s.Validate()
+	if !hasField(errs, "region") {
+		t.Errorf("expected provider-level region error, got %v", errs)
+	}
+}
+
+// TestSecretStoreInput_AWSIntegration_ToYAML asserts the wizard preview's
+// emitted YAML places the spec under spec.provider.aws and does not leak the
+// wizard's transport keys at the wrong nesting level.
+func TestSecretStoreInput_AWSIntegration_ToYAML(t *testing.T) {
+	s := SecretStoreInput{
+		Scope:        StoreScopeNamespaced,
+		Name:         "aws-store",
+		Namespace:    "apps",
+		Provider:     SecretStoreProviderAWS,
+		ProviderSpec: validAWSSpec(),
+	}
+	y, err := s.ToYAML()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, want := range []string{
+		"apiVersion: external-secrets.io/v1",
+		"kind: SecretStore",
+	} {
+		if !strings.Contains(y, want) {
+			t.Errorf("expected YAML to contain %q\n%s", want, y)
+		}
+	}
+
+	// Structural assertion: spec.provider.aws.auth.jwt.serviceAccountRef.name.
+	var doc map[string]any
+	if err := yaml.Unmarshal([]byte(y), &doc); err != nil {
+		t.Fatalf("failed to parse YAML: %v\n%s", err, y)
+	}
+	spec, _ := doc["spec"].(map[string]any)
+	provider, _ := spec["provider"].(map[string]any)
+	awsSpec, _ := provider["aws"].(map[string]any)
+	if awsSpec == nil {
+		t.Fatalf("expected spec.provider.aws, got provider keys: %v", keys(provider))
+	}
+	if awsSpec["region"] != "us-east-1" {
+		t.Errorf("expected region=us-east-1, got %v", awsSpec["region"])
+	}
+	auth, _ := awsSpec["auth"].(map[string]any)
+	jwt, _ := auth["jwt"].(map[string]any)
+	saRef, _ := jwt["serviceAccountRef"].(map[string]any)
+	if saRef == nil {
+		t.Fatalf("expected spec.provider.aws.auth.jwt.serviceAccountRef to be non-nil; auth=%v", auth)
+	}
+	if saRef["name"] == nil {
+		t.Errorf("expected serviceAccountRef.name to be present; got %v", saRef)
+	}
+}

--- a/frontend/components/wizard/secretstore/AWSForm.tsx
+++ b/frontend/components/wizard/secretstore/AWSForm.tsx
@@ -1,0 +1,363 @@
+import { useSignal } from "@preact/signals";
+import { Input } from "@/components/ui/Input.tsx";
+
+/**
+ * AWS Secrets Manager provider form for SecretStoreWizard. Writes into the
+ * wizard's `providerSpec: Record<string, unknown>` slot under the shape
+ * `{ region, role?, auth: { <method>: {...} } }`.
+ *
+ * v1 supports two auth methods:
+ * - jwt: IAM workload identity via a Kubernetes service account reference.
+ * - secretRef: static credentials (Access Key ID + Secret Access Key) stored
+ *   in Kubernetes Secrets.
+ *
+ * The `service` field is intentionally absent from this form — ESO defaults
+ * to SecretsManager when omitted, and the synthetic "awsps" UX discriminator
+ * (AWS Parameter Store) injects service: ParameterStore upstream in the
+ * backend's ToSecretStore remap. AWSPS will have its own form sub-PR.
+ *
+ * Switching auth method clears the auth slate via onUpdateSpec so stale fields
+ * from the prior method don't leak into the YAML preview.
+ */
+
+export type AWSAuthMethod = "jwt" | "secretRef";
+
+export interface AWSFormProps {
+  spec: Record<string, unknown>;
+  errors: Record<string, string>;
+  onUpdateSpec: (spec: Record<string, unknown>) => void;
+}
+
+interface SecretKeyRef {
+  name?: string;
+  key?: string;
+}
+
+/** Typed sub-shapes for each AWS auth method block. */
+interface AWSAuthSpec {
+  jwt?: { serviceAccountRef?: { name?: string } };
+  secretRef?: {
+    accessKeyIDSecretRef?: SecretKeyRef;
+    secretAccessKeySecretRef?: SecretKeyRef;
+  };
+}
+
+/** Typed shape for an AWS provider spec block (spec.provider.aws). */
+interface AWSSpec {
+  region?: string;
+  role?: string;
+  auth?: AWSAuthSpec;
+}
+
+const AUTH_METHODS: {
+  id: AWSAuthMethod;
+  label: string;
+  description: string;
+}[] = [
+  {
+    id: "jwt",
+    label: "IAM / IRSA",
+    description:
+      "Workload identity: the pod's service account assumes an IAM role via IRSA or EKS Pod Identity.",
+  },
+  {
+    id: "secretRef",
+    label: "Static credentials",
+    description:
+      "Access Key ID + Secret Access Key pair stored in Kubernetes Secrets.",
+  },
+];
+
+/** Determine which auth method the spec currently encodes, or "" when none. */
+function detectMethod(spec: Record<string, unknown>): AWSAuthMethod | "" {
+  const auth = spec.auth as Record<string, unknown> | undefined;
+  if (!auth) return "";
+  for (const m of AUTH_METHODS.map((x) => x.id)) {
+    if (m in auth) return m;
+  }
+  return "";
+}
+
+/** Read a top-level string field from the spec. */
+function getStr(spec: Record<string, unknown>, key: string): string {
+  const v = spec[key];
+  return typeof v === "string" ? v : "";
+}
+
+function getAuthBlock(
+  spec: Record<string, unknown>,
+  method: AWSAuthMethod,
+): Record<string, unknown> {
+  const auth = (spec.auth as Record<string, unknown>) ?? {};
+  return (auth[method] as Record<string, unknown>) ?? {};
+}
+
+export function AWSForm({ spec, errors, onUpdateSpec }: AWSFormProps) {
+  // AWSSpec / AWSAuthSpec interfaces above document the shape; field reads go
+  // through getStr() and getAuthBlock() helpers which narrow at each access
+  // site rather than via a single top-level cast.
+
+  // Track which auth method's fields are currently shown. Persisted in the
+  // spec itself (via detectMethod) so the form survives Back/Next navigation.
+  const method = useSignal<AWSAuthMethod | "">(detectMethod(spec));
+
+  function patchTop(field: string, value: string) {
+    const next = { ...spec };
+    if (value === "") delete next[field];
+    else next[field] = value;
+    onUpdateSpec(next);
+  }
+
+  function setMethod(m: AWSAuthMethod) {
+    if (method.value === m) return;
+    method.value = m;
+    // Clear the auth slate; preserve top-level fields (region, role).
+    onUpdateSpec({
+      ...spec,
+      auth: { [m]: emptyMethodSpec(m) },
+    });
+  }
+
+  function patchAuth(
+    authMethod: AWSAuthMethod,
+    patch: Record<string, unknown>,
+  ) {
+    const auth = (spec.auth as Record<string, unknown>) ?? {};
+    const block = (auth[authMethod] as Record<string, unknown>) ?? {};
+    onUpdateSpec({
+      ...spec,
+      auth: { ...auth, [authMethod]: { ...block, ...patch } },
+    });
+  }
+
+  function patchSecretKeyRef(
+    authMethod: AWSAuthMethod,
+    refField: string,
+    patch: SecretKeyRef,
+  ) {
+    const block = getAuthBlock(spec, authMethod);
+    const existing = (block[refField] as SecretKeyRef) ?? {};
+    patchAuth(authMethod, { [refField]: { ...existing, ...patch } });
+  }
+
+  return (
+    <div class="space-y-5">
+      <div class="rounded-md border border-border-primary bg-surface/50 p-4 text-sm text-text-muted">
+        Configure the AWS Secrets Manager connection and authentication method.
+        Credentials must already exist as Kubernetes Secrets in this namespace;
+        this wizard only references them — it never holds AWS credentials
+        directly.
+      </div>
+
+      {/* Top-level AWS fields */}
+      <div class="grid grid-cols-2 gap-4">
+        <Input
+          id="aws-region"
+          label="AWS Region"
+          required
+          value={getStr(spec, "region")}
+          onInput={(e) =>
+            patchTop("region", (e.target as HTMLInputElement).value)}
+          placeholder="us-east-1"
+          description="The AWS region where your secrets are stored."
+          error={errors["region"]}
+        />
+        <Input
+          id="aws-role"
+          label="Assume-role ARN (optional)"
+          value={getStr(spec, "role")}
+          onInput={(e) =>
+            patchTop("role", (e.target as HTMLInputElement).value)}
+          placeholder="arn:aws:iam::123456789012:role/my-role"
+          description="IAM role to assume before fetching secrets. Leave blank to use the pod's own identity."
+          error={errors["role"]}
+        />
+      </div>
+
+      {/* Auth method picker */}
+      <div class="space-y-3">
+        <h3 class="text-sm font-semibold text-text-primary">
+          Authentication method
+          <span aria-hidden="true" class="text-danger ml-0.5">*</span>
+        </h3>
+        <div class="grid gap-2 sm:grid-cols-2">
+          {AUTH_METHODS.map((m) => {
+            const active = method.value === m.id;
+            return (
+              <button
+                key={m.id}
+                type="button"
+                onClick={() => setMethod(m.id)}
+                class={`text-left rounded-lg border p-3 transition-colors ${
+                  active
+                    ? "border-brand bg-brand/5"
+                    : "border-border-primary bg-surface hover:border-border-emphasis"
+                }`}
+                aria-pressed={active}
+              >
+                <div class="font-medium text-text-primary">{m.label}</div>
+                <p class="mt-1 text-xs text-text-muted">{m.description}</p>
+              </button>
+            );
+          })}
+        </div>
+        {errors["auth"] && <p class="text-sm text-danger">{errors["auth"]}</p>}
+      </div>
+
+      {/* Auth-method-specific fields */}
+      {method.value === "jwt" && (
+        <JWTAuthFields
+          block={getAuthBlock(spec, "jwt")}
+          errors={errors}
+          onPatch={(patch) => patchAuth("jwt", patch)}
+        />
+      )}
+      {method.value === "secretRef" && (
+        <StaticCredAuthFields
+          block={getAuthBlock(spec, "secretRef")}
+          errors={errors}
+          onPatchAccessKeyRef={(patch) =>
+            patchSecretKeyRef("secretRef", "accessKeyIDSecretRef", patch)}
+          onPatchSecretKeyRef={(patch) =>
+            patchSecretKeyRef("secretRef", "secretAccessKeySecretRef", patch)}
+        />
+      )}
+    </div>
+  );
+}
+
+/** Initial empty block for a freshly-selected auth method. The wizard's
+ *  validator rejects empty blocks so the user must populate before preview. */
+function emptyMethodSpec(m: AWSAuthMethod): Record<string, unknown> {
+  switch (m) {
+    case "jwt":
+      return { serviceAccountRef: {} };
+    case "secretRef":
+      return { accessKeyIDSecretRef: {}, secretAccessKeySecretRef: {} };
+  }
+}
+
+// --- Per-method field components ---------------------------------------
+
+interface JWTAuthFieldsProps {
+  block: Record<string, unknown>;
+  errors: Record<string, string>;
+  onPatch: (patch: Record<string, unknown>) => void;
+}
+
+function JWTAuthFields({ block, errors, onPatch }: JWTAuthFieldsProps) {
+  const saRef = (block.serviceAccountRef as { name?: string }) ?? {};
+  return (
+    <div class="rounded-md border border-border-primary p-4 space-y-3">
+      <h4 class="text-sm font-medium text-text-primary">
+        IAM / IRSA — service account reference
+      </h4>
+      <p class="text-xs text-text-muted">
+        The service account must have an IAM role ARN annotation
+        (eks.amazonaws.com/role-arn) or be bound via EKS Pod Identity. The
+        assume-role ARN above takes precedence if set.
+      </p>
+      <Input
+        id="aws-jwt-sa-name"
+        label="Service account name"
+        required
+        value={saRef.name ?? ""}
+        onInput={(e) =>
+          onPatch({
+            serviceAccountRef: {
+              ...saRef,
+              name: (e.target as HTMLInputElement).value,
+            },
+          })}
+        placeholder="my-service-account"
+        description="The Kubernetes ServiceAccount whose projected token is exchanged for AWS credentials."
+        error={errors["auth.jwt.serviceAccountRef.name"]}
+      />
+    </div>
+  );
+}
+
+interface StaticCredAuthFieldsProps {
+  block: Record<string, unknown>;
+  errors: Record<string, string>;
+  onPatchAccessKeyRef: (patch: SecretKeyRef) => void;
+  onPatchSecretKeyRef: (patch: SecretKeyRef) => void;
+}
+
+function StaticCredAuthFields(
+  {
+    block,
+    errors,
+    onPatchAccessKeyRef,
+    onPatchSecretKeyRef,
+  }: StaticCredAuthFieldsProps,
+) {
+  const akRef = (block.accessKeyIDSecretRef as SecretKeyRef) ?? {};
+  const sakRef = (block.secretAccessKeySecretRef as SecretKeyRef) ?? {};
+  return (
+    <div class="rounded-md border border-border-primary p-4 space-y-4">
+      <div>
+        <h4 class="text-sm font-medium text-text-primary mb-2">
+          Access Key ID Secret reference
+        </h4>
+        <div class="grid grid-cols-2 gap-3">
+          <Input
+            id="aws-akid-name"
+            label="Secret name"
+            required
+            value={akRef.name ?? ""}
+            onInput={(e) =>
+              onPatchAccessKeyRef({
+                name: (e.target as HTMLInputElement).value,
+              })}
+            placeholder="aws-credentials"
+            error={errors["auth.secretRef.accessKeyIDSecretRef.name"]}
+          />
+          <Input
+            id="aws-akid-key"
+            label="Key"
+            required
+            value={akRef.key ?? ""}
+            onInput={(e) =>
+              onPatchAccessKeyRef({
+                key: (e.target as HTMLInputElement).value,
+              })}
+            placeholder="access-key-id"
+            error={errors["auth.secretRef.accessKeyIDSecretRef.key"]}
+          />
+        </div>
+      </div>
+      <div>
+        <h4 class="text-sm font-medium text-text-primary mb-2">
+          Secret Access Key Secret reference
+        </h4>
+        <div class="grid grid-cols-2 gap-3">
+          <Input
+            id="aws-sak-name"
+            label="Secret name"
+            required
+            value={sakRef.name ?? ""}
+            onInput={(e) =>
+              onPatchSecretKeyRef({
+                name: (e.target as HTMLInputElement).value,
+              })}
+            placeholder="aws-credentials"
+            error={errors["auth.secretRef.secretAccessKeySecretRef.name"]}
+          />
+          <Input
+            id="aws-sak-key"
+            label="Key"
+            required
+            value={sakRef.key ?? ""}
+            onInput={(e) =>
+              onPatchSecretKeyRef({
+                key: (e.target as HTMLInputElement).value,
+              })}
+            placeholder="secret-access-key"
+            error={errors["auth.secretRef.secretAccessKeySecretRef.key"]}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/islands/SecretStoreWizard.tsx
+++ b/frontend/islands/SecretStoreWizard.tsx
@@ -12,6 +12,7 @@ import { SecretStoreProviderPickerStep } from "@/components/wizard/secretstore/S
 import { VaultForm } from "@/components/wizard/secretstore/VaultForm.tsx";
 import type { VaultFormProps } from "@/components/wizard/secretstore/VaultForm.tsx";
 import { OnePasswordForm } from "@/components/wizard/secretstore/OnePasswordForm.tsx";
+import { AWSForm } from "@/components/wizard/secretstore/AWSForm.tsx";
 import { Input } from "@/components/ui/Input.tsx";
 import { NamespaceSelect } from "@/components/ui/NamespaceSelect.tsx";
 import { Button } from "@/components/ui/Button.tsx";
@@ -32,6 +33,7 @@ const PROVIDER_FORMS: Partial<
 > = {
   vault: VaultForm,
   onepassword: OnePasswordForm,
+  aws: AWSForm,
 };
 
 // Re-export for any downstream consumers that imported from this island.

--- a/frontend/lib/eso-types.ts
+++ b/frontend/lib/eso-types.ts
@@ -237,6 +237,7 @@ export type SecretStoreProvider =
 export const READY_SECRET_STORE_PROVIDERS = new Set<SecretStoreProvider>([
   "vault",
   "onepassword",
+  "aws",
 ]);
 
 // --- Phase G path-discovery types ------------------------------------------


### PR DESCRIPTION
## Summary

- Implements the AWS Secrets Manager provider wizard, the 2nd of 8 per-provider sub-PRs. Mirrors the Vault pattern from PR #217.
- **Backend**: `validateAWSSpec` validates `region` (required), `role` (optional ARN), and an `auth` block with exactly one method. Registers itself under `SecretStoreProviderAWS` via `init()`.
- **Auth methods**: IAM workload identity (`auth.jwt.serviceAccountRef`) and static credentials (`auth.secretRef.{accessKeyIDSecretRef, secretAccessKeySecretRef}`).
- **Tests**: 23 table-driven tests covering both auth methods × happy path, missing-required, and edge cases, plus dispatcher integration and ToYAML structural assertion.
- **Frontend**: `AWSForm.tsx` with auth-method picker, `"aws"` added to `READY_SECRET_STORE_PROVIDERS`, form registered in `PROVIDER_FORMS` in `SecretStoreWizard.tsx`.

AWS Parameter Store (`awsps`) will land as a separate sub-PR. The U18 `ToSecretStore` remap of `awsps → aws + service: ParameterStore` is already wired.

## Test plan

- [ ] `cd backend && go vet ./... && go test ./internal/wizard/ -count=10` — all pass
- [ ] `cd frontend && deno check && deno fmt --check && deno lint` on changed files — all pass
- [ ] In the SecretStore wizard, select "AWS Secrets Manager" provider and verify the Configure step shows region + role fields plus the IAM/IRSA and Static credentials method picker
- [ ] Verify switching auth method clears stale fields (spec.auth is replaced, not merged)
- [ ] Verify Preview YAML step produces valid ESO v1 YAML with `spec.provider.aws` containing `region` and `auth`

🤖 Generated with [Claude Code](https://claude.com/claude-code)