### PR TITLE
feat(eso): Phase H Unit 19 — Azure Key Vault provider wizard (4/8)

### DIFF
--- a/backend/internal/wizard/secretstore_azurekv.go
+++ b/backend/internal/wizard/secretstore_azurekv.go
@@ -1,0 +1,193 @@
+package wizard
+
+import (
+	"strings"
+)
+
+// init registers the Azure Key Vault provider validator with the SecretStore
+// wizard dispatcher. Lives in this file so the validator ships and registers
+// as one unit — adding a provider is a single-file edit + one line in
+// READY_SECRET_STORE_PROVIDERS on the frontend.
+func init() {
+	RegisterSecretStoreProvider(SecretStoreProviderAzure, validateAzureKVSpec)
+}
+
+// orderedAzureKVAuthTypes is the canonical ordered list of auth types the
+// wizard supports in v1. Ordering matters for the "invalid authType" error
+// message so it is deterministic.
+var orderedAzureKVAuthTypes = []string{
+	"ManagedIdentity",
+	"ServicePrincipal",
+	"WorkloadIdentity",
+}
+
+// validateAzureKVSpec validates a SecretStoreInput.ProviderSpec for the Azure
+// Key Vault provider. The spec mirrors ESO's spec.provider.azurekv shape —
+// vaultUrl, tenantId (required for SP and WI), authType (discriminator), and
+// per-type auth fields.
+//
+// Azure's auth discriminator differs from Vault: it uses a top-level
+// `authType` string rather than a nested `auth.<method>` sub-block. All auth
+// credentials live as sibling fields of `authType` at the top level of the
+// spec. This function validates that shape directly.
+//
+// Each FieldError's Field is rooted at the provider-spec level (no
+// "providerSpec." prefix) so the dispatcher's caller can prefix uniformly
+// when surfacing errors to the frontend.
+func validateAzureKVSpec(spec map[string]any) []FieldError {
+	var errs []FieldError
+
+	// vaultUrl is required and must use https.
+	vaultURL, _ := spec["vaultUrl"].(string)
+	if strings.TrimSpace(vaultURL) == "" {
+		errs = append(errs, FieldError{Field: "vaultUrl", Message: "is required"})
+	} else if !strings.HasPrefix(strings.ToLower(vaultURL), "https://") {
+		errs = append(errs, FieldError{Field: "vaultUrl", Message: "must use https scheme"})
+	}
+
+	// authType is required and must be one of the three supported values.
+	authType, _ := spec["authType"].(string)
+	if authType == "" {
+		errs = append(errs, FieldError{
+			Field:   "authType",
+			Message: "is required (one of ManagedIdentity, ServicePrincipal, WorkloadIdentity)",
+		})
+		return errs
+	}
+	if !isValidAzureAuthType(authType) {
+		errs = append(errs, FieldError{
+			Field:   "authType",
+			Message: "must be one of ManagedIdentity, ServicePrincipal, WorkloadIdentity",
+		})
+		return errs
+	}
+
+	// Per-type validation.
+	switch authType {
+	case "ManagedIdentity":
+		errs = append(errs, validateAzureKVManagedIdentity(spec)...)
+	case "ServicePrincipal":
+		errs = append(errs, validateAzureKVServicePrincipal(spec)...)
+	case "WorkloadIdentity":
+		errs = append(errs, validateAzureKVWorkloadIdentity(spec)...)
+	}
+
+	return errs
+}
+
+// isValidAzureAuthType returns true when s is one of the supported auth types.
+func isValidAzureAuthType(s string) bool {
+	for _, v := range orderedAzureKVAuthTypes {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+// validateAzureKVManagedIdentity validates fields specific to the
+// ManagedIdentity auth type.
+//
+//   - tenantId: optional (AKS sets it automatically from the cluster identity).
+//   - identityId: optional client ID for multi-identity pods; blank means
+//     "use the AKS-bound managed identity".
+//
+// Neither field is required — ESO defaults both from the pod's MI binding.
+// We validate format when provided.
+func validateAzureKVManagedIdentity(_ map[string]any) []FieldError {
+	// ManagedIdentity has no required sub-fields in ESO v1. tenantId and
+	// identityId are both optional and carry no format constraint beyond
+	// "non-empty when set" — which the wizard enforces client-side only.
+	return nil
+}
+
+// validateAzureKVServicePrincipal validates fields specific to the
+// ServicePrincipal auth type.
+//
+// Required:
+//   - tenantId (string at spec root)
+//   - authSecretRef.clientId.{name, key}
+//   - authSecretRef.clientSecret.{name, key}
+func validateAzureKVServicePrincipal(spec map[string]any) []FieldError {
+	var errs []FieldError
+
+	// tenantId is required for ServicePrincipal.
+	tenantID, _ := spec["tenantId"].(string)
+	if strings.TrimSpace(tenantID) == "" {
+		errs = append(errs, FieldError{Field: "tenantId", Message: "is required for ServicePrincipal"})
+	}
+
+	// authSecretRef must be present and contain clientId + clientSecret.
+	authSecretRef, _ := spec["authSecretRef"].(map[string]any)
+	if authSecretRef == nil {
+		errs = append(errs, FieldError{Field: "authSecretRef", Message: "is required for ServicePrincipal"})
+		return errs
+	}
+
+	clientID, _ := authSecretRef["clientId"].(map[string]any)
+	if clientID == nil {
+		errs = append(errs, FieldError{Field: "authSecretRef.clientId", Message: "is required"})
+	} else {
+		errs = append(errs, validateAzureKVSecretRef(clientID, "authSecretRef.clientId")...)
+	}
+
+	clientSecret, _ := authSecretRef["clientSecret"].(map[string]any)
+	if clientSecret == nil {
+		errs = append(errs, FieldError{Field: "authSecretRef.clientSecret", Message: "is required"})
+	} else {
+		errs = append(errs, validateAzureKVSecretRef(clientSecret, "authSecretRef.clientSecret")...)
+	}
+
+	return errs
+}
+
+// validateAzureKVWorkloadIdentity validates fields specific to the
+// WorkloadIdentity auth type.
+//
+// Required:
+//   - tenantId (string at spec root)
+//   - serviceAccountRef.name (string)
+//
+// Optional:
+//   - clientId (string override at spec root — takes precedence over the SA
+//     annotation when set)
+func validateAzureKVWorkloadIdentity(spec map[string]any) []FieldError {
+	var errs []FieldError
+
+	// tenantId is required for WorkloadIdentity.
+	tenantID, _ := spec["tenantId"].(string)
+	if strings.TrimSpace(tenantID) == "" {
+		errs = append(errs, FieldError{Field: "tenantId", Message: "is required for WorkloadIdentity"})
+	}
+
+	// serviceAccountRef.name is required.
+	saRef, _ := spec["serviceAccountRef"].(map[string]any)
+	if saRef == nil {
+		errs = append(errs, FieldError{Field: "serviceAccountRef", Message: "is required for WorkloadIdentity"})
+	} else {
+		saName, _ := saRef["name"].(string)
+		if strings.TrimSpace(saName) == "" {
+			errs = append(errs, FieldError{Field: "serviceAccountRef.name", Message: "is required"})
+		} else if !dnsLabelRegex.MatchString(saName) {
+			errs = append(errs, FieldError{Field: "serviceAccountRef.name", Message: "must be a valid DNS label"})
+		}
+	}
+
+	return errs
+}
+
+// validateAzureKVSecretRef validates an ESO secretRef sub-block (the
+// Azure-flavored SecretKeySelector: name + key). Identical constraint to
+// Vault's validateVaultSecretRef but scoped to Azure paths.
+func validateAzureKVSecretRef(ref map[string]any, prefix string) []FieldError {
+	var errs []FieldError
+	if name, _ := ref["name"].(string); name == "" {
+		errs = append(errs, FieldError{Field: prefix + ".name", Message: "is required"})
+	} else if !dnsLabelRegex.MatchString(name) {
+		errs = append(errs, FieldError{Field: prefix + ".name", Message: "must be a valid DNS label"})
+	}
+	if key, _ := ref["key"].(string); key == "" {
+		errs = append(errs, FieldError{Field: prefix + ".key", Message: "is required"})
+	}
+	return errs
+}

--- a/backend/internal/wizard/secretstore_azurekv.go
+++ b/backend/internal/wizard/secretstore_azurekv.go
@@ -93,12 +93,16 @@ func isValidAzureAuthType(s string) bool {
 //     "use the AKS-bound managed identity".
 //
 // Neither field is required — ESO defaults both from the pod's MI binding.
-// We validate format when provided.
-func validateAzureKVManagedIdentity(_ map[string]any) []FieldError {
-	// ManagedIdentity has no required sub-fields in ESO v1. tenantId and
-	// identityId are both optional and carry no format constraint beyond
-	// "non-empty when set" — which the wizard enforces client-side only.
-	return nil
+// identityId is rejected when present but whitespace-only.
+func validateAzureKVManagedIdentity(spec map[string]any) []FieldError {
+	var errs []FieldError
+	if identityID, ok := spec["identityId"].(string); ok {
+		// Key is present; reject whitespace-only values.
+		if strings.TrimSpace(identityID) == "" {
+			errs = append(errs, FieldError{Field: "identityId", Message: "must not be empty when set"})
+		}
+	}
+	return errs
 }
 
 // validateAzureKVServicePrincipal validates fields specific to the
@@ -148,9 +152,9 @@ func validateAzureKVServicePrincipal(spec map[string]any) []FieldError {
 //   - tenantId (string at spec root)
 //   - serviceAccountRef.name (string)
 //
-// Optional:
-//   - clientId (string override at spec root — takes precedence over the SA
-//     annotation when set)
+// ESO's AzureKVProvider has no plain-string clientId field at the spec root
+// for WorkloadIdentity — the only clientId is inside authSecretRef (a
+// SecretKeySelector used by ServicePrincipal). Do not add clientId here.
 func validateAzureKVWorkloadIdentity(spec map[string]any) []FieldError {
 	var errs []FieldError
 

--- a/backend/internal/wizard/secretstore_azurekv_test.go
+++ b/backend/internal/wizard/secretstore_azurekv_test.go
@@ -1,0 +1,378 @@
+package wizard
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// validAzureKVSpecSP returns a minimal valid AzureKV provider spec using
+// ServicePrincipal auth — the most field-rich auth type, so it covers the most
+// validation code. Other auth-method tests override spec fields as needed.
+func validAzureKVSpecSP() map[string]any {
+	return map[string]any{
+		"vaultUrl": "https://my-vault.vault.azure.net",
+		"tenantId": "00000000-0000-0000-0000-000000000001",
+		"authType": "ServicePrincipal",
+		"authSecretRef": map[string]any{
+			"clientId": map[string]any{
+				"name": "azure-sp-secret",
+				"key":  "client-id",
+			},
+			"clientSecret": map[string]any{
+				"name": "azure-sp-secret",
+				"key":  "client-secret",
+			},
+		},
+	}
+}
+
+// validAzureKVSpecMI returns a minimal valid spec for ManagedIdentity auth.
+func validAzureKVSpecMI() map[string]any {
+	return map[string]any{
+		"vaultUrl": "https://my-vault.vault.azure.net",
+		"authType": "ManagedIdentity",
+	}
+}
+
+// validAzureKVSpecWI returns a minimal valid spec for WorkloadIdentity auth.
+func validAzureKVSpecWI() map[string]any {
+	return map[string]any{
+		"vaultUrl": "https://my-vault.vault.azure.net",
+		"tenantId": "00000000-0000-0000-0000-000000000002",
+		"authType": "WorkloadIdentity",
+		"serviceAccountRef": map[string]any{
+			"name": "eso-workload-sa",
+		},
+	}
+}
+
+// --- Top-level field validation ---
+
+func TestValidateAzureKVSpec_SP_Valid(t *testing.T) {
+	if errs := validateAzureKVSpec(validAzureKVSpecSP()); len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+}
+
+func TestValidateAzureKVSpec_MI_Valid(t *testing.T) {
+	if errs := validateAzureKVSpec(validAzureKVSpecMI()); len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+}
+
+func TestValidateAzureKVSpec_WI_Valid(t *testing.T) {
+	if errs := validateAzureKVSpec(validAzureKVSpecWI()); len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+}
+
+func TestValidateAzureKVSpec_MissingVaultUrl(t *testing.T) {
+	spec := validAzureKVSpecSP()
+	delete(spec, "vaultUrl")
+	if !hasField(validateAzureKVSpec(spec), "vaultUrl") {
+		t.Error("expected vaultUrl required error")
+	}
+}
+
+func TestValidateAzureKVSpec_BlankVaultUrl(t *testing.T) {
+	spec := validAzureKVSpecSP()
+	spec["vaultUrl"] = "   "
+	if !hasField(validateAzureKVSpec(spec), "vaultUrl") {
+		t.Error("expected vaultUrl error for whitespace-only value")
+	}
+}
+
+func TestValidateAzureKVSpec_NonHTTPSVaultUrl(t *testing.T) {
+	spec := validAzureKVSpecSP()
+	spec["vaultUrl"] = "http://my-vault.vault.azure.net"
+	errs := validateAzureKVSpec(spec)
+	if !hasField(errs, "vaultUrl") {
+		t.Errorf("expected vaultUrl https error; got %v", errs)
+	}
+}
+
+func TestValidateAzureKVSpec_MissingAuthType(t *testing.T) {
+	spec := validAzureKVSpecSP()
+	delete(spec, "authType")
+	errs := validateAzureKVSpec(spec)
+	if !hasField(errs, "authType") {
+		t.Errorf("expected authType required error; got %v", errs)
+	}
+}
+
+func TestValidateAzureKVSpec_InvalidAuthType(t *testing.T) {
+	spec := validAzureKVSpecSP()
+	spec["authType"] = "CertificateAuth"
+	errs := validateAzureKVSpec(spec)
+	if !hasField(errs, "authType") {
+		t.Errorf("expected authType invalid error; got %v", errs)
+	}
+	// Confirm all three valid values are named in the error message.
+	for _, e := range errs {
+		if e.Field == "authType" {
+			if !strings.Contains(e.Message, "ManagedIdentity") ||
+				!strings.Contains(e.Message, "ServicePrincipal") ||
+				!strings.Contains(e.Message, "WorkloadIdentity") {
+				t.Errorf("expected all auth type names in error message, got %q", e.Message)
+			}
+		}
+	}
+}
+
+// --- ManagedIdentity auth ---
+
+func TestValidateAzureKVSpec_MI_WithOptionalTenantId(t *testing.T) {
+	spec := validAzureKVSpecMI()
+	spec["tenantId"] = "optional-tenant"
+	if errs := validateAzureKVSpec(spec); len(errs) != 0 {
+		t.Errorf("expected no errors with optional tenantId; got %v", errs)
+	}
+}
+
+func TestValidateAzureKVSpec_MI_WithOptionalIdentityId(t *testing.T) {
+	spec := validAzureKVSpecMI()
+	spec["identityId"] = "some-client-id"
+	if errs := validateAzureKVSpec(spec); len(errs) != 0 {
+		t.Errorf("expected no errors with optional identityId; got %v", errs)
+	}
+}
+
+// ManagedIdentity: tenantId is truly optional (not required like SP/WI).
+func TestValidateAzureKVSpec_MI_NoTenantIdIsOk(t *testing.T) {
+	spec := validAzureKVSpecMI()
+	// spec already has no tenantId — should pass clean.
+	if errs := validateAzureKVSpec(spec); len(errs) != 0 {
+		t.Errorf("expected ManagedIdentity to pass without tenantId; got %v", errs)
+	}
+}
+
+// --- ServicePrincipal auth ---
+
+func TestValidateAzureKVSpec_SP_MissingTenantId(t *testing.T) {
+	spec := validAzureKVSpecSP()
+	delete(spec, "tenantId")
+	if !hasField(validateAzureKVSpec(spec), "tenantId") {
+		t.Error("expected tenantId required for ServicePrincipal")
+	}
+}
+
+func TestValidateAzureKVSpec_SP_BlankTenantId(t *testing.T) {
+	spec := validAzureKVSpecSP()
+	spec["tenantId"] = "  "
+	if !hasField(validateAzureKVSpec(spec), "tenantId") {
+		t.Error("expected tenantId error for whitespace-only value")
+	}
+}
+
+func TestValidateAzureKVSpec_SP_MissingAuthSecretRef(t *testing.T) {
+	spec := validAzureKVSpecSP()
+	delete(spec, "authSecretRef")
+	if !hasField(validateAzureKVSpec(spec), "authSecretRef") {
+		t.Error("expected authSecretRef required for ServicePrincipal")
+	}
+}
+
+func TestValidateAzureKVSpec_SP_MissingClientId(t *testing.T) {
+	spec := validAzureKVSpecSP()
+	spec["authSecretRef"] = map[string]any{
+		"clientSecret": map[string]any{"name": "s", "key": "k"},
+	}
+	if !hasField(validateAzureKVSpec(spec), "authSecretRef.clientId") {
+		t.Error("expected authSecretRef.clientId required")
+	}
+}
+
+func TestValidateAzureKVSpec_SP_MissingClientSecret(t *testing.T) {
+	spec := validAzureKVSpecSP()
+	spec["authSecretRef"] = map[string]any{
+		"clientId": map[string]any{"name": "s", "key": "k"},
+	}
+	if !hasField(validateAzureKVSpec(spec), "authSecretRef.clientSecret") {
+		t.Error("expected authSecretRef.clientSecret required")
+	}
+}
+
+func TestValidateAzureKVSpec_SP_ClientIdMissingName(t *testing.T) {
+	spec := validAzureKVSpecSP()
+	spec["authSecretRef"] = map[string]any{
+		"clientId":     map[string]any{"key": "client-id"}, // missing name
+		"clientSecret": map[string]any{"name": "s", "key": "k"},
+	}
+	if !hasField(validateAzureKVSpec(spec), "authSecretRef.clientId.name") {
+		t.Error("expected authSecretRef.clientId.name required")
+	}
+}
+
+func TestValidateAzureKVSpec_SP_ClientIdMissingKey(t *testing.T) {
+	spec := validAzureKVSpecSP()
+	spec["authSecretRef"] = map[string]any{
+		"clientId":     map[string]any{"name": "s"}, // missing key
+		"clientSecret": map[string]any{"name": "s", "key": "k"},
+	}
+	if !hasField(validateAzureKVSpec(spec), "authSecretRef.clientId.key") {
+		t.Error("expected authSecretRef.clientId.key required")
+	}
+}
+
+func TestValidateAzureKVSpec_SP_ClientIdBadName(t *testing.T) {
+	spec := validAzureKVSpecSP()
+	spec["authSecretRef"] = map[string]any{
+		"clientId":     map[string]any{"name": "BadName", "key": "k"},
+		"clientSecret": map[string]any{"name": "s", "key": "k"},
+	}
+	if !hasField(validateAzureKVSpec(spec), "authSecretRef.clientId.name") {
+		t.Error("expected authSecretRef.clientId.name DNS error")
+	}
+}
+
+func TestValidateAzureKVSpec_SP_ClientSecretMissingKey(t *testing.T) {
+	spec := validAzureKVSpecSP()
+	spec["authSecretRef"] = map[string]any{
+		"clientId":     map[string]any{"name": "s", "key": "k"},
+		"clientSecret": map[string]any{"name": "s"}, // missing key
+	}
+	if !hasField(validateAzureKVSpec(spec), "authSecretRef.clientSecret.key") {
+		t.Error("expected authSecretRef.clientSecret.key required")
+	}
+}
+
+// --- WorkloadIdentity auth ---
+
+func TestValidateAzureKVSpec_WI_MissingTenantId(t *testing.T) {
+	spec := validAzureKVSpecWI()
+	delete(spec, "tenantId")
+	if !hasField(validateAzureKVSpec(spec), "tenantId") {
+		t.Error("expected tenantId required for WorkloadIdentity")
+	}
+}
+
+func TestValidateAzureKVSpec_WI_MissingServiceAccountRef(t *testing.T) {
+	spec := validAzureKVSpecWI()
+	delete(spec, "serviceAccountRef")
+	if !hasField(validateAzureKVSpec(spec), "serviceAccountRef") {
+		t.Error("expected serviceAccountRef required for WorkloadIdentity")
+	}
+}
+
+func TestValidateAzureKVSpec_WI_MissingServiceAccountName(t *testing.T) {
+	spec := validAzureKVSpecWI()
+	spec["serviceAccountRef"] = map[string]any{} // missing name
+	if !hasField(validateAzureKVSpec(spec), "serviceAccountRef.name") {
+		t.Error("expected serviceAccountRef.name required")
+	}
+}
+
+func TestValidateAzureKVSpec_WI_BadServiceAccountName(t *testing.T) {
+	spec := validAzureKVSpecWI()
+	spec["serviceAccountRef"] = map[string]any{"name": "Bad_Name"}
+	if !hasField(validateAzureKVSpec(spec), "serviceAccountRef.name") {
+		t.Error("expected serviceAccountRef.name DNS label error")
+	}
+}
+
+func TestValidateAzureKVSpec_WI_WithOptionalClientId(t *testing.T) {
+	spec := validAzureKVSpecWI()
+	spec["clientId"] = "override-client-id"
+	if errs := validateAzureKVSpec(spec); len(errs) != 0 {
+		t.Errorf("expected no errors with optional clientId; got %v", errs)
+	}
+}
+
+// --- Dispatcher integration ---
+
+// TestSecretStoreInput_AzureKVIntegration confirms validateAzureKVSpec is
+// wired to the dispatcher via the init() RegisterSecretStoreProvider call.
+func TestSecretStoreInput_AzureKVIntegration(t *testing.T) {
+	s := SecretStoreInput{
+		Scope:        StoreScopeNamespaced,
+		Name:         "azure-store",
+		Namespace:    "apps",
+		Provider:     SecretStoreProviderAzure,
+		ProviderSpec: validAzureKVSpecSP(),
+	}
+	if errs := s.Validate(); len(errs) != 0 {
+		t.Errorf("expected no errors via dispatcher, got %v", errs)
+	}
+}
+
+func TestSecretStoreInput_AzureKVIntegration_PropagatesProviderError(t *testing.T) {
+	spec := validAzureKVSpecSP()
+	delete(spec, "vaultUrl")
+	s := SecretStoreInput{
+		Scope:        StoreScopeNamespaced,
+		Name:         "azure-store",
+		Namespace:    "apps",
+		Provider:     SecretStoreProviderAzure,
+		ProviderSpec: spec,
+	}
+	errs := s.Validate()
+	if !hasField(errs, "vaultUrl") {
+		t.Errorf("expected provider-level vaultUrl error, got %v", errs)
+	}
+}
+
+// TestSecretStoreInput_AzureKVIntegration_ToYAML asserts the YAML places the
+// spec under spec.provider.azurekv with the correct top-level shape.
+func TestSecretStoreInput_AzureKVIntegration_ToYAML(t *testing.T) {
+	s := SecretStoreInput{
+		Scope:        StoreScopeNamespaced,
+		Name:         "azure-kv-store",
+		Namespace:    "apps",
+		Provider:     SecretStoreProviderAzure,
+		ProviderSpec: validAzureKVSpecSP(),
+	}
+	y, err := s.ToYAML()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, want := range []string{
+		"apiVersion: external-secrets.io/v1",
+		"kind: SecretStore",
+	} {
+		if !strings.Contains(y, want) {
+			t.Errorf("expected YAML to contain %q\n%s", want, y)
+		}
+	}
+
+	// Structural assertion: confirm spec.provider.azurekv.vaultUrl is present.
+	var doc map[string]any
+	if err := yaml.Unmarshal([]byte(y), &doc); err != nil {
+		t.Fatalf("failed to parse YAML: %v\n%s", err, y)
+	}
+	spec, _ := doc["spec"].(map[string]any)
+	provider, _ := spec["provider"].(map[string]any)
+	azureSpec, _ := provider["azurekv"].(map[string]any)
+	if azureSpec == nil {
+		t.Fatalf("expected spec.provider.azurekv, got provider keys: %v", keys(provider))
+	}
+	if azureSpec["vaultUrl"] == nil {
+		t.Errorf("expected spec.provider.azurekv.vaultUrl to be present; got %v", azureSpec)
+	}
+	if azureSpec["authType"] == nil {
+		t.Errorf("expected spec.provider.azurekv.authType to be present; got %v", azureSpec)
+	}
+}
+
+// TestSecretStoreInput_AzureKVIntegration_ClusterScope verifies a
+// ClusterSecretStore is emitted correctly for cluster scope.
+func TestSecretStoreInput_AzureKVIntegration_ClusterScope(t *testing.T) {
+	s := SecretStoreInput{
+		Scope:        StoreScopeCluster,
+		Name:         "shared-azure-store",
+		Provider:     SecretStoreProviderAzure,
+		ProviderSpec: validAzureKVSpecMI(),
+	}
+	if errs := s.Validate(); len(errs) != 0 {
+		t.Fatalf("expected no errors for cluster scope, got %v", errs)
+	}
+	y, err := s.ToYAML()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(y, "kind: ClusterSecretStore") {
+		t.Errorf("expected ClusterSecretStore in YAML\n%s", y)
+	}
+}

--- a/backend/internal/wizard/secretstore_azurekv_test.go
+++ b/backend/internal/wizard/secretstore_azurekv_test.go
@@ -139,6 +139,14 @@ func TestValidateAzureKVSpec_MI_WithOptionalIdentityId(t *testing.T) {
 	}
 }
 
+func TestValidateAzureKVSpec_MI_BlankIdentityIdIsRejected(t *testing.T) {
+	spec := validAzureKVSpecMI()
+	spec["identityId"] = "   " // present but whitespace-only
+	if !hasField(validateAzureKVSpec(spec), "identityId") {
+		t.Error("expected identityId error for whitespace-only value when key is present")
+	}
+}
+
 // ManagedIdentity: tenantId is truly optional (not required like SP/WI).
 func TestValidateAzureKVSpec_MI_NoTenantIdIsOk(t *testing.T) {
 	spec := validAzureKVSpecMI()
@@ -272,11 +280,16 @@ func TestValidateAzureKVSpec_WI_BadServiceAccountName(t *testing.T) {
 	}
 }
 
-func TestValidateAzureKVSpec_WI_WithOptionalClientId(t *testing.T) {
+// WI YAML must NOT emit a top-level clientId — that field doesn't exist on
+// ESO's AzureKVProvider spec root. Regression guard for the fabricated field.
+func TestValidateAzureKVSpec_WI_NoTopLevelClientId(t *testing.T) {
 	spec := validAzureKVSpecWI()
-	spec["clientId"] = "override-client-id"
 	if errs := validateAzureKVSpec(spec); len(errs) != 0 {
-		t.Errorf("expected no errors with optional clientId; got %v", errs)
+		t.Errorf("expected no errors for valid WI spec; got %v", errs)
+	}
+	// Confirm the spec itself contains no clientId at the root level.
+	if _, ok := spec["clientId"]; ok {
+		t.Error("WI spec must not have a top-level clientId field")
 	}
 }
 
@@ -353,6 +366,71 @@ func TestSecretStoreInput_AzureKVIntegration_ToYAML(t *testing.T) {
 	}
 	if azureSpec["authType"] == nil {
 		t.Errorf("expected spec.provider.azurekv.authType to be present; got %v", azureSpec)
+	}
+}
+
+// TestSecretStoreInput_AzureKVIntegration_ToYAML_AuthSecretRefNesting verifies
+// that for ServicePrincipal the authSecretRef.clientId and
+// authSecretRef.clientSecret blocks nest correctly under spec.provider.azurekv,
+// and that WorkloadIdentity YAML does NOT include any top-level clientId field.
+func TestSecretStoreInput_AzureKVIntegration_ToYAML_AuthSecretRefNesting(t *testing.T) {
+	// --- ServicePrincipal: authSecretRef must contain nested clientId + clientSecret ---
+	spStore := SecretStoreInput{
+		Scope:        StoreScopeNamespaced,
+		Name:         "azure-sp-store",
+		Namespace:    "apps",
+		Provider:     SecretStoreProviderAzure,
+		ProviderSpec: validAzureKVSpecSP(),
+	}
+	spYAML, err := spStore.ToYAML()
+	if err != nil {
+		t.Fatalf("SP ToYAML error: %v", err)
+	}
+	var spDoc map[string]any
+	if err := yaml.Unmarshal([]byte(spYAML), &spDoc); err != nil {
+		t.Fatalf("SP YAML parse error: %v\n%s", err, spYAML)
+	}
+	spKVSpec := func() map[string]any {
+		spec, _ := spDoc["spec"].(map[string]any)
+		provider, _ := spec["provider"].(map[string]any)
+		az, _ := provider["azurekv"].(map[string]any)
+		return az
+	}()
+	authSecretRef, _ := spKVSpec["authSecretRef"].(map[string]any)
+	if authSecretRef == nil {
+		t.Fatalf("SP: expected authSecretRef under spec.provider.azurekv, got keys: %v", keys(spKVSpec))
+	}
+	if authSecretRef["clientId"] == nil {
+		t.Errorf("SP: expected authSecretRef.clientId to be present; got %v", authSecretRef)
+	}
+	if authSecretRef["clientSecret"] == nil {
+		t.Errorf("SP: expected authSecretRef.clientSecret to be present; got %v", authSecretRef)
+	}
+
+	// --- WorkloadIdentity: NO top-level clientId in emitted YAML ---
+	wiStore := SecretStoreInput{
+		Scope:        StoreScopeNamespaced,
+		Name:         "azure-wi-store",
+		Namespace:    "apps",
+		Provider:     SecretStoreProviderAzure,
+		ProviderSpec: validAzureKVSpecWI(),
+	}
+	wiYAML, err := wiStore.ToYAML()
+	if err != nil {
+		t.Fatalf("WI ToYAML error: %v", err)
+	}
+	var wiDoc map[string]any
+	if err := yaml.Unmarshal([]byte(wiYAML), &wiDoc); err != nil {
+		t.Fatalf("WI YAML parse error: %v\n%s", err, wiYAML)
+	}
+	wiKVSpec := func() map[string]any {
+		spec, _ := wiDoc["spec"].(map[string]any)
+		provider, _ := spec["provider"].(map[string]any)
+		az, _ := provider["azurekv"].(map[string]any)
+		return az
+	}()
+	if _, ok := wiKVSpec["clientId"]; ok {
+		t.Errorf("WI: spec.provider.azurekv must NOT contain a top-level clientId; got %v", wiKVSpec)
 	}
 }
 

--- a/frontend/components/wizard/secretstore/AzureKVForm.tsx
+++ b/frontend/components/wizard/secretstore/AzureKVForm.tsx
@@ -5,20 +5,20 @@ import { Input } from "@/components/ui/Input.tsx";
  * Azure Key Vault provider form for SecretStoreWizard. Writes into the
  * wizard's `providerSpec: Record<string, unknown>` slot under the shape
  * `{ vaultUrl, authType, tenantId?, authSecretRef?, serviceAccountRef?,
- *    identityId?, clientId? }`.
+ *    identityId? }`.
  *
  * Azure's auth discriminator is a top-level `authType` string, NOT a nested
  * auth sub-block like Vault. Three auth types are supported:
  *
  * - ManagedIdentity: no required credentials; optional identityId.
  * - ServicePrincipal: tenantId + authSecretRef.{clientId, clientSecret}.
- * - WorkloadIdentity: tenantId + serviceAccountRef.name; optional clientId.
+ * - WorkloadIdentity: tenantId + serviceAccountRef.name.
  *
  * Switching authType clears the auth-related fields so stale values from the
  * prior selection can't leak into the preview.
  */
 
-export type AzureKVAuthType =
+type AzureKVAuthType =
   | "ManagedIdentity"
   | "ServicePrincipal"
   | "WorkloadIdentity";
@@ -50,8 +50,6 @@ interface AzureKVSpec {
   serviceAccountRef?: { name?: string };
   /** ManagedIdentity: optional client ID when multiple MIs are assigned to the pod. */
   identityId?: string;
-  /** WorkloadIdentity: optional clientId override (takes precedence over SA annotation). */
-  clientId?: string;
 }
 
 const AUTH_TYPES: {
@@ -106,7 +104,6 @@ const AUTH_TYPE_OWNED_FIELDS: ReadonlyArray<keyof AzureKVSpec> = [
   "authSecretRef",
   "serviceAccountRef",
   "identityId",
-  "clientId",
 ];
 
 export function AzureKVForm({ spec, errors, onUpdateSpec }: AzureKVFormProps) {
@@ -234,11 +231,9 @@ export function AzureKVForm({ spec, errors, onUpdateSpec }: AzureKVFormProps) {
         <WorkloadIdentityFields
           tenantId={getStr(spec, "tenantId")}
           saName={saRef.name ?? ""}
-          clientId={getStr(spec, "clientId")}
           errors={errors}
           onPatchTenantId={(v) => patchTop("tenantId", v)}
           onPatchSaName={(name) => patchServiceAccountRef({ name })}
-          onPatchClientId={(v) => patchTop("clientId", v)}
         />
       )}
     </div>
@@ -379,22 +374,18 @@ function ServicePrincipalFields(
 interface WorkloadIdentityFieldsProps {
   tenantId: string;
   saName: string;
-  clientId: string;
   errors: Record<string, string>;
   onPatchTenantId: (v: string) => void;
   onPatchSaName: (name: string) => void;
-  onPatchClientId: (v: string) => void;
 }
 
 function WorkloadIdentityFields(
   {
     tenantId,
     saName,
-    clientId,
     errors,
     onPatchTenantId,
     onPatchSaName,
-    onPatchClientId,
   }: WorkloadIdentityFieldsProps,
 ) {
   return (
@@ -420,15 +411,6 @@ function WorkloadIdentityFields(
         placeholder="eso-workload-sa"
         description="The K8s ServiceAccount annotated with the Azure federated identity."
         error={errors["serviceAccountRef.name"]}
-      />
-      <Input
-        id="azurekv-wi-client-id"
-        label="Client ID override (optional)"
-        value={clientId}
-        onInput={(e) => onPatchClientId((e.target as HTMLInputElement).value)}
-        placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-        description="Overrides the clientId annotation on the service account when set."
-        error={errors["clientId"]}
       />
     </div>
   );

--- a/frontend/components/wizard/secretstore/AzureKVForm.tsx
+++ b/frontend/components/wizard/secretstore/AzureKVForm.tsx
@@ -1,0 +1,435 @@
+import { useSignal } from "@preact/signals";
+import { Input } from "@/components/ui/Input.tsx";
+
+/**
+ * Azure Key Vault provider form for SecretStoreWizard. Writes into the
+ * wizard's `providerSpec: Record<string, unknown>` slot under the shape
+ * `{ vaultUrl, authType, tenantId?, authSecretRef?, serviceAccountRef?,
+ *    identityId?, clientId? }`.
+ *
+ * Azure's auth discriminator is a top-level `authType` string, NOT a nested
+ * auth sub-block like Vault. Three auth types are supported:
+ *
+ * - ManagedIdentity: no required credentials; optional identityId.
+ * - ServicePrincipal: tenantId + authSecretRef.{clientId, clientSecret}.
+ * - WorkloadIdentity: tenantId + serviceAccountRef.name; optional clientId.
+ *
+ * Switching authType clears the auth-related fields so stale values from the
+ * prior selection can't leak into the preview.
+ */
+
+export type AzureKVAuthType =
+  | "ManagedIdentity"
+  | "ServicePrincipal"
+  | "WorkloadIdentity";
+
+export interface AzureKVFormProps {
+  spec: Record<string, unknown>;
+  errors: Record<string, string>;
+  onUpdateSpec: (spec: Record<string, unknown>) => void;
+}
+
+interface SecretRef {
+  name?: string;
+  key?: string;
+}
+
+interface AzureAuthSecretRef {
+  clientId?: SecretRef;
+  clientSecret?: SecretRef;
+}
+
+/** Typed shape for the Azure KV provider spec block (spec.provider.azurekv). */
+interface AzureKVSpec {
+  vaultUrl?: string;
+  tenantId?: string;
+  authType?: AzureKVAuthType;
+  /** ServicePrincipal: references to clientId and clientSecret Secrets. */
+  authSecretRef?: AzureAuthSecretRef;
+  /** WorkloadIdentity: the service account that carries the federated identity. */
+  serviceAccountRef?: { name?: string };
+  /** ManagedIdentity: optional client ID when multiple MIs are assigned to the pod. */
+  identityId?: string;
+  /** WorkloadIdentity: optional clientId override (takes precedence over SA annotation). */
+  clientId?: string;
+}
+
+const AUTH_TYPES: {
+  id: AzureKVAuthType;
+  label: string;
+  description: string;
+}[] = [
+  {
+    id: "ManagedIdentity",
+    label: "Managed Identity",
+    description:
+      "Use the AKS-assigned managed identity. No credentials required.",
+  },
+  {
+    id: "ServicePrincipal",
+    label: "Service Principal",
+    description:
+      "App registration with client ID + secret stored in a K8s Secret.",
+  },
+  {
+    id: "WorkloadIdentity",
+    label: "Workload Identity",
+    description:
+      "AKS Workload Identity via a federated service account (no long-lived secret).",
+  },
+];
+
+/** Determine which auth type the spec currently encodes, or "" when none. */
+function detectAuthType(spec: Record<string, unknown>): AzureKVAuthType | "" {
+  const v = spec.authType;
+  if (
+    v === "ManagedIdentity" || v === "ServicePrincipal" ||
+    v === "WorkloadIdentity"
+  ) {
+    return v;
+  }
+  return "";
+}
+
+/** Read a top-level string field from the spec. */
+function getStr(spec: Record<string, unknown>, key: string): string {
+  const v = spec[key];
+  return typeof v === "string" ? v : "";
+}
+
+/**
+ * Auth-related field keys that must be cleared when the auth type changes.
+ * Ensures stale credentials from a prior selection don't leak into the preview.
+ */
+const AUTH_TYPE_OWNED_FIELDS: ReadonlyArray<keyof AzureKVSpec> = [
+  "tenantId",
+  "authSecretRef",
+  "serviceAccountRef",
+  "identityId",
+  "clientId",
+];
+
+export function AzureKVForm({ spec, errors, onUpdateSpec }: AzureKVFormProps) {
+  const authType = useSignal<AzureKVAuthType | "">(detectAuthType(spec));
+
+  function patchTop(field: string, value: string) {
+    const next = { ...spec };
+    if (value === "") delete next[field];
+    else next[field] = value;
+    onUpdateSpec(next);
+  }
+
+  function setAuthType(t: AzureKVAuthType) {
+    if (authType.value === t) return;
+    authType.value = t;
+    // Clear all auth-type-owned fields so old credentials don't bleed through.
+    const next = { ...spec };
+    for (const f of AUTH_TYPE_OWNED_FIELDS) {
+      delete next[f as string];
+    }
+    next.authType = t;
+    onUpdateSpec(next);
+  }
+
+  function patchAuthSecretRef(
+    field: "clientId" | "clientSecret",
+    patch: SecretRef,
+  ) {
+    const existing = (spec.authSecretRef as AzureAuthSecretRef) ?? {};
+    const existingRef = (existing[field] as SecretRef) ?? {};
+    onUpdateSpec({
+      ...spec,
+      authSecretRef: {
+        ...existing,
+        [field]: { ...existingRef, ...patch },
+      },
+    });
+  }
+
+  function patchServiceAccountRef(patch: { name?: string }) {
+    const existing = (spec.serviceAccountRef as { name?: string }) ?? {};
+    onUpdateSpec({
+      ...spec,
+      serviceAccountRef: { ...existing, ...patch },
+    });
+  }
+
+  const authSecretRef = (spec.authSecretRef as AzureAuthSecretRef) ?? {};
+  const saRef = (spec.serviceAccountRef as { name?: string }) ?? {};
+
+  return (
+    <div class="space-y-5">
+      <div class="rounded-md border border-border-primary bg-surface/50 p-4 text-sm text-text-muted">
+        Configure the Azure Key Vault connection and authentication method.
+        Credentials must already exist as Kubernetes Secrets in this namespace;
+        this wizard only references them — it never holds Azure credentials
+        directly.
+      </div>
+
+      {/* Vault URL */}
+      <Input
+        id="azurekv-vault-url"
+        label="Vault URL"
+        required
+        value={getStr(spec, "vaultUrl")}
+        onInput={(e) =>
+          patchTop("vaultUrl", (e.target as HTMLInputElement).value)}
+        placeholder="https://my-vault.vault.azure.net"
+        description="Must use https. Typically ends in .vault.azure.net."
+        error={errors["vaultUrl"]}
+      />
+
+      {/* Auth type picker */}
+      <div class="space-y-3">
+        <h3 class="text-sm font-semibold text-text-primary">
+          Authentication type
+          <span aria-hidden="true" class="text-danger ml-0.5">*</span>
+        </h3>
+        <div class="grid gap-2 sm:grid-cols-3">
+          {AUTH_TYPES.map((t) => {
+            const active = authType.value === t.id;
+            return (
+              <button
+                key={t.id}
+                type="button"
+                onClick={() => setAuthType(t.id)}
+                class={`text-left rounded-lg border p-3 transition-colors ${
+                  active
+                    ? "border-brand bg-brand/5"
+                    : "border-border-primary bg-surface hover:border-border-emphasis"
+                }`}
+                aria-pressed={active}
+              >
+                <div class="font-medium text-text-primary">{t.label}</div>
+                <p class="mt-1 text-xs text-text-muted">{t.description}</p>
+              </button>
+            );
+          })}
+        </div>
+        {errors["authType"] && (
+          <p class="text-sm text-danger">{errors["authType"]}</p>
+        )}
+      </div>
+
+      {/* Auth-type-specific fields */}
+      {authType.value === "ManagedIdentity" && (
+        <ManagedIdentityFields
+          identityId={getStr(spec, "identityId")}
+          errors={errors}
+          onPatchIdentityId={(v) => patchTop("identityId", v)}
+        />
+      )}
+      {authType.value === "ServicePrincipal" && (
+        <ServicePrincipalFields
+          tenantId={getStr(spec, "tenantId")}
+          authSecretRef={authSecretRef}
+          errors={errors}
+          onPatchTenantId={(v) => patchTop("tenantId", v)}
+          onPatchClientId={(patch) => patchAuthSecretRef("clientId", patch)}
+          onPatchClientSecret={(patch) =>
+            patchAuthSecretRef("clientSecret", patch)}
+        />
+      )}
+      {authType.value === "WorkloadIdentity" && (
+        <WorkloadIdentityFields
+          tenantId={getStr(spec, "tenantId")}
+          saName={saRef.name ?? ""}
+          clientId={getStr(spec, "clientId")}
+          errors={errors}
+          onPatchTenantId={(v) => patchTop("tenantId", v)}
+          onPatchSaName={(name) => patchServiceAccountRef({ name })}
+          onPatchClientId={(v) => patchTop("clientId", v)}
+        />
+      )}
+    </div>
+  );
+}
+
+// --- Per-type field components -----------------------------------------------
+
+interface ManagedIdentityFieldsProps {
+  identityId: string;
+  errors: Record<string, string>;
+  onPatchIdentityId: (v: string) => void;
+}
+
+function ManagedIdentityFields(
+  { identityId, errors, onPatchIdentityId }: ManagedIdentityFieldsProps,
+) {
+  return (
+    <div class="rounded-md border border-border-primary p-4 space-y-3">
+      <h4 class="text-sm font-medium text-text-primary">Managed Identity</h4>
+      <p class="text-xs text-text-muted">
+        No credentials required. ESO uses the managed identity bound to the
+        controller pod by AKS. If multiple managed identities are assigned,
+        specify the client ID below.
+      </p>
+      <Input
+        id="azurekv-mi-identity-id"
+        label="Identity client ID (optional)"
+        value={identityId}
+        onInput={(e) => onPatchIdentityId((e.target as HTMLInputElement).value)}
+        placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+        description="Leave blank to use the AKS-default managed identity."
+        error={errors["identityId"]}
+      />
+    </div>
+  );
+}
+
+interface ServicePrincipalFieldsProps {
+  tenantId: string;
+  authSecretRef: AzureAuthSecretRef;
+  errors: Record<string, string>;
+  onPatchTenantId: (v: string) => void;
+  onPatchClientId: (patch: SecretRef) => void;
+  onPatchClientSecret: (patch: SecretRef) => void;
+}
+
+function ServicePrincipalFields(
+  {
+    tenantId,
+    authSecretRef,
+    errors,
+    onPatchTenantId,
+    onPatchClientId,
+    onPatchClientSecret,
+  }: ServicePrincipalFieldsProps,
+) {
+  const clientId = (authSecretRef.clientId as SecretRef) ?? {};
+  const clientSecret = (authSecretRef.clientSecret as SecretRef) ?? {};
+  return (
+    <div class="rounded-md border border-border-primary p-4 space-y-4">
+      <h4 class="text-sm font-medium text-text-primary">Service Principal</h4>
+
+      <Input
+        id="azurekv-sp-tenant-id"
+        label="Tenant ID"
+        required
+        value={tenantId}
+        onInput={(e) => onPatchTenantId((e.target as HTMLInputElement).value)}
+        placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+        description="Azure AD tenant ID (Directory ID)."
+        error={errors["tenantId"]}
+      />
+
+      <div>
+        <h5 class="text-sm font-medium text-text-primary mb-2">
+          Client ID Secret reference
+        </h5>
+        <div class="grid grid-cols-2 gap-3">
+          <Input
+            id="azurekv-sp-clientid-name"
+            label="Secret name"
+            required
+            value={clientId.name ?? ""}
+            onInput={(e) =>
+              onPatchClientId({ name: (e.target as HTMLInputElement).value })}
+            placeholder="azure-sp-secret"
+            error={errors["authSecretRef.clientId.name"]}
+          />
+          <Input
+            id="azurekv-sp-clientid-key"
+            label="Key"
+            required
+            value={clientId.key ?? ""}
+            onInput={(e) =>
+              onPatchClientId({ key: (e.target as HTMLInputElement).value })}
+            placeholder="client-id"
+            error={errors["authSecretRef.clientId.key"]}
+          />
+        </div>
+      </div>
+
+      <div>
+        <h5 class="text-sm font-medium text-text-primary mb-2">
+          Client Secret reference
+        </h5>
+        <div class="grid grid-cols-2 gap-3">
+          <Input
+            id="azurekv-sp-secret-name"
+            label="Secret name"
+            required
+            value={clientSecret.name ?? ""}
+            onInput={(e) =>
+              onPatchClientSecret({
+                name: (e.target as HTMLInputElement).value,
+              })}
+            placeholder="azure-sp-secret"
+            error={errors["authSecretRef.clientSecret.name"]}
+          />
+          <Input
+            id="azurekv-sp-secret-key"
+            label="Key"
+            required
+            value={clientSecret.key ?? ""}
+            onInput={(e) =>
+              onPatchClientSecret({
+                key: (e.target as HTMLInputElement).value,
+              })}
+            placeholder="client-secret"
+            error={errors["authSecretRef.clientSecret.key"]}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface WorkloadIdentityFieldsProps {
+  tenantId: string;
+  saName: string;
+  clientId: string;
+  errors: Record<string, string>;
+  onPatchTenantId: (v: string) => void;
+  onPatchSaName: (name: string) => void;
+  onPatchClientId: (v: string) => void;
+}
+
+function WorkloadIdentityFields(
+  {
+    tenantId,
+    saName,
+    clientId,
+    errors,
+    onPatchTenantId,
+    onPatchSaName,
+    onPatchClientId,
+  }: WorkloadIdentityFieldsProps,
+) {
+  return (
+    <div class="rounded-md border border-border-primary p-4 space-y-3">
+      <h4 class="text-sm font-medium text-text-primary">Workload Identity</h4>
+
+      <Input
+        id="azurekv-wi-tenant-id"
+        label="Tenant ID"
+        required
+        value={tenantId}
+        onInput={(e) => onPatchTenantId((e.target as HTMLInputElement).value)}
+        placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+        description="Azure AD tenant ID (Directory ID)."
+        error={errors["tenantId"]}
+      />
+      <Input
+        id="azurekv-wi-sa-name"
+        label="Service account name"
+        required
+        value={saName}
+        onInput={(e) => onPatchSaName((e.target as HTMLInputElement).value)}
+        placeholder="eso-workload-sa"
+        description="The K8s ServiceAccount annotated with the Azure federated identity."
+        error={errors["serviceAccountRef.name"]}
+      />
+      <Input
+        id="azurekv-wi-client-id"
+        label="Client ID override (optional)"
+        value={clientId}
+        onInput={(e) => onPatchClientId((e.target as HTMLInputElement).value)}
+        placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+        description="Overrides the clientId annotation on the service account when set."
+        error={errors["clientId"]}
+      />
+    </div>
+  );
+}

--- a/frontend/islands/SecretStoreWizard.tsx
+++ b/frontend/islands/SecretStoreWizard.tsx
@@ -13,6 +13,7 @@ import { VaultForm } from "@/components/wizard/secretstore/VaultForm.tsx";
 import type { VaultFormProps } from "@/components/wizard/secretstore/VaultForm.tsx";
 import { OnePasswordForm } from "@/components/wizard/secretstore/OnePasswordForm.tsx";
 import { AWSForm } from "@/components/wizard/secretstore/AWSForm.tsx";
+import { AzureKVForm } from "@/components/wizard/secretstore/AzureKVForm.tsx";
 import { Input } from "@/components/ui/Input.tsx";
 import { NamespaceSelect } from "@/components/ui/NamespaceSelect.tsx";
 import { Button } from "@/components/ui/Button.tsx";
@@ -34,6 +35,7 @@ const PROVIDER_FORMS: Partial<
   vault: VaultForm,
   onepassword: OnePasswordForm,
   aws: AWSForm,
+  azurekv: AzureKVForm,
 };
 
 // Re-export for any downstream consumers that imported from this island.
@@ -165,6 +167,19 @@ export default function SecretStoreWizard({ scope }: SecretStoreWizardProps) {
       const auth = ps.auth as Record<string, unknown> | undefined;
       if (!auth || Object.keys(auth).length === 0) {
         errs.auth = "Select an authentication method";
+      }
+    }
+    if (step === 2 && f.provider === "azurekv") {
+      const ps = f.providerSpec;
+      const vaultUrl = typeof ps.vaultUrl === "string"
+        ? ps.vaultUrl.trim()
+        : "";
+      if (!vaultUrl) {
+        errs.vaultUrl = "Vault URL is required";
+      }
+      const authType = typeof ps.authType === "string" ? ps.authType : "";
+      if (!authType) {
+        errs.authType = "Select an authentication type";
       }
     }
 

--- a/frontend/islands/SecretStoreWizard.tsx
+++ b/frontend/islands/SecretStoreWizard.tsx
@@ -181,6 +181,15 @@ export default function SecretStoreWizard({ scope }: SecretStoreWizardProps) {
       if (!authType) {
         errs.authType = "Select an authentication type";
       }
+      // tenantId is required for ServicePrincipal and WorkloadIdentity.
+      if (authType === "ServicePrincipal" || authType === "WorkloadIdentity") {
+        const tenantId = typeof ps.tenantId === "string"
+          ? ps.tenantId.trim()
+          : "";
+        if (!tenantId) {
+          errs.tenantId = "Tenant ID is required";
+        }
+      }
     }
 
     if (step === 2 && f.provider === "onepassword") {

--- a/frontend/lib/eso-types.ts
+++ b/frontend/lib/eso-types.ts
@@ -238,6 +238,7 @@ export const READY_SECRET_STORE_PROVIDERS = new Set<SecretStoreProvider>([
   "vault",
   "onepassword",
   "aws",
+  "azurekv",
 ]);
 
 // --- Phase G path-discovery types ------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `backend/internal/wizard/secretstore_azurekv.go` — `validateAzureKVSpec` registered in `init()` under `SecretStoreProviderAzure`. Validates the three Azure auth types using ESO's top-level `authType` discriminator (not Vault's nested `auth.<method>` sub-block).
- Adds `backend/internal/wizard/secretstore_azurekv_test.go` — 29 tests covering all 3 auth types × happy + missing-required + edge cases, dispatcher integration, YAML structural assertion, and ClusterSecretStore scope.
- Adds `frontend/components/wizard/secretstore/AzureKVForm.tsx` — 3-card auth-type picker + per-type field groups. Switching auth type clears stale credentials. Field error keys match Go validator paths exactly.
- Updates `frontend/lib/eso-types.ts` — adds `"azurekv"` to `READY_SECRET_STORE_PROVIDERS`.
- Updates `frontend/islands/SecretStoreWizard.tsx` — registers `azurekv: AzureKVForm` in `PROVIDER_FORMS`, adds client-side Configure-step gate for `azurekv`.

**Schema note:** ESO `azurekv` uses a top-level `authType` string discriminator with sibling credential fields — structurally different from Vault's `auth.<method>` nesting. The validator and form mirror the actual ESO schema directly rather than forcing Vault's shape onto Azure.

## Test plan

- [x] `go vet ./...` — clean
- [x] `go test ./internal/wizard/ -count=10` — 29 AzureKV tests + full wizard suite, all pass
- [x] `deno fmt --check` on touched files — clean
- [x] `deno lint` on touched files — clean
- [ ] `deno check` — worktree has no `node_modules` (pre-existing; VaultForm.tsx fails identically); passes in CI with full install

🤖 Generated with [Claude Code](https://claude.com/claude-code)