### PR TITLE
feat(eso): Phase H Unit 19 — GCP Secret Manager provider wizard (5/8)

### DIFF
--- a/backend/internal/wizard/secretstore_gcpsm.go
+++ b/backend/internal/wizard/secretstore_gcpsm.go
@@ -1,0 +1,206 @@
+package wizard
+
+import (
+	"strings"
+)
+
+// init registers the GCP Secret Manager provider validator with the SecretStore
+// wizard dispatcher. Lives in this file so the validator ships and registers as
+// one unit — adding a provider is a single-file edit + one line in
+// READY_SECRET_STORE_PROVIDERS on the frontend.
+func init() {
+	RegisterSecretStoreProvider(SecretStoreProviderGCP, validateGCPSMSpec)
+}
+
+// orderedGCPSMAuthMethods is the canonical ordered list of auth methods the
+// wizard surface supports in v1.
+//
+// workloadIdentityFederation (credConfig / AWS token exchange) is accessible
+// via the YAML editor but not driven by guided fields here — per the plan's
+// L7.2 culling pass (niche multi-cloud federation path).
+//
+// Ordering matters: pickGCPSMAuthMethod iterates this slice to build the
+// "present" list so the multi-method error message is deterministic rather
+// than random-map-order.
+var orderedGCPSMAuthMethods = []string{"workloadIdentity", "secretRef"}
+
+// validateGCPSMSpec validates a SecretStoreInput.ProviderSpec for the GCP
+// Secret Manager provider. The spec mirrors ESO's spec.provider.gcpsm shape —
+// projectID (required), location (optional), plus an auth block with at most
+// one method populated. An empty auth block is also accepted — that means
+// "use the in-cluster default credentials" (GKE metadata server / node
+// identity), which is a valid ESO configuration.
+//
+// Each FieldError's Field is rooted at the provider-spec level (no
+// "providerSpec." prefix) so the dispatcher's caller can prefix uniformly
+// when surfacing errors to the frontend.
+func validateGCPSMSpec(spec map[string]any) []FieldError {
+	var errs []FieldError
+
+	projectID, _ := spec["projectID"].(string)
+	if strings.TrimSpace(projectID) == "" {
+		errs = append(errs, FieldError{Field: "projectID", Message: "is required (GCP project ID)"})
+	}
+
+	if loc, ok := spec["location"]; ok {
+		s, _ := loc.(string)
+		if s == "" {
+			errs = append(errs, FieldError{Field: "location", Message: "must not be empty when set"})
+		}
+	}
+
+	// auth is optional in ESO — omitting it falls back to the node / pod
+	// identity (GKE workload identity default or Application Default Credentials).
+	// When auth is present it must be valid; we parse it regardless.
+	authRaw, hasAuth := spec["auth"].(map[string]any)
+	if !hasAuth {
+		// No auth block — valid (default-credentials path).
+		return errs
+	}
+
+	method, methodErrs := pickGCPSMAuthMethod(authRaw)
+	errs = append(errs, methodErrs...)
+	if method == "" {
+		// Either empty block (default-credentials) or multi-method error already
+		// appended. Return early to avoid spurious sub-errors on nil sub-blocks.
+		return errs
+	}
+
+	switch method {
+	case "workloadIdentity":
+		errs = append(errs, validateGCPSMAuthWorkloadIdentity(authRaw)...)
+	case "secretRef":
+		errs = append(errs, validateGCPSMAuthSecretRef(authRaw)...)
+	}
+
+	return errs
+}
+
+// pickGCPSMAuthMethod returns the single auth method present in the auth
+// block, or "" with no error when the block is empty (default-credentials
+// path). Multiple methods produce an error so the wizard rejects ambiguity.
+//
+// Iterates orderedGCPSMAuthMethods (not a map) so the multi-method error
+// message lists methods in a deterministic, readable order.
+func pickGCPSMAuthMethod(auth map[string]any) (string, []FieldError) {
+	var present []string
+	for _, method := range orderedGCPSMAuthMethods {
+		if _, ok := auth[method]; ok {
+			present = append(present, method)
+		}
+	}
+	switch len(present) {
+	case 0:
+		// Empty block — valid default-credentials path; caller handles it.
+		return "", nil
+	case 1:
+		return present[0], nil
+	default:
+		return "", []FieldError{{
+			Field: "auth",
+			Message: "only one auth method may be set; got " + strings.Join(present, ", ") +
+				" (workloadIdentity and secretRef are mutually exclusive)",
+		}}
+	}
+}
+
+// validateGCPSMAuthWorkloadIdentity validates the workloadIdentity auth block.
+//
+// ESO requires serviceAccountRef.name; clusterLocation, clusterName, and
+// clusterProjectID are optional (fetched from the GKE metadata server when
+// omitted). The wizard enforces serviceAccountRef.name since omitting it
+// produces an ambiguous ESO error at runtime.
+func validateGCPSMAuthWorkloadIdentity(auth map[string]any) []FieldError {
+	var errs []FieldError
+	wi, _ := auth["workloadIdentity"].(map[string]any)
+	if wi == nil {
+		return []FieldError{{Field: "auth.workloadIdentity", Message: "is required"}}
+	}
+
+	saRef, _ := wi["serviceAccountRef"].(map[string]any)
+	if saRef == nil {
+		errs = append(errs, FieldError{
+			Field:   "auth.workloadIdentity.serviceAccountRef",
+			Message: "is required",
+		})
+	} else {
+		name, _ := saRef["name"].(string)
+		if strings.TrimSpace(name) == "" {
+			errs = append(errs, FieldError{
+				Field:   "auth.workloadIdentity.serviceAccountRef.name",
+				Message: "is required (Kubernetes ServiceAccount name to impersonate)",
+			})
+		} else if !dnsLabelRegex.MatchString(name) {
+			errs = append(errs, FieldError{
+				Field:   "auth.workloadIdentity.serviceAccountRef.name",
+				Message: "must be a valid DNS label",
+			})
+		}
+	}
+
+	// Optional string fields — reject explicitly-empty values so the wizard
+	// avoids sending confusing empty strings to ESO.
+	for _, field := range []struct {
+		key   string
+		label string
+	}{
+		{"clusterLocation", "auth.workloadIdentity.clusterLocation"},
+		{"clusterName", "auth.workloadIdentity.clusterName"},
+		{"clusterProjectID", "auth.workloadIdentity.clusterProjectID"},
+	} {
+		if v, ok := wi[field.key]; ok {
+			s, _ := v.(string)
+			if s == "" {
+				errs = append(errs, FieldError{
+					Field:   field.label,
+					Message: "must not be empty when set",
+				})
+			}
+		}
+	}
+
+	return errs
+}
+
+// validateGCPSMAuthSecretRef validates the secretRef auth block.
+//
+// ESO expects auth.secretRef.secretAccessKeySecretRef.{name, key} — the
+// Kubernetes Secret containing the GCP Service Account JSON key file.
+func validateGCPSMAuthSecretRef(auth map[string]any) []FieldError {
+	var errs []FieldError
+	ref, _ := auth["secretRef"].(map[string]any)
+	if ref == nil {
+		return []FieldError{{Field: "auth.secretRef", Message: "is required"}}
+	}
+
+	sakRef, _ := ref["secretAccessKeySecretRef"].(map[string]any)
+	if sakRef == nil {
+		return []FieldError{{
+			Field:   "auth.secretRef.secretAccessKeySecretRef",
+			Message: "is required (Kubernetes Secret containing the GCP SA JSON key)",
+		}}
+	}
+
+	name, _ := sakRef["name"].(string)
+	if strings.TrimSpace(name) == "" {
+		errs = append(errs, FieldError{
+			Field:   "auth.secretRef.secretAccessKeySecretRef.name",
+			Message: "is required",
+		})
+	} else if !dnsLabelRegex.MatchString(name) {
+		errs = append(errs, FieldError{
+			Field:   "auth.secretRef.secretAccessKeySecretRef.name",
+			Message: "must be a valid DNS label",
+		})
+	}
+
+	key, _ := sakRef["key"].(string)
+	if strings.TrimSpace(key) == "" {
+		errs = append(errs, FieldError{
+			Field:   "auth.secretRef.secretAccessKeySecretRef.key",
+			Message: "is required (key within the Secret holding the SA JSON)",
+		})
+	}
+
+	return errs
+}

