### PR TITLE
feat(eso): Phase H Unit 19 — AWS Parameter Store provider wizard (3/8)

### DIFF
--- a/backend/internal/wizard/secretstore_awsps.go
+++ b/backend/internal/wizard/secretstore_awsps.go
@@ -43,12 +43,8 @@ func validateAWSPSSpec(spec map[string]any) []FieldError {
 		errs = append(errs, FieldError{Field: "region", Message: "is required"})
 	}
 
-	if role, ok := spec["role"]; ok {
-		r, _ := role.(string)
-		if strings.TrimSpace(r) == "" {
-			errs = append(errs, FieldError{Field: "role", Message: "must not be empty when set"})
-		}
-	}
+	// role is validated after auth method is determined (required for jwt,
+	// optional for secretRef — assume-role with static creds is valid without it).
 
 	authRaw, hasAuth := spec["auth"].(map[string]any)
 	if !hasAuth {
@@ -64,8 +60,21 @@ func validateAWSPSSpec(spec map[string]any) []FieldError {
 
 	switch method {
 	case "jwt":
+		// role is required at the top-level AWSProvider when using workload
+		// identity (IRSA). AWSJWTAuth has only serviceAccountRef — no role field.
+		role, _ := spec["role"].(string)
+		if strings.TrimSpace(role) == "" {
+			errs = append(errs, FieldError{Field: "role", Message: "is required when using jwt auth (IAM role ARN for IRSA)"})
+		}
 		errs = append(errs, validateAWSPSAuthJWT(authRaw)...)
 	case "secretRef":
+		// role is optional for secretRef (assume-role with static creds is valid).
+		if role, ok := spec["role"]; ok {
+			r, _ := role.(string)
+			if strings.TrimSpace(r) == "" {
+				errs = append(errs, FieldError{Field: "role", Message: "must not be empty when set"})
+			}
+		}
 		errs = append(errs, validateAWSPSAuthSecretRef(authRaw)...)
 	}
 
@@ -97,7 +106,8 @@ func pickAWSPSAuthMethod(auth map[string]any) (string, []FieldError) {
 
 // validateAWSPSAuthJWT validates IAM workload identity auth via a Kubernetes
 // service account JWT. ESO maps this to IRSA (IAM Roles for Service Accounts).
-// The auth.jwt block requires serviceAccountRef.name + role.
+// Per the ESO API, AWSJWTAuth contains only serviceAccountRef — the role ARN
+// lives at spec.provider.aws.role (top-level on AWSProvider), not here.
 func validateAWSPSAuthJWT(auth map[string]any) []FieldError {
 	var errs []FieldError
 	j, _ := auth["jwt"].(map[string]any)
@@ -114,10 +124,6 @@ func validateAWSPSAuthJWT(auth map[string]any) []FieldError {
 		} else if !dnsLabelRegex.MatchString(name) {
 			errs = append(errs, FieldError{Field: "auth.jwt.serviceAccountRef.name", Message: "must be a valid DNS label"})
 		}
-	}
-
-	if role, _ := j["role"].(string); strings.TrimSpace(role) == "" {
-		errs = append(errs, FieldError{Field: "auth.jwt.role", Message: "is required (IAM role ARN)"})
 	}
 
 	return errs

--- a/backend/internal/wizard/secretstore_awsps.go
+++ b/backend/internal/wizard/secretstore_awsps.go
@@ -1,0 +1,174 @@
+package wizard
+
+import (
+	"fmt"
+	"strings"
+)
+
+// init registers the AWS Parameter Store provider validator with the
+// SecretStore wizard dispatcher. Lives in this file so the validator ships and
+// registers as one unit — adding a provider is a single-file edit + one line
+// in READY_SECRET_STORE_PROVIDERS on the frontend.
+func init() {
+	RegisterSecretStoreProvider(SecretStoreProviderAWSPS, validateAWSPSSpec)
+}
+
+// orderedAWSPSAuthMethods is the canonical ordered list of auth methods the
+// wizard surface supports in v1.
+//
+// Ordering matters: pickAWSPSAuthMethod iterates this slice to build the
+// "present" list so the multi-method error message is deterministic rather
+// than random-map-order.
+var orderedAWSPSAuthMethods = []string{"jwt", "secretRef"}
+
+// validateAWSPSSpec validates a SecretStoreInput.ProviderSpec for the AWS
+// Parameter Store provider. The spec mirrors ESO's spec.provider.aws shape
+// for ParameterStore — region (required), optional role ARN, and an auth
+// block with exactly one method populated (IAM workload identity via jwt, or
+// static credentials via secretRef).
+//
+// Note: the "service: ParameterStore" field is NOT part of the wizard spec
+// here; it is injected automatically by ToSecretStore when provider == awsps.
+// Including it in providerSpec would produce a duplicate key in the emitted
+// YAML.
+//
+// Each FieldError's Field is rooted at the provider-spec level (no
+// "providerSpec." prefix) so the dispatcher's caller can prefix uniformly
+// when surfacing errors to the frontend.
+func validateAWSPSSpec(spec map[string]any) []FieldError {
+	var errs []FieldError
+
+	region, _ := spec["region"].(string)
+	if strings.TrimSpace(region) == "" {
+		errs = append(errs, FieldError{Field: "region", Message: "is required"})
+	}
+
+	if role, ok := spec["role"]; ok {
+		r, _ := role.(string)
+		if strings.TrimSpace(r) == "" {
+			errs = append(errs, FieldError{Field: "role", Message: "must not be empty when set"})
+		}
+	}
+
+	authRaw, hasAuth := spec["auth"].(map[string]any)
+	if !hasAuth {
+		errs = append(errs, FieldError{Field: "auth", Message: "is required (one of jwt, secretRef)"})
+		return errs
+	}
+
+	method, methodErrs := pickAWSPSAuthMethod(authRaw)
+	errs = append(errs, methodErrs...)
+	if method == "" {
+		return errs
+	}
+
+	switch method {
+	case "jwt":
+		errs = append(errs, validateAWSPSAuthJWT(authRaw)...)
+	case "secretRef":
+		errs = append(errs, validateAWSPSAuthSecretRef(authRaw)...)
+	}
+
+	return errs
+}
+
+// pickAWSPSAuthMethod returns the single auth method present in the auth
+// block. Multiple methods or no method both produce errors so the wizard
+// rejects ambiguity rather than letting the controller pick silently.
+//
+// Iterates orderedAWSPSAuthMethods (not a map) so the multi-method error
+// message lists methods in a deterministic, readable order.
+func pickAWSPSAuthMethod(auth map[string]any) (string, []FieldError) {
+	var present []string
+	for _, method := range orderedAWSPSAuthMethods {
+		if _, ok := auth[method]; ok {
+			present = append(present, method)
+		}
+	}
+	switch len(present) {
+	case 0:
+		return "", []FieldError{{Field: "auth", Message: "exactly one of jwt, secretRef must be set"}}
+	case 1:
+		return present[0], nil
+	default:
+		return "", []FieldError{{Field: "auth", Message: fmt.Sprintf("only one auth method may be set; got %d (%s)", len(present), strings.Join(present, ", "))}}
+	}
+}
+
+// validateAWSPSAuthJWT validates IAM workload identity auth via a Kubernetes
+// service account JWT. ESO maps this to IRSA (IAM Roles for Service Accounts).
+// The auth.jwt block requires serviceAccountRef.name + role.
+func validateAWSPSAuthJWT(auth map[string]any) []FieldError {
+	var errs []FieldError
+	j, _ := auth["jwt"].(map[string]any)
+	if j == nil {
+		return []FieldError{{Field: "auth.jwt", Message: "is required"}}
+	}
+
+	saRef, _ := j["serviceAccountRef"].(map[string]any)
+	if saRef == nil {
+		errs = append(errs, FieldError{Field: "auth.jwt.serviceAccountRef", Message: "is required"})
+	} else {
+		if name, _ := saRef["name"].(string); strings.TrimSpace(name) == "" {
+			errs = append(errs, FieldError{Field: "auth.jwt.serviceAccountRef.name", Message: "is required"})
+		} else if !dnsLabelRegex.MatchString(name) {
+			errs = append(errs, FieldError{Field: "auth.jwt.serviceAccountRef.name", Message: "must be a valid DNS label"})
+		}
+	}
+
+	if role, _ := j["role"].(string); strings.TrimSpace(role) == "" {
+		errs = append(errs, FieldError{Field: "auth.jwt.role", Message: "is required (IAM role ARN)"})
+	}
+
+	return errs
+}
+
+// validateAWSPSAuthSecretRef validates static credential auth via two Kubernetes
+// Secrets: one for the Access Key ID and one for the Secret Access Key.
+func validateAWSPSAuthSecretRef(auth map[string]any) []FieldError {
+	var errs []FieldError
+	sr, _ := auth["secretRef"].(map[string]any)
+	if sr == nil {
+		return []FieldError{{Field: "auth.secretRef", Message: "is required"}}
+	}
+
+	akRef, _ := sr["accessKeyIDSecretRef"].(map[string]any)
+	if akRef == nil {
+		errs = append(errs, FieldError{Field: "auth.secretRef.accessKeyIDSecretRef", Message: "is required"})
+	} else {
+		errs = append(errs, validateAWSPSSecretKeyRef(akRef, "auth.secretRef.accessKeyIDSecretRef")...)
+	}
+
+	sakRef, _ := sr["secretAccessKeySecretRef"].(map[string]any)
+	if sakRef == nil {
+		errs = append(errs, FieldError{Field: "auth.secretRef.secretAccessKeySecretRef", Message: "is required"})
+	} else {
+		errs = append(errs, validateAWSPSSecretKeyRef(sakRef, "auth.secretRef.secretAccessKeySecretRef")...)
+	}
+
+	return errs
+}
+
+// validateAWSPSSecretKeyRef validates an ESO SecretKeySelector sub-block at
+// the given field prefix. Requires name and key; namespace is optional.
+func validateAWSPSSecretKeyRef(ref map[string]any, prefix string) []FieldError {
+	var errs []FieldError
+	if ref == nil {
+		errs = append(errs, FieldError{Field: prefix, Message: "is required"})
+		return errs
+	}
+	if name, _ := ref["name"].(string); name == "" {
+		errs = append(errs, FieldError{Field: prefix + ".name", Message: "is required"})
+	} else if !dnsLabelRegex.MatchString(name) {
+		errs = append(errs, FieldError{Field: prefix + ".name", Message: "must be a valid DNS label"})
+	}
+	if key, _ := ref["key"].(string); key == "" {
+		errs = append(errs, FieldError{Field: prefix + ".key", Message: "is required"})
+	}
+	if ns, ok := ref["namespace"]; ok {
+		if s, _ := ns.(string); s != "" && !dnsLabelRegex.MatchString(s) {
+			errs = append(errs, FieldError{Field: prefix + ".namespace", Message: "must be a valid DNS label"})
+		}
+	}
+	return errs
+}

--- a/backend/internal/wizard/secretstore_awsps_test.go
+++ b/backend/internal/wizard/secretstore_awsps_test.go
@@ -13,12 +13,14 @@ import (
 func validAWSPSSpec() map[string]any {
 	return map[string]any{
 		"region": "us-east-1",
+		// role is a top-level field on AWSProvider (spec.provider.aws.role),
+		// not inside auth.jwt. AWSJWTAuth has only serviceAccountRef.
+		"role": "arn:aws:iam::123456789012:role/my-role",
 		"auth": map[string]any{
 			"jwt": map[string]any{
 				"serviceAccountRef": map[string]any{
 					"name": "my-service-account",
 				},
-				"role": "arn:aws:iam::123456789012:role/my-role",
 			},
 		},
 	}
@@ -87,7 +89,6 @@ func TestValidateAWSPSSpec_AuthMultipleMethods(t *testing.T) {
 	spec["auth"] = map[string]any{
 		"jwt": map[string]any{
 			"serviceAccountRef": map[string]any{"name": "sa"},
-			"role":              "arn:aws:iam::123:role/r",
 		},
 		"secretRef": map[string]any{},
 	}
@@ -118,9 +119,7 @@ func TestValidateAWSPSSpec_JWTAuth_Valid(t *testing.T) {
 func TestValidateAWSPSSpec_JWTAuth_MissingServiceAccountRef(t *testing.T) {
 	spec := validAWSPSSpec()
 	spec["auth"] = map[string]any{
-		"jwt": map[string]any{
-			"role": "arn:aws:iam::123:role/r",
-		},
+		"jwt": map[string]any{},
 	}
 	if !hasField(validateAWSPSSpec(spec), "auth.jwt.serviceAccountRef") {
 		t.Error("expected serviceAccountRef required error")
@@ -132,7 +131,6 @@ func TestValidateAWSPSSpec_JWTAuth_BlankServiceAccountName(t *testing.T) {
 	spec["auth"] = map[string]any{
 		"jwt": map[string]any{
 			"serviceAccountRef": map[string]any{"name": ""},
-			"role":              "arn:aws:iam::123:role/r",
 		},
 	}
 	if !hasField(validateAWSPSSpec(spec), "auth.jwt.serviceAccountRef.name") {
@@ -145,7 +143,6 @@ func TestValidateAWSPSSpec_JWTAuth_BadServiceAccountName(t *testing.T) {
 	spec["auth"] = map[string]any{
 		"jwt": map[string]any{
 			"serviceAccountRef": map[string]any{"name": "BadName"},
-			"role":              "arn:aws:iam::123:role/r",
 		},
 	}
 	if !hasField(validateAWSPSSpec(spec), "auth.jwt.serviceAccountRef.name") {
@@ -154,14 +151,12 @@ func TestValidateAWSPSSpec_JWTAuth_BadServiceAccountName(t *testing.T) {
 }
 
 func TestValidateAWSPSSpec_JWTAuth_MissingRole(t *testing.T) {
+	// role is a top-level AWSProvider field; deleting it when jwt auth is
+	// selected should produce an error on the top-level "role" field.
 	spec := validAWSPSSpec()
-	spec["auth"] = map[string]any{
-		"jwt": map[string]any{
-			"serviceAccountRef": map[string]any{"name": "my-sa"},
-		},
-	}
-	if !hasField(validateAWSPSSpec(spec), "auth.jwt.role") {
-		t.Error("expected role required error")
+	delete(spec, "role")
+	if !hasField(validateAWSPSSpec(spec), "role") {
+		t.Error("expected top-level role required error when jwt auth selected")
 	}
 }
 

--- a/backend/internal/wizard/secretstore_awsps_test.go
+++ b/backend/internal/wizard/secretstore_awsps_test.go
@@ -1,0 +1,412 @@
+package wizard
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// validAWSPSSpec returns a minimal valid AWS Parameter Store provider spec
+// using IAM workload identity (jwt) auth — the simplest auth method to
+// construct in tests. Static-credentials tests override the auth block.
+func validAWSPSSpec() map[string]any {
+	return map[string]any{
+		"region": "us-east-1",
+		"auth": map[string]any{
+			"jwt": map[string]any{
+				"serviceAccountRef": map[string]any{
+					"name": "my-service-account",
+				},
+				"role": "arn:aws:iam::123456789012:role/my-role",
+			},
+		},
+	}
+}
+
+func TestValidateAWSPSSpec_Valid(t *testing.T) {
+	if errs := validateAWSPSSpec(validAWSPSSpec()); len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+}
+
+// --- Top-level fields ---
+
+func TestValidateAWSPSSpec_MissingRegion(t *testing.T) {
+	spec := validAWSPSSpec()
+	delete(spec, "region")
+	if !hasField(validateAWSPSSpec(spec), "region") {
+		t.Error("expected region required error")
+	}
+}
+
+func TestValidateAWSPSSpec_BlankRegion(t *testing.T) {
+	spec := validAWSPSSpec()
+	spec["region"] = "   "
+	if !hasField(validateAWSPSSpec(spec), "region") {
+		t.Error("expected region error for whitespace-only value")
+	}
+}
+
+func TestValidateAWSPSSpec_OptionalRole_AcceptsWhenSet(t *testing.T) {
+	spec := validAWSPSSpec()
+	spec["role"] = "arn:aws:iam::123456789012:role/assume-role"
+	if errs := validateAWSPSSpec(spec); len(errs) != 0 {
+		t.Errorf("expected no errors with optional role set; got %v", errs)
+	}
+}
+
+func TestValidateAWSPSSpec_OptionalRole_EmptyStringRejected(t *testing.T) {
+	spec := validAWSPSSpec()
+	spec["role"] = "   "
+	if !hasField(validateAWSPSSpec(spec), "role") {
+		t.Error("expected role error for whitespace-only value when set")
+	}
+}
+
+// --- Auth method selection ---
+
+func TestValidateAWSPSSpec_NoAuth(t *testing.T) {
+	spec := validAWSPSSpec()
+	delete(spec, "auth")
+	if !hasField(validateAWSPSSpec(spec), "auth") {
+		t.Error("expected auth required error")
+	}
+}
+
+func TestValidateAWSPSSpec_AuthNoMethod(t *testing.T) {
+	spec := validAWSPSSpec()
+	spec["auth"] = map[string]any{}
+	if !hasField(validateAWSPSSpec(spec), "auth") {
+		t.Error("expected auth error for empty block")
+	}
+}
+
+func TestValidateAWSPSSpec_AuthMultipleMethods(t *testing.T) {
+	spec := validAWSPSSpec()
+	spec["auth"] = map[string]any{
+		"jwt": map[string]any{
+			"serviceAccountRef": map[string]any{"name": "sa"},
+			"role":              "arn:aws:iam::123:role/r",
+		},
+		"secretRef": map[string]any{},
+	}
+	errs := validateAWSPSSpec(spec)
+	if !hasField(errs, "auth") {
+		t.Errorf("expected auth error for multiple methods; got %v", errs)
+	}
+	// Verify the message names both methods so users can disambiguate.
+	found := false
+	for _, e := range errs {
+		if e.Field == "auth" && strings.Contains(e.Message, "only one") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected only-one error message; got %v", errs)
+	}
+}
+
+// --- JWT auth (IAM workload identity / IRSA) ---
+
+func TestValidateAWSPSSpec_JWTAuth_Valid(t *testing.T) {
+	if errs := validateAWSPSSpec(validAWSPSSpec()); len(errs) != 0 {
+		t.Errorf("expected no errors for valid jwt auth; got %v", errs)
+	}
+}
+
+func TestValidateAWSPSSpec_JWTAuth_MissingServiceAccountRef(t *testing.T) {
+	spec := validAWSPSSpec()
+	spec["auth"] = map[string]any{
+		"jwt": map[string]any{
+			"role": "arn:aws:iam::123:role/r",
+		},
+	}
+	if !hasField(validateAWSPSSpec(spec), "auth.jwt.serviceAccountRef") {
+		t.Error("expected serviceAccountRef required error")
+	}
+}
+
+func TestValidateAWSPSSpec_JWTAuth_BlankServiceAccountName(t *testing.T) {
+	spec := validAWSPSSpec()
+	spec["auth"] = map[string]any{
+		"jwt": map[string]any{
+			"serviceAccountRef": map[string]any{"name": ""},
+			"role":              "arn:aws:iam::123:role/r",
+		},
+	}
+	if !hasField(validateAWSPSSpec(spec), "auth.jwt.serviceAccountRef.name") {
+		t.Error("expected serviceAccountRef.name required error")
+	}
+}
+
+func TestValidateAWSPSSpec_JWTAuth_BadServiceAccountName(t *testing.T) {
+	spec := validAWSPSSpec()
+	spec["auth"] = map[string]any{
+		"jwt": map[string]any{
+			"serviceAccountRef": map[string]any{"name": "BadName"},
+			"role":              "arn:aws:iam::123:role/r",
+		},
+	}
+	if !hasField(validateAWSPSSpec(spec), "auth.jwt.serviceAccountRef.name") {
+		t.Error("expected serviceAccountRef.name DNS error for BadName")
+	}
+}
+
+func TestValidateAWSPSSpec_JWTAuth_MissingRole(t *testing.T) {
+	spec := validAWSPSSpec()
+	spec["auth"] = map[string]any{
+		"jwt": map[string]any{
+			"serviceAccountRef": map[string]any{"name": "my-sa"},
+		},
+	}
+	if !hasField(validateAWSPSSpec(spec), "auth.jwt.role") {
+		t.Error("expected role required error")
+	}
+}
+
+// --- Static credentials auth (secretRef) ---
+
+func TestValidateAWSPSSpec_SecretRefAuth_Valid(t *testing.T) {
+	spec := validAWSPSSpec()
+	spec["auth"] = map[string]any{
+		"secretRef": map[string]any{
+			"accessKeyIDSecretRef": map[string]any{
+				"name": "aws-creds",
+				"key":  "access-key-id",
+			},
+			"secretAccessKeySecretRef": map[string]any{
+				"name": "aws-creds",
+				"key":  "secret-access-key",
+			},
+		},
+	}
+	if errs := validateAWSPSSpec(spec); len(errs) != 0 {
+		t.Errorf("expected no errors for valid secretRef auth; got %v", errs)
+	}
+}
+
+func TestValidateAWSPSSpec_SecretRefAuth_MissingAccessKeyRef(t *testing.T) {
+	spec := validAWSPSSpec()
+	spec["auth"] = map[string]any{
+		"secretRef": map[string]any{
+			"secretAccessKeySecretRef": map[string]any{
+				"name": "aws-creds",
+				"key":  "secret-access-key",
+			},
+		},
+	}
+	if !hasField(validateAWSPSSpec(spec), "auth.secretRef.accessKeyIDSecretRef") {
+		t.Error("expected accessKeyIDSecretRef required error")
+	}
+}
+
+func TestValidateAWSPSSpec_SecretRefAuth_MissingSecretAccessKeyRef(t *testing.T) {
+	spec := validAWSPSSpec()
+	spec["auth"] = map[string]any{
+		"secretRef": map[string]any{
+			"accessKeyIDSecretRef": map[string]any{
+				"name": "aws-creds",
+				"key":  "access-key-id",
+			},
+		},
+	}
+	if !hasField(validateAWSPSSpec(spec), "auth.secretRef.secretAccessKeySecretRef") {
+		t.Error("expected secretAccessKeySecretRef required error")
+	}
+}
+
+func TestValidateAWSPSSpec_SecretRefAuth_AccessKeyRef_MissingName(t *testing.T) {
+	spec := validAWSPSSpec()
+	spec["auth"] = map[string]any{
+		"secretRef": map[string]any{
+			"accessKeyIDSecretRef": map[string]any{
+				"key": "access-key-id",
+			},
+			"secretAccessKeySecretRef": map[string]any{
+				"name": "aws-creds",
+				"key":  "secret-access-key",
+			},
+		},
+	}
+	if !hasField(validateAWSPSSpec(spec), "auth.secretRef.accessKeyIDSecretRef.name") {
+		t.Error("expected accessKeyIDSecretRef.name required error")
+	}
+}
+
+func TestValidateAWSPSSpec_SecretRefAuth_AccessKeyRef_MissingKey(t *testing.T) {
+	spec := validAWSPSSpec()
+	spec["auth"] = map[string]any{
+		"secretRef": map[string]any{
+			"accessKeyIDSecretRef": map[string]any{
+				"name": "aws-creds",
+				// key intentionally omitted
+			},
+			"secretAccessKeySecretRef": map[string]any{
+				"name": "aws-creds",
+				"key":  "secret-access-key",
+			},
+		},
+	}
+	if !hasField(validateAWSPSSpec(spec), "auth.secretRef.accessKeyIDSecretRef.key") {
+		t.Error("expected accessKeyIDSecretRef.key required error")
+	}
+}
+
+func TestValidateAWSPSSpec_SecretRefAuth_BadRefName(t *testing.T) {
+	spec := validAWSPSSpec()
+	spec["auth"] = map[string]any{
+		"secretRef": map[string]any{
+			"accessKeyIDSecretRef": map[string]any{
+				"name": "Bad_Name",
+				"key":  "access-key-id",
+			},
+			"secretAccessKeySecretRef": map[string]any{
+				"name": "aws-creds",
+				"key":  "secret-access-key",
+			},
+		},
+	}
+	if !hasField(validateAWSPSSpec(spec), "auth.secretRef.accessKeyIDSecretRef.name") {
+		t.Error("expected DNS error for bad Secret name")
+	}
+}
+
+// --- Dispatcher integration ---
+
+// TestSecretStoreInput_AWSPSIntegration confirms validateAWSPSSpec is wired
+// to the dispatcher via the init() RegisterSecretStoreProvider call. A
+// SecretStoreInput with provider=awsps should route through validateAWSPSSpec
+// and surface its errors at the providerSpec level.
+func TestSecretStoreInput_AWSPSIntegration(t *testing.T) {
+	s := SecretStoreInput{
+		Scope:        StoreScopeNamespaced,
+		Name:         "ps-store",
+		Namespace:    "apps",
+		Provider:     SecretStoreProviderAWSPS,
+		ProviderSpec: validAWSPSSpec(),
+	}
+	if errs := s.Validate(); len(errs) != 0 {
+		t.Errorf("expected no errors via dispatcher, got %v", errs)
+	}
+}
+
+func TestSecretStoreInput_AWSPSIntegration_PropagatesProviderError(t *testing.T) {
+	spec := validAWSPSSpec()
+	delete(spec, "region")
+	s := SecretStoreInput{
+		Scope:        StoreScopeNamespaced,
+		Name:         "ps-store",
+		Namespace:    "apps",
+		Provider:     SecretStoreProviderAWSPS,
+		ProviderSpec: spec,
+	}
+	errs := s.Validate()
+	if !hasField(errs, "region") {
+		t.Errorf("expected provider-level region error, got %v", errs)
+	}
+}
+
+// TestSecretStoreInput_AWSPSIntegration_ToYAML confirms the critical U18
+// remap: the synthetic "awsps" provider key must be translated to
+// spec.provider.aws with service: ParameterStore injected. This test pins the
+// end-to-end contract between the wizard's UX discriminator and the ESO v1
+// API shape.
+func TestSecretStoreInput_AWSPSIntegration_ToYAML(t *testing.T) {
+	s := SecretStoreInput{
+		Scope:        StoreScopeNamespaced,
+		Name:         "ps-store",
+		Namespace:    "apps",
+		Provider:     SecretStoreProviderAWSPS,
+		ProviderSpec: validAWSPSSpec(),
+	}
+	y, err := s.ToYAML()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The synthetic "awsps" key must never appear in the emitted YAML.
+	if strings.Contains(y, "awsps:") {
+		t.Errorf("YAML must not contain synthetic 'awsps' key; got\n%s", y)
+	}
+
+	// Top-level kind and apiVersion must be correct.
+	for _, want := range []string{
+		"apiVersion: external-secrets.io/v1",
+		"kind: SecretStore",
+	} {
+		if !strings.Contains(y, want) {
+			t.Errorf("expected YAML to contain %q\n%s", want, y)
+		}
+	}
+
+	// Structural walk: spec.provider.aws must be present (not spec.provider.awsps).
+	var doc map[string]any
+	if err := yaml.Unmarshal([]byte(y), &doc); err != nil {
+		t.Fatalf("failed to parse YAML: %v\n%s", err, y)
+	}
+	spec, _ := doc["spec"].(map[string]any)
+	provider, _ := spec["provider"].(map[string]any)
+	awsSpec, _ := provider["aws"].(map[string]any)
+	if awsSpec == nil {
+		t.Fatalf("expected spec.provider.aws (U18 remap), got provider keys: %v", keys(provider))
+	}
+
+	// service: ParameterStore must be injected by ToSecretStore.
+	if awsSpec["service"] != "ParameterStore" {
+		t.Errorf("expected service=ParameterStore injected by U18 remap; got %v", awsSpec["service"])
+	}
+
+	// region from providerSpec must be preserved verbatim.
+	if awsSpec["region"] != "us-east-1" {
+		t.Errorf("expected region=us-east-1 preserved; got %v", awsSpec["region"])
+	}
+
+	// auth.jwt block must be nested under aws, not leaked to the top level.
+	auth, _ := awsSpec["auth"].(map[string]any)
+	jwtBlock, _ := auth["jwt"].(map[string]any)
+	if jwtBlock == nil {
+		t.Fatalf("expected spec.provider.aws.auth.jwt to be non-nil; auth=%v", auth)
+	}
+	saRef, _ := jwtBlock["serviceAccountRef"].(map[string]any)
+	if saRef == nil {
+		t.Fatalf("expected serviceAccountRef to be non-nil; jwt=%v", jwtBlock)
+	}
+	if saRef["name"] == nil {
+		t.Errorf("expected serviceAccountRef.name to be present; got %v", saRef)
+	}
+}
+
+// TestSecretStoreInput_AWSPSIntegration_ToYAML_ClusterScope verifies the
+// remap also works for ClusterSecretStore scope.
+func TestSecretStoreInput_AWSPSIntegration_ToYAML_ClusterScope(t *testing.T) {
+	s := SecretStoreInput{
+		Scope:        StoreScopeCluster,
+		Name:         "shared-ps-store",
+		Provider:     SecretStoreProviderAWSPS,
+		ProviderSpec: validAWSPSSpec(),
+	}
+	y, err := s.ToYAML()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(y, "kind: ClusterSecretStore") {
+		t.Errorf("expected ClusterSecretStore kind; got\n%s", y)
+	}
+	if strings.Contains(y, "namespace:") {
+		t.Errorf("ClusterSecretStore must not emit namespace; got\n%s", y)
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal([]byte(y), &doc); err != nil {
+		t.Fatalf("failed to parse YAML: %v\n%s", err, y)
+	}
+	spec, _ := doc["spec"].(map[string]any)
+	provider, _ := spec["provider"].(map[string]any)
+	awsSpec, _ := provider["aws"].(map[string]any)
+	if awsSpec == nil {
+		t.Fatalf("expected spec.provider.aws for ClusterSecretStore; got keys: %v", keys(provider))
+	}
+	if awsSpec["service"] != "ParameterStore" {
+		t.Errorf("expected service=ParameterStore for ClusterSecretStore; got %v", awsSpec["service"])
+	}
+}

--- a/frontend/components/wizard/secretstore/AWSPSForm.tsx
+++ b/frontend/components/wizard/secretstore/AWSPSForm.tsx
@@ -1,0 +1,391 @@
+import { useSignal } from "@preact/signals";
+import { Input } from "@/components/ui/Input.tsx";
+
+/**
+ * AWS Parameter Store provider form for SecretStoreWizard. Writes into the
+ * wizard's `providerSpec: Record<string, unknown>` slot under the shape
+ * `{ region, role?, auth: { <method>: {...} } }`.
+ *
+ * v1 supports two auth methods:
+ *   - jwt: IAM workload identity (IRSA) via a Kubernetes service account.
+ *   - secretRef: static AWS credentials stored in Kubernetes Secrets.
+ *
+ * The AWS Parameter Store path is set in the ExternalSecret remoteRef.key, not
+ * here — this form only configures the store connection and authentication.
+ * Switching auth method clears the previously-entered method so stale fields
+ * don't leak into the preview.
+ *
+ * Note: "service: ParameterStore" is NOT a field in this form. The backend
+ * injects it automatically when provider == "awsps" (U18 ToSecretStore remap).
+ */
+
+export type AWSPSAuthMethod = "jwt" | "secretRef";
+
+export interface AWSPSFormProps {
+  spec: Record<string, unknown>;
+  errors: Record<string, string>;
+  onUpdateSpec: (spec: Record<string, unknown>) => void;
+}
+
+interface SecretKeyRef {
+  name?: string;
+  key?: string;
+}
+
+/** Typed sub-shapes for each AWSPS auth method block. */
+interface AWSPSAuthSpec {
+  jwt?: {
+    serviceAccountRef?: { name?: string };
+    role?: string;
+  };
+  secretRef?: {
+    accessKeyIDSecretRef?: SecretKeyRef;
+    secretAccessKeySecretRef?: SecretKeyRef;
+  };
+}
+
+/** Typed shape for an AWS Parameter Store provider spec block. */
+interface AWSPSSpec {
+  region?: string;
+  role?: string;
+  auth?: AWSPSAuthSpec;
+}
+
+const AUTH_METHODS: {
+  id: AWSPSAuthMethod;
+  label: string;
+  description: string;
+}[] = [
+  {
+    id: "jwt",
+    label: "IAM (IRSA)",
+    description:
+      "Workload identity via a Kubernetes service account JWT. Recommended for EKS.",
+  },
+  {
+    id: "secretRef",
+    label: "Static credentials",
+    description:
+      "Access Key ID + Secret Access Key stored in Kubernetes Secrets.",
+  },
+];
+
+/** Determine which auth method the spec currently encodes, or "" when none. */
+function detectMethod(spec: Record<string, unknown>): AWSPSAuthMethod | "" {
+  const auth = spec.auth as Record<string, unknown> | undefined;
+  if (!auth) return "";
+  // Iterate AUTH_METHODS (single source of truth) instead of a separate array.
+  for (const m of AUTH_METHODS.map((x) => x.id)) {
+    if (m in auth) return m;
+  }
+  return "";
+}
+
+/** Read a top-level string field from the spec. */
+function getStr(spec: Record<string, unknown>, key: string): string {
+  const v = spec[key];
+  return typeof v === "string" ? v : "";
+}
+
+function getAuthBlock(
+  spec: Record<string, unknown>,
+  method: AWSPSAuthMethod,
+): Record<string, unknown> {
+  const auth = (spec.auth as Record<string, unknown>) ?? {};
+  return (auth[method] as Record<string, unknown>) ?? {};
+}
+
+export function AWSPSForm({ spec, errors, onUpdateSpec }: AWSPSFormProps) {
+  // AWSPSSpec / AWSPSAuthSpec interfaces above document the shape; field reads
+  // go through getStr() and getAuthBlock() helpers which narrow at each access
+  // site rather than via a single top-level cast.
+
+  // Track which auth method's fields are currently shown. Persisted in the
+  // spec itself (via detectMethod) so the form survives Back/Next navigation.
+  const method = useSignal<AWSPSAuthMethod | "">(detectMethod(spec));
+
+  function patchTop(field: string, value: string) {
+    const next = { ...spec };
+    if (value === "") delete next[field];
+    else next[field] = value;
+    onUpdateSpec(next);
+  }
+
+  function setMethod(m: AWSPSAuthMethod) {
+    if (method.value === m) return;
+    method.value = m;
+    // Clear the auth slate; preserve top-level fields (region, role).
+    onUpdateSpec({
+      ...spec,
+      auth: { [m]: emptyMethodSpec(m) },
+    });
+  }
+
+  function patchAuth(
+    authMethod: AWSPSAuthMethod,
+    patch: Record<string, unknown>,
+  ) {
+    const auth = (spec.auth as Record<string, unknown>) ?? {};
+    const block = (auth[authMethod] as Record<string, unknown>) ?? {};
+    onUpdateSpec({
+      ...spec,
+      auth: { ...auth, [authMethod]: { ...block, ...patch } },
+    });
+  }
+
+  function patchSecretKeyRef(
+    refPath: string[],
+    patch: SecretKeyRef,
+  ) {
+    // refPath is ["secretRef", "accessKeyIDSecretRef"] or similar.
+    // Walk the auth block and merge the patch at the leaf.
+    const auth = (spec.auth as Record<string, unknown>) ?? {};
+    const topBlock = (auth["secretRef"] as Record<string, unknown>) ?? {};
+    const [, leafKey] = refPath;
+    const existing = (topBlock[leafKey] as SecretKeyRef) ?? {};
+    onUpdateSpec({
+      ...spec,
+      auth: {
+        ...auth,
+        secretRef: { ...topBlock, [leafKey]: { ...existing, ...patch } },
+      },
+    });
+  }
+
+  return (
+    <div class="space-y-5">
+      <div class="rounded-md border border-border-primary bg-surface/50 p-4 text-sm text-text-muted">
+        Configure the AWS Parameter Store connection and authentication method.
+        The Parameter Store path is set in the ExternalSecret{" "}
+        <code class="font-mono">remoteRef.key</code>, not here. Credentials must
+        already exist as Kubernetes Secrets in this namespace; this wizard only
+        references them — it never holds AWS credentials directly.
+      </div>
+
+      {/* Top-level fields */}
+      <div class="grid grid-cols-2 gap-4">
+        <Input
+          id="awsps-region"
+          label="AWS Region"
+          required
+          value={getStr(spec, "region")}
+          onInput={(e) =>
+            patchTop("region", (e.target as HTMLInputElement).value)}
+          placeholder="us-east-1"
+          description="AWS region where Parameter Store is accessed."
+          error={errors["region"]}
+        />
+        <Input
+          id="awsps-role"
+          label="Assume-role ARN (optional)"
+          value={getStr(spec, "role")}
+          onInput={(e) =>
+            patchTop("role", (e.target as HTMLInputElement).value)}
+          placeholder="arn:aws:iam::123456789012:role/my-role"
+          description="IAM role to assume before reading parameters. Leave blank to use the pod's identity directly."
+          error={errors["role"]}
+        />
+      </div>
+
+      {/* Auth method picker */}
+      <div class="space-y-3">
+        <h3 class="text-sm font-semibold text-text-primary">
+          Authentication method
+          <span aria-hidden="true" class="text-danger ml-0.5">*</span>
+        </h3>
+        <div class="grid gap-2 sm:grid-cols-2">
+          {AUTH_METHODS.map((m) => {
+            const active = method.value === m.id;
+            return (
+              <button
+                key={m.id}
+                type="button"
+                onClick={() => setMethod(m.id)}
+                class={`text-left rounded-lg border p-3 transition-colors ${
+                  active
+                    ? "border-brand bg-brand/5"
+                    : "border-border-primary bg-surface hover:border-border-emphasis"
+                }`}
+                aria-pressed={active}
+              >
+                <div class="font-medium text-text-primary">{m.label}</div>
+                <p class="mt-1 text-xs text-text-muted">{m.description}</p>
+              </button>
+            );
+          })}
+        </div>
+        {errors["auth"] && <p class="text-sm text-danger">{errors["auth"]}</p>}
+      </div>
+
+      {/* Auth-method-specific fields */}
+      {method.value === "jwt" && (
+        <JWTAuthFields
+          block={getAuthBlock(spec, "jwt")}
+          errors={errors}
+          onPatch={(patch) => patchAuth("jwt", patch)}
+        />
+      )}
+      {method.value === "secretRef" && (
+        <StaticCredsAuthFields
+          block={getAuthBlock(spec, "secretRef")}
+          errors={errors}
+          onPatchAccessKey={(patch) =>
+            patchSecretKeyRef(["secretRef", "accessKeyIDSecretRef"], patch)}
+          onPatchSecretKey={(patch) =>
+            patchSecretKeyRef(
+              ["secretRef", "secretAccessKeySecretRef"],
+              patch,
+            )}
+        />
+      )}
+    </div>
+  );
+}
+
+/** Initial empty block for a freshly-selected auth method. The wizard's
+ *  validator rejects empty blocks so the user must populate before preview. */
+function emptyMethodSpec(m: AWSPSAuthMethod): Record<string, unknown> {
+  switch (m) {
+    case "jwt":
+      return { serviceAccountRef: {}, role: "" };
+    case "secretRef":
+      return { accessKeyIDSecretRef: {}, secretAccessKeySecretRef: {} };
+  }
+}
+
+// --- Per-method field components ---------------------------------------
+
+interface JWTAuthFieldsProps {
+  block: Record<string, unknown>;
+  errors: Record<string, string>;
+  onPatch: (patch: Record<string, unknown>) => void;
+}
+
+function JWTAuthFields({ block, errors, onPatch }: JWTAuthFieldsProps) {
+  // Typed reads via AWSPSAuthSpec.jwt shape.
+  const jwtBlock = block as {
+    serviceAccountRef?: { name?: string };
+    role?: string;
+  };
+  const saName = jwtBlock.serviceAccountRef?.name ?? "";
+  const role = jwtBlock.role ?? "";
+
+  function patchSARef(name: string) {
+    const existing = (block.serviceAccountRef as Record<string, unknown>) ?? {};
+    onPatch({ serviceAccountRef: { ...existing, name } });
+  }
+
+  return (
+    <div class="rounded-md border border-border-primary p-4 space-y-3">
+      <h4 class="text-sm font-medium text-text-primary">
+        IAM workload identity (IRSA)
+      </h4>
+      <div class="grid grid-cols-2 gap-3">
+        <Input
+          id="awsps-jwt-sa-name"
+          label="Service account name"
+          required
+          value={saName}
+          onInput={(e) => patchSARef((e.target as HTMLInputElement).value)}
+          placeholder="my-app"
+          description="Kubernetes ServiceAccount annotated with the IAM role ARN."
+          error={errors["auth.jwt.serviceAccountRef.name"]}
+        />
+        <Input
+          id="awsps-jwt-role"
+          label="IAM role ARN"
+          required
+          value={role}
+          onInput={(e) =>
+            onPatch({ role: (e.target as HTMLInputElement).value })}
+          placeholder="arn:aws:iam::123456789012:role/my-role"
+          description="Role ARN bound to the service account via IRSA annotation."
+          error={errors["auth.jwt.role"]}
+        />
+      </div>
+    </div>
+  );
+}
+
+interface StaticCredsAuthFieldsProps {
+  block: Record<string, unknown>;
+  errors: Record<string, string>;
+  onPatchAccessKey: (patch: SecretKeyRef) => void;
+  onPatchSecretKey: (patch: SecretKeyRef) => void;
+}
+
+function StaticCredsAuthFields(
+  { block, errors, onPatchAccessKey, onPatchSecretKey }:
+    StaticCredsAuthFieldsProps,
+) {
+  // Typed reads via AWSPSAuthSpec.secretRef shape.
+  const srBlock = block as {
+    accessKeyIDSecretRef?: SecretKeyRef;
+    secretAccessKeySecretRef?: SecretKeyRef;
+  };
+  const akRef = srBlock.accessKeyIDSecretRef ?? {};
+  const sakRef = srBlock.secretAccessKeySecretRef ?? {};
+
+  return (
+    <div class="rounded-md border border-border-primary p-4 space-y-4">
+      <div>
+        <h4 class="text-sm font-medium text-text-primary mb-2">
+          Access Key ID Secret reference
+        </h4>
+        <div class="grid grid-cols-2 gap-3">
+          <Input
+            id="awsps-ak-name"
+            label="Secret name"
+            required
+            value={akRef.name ?? ""}
+            onInput={(e) =>
+              onPatchAccessKey({
+                name: (e.target as HTMLInputElement).value,
+              })}
+            placeholder="aws-creds"
+            error={errors["auth.secretRef.accessKeyIDSecretRef.name"]}
+          />
+          <Input
+            id="awsps-ak-key"
+            label="Key"
+            required
+            value={akRef.key ?? ""}
+            onInput={(e) =>
+              onPatchAccessKey({ key: (e.target as HTMLInputElement).value })}
+            placeholder="access-key-id"
+            error={errors["auth.secretRef.accessKeyIDSecretRef.key"]}
+          />
+        </div>
+      </div>
+      <div>
+        <h4 class="text-sm font-medium text-text-primary mb-2">
+          Secret Access Key Secret reference
+        </h4>
+        <div class="grid grid-cols-2 gap-3">
+          <Input
+            id="awsps-sak-name"
+            label="Secret name"
+            required
+            value={sakRef.name ?? ""}
+            onInput={(e) =>
+              onPatchSecretKey({
+                name: (e.target as HTMLInputElement).value,
+              })}
+            placeholder="aws-creds"
+            error={errors["auth.secretRef.secretAccessKeySecretRef.name"]}
+          />
+          <Input
+            id="awsps-sak-key"
+            label="Key"
+            required
+            value={sakRef.key ?? ""}
+            onInput={(e) =>
+              onPatchSecretKey({ key: (e.target as HTMLInputElement).value })}
+            placeholder="secret-access-key"
+            error={errors["auth.secretRef.secretAccessKeySecretRef.key"]}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/wizard/secretstore/AWSPSForm.tsx
+++ b/frontend/components/wizard/secretstore/AWSPSForm.tsx
@@ -35,8 +35,9 @@ interface SecretKeyRef {
 /** Typed sub-shapes for each AWSPS auth method block. */
 interface AWSPSAuthSpec {
   jwt?: {
+    // Note: AWSJWTAuth has only serviceAccountRef. The IAM role ARN lives at
+    // the top-level AWSProvider.role field (spec.provider.aws.role), not here.
     serviceAccountRef?: { name?: string };
-    role?: string;
   };
   secretRef?: {
     accessKeyIDSecretRef?: SecretKeyRef;
@@ -134,14 +135,12 @@ export function AWSPSForm({ spec, errors, onUpdateSpec }: AWSPSFormProps) {
   }
 
   function patchSecretKeyRef(
-    refPath: string[],
+    leafKey: string,
     patch: SecretKeyRef,
   ) {
-    // refPath is ["secretRef", "accessKeyIDSecretRef"] or similar.
-    // Walk the auth block and merge the patch at the leaf.
+    // leafKey is "accessKeyIDSecretRef" or "secretAccessKeySecretRef".
     const auth = (spec.auth as Record<string, unknown>) ?? {};
     const topBlock = (auth["secretRef"] as Record<string, unknown>) ?? {};
-    const [, leafKey] = refPath;
     const existing = (topBlock[leafKey] as SecretKeyRef) ?? {};
     onUpdateSpec({
       ...spec,
@@ -177,12 +176,17 @@ export function AWSPSForm({ spec, errors, onUpdateSpec }: AWSPSFormProps) {
         />
         <Input
           id="awsps-role"
-          label="Assume-role ARN (optional)"
+          label={method.value === "jwt"
+            ? "IAM role ARN"
+            : "Assume-role ARN (optional)"}
+          required={method.value === "jwt"}
           value={getStr(spec, "role")}
           onInput={(e) =>
             patchTop("role", (e.target as HTMLInputElement).value)}
           placeholder="arn:aws:iam::123456789012:role/my-role"
-          description="IAM role to assume before reading parameters. Leave blank to use the pod's identity directly."
+          description={method.value === "jwt"
+            ? "Role ARN bound to the service account via IRSA annotation."
+            : "IAM role to assume before reading parameters. Leave blank to use the pod's identity directly."}
           error={errors["role"]}
         />
       </div>
@@ -230,12 +234,9 @@ export function AWSPSForm({ spec, errors, onUpdateSpec }: AWSPSFormProps) {
           block={getAuthBlock(spec, "secretRef")}
           errors={errors}
           onPatchAccessKey={(patch) =>
-            patchSecretKeyRef(["secretRef", "accessKeyIDSecretRef"], patch)}
+            patchSecretKeyRef("accessKeyIDSecretRef", patch)}
           onPatchSecretKey={(patch) =>
-            patchSecretKeyRef(
-              ["secretRef", "secretAccessKeySecretRef"],
-              patch,
-            )}
+            patchSecretKeyRef("secretAccessKeySecretRef", patch)}
         />
       )}
     </div>
@@ -247,7 +248,8 @@ export function AWSPSForm({ spec, errors, onUpdateSpec }: AWSPSFormProps) {
 function emptyMethodSpec(m: AWSPSAuthMethod): Record<string, unknown> {
   switch (m) {
     case "jwt":
-      return { serviceAccountRef: {}, role: "" };
+      // role lives at top-level spec (patchTop), not inside this auth block.
+      return { serviceAccountRef: {} };
     case "secretRef":
       return { accessKeyIDSecretRef: {}, secretAccessKeySecretRef: {} };
   }
@@ -263,12 +265,12 @@ interface JWTAuthFieldsProps {
 
 function JWTAuthFields({ block, errors, onPatch }: JWTAuthFieldsProps) {
   // Typed reads via AWSPSAuthSpec.jwt shape.
+  // Note: role ARN is a top-level AWSProvider field edited in the region/role
+  // row above — AWSJWTAuth has only serviceAccountRef.
   const jwtBlock = block as {
     serviceAccountRef?: { name?: string };
-    role?: string;
   };
   const saName = jwtBlock.serviceAccountRef?.name ?? "";
-  const role = jwtBlock.role ?? "";
 
   function patchSARef(name: string) {
     const existing = (block.serviceAccountRef as Record<string, unknown>) ?? {};
@@ -280,29 +282,16 @@ function JWTAuthFields({ block, errors, onPatch }: JWTAuthFieldsProps) {
       <h4 class="text-sm font-medium text-text-primary">
         IAM workload identity (IRSA)
       </h4>
-      <div class="grid grid-cols-2 gap-3">
-        <Input
-          id="awsps-jwt-sa-name"
-          label="Service account name"
-          required
-          value={saName}
-          onInput={(e) => patchSARef((e.target as HTMLInputElement).value)}
-          placeholder="my-app"
-          description="Kubernetes ServiceAccount annotated with the IAM role ARN."
-          error={errors["auth.jwt.serviceAccountRef.name"]}
-        />
-        <Input
-          id="awsps-jwt-role"
-          label="IAM role ARN"
-          required
-          value={role}
-          onInput={(e) =>
-            onPatch({ role: (e.target as HTMLInputElement).value })}
-          placeholder="arn:aws:iam::123456789012:role/my-role"
-          description="Role ARN bound to the service account via IRSA annotation."
-          error={errors["auth.jwt.role"]}
-        />
-      </div>
+      <Input
+        id="awsps-jwt-sa-name"
+        label="Service account name"
+        required
+        value={saName}
+        onInput={(e) => patchSARef((e.target as HTMLInputElement).value)}
+        placeholder="my-app"
+        description="Kubernetes ServiceAccount annotated with the IAM role ARN (set above)."
+        error={errors["auth.jwt.serviceAccountRef.name"]}
+      />
     </div>
   );
 }

--- a/frontend/islands/SecretStoreWizard.tsx
+++ b/frontend/islands/SecretStoreWizard.tsx
@@ -14,6 +14,7 @@ import type { VaultFormProps } from "@/components/wizard/secretstore/VaultForm.t
 import { OnePasswordForm } from "@/components/wizard/secretstore/OnePasswordForm.tsx";
 import { AWSForm } from "@/components/wizard/secretstore/AWSForm.tsx";
 import { AzureKVForm } from "@/components/wizard/secretstore/AzureKVForm.tsx";
+import { AWSPSForm } from "@/components/wizard/secretstore/AWSPSForm.tsx";
 import { Input } from "@/components/ui/Input.tsx";
 import { NamespaceSelect } from "@/components/ui/NamespaceSelect.tsx";
 import { Button } from "@/components/ui/Button.tsx";
@@ -36,6 +37,7 @@ const PROVIDER_FORMS: Partial<
   onepassword: OnePasswordForm,
   aws: AWSForm,
   azurekv: AzureKVForm,
+  awsps: AWSPSForm,
 };
 
 // Re-export for any downstream consumers that imported from this island.
@@ -199,6 +201,18 @@ export default function SecretStoreWizard({ scope }: SecretStoreWizardProps) {
         : "";
       if (!connectHost) {
         errs.connectHost = "is required";
+      }
+    }
+
+    if (step === 2 && f.provider === "awsps") {
+      const ps = f.providerSpec;
+      const region = typeof ps.region === "string" ? ps.region.trim() : "";
+      if (!region) {
+        errs.region = "AWS Region is required";
+      }
+      const auth = ps.auth as Record<string, unknown> | undefined;
+      if (!auth || Object.keys(auth).length === 0) {
+        errs.auth = "Select an authentication method";
       }
     }
 

--- a/frontend/islands/SecretStoreWizard.tsx
+++ b/frontend/islands/SecretStoreWizard.tsx
@@ -214,6 +214,13 @@ export default function SecretStoreWizard({ scope }: SecretStoreWizardProps) {
       if (!auth || Object.keys(auth).length === 0) {
         errs.auth = "Select an authentication method";
       }
+      // role is a top-level AWSProvider field; required when using jwt (IRSA).
+      if (auth && "jwt" in auth) {
+        const role = typeof ps.role === "string" ? ps.role.trim() : "";
+        if (!role) {
+          errs.role = "IAM role ARN is required for IRSA";
+        }
+      }
     }
 
     errors.value = errs;

--- a/frontend/lib/eso-types.ts
+++ b/frontend/lib/eso-types.ts
@@ -239,6 +239,7 @@ export const READY_SECRET_STORE_PROVIDERS = new Set<SecretStoreProvider>([
   "onepassword",
   "aws",
   "azurekv",
+  "awsps",
 ]);
 
 // --- Phase G path-discovery types ------------------------------------------


### PR DESCRIPTION
## Summary

- Adds the `awsps` provider to the `SecretStoreWizard`, completing the 3rd of 8 per-provider sub-PRs in Phase H Unit 19. Mirrors the Vault pattern from PR #217.
- The synthetic `awsps` UX discriminator is remapped by U18's `ToSecretStore` to `spec.provider.aws` + `service: ParameterStore` — this PR includes a dedicated end-to-end test that pins that contract.
- Two auth methods supported: IAM workload identity (IRSA via `auth.jwt`) and static credentials (`auth.secretRef`).

## Files changed

- **CREATE** `backend/internal/wizard/secretstore_awsps.go` — `validateAWSPSSpec`, `pickAWSPSAuthMethod` (ordered-slice, deterministic), `validateAWSPSAuthJWT`, `validateAWSPSAuthSecretRef`, `validateAWSPSSecretKeyRef`, `init()` registers under `SecretStoreProviderAWSPS`.
- **CREATE** `backend/internal/wizard/secretstore_awsps_test.go` — ~25 tests (run -count=10, all green). Includes `TestSecretStoreInput_AWSPSIntegration_ToYAML` which structurally walks the emitted YAML to confirm the U18 remap: no `awsps:` key, `spec.provider.aws` present, `service: ParameterStore` injected.
- **CREATE** `frontend/components/wizard/secretstore/AWSPSForm.tsx` — `AWSPSForm` component with typed `AWSPSSpec`/`AWSPSAuthSpec` interfaces, `JWTAuthFields`, `StaticCredsAuthFields`, `detectMethod` iterating `AUTH_METHODS` slice. INFO callout explains the Parameter Store path lives in `ExternalSecret.remoteRef.key`.
- **MODIFY** `frontend/lib/eso-types.ts` — adds `"awsps"` to `READY_SECRET_STORE_PROVIDERS`.
- **MODIFY** `frontend/islands/SecretStoreWizard.tsx` — registers `awsps: AWSPSForm` in `PROVIDER_FORMS`; extends Configure step client-side guard for `awsps` (region + auth).

## Coordination note

The sibling AWS SM sub-PR (provider key `aws`) is built separately and shares no files with this PR — `secretstore_awsps.go` vs `secretstore_aws.go` are independent files with no overlap.

## Test plan

- [x] `cd backend && go vet ./... && go test ./internal/wizard/ -count=10` — all pass
- [x] `cd backend && go test ./...` — all packages pass
- [x] `deno fmt --check` + `deno lint` on `AWSPSForm.tsx` — clean
- [x] `deno lint` on modified `eso-types.ts` + `SecretStoreWizard.tsx` — clean
- [x] Pre-existing CRLF line-ending failures in `deno fmt --check` are a Windows worktree artifact, not introduced by this PR (same failures on VaultForm.tsx and 200+ other files)
- [ ] Smoke test: create a namespaced SecretStore with provider=awsps, verify YAML preview shows `spec.provider.aws.service: ParameterStore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)