--- a/backend/internal/wizard/secretstore_gcpsm_test.go
+++ b/backend/internal/wizard/secretstore_gcpsm_test.go
@@ -1,0 +1,379 @@
+package wizard
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// validGCPSMSpec returns a minimal valid GCP Secret Manager provider spec using
+// the workloadIdentity auth method — the most common GKE path.
+func validGCPSMSpec() map[string]any {
+	return map[string]any{
+		"projectID": "my-gcp-project",
+		"auth": map[string]any{
+			"workloadIdentity": map[string]any{
+				"serviceAccountRef": map[string]any{
+					"name": "eso-gcp-sa",
+				},
+			},
+		},
+	}
+}
+
+// validGCPSMSpecSecretRef returns a minimal valid spec using the Service
+// Account JSON key (secretRef) auth path.
+func validGCPSMSpecSecretRef() map[string]any {
+	return map[string]any{
+		"projectID": "my-gcp-project",
+		"auth": map[string]any{
+			"secretRef": map[string]any{
+				"secretAccessKeySecretRef": map[string]any{
+					"name": "gcp-sa-key",
+					"key":  "key.json",
+				},
+			},
+		},
+	}
+}
+
+// --- Top-level field tests ---
+
+func TestValidateGCPSMSpec_Valid_WorkloadIdentity(t *testing.T) {
+	if errs := validateGCPSMSpec(validGCPSMSpec()); len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+}
+
+func TestValidateGCPSMSpec_Valid_SecretRef(t *testing.T) {
+	if errs := validateGCPSMSpec(validGCPSMSpecSecretRef()); len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+}
+
+func TestValidateGCPSMSpec_Valid_DefaultCredentials(t *testing.T) {
+	// Omitting auth entirely is valid — ESO uses GKE node identity or ADC.
+	spec := map[string]any{"projectID": "my-project"}
+	if errs := validateGCPSMSpec(spec); len(errs) != 0 {
+		t.Errorf("expected no errors for default-credentials path, got %v", errs)
+	}
+}
+
+func TestValidateGCPSMSpec_Valid_WithOptionalLocation(t *testing.T) {
+	spec := validGCPSMSpec()
+	spec["location"] = "us-central1"
+	if errs := validateGCPSMSpec(spec); len(errs) != 0 {
+		t.Errorf("expected no errors with location set, got %v", errs)
+	}
+}
+
+func TestValidateGCPSMSpec_MissingProjectID(t *testing.T) {
+	spec := validGCPSMSpec()
+	delete(spec, "projectID")
+	if !hasField(validateGCPSMSpec(spec), "projectID") {
+		t.Error("expected projectID required error")
+	}
+}
+
+func TestValidateGCPSMSpec_BlankProjectID(t *testing.T) {
+	spec := validGCPSMSpec()
+	spec["projectID"] = "   "
+	if !hasField(validateGCPSMSpec(spec), "projectID") {
+		t.Error("expected projectID error for whitespace-only value")
+	}
+}
+
+func TestValidateGCPSMSpec_EmptyLocationRejected(t *testing.T) {
+	spec := validGCPSMSpec()
+	spec["location"] = ""
+	if !hasField(validateGCPSMSpec(spec), "location") {
+		t.Error("expected location error for empty when set")
+	}
+}
+
+// --- Auth method picker tests ---
+
+func TestValidateGCPSMSpec_AuthMultipleMethods(t *testing.T) {
+	spec := validGCPSMSpec()
+	spec["auth"] = map[string]any{
+		"workloadIdentity": map[string]any{
+			"serviceAccountRef": map[string]any{"name": "sa"},
+		},
+		"secretRef": map[string]any{
+			"secretAccessKeySecretRef": map[string]any{"name": "s", "key": "k"},
+		},
+	}
+	errs := validateGCPSMSpec(spec)
+	if !hasField(errs, "auth") {
+		t.Errorf("expected auth error for multiple methods; got %v", errs)
+	}
+	// Error message should name both methods.
+	found := false
+	for _, e := range errs {
+		if e.Field == "auth" && strings.Contains(e.Message, "only one") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected only-one error message; got %v", errs)
+	}
+}
+
+// --- Workload Identity auth tests ---
+
+func TestValidateGCPSMSpec_WorkloadIdentity_WithAllOptionals(t *testing.T) {
+	spec := validGCPSMSpec()
+	spec["auth"] = map[string]any{
+		"workloadIdentity": map[string]any{
+			"serviceAccountRef": map[string]any{"name": "eso-sa"},
+			"clusterLocation":   "us-central1",
+			"clusterName":       "my-cluster",
+			"clusterProjectID":  "my-project",
+		},
+	}
+	if errs := validateGCPSMSpec(spec); len(errs) != 0 {
+		t.Errorf("expected no errors with all optional WI fields set; got %v", errs)
+	}
+}
+
+func TestValidateGCPSMSpec_WorkloadIdentity_MissingServiceAccountRef(t *testing.T) {
+	spec := validGCPSMSpec()
+	spec["auth"] = map[string]any{
+		"workloadIdentity": map[string]any{},
+	}
+	if !hasField(validateGCPSMSpec(spec), "auth.workloadIdentity.serviceAccountRef") {
+		t.Error("expected serviceAccountRef required error")
+	}
+}
+
+func TestValidateGCPSMSpec_WorkloadIdentity_BlankServiceAccountName(t *testing.T) {
+	spec := validGCPSMSpec()
+	spec["auth"] = map[string]any{
+		"workloadIdentity": map[string]any{
+			"serviceAccountRef": map[string]any{"name": ""},
+		},
+	}
+	if !hasField(validateGCPSMSpec(spec), "auth.workloadIdentity.serviceAccountRef.name") {
+		t.Error("expected serviceAccountRef.name required error")
+	}
+}
+
+func TestValidateGCPSMSpec_WorkloadIdentity_InvalidServiceAccountName(t *testing.T) {
+	spec := validGCPSMSpec()
+	spec["auth"] = map[string]any{
+		"workloadIdentity": map[string]any{
+			"serviceAccountRef": map[string]any{"name": "InvalidName_123"},
+		},
+	}
+	if !hasField(validateGCPSMSpec(spec), "auth.workloadIdentity.serviceAccountRef.name") {
+		t.Error("expected DNS label error for invalid service account name")
+	}
+}
+
+func TestValidateGCPSMSpec_WorkloadIdentity_EmptyClusterLocation(t *testing.T) {
+	spec := validGCPSMSpec()
+	spec["auth"] = map[string]any{
+		"workloadIdentity": map[string]any{
+			"serviceAccountRef": map[string]any{"name": "sa"},
+			"clusterLocation":   "",
+		},
+	}
+	if !hasField(validateGCPSMSpec(spec), "auth.workloadIdentity.clusterLocation") {
+		t.Error("expected clusterLocation error for empty-when-set")
+	}
+}
+
+func TestValidateGCPSMSpec_WorkloadIdentity_EmptyClusterName(t *testing.T) {
+	spec := validGCPSMSpec()
+	spec["auth"] = map[string]any{
+		"workloadIdentity": map[string]any{
+			"serviceAccountRef": map[string]any{"name": "sa"},
+			"clusterName":       "",
+		},
+	}
+	if !hasField(validateGCPSMSpec(spec), "auth.workloadIdentity.clusterName") {
+		t.Error("expected clusterName error for empty-when-set")
+	}
+}
+
+func TestValidateGCPSMSpec_WorkloadIdentity_EmptyClusterProjectID(t *testing.T) {
+	spec := validGCPSMSpec()
+	spec["auth"] = map[string]any{
+		"workloadIdentity": map[string]any{
+			"serviceAccountRef": map[string]any{"name": "sa"},
+			"clusterProjectID":  "",
+		},
+	}
+	if !hasField(validateGCPSMSpec(spec), "auth.workloadIdentity.clusterProjectID") {
+		t.Error("expected clusterProjectID error for empty-when-set")
+	}
+}
+
+// --- Service Account Key (secretRef) auth tests ---
+
+func TestValidateGCPSMSpec_SecretRef_MissingSecretAccessKeyRef(t *testing.T) {
+	spec := validGCPSMSpec()
+	spec["auth"] = map[string]any{
+		"secretRef": map[string]any{},
+	}
+	if !hasField(validateGCPSMSpec(spec), "auth.secretRef.secretAccessKeySecretRef") {
+		t.Error("expected secretAccessKeySecretRef required error")
+	}
+}
+
+func TestValidateGCPSMSpec_SecretRef_MissingName(t *testing.T) {
+	spec := validGCPSMSpec()
+	spec["auth"] = map[string]any{
+		"secretRef": map[string]any{
+			"secretAccessKeySecretRef": map[string]any{"key": "key.json"},
+		},
+	}
+	if !hasField(validateGCPSMSpec(spec), "auth.secretRef.secretAccessKeySecretRef.name") {
+		t.Error("expected secretAccessKeySecretRef.name required error")
+	}
+}
+
+func TestValidateGCPSMSpec_SecretRef_InvalidName(t *testing.T) {
+	spec := validGCPSMSpec()
+	spec["auth"] = map[string]any{
+		"secretRef": map[string]any{
+			"secretAccessKeySecretRef": map[string]any{"name": "InvalidName", "key": "k"},
+		},
+	}
+	if !hasField(validateGCPSMSpec(spec), "auth.secretRef.secretAccessKeySecretRef.name") {
+		t.Error("expected DNS label error for invalid secret name")
+	}
+}
+
+func TestValidateGCPSMSpec_SecretRef_MissingKey(t *testing.T) {
+	spec := validGCPSMSpec()
+	spec["auth"] = map[string]any{
+		"secretRef": map[string]any{
+			"secretAccessKeySecretRef": map[string]any{"name": "gcp-sa-key"},
+		},
+	}
+	if !hasField(validateGCPSMSpec(spec), "auth.secretRef.secretAccessKeySecretRef.key") {
+		t.Error("expected secretAccessKeySecretRef.key required error")
+	}
+}
+
+func TestValidateGCPSMSpec_SecretRef_BlankKey(t *testing.T) {
+	spec := validGCPSMSpec()
+	spec["auth"] = map[string]any{
+		"secretRef": map[string]any{
+			"secretAccessKeySecretRef": map[string]any{"name": "gcp-sa-key", "key": "  "},
+		},
+	}
+	if !hasField(validateGCPSMSpec(spec), "auth.secretRef.secretAccessKeySecretRef.key") {
+		t.Error("expected key error for whitespace-only value")
+	}
+}
+
+// --- Dispatcher integration tests ---
+
+// TestSecretStoreInput_GCPSMIntegration confirms validateGCPSMSpec is wired to
+// the dispatcher via the init() RegisterSecretStoreProvider call.
+func TestSecretStoreInput_GCPSMIntegration(t *testing.T) {
+	s := SecretStoreInput{
+		Scope:        StoreScopeNamespaced,
+		Name:         "gcpsm-store",
+		Namespace:    "apps",
+		Provider:     SecretStoreProviderGCP,
+		ProviderSpec: validGCPSMSpec(),
+	}
+	if errs := s.Validate(); len(errs) != 0 {
+		t.Errorf("expected no errors via dispatcher, got %v", errs)
+	}
+}
+
+func TestSecretStoreInput_GCPSMIntegration_SecretRef(t *testing.T) {
+	s := SecretStoreInput{
+		Scope:        StoreScopeCluster,
+		Name:         "gcpsm-store",
+		Provider:     SecretStoreProviderGCP,
+		ProviderSpec: validGCPSMSpecSecretRef(),
+	}
+	if errs := s.Validate(); len(errs) != 0 {
+		t.Errorf("expected no errors via dispatcher (secretRef), got %v", errs)
+	}
+}
+
+func TestSecretStoreInput_GCPSMIntegration_DefaultCredentials(t *testing.T) {
+	s := SecretStoreInput{
+		Scope:        StoreScopeNamespaced,
+		Name:         "gcpsm-store",
+		Namespace:    "apps",
+		Provider:     SecretStoreProviderGCP,
+		ProviderSpec: map[string]any{"projectID": "my-project"},
+	}
+	if errs := s.Validate(); len(errs) != 0 {
+		t.Errorf("expected no errors for default-credentials path via dispatcher, got %v", errs)
+	}
+}
+
+func TestSecretStoreInput_GCPSMIntegration_PropagatesProviderError(t *testing.T) {
+	spec := validGCPSMSpec()
+	delete(spec, "projectID")
+	s := SecretStoreInput{
+		Scope:        StoreScopeNamespaced,
+		Name:         "gcpsm-store",
+		Namespace:    "apps",
+		Provider:     SecretStoreProviderGCP,
+		ProviderSpec: spec,
+	}
+	errs := s.Validate()
+	if !hasField(errs, "projectID") {
+		t.Errorf("expected provider-level projectID error, got %v", errs)
+	}
+}
+
+// TestSecretStoreInput_GCPSMIntegration_ToYAML asserts the wizard preview's
+// emitted YAML places the spec under spec.provider.gcpsm and the projectID
+// and auth sub-object are present at the right paths.
+func TestSecretStoreInput_GCPSMIntegration_ToYAML(t *testing.T) {
+	s := SecretStoreInput{
+		Scope:        StoreScopeNamespaced,
+		Name:         "gcpsm-store",
+		Namespace:    "apps",
+		Provider:     SecretStoreProviderGCP,
+		ProviderSpec: validGCPSMSpec(),
+	}
+	y, err := s.ToYAML()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, want := range []string{
+		"apiVersion: external-secrets.io/v1",
+		"kind: SecretStore",
+	} {
+		if !strings.Contains(y, want) {
+			t.Errorf("expected YAML to contain %q\n%s", want, y)
+		}
+	}
+
+	// Walk spec.provider.gcpsm and verify required shape.
+	var doc map[string]any
+	if err := yaml.Unmarshal([]byte(y), &doc); err != nil {
+		t.Fatalf("failed to parse YAML: %v\n%s", err, y)
+	}
+	spec, _ := doc["spec"].(map[string]any)
+	provider, _ := spec["provider"].(map[string]any)
+	gcpsmSpec, _ := provider["gcpsm"].(map[string]any)
+	if gcpsmSpec == nil {
+		t.Fatalf("expected spec.provider.gcpsm, got provider keys: %v", keys(provider))
+	}
+	if gcpsmSpec["projectID"] == nil {
+		t.Errorf("expected spec.provider.gcpsm.projectID to be present; got %v", gcpsmSpec)
+	}
+	auth, _ := gcpsmSpec["auth"].(map[string]any)
+	wi, _ := auth["workloadIdentity"].(map[string]any)
+	saRef, _ := wi["serviceAccountRef"].(map[string]any)
+	if saRef == nil {
+		t.Fatalf("expected spec.provider.gcpsm.auth.workloadIdentity.serviceAccountRef; auth=%v", auth)
+	}
+	if saRef["name"] == nil {
+		t.Errorf("expected serviceAccountRef.name; got %v", saRef)
+	}
+}

--- a/frontend/components/wizard/secretstore/GCPSMForm.tsx
+++ b/frontend/components/wizard/secretstore/GCPSMForm.tsx
@@ -1,0 +1,400 @@
+import { useSignal } from "@preact/signals";
+import { Input } from "@/components/ui/Input.tsx";
+
+/**
+ * GCP Secret Manager provider form for SecretStoreWizard. Writes into the
+ * wizard's `providerSpec: Record<string, unknown>` slot under the shape
+ * `{ projectID, location?, auth?: { <method>: {...} } }`.
+ *
+ * v1 supports two auth methods (workloadIdentity / secretRef) plus the
+ * implicit default-credentials path (no auth block). The third ESO method —
+ * workloadIdentityFederation — covers multi-cloud token exchange (AWS → GCP
+ * etc.) and is accessible via the YAML editor but not driven by guided fields
+ * here (per the plan's L7.2 culling pass).
+ *
+ * Switching auth method clears the previously-entered method so stale fields
+ * don't leak into the preview.
+ */
+
+export type GCPSMAuthMethod = "workloadIdentity" | "secretRef" | "default";
+
+export interface GCPSMFormProps {
+  spec: Record<string, unknown>;
+  errors: Record<string, string>;
+  onUpdateSpec: (spec: Record<string, unknown>) => void;
+}
+
+interface ServiceAccountRef {
+  name?: string;
+}
+
+interface GCPSMWorkloadIdentitySpec {
+  serviceAccountRef?: ServiceAccountRef;
+  clusterLocation?: string;
+  clusterName?: string;
+  clusterProjectID?: string;
+}
+
+interface GCPSMSecretRef {
+  secretAccessKeySecretRef?: {
+    name?: string;
+    key?: string;
+  };
+}
+
+/** Typed auth sub-shapes for each GCP SM auth method block. */
+interface GCPSMAuthSpec {
+  workloadIdentity?: GCPSMWorkloadIdentitySpec;
+  secretRef?: GCPSMSecretRef;
+}
+
+/** Typed shape for a GCP SM provider spec block (spec.provider.gcpsm). */
+interface GCPSMSpec {
+  projectID?: string;
+  location?: string;
+  auth?: GCPSMAuthSpec;
+}
+
+const AUTH_METHODS: {
+  id: GCPSMAuthMethod;
+  label: string;
+  description: string;
+}[] = [
+  {
+    id: "workloadIdentity",
+    label: "Workload Identity",
+    description:
+      "GKE Workload Identity — maps a Kubernetes ServiceAccount to a GCP service account.",
+  },
+  {
+    id: "secretRef",
+    label: "SA Key (JSON)",
+    description:
+      "Service Account JSON key stored in a Kubernetes Secret. Simpler but less secure than Workload Identity.",
+  },
+  {
+    id: "default",
+    label: "Default Credentials",
+    description:
+      "Use the node/pod identity (Application Default Credentials or GKE metadata server). No extra config required.",
+  },
+];
+
+/** Determine which auth method the spec currently encodes, or "default" when
+ *  no explicit auth block is set. */
+function detectMethod(spec: Record<string, unknown>): GCPSMAuthMethod {
+  const auth = spec.auth as Record<string, unknown> | undefined;
+  if (!auth) return "default";
+  if ("workloadIdentity" in auth) return "workloadIdentity";
+  if ("secretRef" in auth) return "secretRef";
+  return "default";
+}
+
+function getStr(spec: Record<string, unknown>, key: string): string {
+  const v = spec[key];
+  return typeof v === "string" ? v : "";
+}
+
+function getAuthBlock(
+  spec: Record<string, unknown>,
+  method: GCPSMAuthMethod,
+): Record<string, unknown> {
+  if (method === "default") return {};
+  const auth = (spec.auth as Record<string, unknown>) ?? {};
+  return (auth[method] as Record<string, unknown>) ?? {};
+}
+
+export function GCPSMForm({ spec, errors, onUpdateSpec }: GCPSMFormProps) {
+  // GCPSMSpec / GCPSMAuthSpec interfaces above document the shape; field reads
+  // go through getStr() and getAuthBlock() helpers which narrow at each access
+  // site rather than via a single top-level cast.
+
+  // Track which auth method's fields are currently shown. Persisted in the
+  // spec itself (via detectMethod) so the form survives Back/Next navigation.
+  const method = useSignal<GCPSMAuthMethod>(detectMethod(spec));
+
+  function patchTop(field: string, value: string) {
+    const next = { ...spec };
+    if (value === "") delete next[field];
+    else next[field] = value;
+    onUpdateSpec(next);
+  }
+
+  function setMethod(m: GCPSMAuthMethod) {
+    if (method.value === m) return;
+    method.value = m;
+    // Clear the auth slate; preserve top-level fields (projectID, location).
+    if (m === "default") {
+      const next = { ...spec };
+      delete next.auth;
+      onUpdateSpec(next);
+    } else {
+      onUpdateSpec({
+        ...spec,
+        auth: { [m]: emptyMethodSpec(m) },
+      });
+    }
+  }
+
+  function patchWI(patch: Partial<GCPSMWorkloadIdentitySpec>) {
+    const auth = (spec.auth as Record<string, unknown>) ?? {};
+    const block = (auth["workloadIdentity"] as Record<string, unknown>) ?? {};
+    onUpdateSpec({
+      ...spec,
+      auth: { ...auth, workloadIdentity: { ...block, ...patch } },
+    });
+  }
+
+  function patchSARef(patch: { name?: string; key?: string }) {
+    const auth = (spec.auth as Record<string, unknown>) ?? {};
+    const block = (auth["secretRef"] as Record<string, unknown>) ?? {};
+    const existing =
+      (block["secretAccessKeySecretRef"] as Record<string, unknown>) ?? {};
+    onUpdateSpec({
+      ...spec,
+      auth: {
+        ...auth,
+        secretRef: {
+          ...block,
+          secretAccessKeySecretRef: { ...existing, ...patch },
+        },
+      },
+    });
+  }
+
+  return (
+    <div class="space-y-5">
+      <div class="rounded-md border border-border-primary bg-surface/50 p-4 text-sm text-text-muted">
+        Configure the GCP Secret Manager connection. The project ID is the only
+        required field. Credentials are referenced by name from Kubernetes
+        Secrets — this wizard never holds GCP credentials directly.
+      </div>
+
+      {/* Top-level GCP SM fields */}
+      <div class="grid grid-cols-2 gap-4">
+        <Input
+          id="gcpsm-project-id"
+          label="Project ID"
+          required
+          value={getStr(spec, "projectID")}
+          onInput={(e) =>
+            patchTop("projectID", (e.target as HTMLInputElement).value)}
+          placeholder="my-gcp-project"
+          description="GCP project ID where your secrets are stored."
+          error={errors["projectID"]}
+        />
+        <Input
+          id="gcpsm-location"
+          label="Location (optional)"
+          value={getStr(spec, "location")}
+          onInput={(e) =>
+            patchTop("location", (e.target as HTMLInputElement).value)}
+          placeholder="us-central1"
+          description="Regional endpoint. Leave blank to use the global endpoint."
+          error={errors["location"]}
+        />
+      </div>
+
+      {/* Auth method picker */}
+      <div class="space-y-3">
+        <h3 class="text-sm font-semibold text-text-primary">
+          Authentication method
+          <span aria-hidden="true" class="text-danger ml-0.5">*</span>
+        </h3>
+        <div class="grid gap-2 sm:grid-cols-3">
+          {AUTH_METHODS.map((m) => {
+            const active = method.value === m.id;
+            return (
+              <button
+                key={m.id}
+                type="button"
+                onClick={() => setMethod(m.id)}
+                class={`text-left rounded-lg border p-3 transition-colors ${
+                  active
+                    ? "border-brand bg-brand/5"
+                    : "border-border-primary bg-surface hover:border-border-emphasis"
+                }`}
+                aria-pressed={active}
+              >
+                <div class="font-medium text-text-primary">{m.label}</div>
+                <p class="mt-1 text-xs text-text-muted">{m.description}</p>
+              </button>
+            );
+          })}
+        </div>
+        {errors["auth"] && <p class="text-sm text-danger">{errors["auth"]}</p>}
+      </div>
+
+      {/* Auth-method-specific fields */}
+      {method.value === "workloadIdentity" && (
+        <WorkloadIdentityFields
+          block={getAuthBlock(spec, "workloadIdentity")}
+          errors={errors}
+          onPatch={patchWI}
+        />
+      )}
+      {method.value === "secretRef" && (
+        <SAKeyFields
+          block={getAuthBlock(spec, "secretRef")}
+          errors={errors}
+          onPatchRef={patchSARef}
+        />
+      )}
+      {method.value === "default" && (
+        <div class="rounded-md border border-border-primary bg-surface/50 p-4 text-sm text-text-muted">
+          No additional configuration required. ESO will use Application Default
+          Credentials — typically the GKE node service account or a
+          metadata-server-provided identity. Ensure the identity has{" "}
+          <code class="font-mono">secretmanager.versions.access</code>{" "}
+          permission on the target project.
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Initial empty block for a freshly-selected auth method. */
+function emptyMethodSpec(
+  m: Exclude<GCPSMAuthMethod, "default">,
+): Record<string, unknown> {
+  switch (m) {
+    case "workloadIdentity":
+      return { serviceAccountRef: {} };
+    case "secretRef":
+      return { secretAccessKeySecretRef: {} };
+  }
+}
+
+// --- Per-method field components -------------------------------------------
+
+interface WorkloadIdentityFieldsProps {
+  block: Record<string, unknown>;
+  errors: Record<string, string>;
+  onPatch: (patch: Partial<GCPSMWorkloadIdentitySpec>) => void;
+}
+
+function WorkloadIdentityFields(
+  { block, errors, onPatch }: WorkloadIdentityFieldsProps,
+) {
+  const saRef = (block.serviceAccountRef as ServiceAccountRef) ?? {};
+  const clusterLocation = (block.clusterLocation as string) ?? "";
+  const clusterName = (block.clusterName as string) ?? "";
+  const clusterProjectID = (block.clusterProjectID as string) ?? "";
+
+  function patchSARefName(name: string) {
+    onPatch({ serviceAccountRef: { ...saRef, name } });
+  }
+
+  return (
+    <div class="rounded-md border border-border-primary p-4 space-y-4">
+      <div>
+        <h4 class="text-sm font-medium text-text-primary mb-2">
+          Kubernetes ServiceAccount
+        </h4>
+        <Input
+          id="gcpsm-wi-sa-name"
+          label="ServiceAccount name"
+          required
+          value={saRef.name ?? ""}
+          onInput={(e) => patchSARefName((e.target as HTMLInputElement).value)}
+          placeholder="eso-gcp-sa"
+          description="The Kubernetes ServiceAccount annotated with the GCP service account email via Workload Identity."
+          error={errors["auth.workloadIdentity.serviceAccountRef.name"] ??
+            errors["auth.workloadIdentity.serviceAccountRef"]}
+        />
+      </div>
+      <div>
+        <h4 class="text-sm font-medium text-text-primary mb-2">
+          Cluster details{" "}
+          <span class="text-text-muted font-normal">
+            (optional — read from metadata server if omitted)
+          </span>
+        </h4>
+        <div class="grid grid-cols-3 gap-3">
+          <Input
+            id="gcpsm-wi-cluster-location"
+            label="Cluster location"
+            value={clusterLocation}
+            onInput={(e) =>
+              onPatch({
+                clusterLocation: (e.target as HTMLInputElement).value ||
+                  undefined,
+              })}
+            placeholder="us-central1"
+            error={errors["auth.workloadIdentity.clusterLocation"]}
+          />
+          <Input
+            id="gcpsm-wi-cluster-name"
+            label="Cluster name"
+            value={clusterName}
+            onInput={(e) =>
+              onPatch({
+                clusterName: (e.target as HTMLInputElement).value || undefined,
+              })}
+            placeholder="my-cluster"
+            error={errors["auth.workloadIdentity.clusterName"]}
+          />
+          <Input
+            id="gcpsm-wi-cluster-project"
+            label="Cluster project ID"
+            value={clusterProjectID}
+            onInput={(e) =>
+              onPatch({
+                clusterProjectID: (e.target as HTMLInputElement).value ||
+                  undefined,
+              })}
+            placeholder="my-infra-project"
+            error={errors["auth.workloadIdentity.clusterProjectID"]}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface SAKeyFieldsProps {
+  block: Record<string, unknown>;
+  errors: Record<string, string>;
+  onPatchRef: (patch: { name?: string; key?: string }) => void;
+}
+
+function SAKeyFields({ block, errors, onPatchRef }: SAKeyFieldsProps) {
+  const sakRef = (
+    (block.secretAccessKeySecretRef as Record<string, unknown>) ?? {}
+  ) as { name?: string; key?: string };
+
+  return (
+    <div class="rounded-md border border-border-primary p-4 space-y-3">
+      <h4 class="text-sm font-medium text-text-primary">
+        Service Account key Secret reference
+      </h4>
+      <p class="text-xs text-text-muted">
+        The Kubernetes Secret containing the GCP Service Account JSON key file
+        (downloaded from IAM &amp; Admin → Service Accounts → Keys).
+      </p>
+      <div class="grid grid-cols-2 gap-3">
+        <Input
+          id="gcpsm-sa-key-name"
+          label="Secret name"
+          required
+          value={sakRef.name ?? ""}
+          onInput={(e) =>
+            onPatchRef({ name: (e.target as HTMLInputElement).value })}
+          placeholder="gcp-sa-key"
+          error={errors["auth.secretRef.secretAccessKeySecretRef.name"]}
+        />
+        <Input
+          id="gcpsm-sa-key-key"
+          label="Key"
+          required
+          value={sakRef.key ?? ""}
+          onInput={(e) =>
+            onPatchRef({ key: (e.target as HTMLInputElement).value })}
+          placeholder="key.json"
+          description="The key within the Secret holding the SA JSON content."
+          error={errors["auth.secretRef.secretAccessKeySecretRef.key"]}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/islands/SecretStoreWizard.tsx
+++ b/frontend/islands/SecretStoreWizard.tsx
@@ -233,6 +233,17 @@ export default function SecretStoreWizard({ scope }: SecretStoreWizardProps) {
       if (!projectID) {
         errs.projectID = "Project ID is required";
       }
+      // Gate on auth only when an auth block is present but empty — a degenerate
+      // state that should not occur via the normal picker UI but could happen if
+      // providerSpec is mutated externally. When auth is absent the form encodes
+      // the "Default Credentials" method, which is a valid ESO configuration
+      // (GKE metadata server / Application Default Credentials) and must not be
+      // blocked. This mirrors the Vault auth gate but accounts for GCP's
+      // first-class default-credentials path.
+      const auth = ps.auth as Record<string, unknown> | undefined;
+      if (auth !== undefined && Object.keys(auth).length === 0) {
+        errs.auth = "Select an authentication method";
+      }
     }
 
     errors.value = errs;

--- a/frontend/islands/SecretStoreWizard.tsx
+++ b/frontend/islands/SecretStoreWizard.tsx
@@ -15,6 +15,7 @@ import { OnePasswordForm } from "@/components/wizard/secretstore/OnePasswordForm
 import { AWSForm } from "@/components/wizard/secretstore/AWSForm.tsx";
 import { AzureKVForm } from "@/components/wizard/secretstore/AzureKVForm.tsx";
 import { AWSPSForm } from "@/components/wizard/secretstore/AWSPSForm.tsx";
+import { GCPSMForm } from "@/components/wizard/secretstore/GCPSMForm.tsx";
 import { Input } from "@/components/ui/Input.tsx";
 import { NamespaceSelect } from "@/components/ui/NamespaceSelect.tsx";
 import { Button } from "@/components/ui/Button.tsx";
@@ -38,6 +39,7 @@ const PROVIDER_FORMS: Partial<
   aws: AWSForm,
   azurekv: AzureKVForm,
   awsps: AWSPSForm,
+  gcpsm: GCPSMForm,
 };
 
 // Re-export for any downstream consumers that imported from this island.
@@ -220,6 +222,16 @@ export default function SecretStoreWizard({ scope }: SecretStoreWizardProps) {
         if (!role) {
           errs.role = "IAM role ARN is required for IRSA";
         }
+      }
+    }
+
+    if (step === 2 && f.provider === "gcpsm") {
+      const ps = f.providerSpec;
+      const projectID = typeof ps.projectID === "string"
+        ? ps.projectID.trim()
+        : "";
+      if (!projectID) {
+        errs.projectID = "Project ID is required";
       }
     }
 

--- a/frontend/lib/eso-types.ts
+++ b/frontend/lib/eso-types.ts
@@ -240,6 +240,7 @@ export const READY_SECRET_STORE_PROVIDERS = new Set<SecretStoreProvider>([
   "aws",
   "azurekv",
   "awsps",
+  "gcpsm",
 ]);
 
 // --- Phase G path-discovery types ------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `validateGCPSMSpec` backend validator for the `gcpsm` provider key, registered via `init()`. Supports three auth paths: **Workload Identity** (`auth.workloadIdentity.serviceAccountRef.name` + optional `clusterLocation/clusterName/clusterProjectID`), **SA Key JSON** (`auth.secretRef.secretAccessKeySecretRef.{name,key}`), and **Default Credentials** (no auth block — GKE node identity / Application Default Credentials).
- 25 tests covering all valid paths, all required-field gates, DNS-label validation, the multi-method mutex, and the YAML-structural ToYAML assertion via the dispatcher.
- `GCPSMForm.tsx` frontend component with 3-card auth method picker, per-method field panels (WI cluster-detail grid, SA key Secret reference), and a Default Credentials info panel. Matches `VaultFormProps` contract.
- Adds `"gcpsm"` to `READY_SECRET_STORE_PROVIDERS` in `lib/eso-types.ts` so the Configure step surfaces automatically for this provider.
- Registers `gcpsm: GCPSMForm` in `SecretStoreWizard.tsx`'s `PROVIDER_FORMS` registry and adds a projectID client-side gate for step 2.
- `workloadIdentityFederation` (multi-cloud token exchange) intentionally deferred to the YAML editor per plan's L7.2 culling pass.

## Canonical pattern

Follows `secretstore_vault.go` + `VaultForm.tsx` (PR #217) exactly: fixed-order auth-method slice for deterministic error messages, typed TS interfaces for each spec sub-shape, 422 error keys match validator field paths.

## Test plan

- [x] `go vet ./...` — clean
- [x] `go test ./internal/wizard/ -count=10` — 25 GCPSM tests + all pre-existing wizard tests pass (10 runs)
- [x] `deno lint` on all 3 changed frontend files — clean
- [x] `deno fmt --check` on `GCPSMForm.tsx` — clean (pre-existing CRLF tree-wide issue is not introduced by this PR)
- [ ] Smoke test: create SecretStore with Workload Identity + SecretRef + Default Credentials paths against homelab

🤖 Generated with [Claude Code](https://claude.com/claude-code)