### PR TITLE
feat(eso): Phase H Unit 19 — Doppler provider wizard (7/8)

### DIFF
--- a/backend/internal/wizard/secretstore_doppler.go
+++ b/backend/internal/wizard/secretstore_doppler.go
@@ -20,10 +20,9 @@ func init() {
 //   - secretRef: a DopplerToken SecretRef pointing to a Kubernetes Secret.
 //   - oidcConfig: OIDC via Kubernetes ServiceAccount token (identity + serviceAccountRef).
 //
-// project and config are required when using oidcConfig auth. With secretRef
-// (service token), they are optional — the service token encodes the
-// project/config scope — but the wizard requires them to produce explicit,
-// self-documenting YAML.
+// project and config are required for both auth methods. With secretRef the
+// service token already encodes the scope, but the wizard requires explicit
+// values to produce self-documenting, reviewable YAML regardless of auth method.
 //
 // Each FieldError's Field is rooted at the provider-spec level (no
 // "providerSpec." prefix) so the dispatcher's caller can prefix uniformly

--- a/backend/internal/wizard/secretstore_doppler.go
+++ b/backend/internal/wizard/secretstore_doppler.go
@@ -1,0 +1,151 @@
+package wizard
+
+import (
+	"strings"
+)
+
+// init registers the Doppler provider validator with the SecretStore wizard
+// dispatcher. Lives in this file so the validator ships and registers as one
+// unit — adding a provider is a single-file edit + one line in
+// READY_SECRET_STORE_PROVIDERS on the frontend.
+func init() {
+	RegisterSecretStoreProvider(SecretStoreProviderDoppler, validateDopplerSpec)
+}
+
+// validateDopplerSpec validates a SecretStoreInput.ProviderSpec for the Doppler
+// provider. The spec mirrors ESO's spec.provider.doppler shape — auth (with
+// exactly one of secretRef or oidcConfig), project, and config.
+//
+// Auth methods:
+//   - secretRef: a DopplerToken SecretRef pointing to a Kubernetes Secret.
+//   - oidcConfig: OIDC via Kubernetes ServiceAccount token (identity + serviceAccountRef).
+//
+// project and config are required when using oidcConfig auth. With secretRef
+// (service token), they are optional — the service token encodes the
+// project/config scope — but the wizard requires them to produce explicit,
+// self-documenting YAML.
+//
+// Each FieldError's Field is rooted at the provider-spec level (no
+// "providerSpec." prefix) so the dispatcher's caller can prefix uniformly
+// when surfacing errors to the frontend.
+func validateDopplerSpec(spec map[string]any) []FieldError {
+	var errs []FieldError
+
+	authRaw, hasAuth := spec["auth"].(map[string]any)
+	if !hasAuth {
+		errs = append(errs, FieldError{Field: "auth", Message: "is required (one of secretRef, oidcConfig)"})
+		return errs
+	}
+
+	method, methodErrs := pickDopplerAuthMethod(authRaw)
+	errs = append(errs, methodErrs...)
+	if method == "" {
+		return errs
+	}
+
+	switch method {
+	case "secretRef":
+		errs = append(errs, validateDopplerAuthSecretRef(authRaw)...)
+	case "oidcConfig":
+		errs = append(errs, validateDopplerAuthOIDC(authRaw)...)
+	}
+
+	// project is required when present and non-empty is set; the wizard
+	// enforces it unconditionally for explicit, reviewable YAML output.
+	project, _ := spec["project"].(string)
+	if strings.TrimSpace(project) == "" {
+		errs = append(errs, FieldError{Field: "project", Message: "is required"})
+	}
+
+	config, _ := spec["config"].(string)
+	if strings.TrimSpace(config) == "" {
+		errs = append(errs, FieldError{Field: "config", Message: "is required"})
+	}
+
+	return errs
+}
+
+// pickDopplerAuthMethod returns the single auth method present in the auth
+// block. ESO requires exactly one of secretRef or oidcConfig.
+// Multiple methods or no method both produce errors.
+func pickDopplerAuthMethod(auth map[string]any) (string, []FieldError) {
+	// orderedDopplerAuthMethods defines the fixed iteration order for a
+	// deterministic error message when multiple methods are set.
+	const (
+		methodSecretRef  = "secretRef"
+		methodOIDCConfig = "oidcConfig"
+	)
+	orderedMethods := []string{methodSecretRef, methodOIDCConfig}
+
+	var present []string
+	for _, m := range orderedMethods {
+		if _, ok := auth[m]; ok {
+			present = append(present, m)
+		}
+	}
+	switch len(present) {
+	case 0:
+		return "", []FieldError{{Field: "auth", Message: "exactly one of secretRef, oidcConfig must be set"}}
+	case 1:
+		return present[0], nil
+	default:
+		return "", []FieldError{{Field: "auth", Message: "only one auth method may be set; got secretRef and oidcConfig"}}
+	}
+}
+
+// validateDopplerAuthSecretRef validates the auth.secretRef block.
+// ESO's DopplerAuthSecretRef requires auth.secretRef.dopplerToken.{name, key}.
+func validateDopplerAuthSecretRef(auth map[string]any) []FieldError {
+	sr, _ := auth["secretRef"].(map[string]any)
+	if sr == nil {
+		return []FieldError{{Field: "auth.secretRef", Message: "is required"}}
+	}
+	tokenRef, _ := sr["dopplerToken"].(map[string]any)
+	if tokenRef == nil {
+		return []FieldError{{Field: "auth.secretRef.dopplerToken", Message: "is required"}}
+	}
+	return validateDopplerSecretRef(tokenRef, "auth.secretRef.dopplerToken")
+}
+
+// validateDopplerAuthOIDC validates the auth.oidcConfig block.
+// ESO's DopplerOIDCAuth requires identity and serviceAccountRef.name.
+func validateDopplerAuthOIDC(auth map[string]any) []FieldError {
+	var errs []FieldError
+	oidc, _ := auth["oidcConfig"].(map[string]any)
+	if oidc == nil {
+		return []FieldError{{Field: "auth.oidcConfig", Message: "is required"}}
+	}
+	if identity, _ := oidc["identity"].(string); strings.TrimSpace(identity) == "" {
+		errs = append(errs, FieldError{Field: "auth.oidcConfig.identity", Message: "is required"})
+	}
+	saRef, _ := oidc["serviceAccountRef"].(map[string]any)
+	if saRef == nil {
+		errs = append(errs, FieldError{Field: "auth.oidcConfig.serviceAccountRef", Message: "is required"})
+	} else {
+		if name, _ := saRef["name"].(string); strings.TrimSpace(name) == "" {
+			errs = append(errs, FieldError{Field: "auth.oidcConfig.serviceAccountRef.name", Message: "is required"})
+		} else if !dnsLabelRegex.MatchString(name) {
+			errs = append(errs, FieldError{Field: "auth.oidcConfig.serviceAccountRef.name", Message: "must be a valid DNS label"})
+		}
+	}
+	return errs
+}
+
+// validateDopplerSecretRef validates an ESO SecretKeySelector at the given
+// field prefix. Requires name and key; namespace is optional.
+func validateDopplerSecretRef(spec map[string]any, prefix string) []FieldError {
+	var errs []FieldError
+	if spec == nil {
+		errs = append(errs, FieldError{Field: prefix, Message: "is required"})
+		return errs
+	}
+	if name, _ := spec["name"].(string); name == "" {
+		errs = append(errs, FieldError{Field: prefix + ".name", Message: "is required"})
+	} else if !dnsLabelRegex.MatchString(name) {
+		errs = append(errs, FieldError{Field: prefix + ".name", Message: "must be a valid DNS label"})
+	}
+	if key, _ := spec["key"].(string); key == "" {
+		errs = append(errs, FieldError{Field: prefix + ".key", Message: "is required"})
+	}
+	return errs
+}

--- a/backend/internal/wizard/secretstore_doppler_test.go
+++ b/backend/internal/wizard/secretstore_doppler_test.go
@@ -1,0 +1,295 @@
+package wizard
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// validDopplerSpec returns a minimal valid Doppler provider spec using
+// secretRef auth — the simpler of the two auth methods.
+func validDopplerSpec() map[string]any {
+	return map[string]any{
+		"project": "my-project",
+		"config":  "prd",
+		"auth": map[string]any{
+			"secretRef": map[string]any{
+				"dopplerToken": map[string]any{
+					"name": "doppler-token",
+					"key":  "serviceToken",
+				},
+			},
+		},
+	}
+}
+
+func TestValidateDopplerSpec_Valid(t *testing.T) {
+	if errs := validateDopplerSpec(validDopplerSpec()); len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+}
+
+func TestValidateDopplerSpec_MissingProject(t *testing.T) {
+	spec := validDopplerSpec()
+	delete(spec, "project")
+	if !hasField(validateDopplerSpec(spec), "project") {
+		t.Error("expected project required error")
+	}
+}
+
+func TestValidateDopplerSpec_BlankProject(t *testing.T) {
+	spec := validDopplerSpec()
+	spec["project"] = "   "
+	if !hasField(validateDopplerSpec(spec), "project") {
+		t.Error("expected project error for whitespace-only value")
+	}
+}
+
+func TestValidateDopplerSpec_MissingConfig(t *testing.T) {
+	spec := validDopplerSpec()
+	delete(spec, "config")
+	if !hasField(validateDopplerSpec(spec), "config") {
+		t.Error("expected config required error")
+	}
+}
+
+func TestValidateDopplerSpec_BlankConfig(t *testing.T) {
+	spec := validDopplerSpec()
+	spec["config"] = ""
+	if !hasField(validateDopplerSpec(spec), "config") {
+		t.Error("expected config error for empty value")
+	}
+}
+
+func TestValidateDopplerSpec_NoAuth(t *testing.T) {
+	spec := validDopplerSpec()
+	delete(spec, "auth")
+	if !hasField(validateDopplerSpec(spec), "auth") {
+		t.Error("expected auth required error")
+	}
+}
+
+func TestValidateDopplerSpec_AuthNoMethod(t *testing.T) {
+	spec := validDopplerSpec()
+	spec["auth"] = map[string]any{}
+	if !hasField(validateDopplerSpec(spec), "auth") {
+		t.Error("expected auth error for empty block")
+	}
+}
+
+func TestValidateDopplerSpec_AuthBothMethods(t *testing.T) {
+	spec := validDopplerSpec()
+	spec["auth"] = map[string]any{
+		"secretRef": map[string]any{
+			"dopplerToken": map[string]any{"name": "tok", "key": "serviceToken"},
+		},
+		"oidcConfig": map[string]any{},
+	}
+	errs := validateDopplerSpec(spec)
+	if !hasField(errs, "auth") {
+		t.Errorf("expected auth error for both methods set; got %v", errs)
+	}
+	// Verify message mentions both methods.
+	found := false
+	for _, e := range errs {
+		if e.Field == "auth" && strings.Contains(e.Message, "only one") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected only-one error message, got %v", errs)
+	}
+}
+
+// --- secretRef auth ---
+
+func TestValidateDopplerSpec_SecretRef_MissingDopplerToken(t *testing.T) {
+	spec := validDopplerSpec()
+	spec["auth"] = map[string]any{
+		"secretRef": map[string]any{}, // missing dopplerToken
+	}
+	if !hasField(validateDopplerSpec(spec), "auth.secretRef.dopplerToken") {
+		t.Error("expected dopplerToken required error")
+	}
+}
+
+func TestValidateDopplerSpec_SecretRef_MissingName(t *testing.T) {
+	spec := validDopplerSpec()
+	spec["auth"] = map[string]any{
+		"secretRef": map[string]any{
+			"dopplerToken": map[string]any{"key": "serviceToken"}, // missing name
+		},
+	}
+	if !hasField(validateDopplerSpec(spec), "auth.secretRef.dopplerToken.name") {
+		t.Error("expected dopplerToken.name required error")
+	}
+}
+
+func TestValidateDopplerSpec_SecretRef_MissingKey(t *testing.T) {
+	spec := validDopplerSpec()
+	spec["auth"] = map[string]any{
+		"secretRef": map[string]any{
+			"dopplerToken": map[string]any{"name": "doppler-token"}, // missing key
+		},
+	}
+	if !hasField(validateDopplerSpec(spec), "auth.secretRef.dopplerToken.key") {
+		t.Error("expected dopplerToken.key required error")
+	}
+}
+
+func TestValidateDopplerSpec_SecretRef_BadRefName(t *testing.T) {
+	spec := validDopplerSpec()
+	spec["auth"] = map[string]any{
+		"secretRef": map[string]any{
+			"dopplerToken": map[string]any{"name": "BadName", "key": "serviceToken"},
+		},
+	}
+	if !hasField(validateDopplerSpec(spec), "auth.secretRef.dopplerToken.name") {
+		t.Error("expected dopplerToken.name DNS label error")
+	}
+}
+
+// --- oidcConfig auth ---
+
+func TestValidateDopplerSpec_OIDC_Valid(t *testing.T) {
+	spec := validDopplerSpec()
+	spec["auth"] = map[string]any{
+		"oidcConfig": map[string]any{
+			"identity": "doppler-identity-id",
+			"serviceAccountRef": map[string]any{
+				"name": "my-sa",
+			},
+		},
+	}
+	if errs := validateDopplerSpec(spec); len(errs) != 0 {
+		t.Errorf("expected no errors for oidcConfig auth, got %v", errs)
+	}
+}
+
+func TestValidateDopplerSpec_OIDC_MissingIdentity(t *testing.T) {
+	spec := validDopplerSpec()
+	spec["auth"] = map[string]any{
+		"oidcConfig": map[string]any{
+			"serviceAccountRef": map[string]any{"name": "my-sa"},
+		},
+	}
+	if !hasField(validateDopplerSpec(spec), "auth.oidcConfig.identity") {
+		t.Error("expected identity required error")
+	}
+}
+
+func TestValidateDopplerSpec_OIDC_MissingServiceAccountRef(t *testing.T) {
+	spec := validDopplerSpec()
+	spec["auth"] = map[string]any{
+		"oidcConfig": map[string]any{
+			"identity": "doppler-identity-id",
+		},
+	}
+	if !hasField(validateDopplerSpec(spec), "auth.oidcConfig.serviceAccountRef") {
+		t.Error("expected serviceAccountRef required error")
+	}
+}
+
+func TestValidateDopplerSpec_OIDC_BadServiceAccountName(t *testing.T) {
+	spec := validDopplerSpec()
+	spec["auth"] = map[string]any{
+		"oidcConfig": map[string]any{
+			"identity":          "doppler-identity-id",
+			"serviceAccountRef": map[string]any{"name": "Bad_SA"},
+		},
+	}
+	if !hasField(validateDopplerSpec(spec), "auth.oidcConfig.serviceAccountRef.name") {
+		t.Error("expected serviceAccountRef.name DNS label error")
+	}
+}
+
+// --- Dispatcher integration ---
+
+// TestSecretStoreInput_DopplerIntegration confirms validateDopplerSpec is wired
+// to the dispatcher via the init() RegisterSecretStoreProvider call.
+func TestSecretStoreInput_DopplerIntegration(t *testing.T) {
+	s := SecretStoreInput{
+		Scope:        StoreScopeNamespaced,
+		Name:         "doppler-store",
+		Namespace:    "apps",
+		Provider:     SecretStoreProviderDoppler,
+		ProviderSpec: validDopplerSpec(),
+	}
+	if errs := s.Validate(); len(errs) != 0 {
+		t.Errorf("expected no errors via dispatcher, got %v", errs)
+	}
+}
+
+func TestSecretStoreInput_DopplerIntegration_PropagatesProviderError(t *testing.T) {
+	spec := validDopplerSpec()
+	delete(spec, "project")
+	s := SecretStoreInput{
+		Scope:        StoreScopeNamespaced,
+		Name:         "doppler-store",
+		Namespace:    "apps",
+		Provider:     SecretStoreProviderDoppler,
+		ProviderSpec: spec,
+	}
+	errs := s.Validate()
+	if !hasField(errs, "project") {
+		t.Errorf("expected provider-level project error, got %v", errs)
+	}
+}
+
+// TestSecretStoreInput_DopplerIntegration_ToYAML asserts the wizard preview's
+// emitted YAML places the spec under spec.provider.doppler with the correct
+// structure and does not leak wizard-internal keys.
+func TestSecretStoreInput_DopplerIntegration_ToYAML(t *testing.T) {
+	s := SecretStoreInput{
+		Scope:        StoreScopeNamespaced,
+		Name:         "doppler-store",
+		Namespace:    "apps",
+		Provider:     SecretStoreProviderDoppler,
+		ProviderSpec: validDopplerSpec(),
+	}
+	y, err := s.ToYAML()
+	if err != nil {
+		t.Fatalf("unexpected ToYAML error: %v", err)
+	}
+	for _, want := range []string{
+		"apiVersion: external-secrets.io/v1",
+		"kind: SecretStore",
+	} {
+		if !strings.Contains(y, want) {
+			t.Errorf("expected YAML to contain %q\n%s", want, y)
+		}
+	}
+
+	// Structural walk: confirm spec.provider.doppler.auth.secretRef.dopplerToken
+	// carries name + key.
+	var doc map[string]any
+	if err := yaml.Unmarshal([]byte(y), &doc); err != nil {
+		t.Fatalf("failed to parse YAML: %v\n%s", err, y)
+	}
+	spec, _ := doc["spec"].(map[string]any)
+	provider, _ := spec["provider"].(map[string]any)
+	dopplerSpec, _ := provider["doppler"].(map[string]any)
+	if dopplerSpec == nil {
+		t.Fatalf("expected spec.provider.doppler, got provider keys: %v", keys(provider))
+	}
+	auth, _ := dopplerSpec["auth"].(map[string]any)
+	sr, _ := auth["secretRef"].(map[string]any)
+	tokenRef, _ := sr["dopplerToken"].(map[string]any)
+	if tokenRef == nil {
+		t.Fatalf("expected spec.provider.doppler.auth.secretRef.dopplerToken; auth=%v", auth)
+	}
+	if tokenRef["name"] == nil {
+		t.Errorf("expected dopplerToken.name, got %v", tokenRef)
+	}
+	if tokenRef["key"] == nil {
+		t.Errorf("expected dopplerToken.key, got %v", tokenRef)
+	}
+	// Verify project and config appear at the doppler-spec level.
+	if dopplerSpec["project"] != "my-project" {
+		t.Errorf("expected project=my-project, got %v", dopplerSpec["project"])
+	}
+	if dopplerSpec["config"] != "prd" {
+		t.Errorf("expected config=prd, got %v", dopplerSpec["config"])
+	}
+}

--- a/frontend/components/wizard/secretstore/DopplerForm.tsx
+++ b/frontend/components/wizard/secretstore/DopplerForm.tsx
@@ -42,7 +42,8 @@ interface DopplerAuthSpec {
   oidcConfig?: {
     identity?: string;
     serviceAccountRef?: { name?: string };
-    expirationSeconds?: number;
+    // Note: ESO's ServiceAccountSelector also accepts optional `namespace` and
+    // `audiences` fields — intentionally omitted for v1 (accessible via YAML editor).
   };
 }
 

--- a/frontend/components/wizard/secretstore/DopplerForm.tsx
+++ b/frontend/components/wizard/secretstore/DopplerForm.tsx
@@ -1,0 +1,336 @@
+import { useSignal } from "@preact/signals";
+import { Input } from "@/components/ui/Input.tsx";
+
+/**
+ * Doppler provider form for SecretStoreWizard. Writes into the wizard's
+ * `providerSpec: Record<string, unknown>` slot under the shape:
+ * ```
+ * {
+ *   project: string,
+ *   config: string,
+ *   auth: {
+ *     secretRef: { dopplerToken: { name, key } }
+ *     | oidcConfig: { identity, serviceAccountRef: { name } }
+ *   }
+ * }
+ * ```
+ *
+ * ESO supports two auth methods for Doppler:
+ *   - secretRef: a service token stored in a Kubernetes Secret.
+ *   - oidcConfig: OIDC via Kubernetes ServiceAccount tokens (Workload Identity).
+ *
+ * Switching auth method clears the previously-entered method block so stale
+ * fields don't leak into the YAML preview.
+ */
+
+export type DopplerAuthMethod = "secretRef" | "oidcConfig";
+
+export interface DopplerFormProps {
+  spec: Record<string, unknown>;
+  errors: Record<string, string>;
+  onUpdateSpec: (spec: Record<string, unknown>) => void;
+}
+
+interface SecretRef {
+  name?: string;
+  key?: string;
+}
+
+/** Typed sub-shapes for Doppler auth methods. */
+interface DopplerAuthSpec {
+  secretRef?: { dopplerToken?: SecretRef };
+  oidcConfig?: {
+    identity?: string;
+    serviceAccountRef?: { name?: string };
+    expirationSeconds?: number;
+  };
+}
+
+/** Typed shape for a Doppler provider spec block (spec.provider.doppler). */
+interface DopplerSpec {
+  project?: string;
+  config?: string;
+  auth?: DopplerAuthSpec;
+}
+
+const AUTH_METHODS: {
+  id: DopplerAuthMethod;
+  label: string;
+  description: string;
+}[] = [
+  {
+    id: "secretRef",
+    label: "Service Token",
+    description:
+      "A Doppler service token stored in a Kubernetes Secret. Recommended for most clusters.",
+  },
+  {
+    id: "oidcConfig",
+    label: "OIDC (Workload Identity)",
+    description:
+      "Authenticate via Kubernetes ServiceAccount tokens — no long-lived secrets required.",
+  },
+];
+
+/** Determine which auth method the spec currently encodes, or "" when none. */
+function detectMethod(spec: Record<string, unknown>): DopplerAuthMethod | "" {
+  const auth = spec.auth as Record<string, unknown> | undefined;
+  if (!auth) return "";
+  for (const m of AUTH_METHODS.map((x) => x.id)) {
+    if (m in auth) return m;
+  }
+  return "";
+}
+
+/** Read a top-level string field from the spec. */
+function getStr(spec: Record<string, unknown>, key: string): string {
+  const v = spec[key];
+  return typeof v === "string" ? v : "";
+}
+
+function getAuthBlock(
+  spec: Record<string, unknown>,
+  method: DopplerAuthMethod,
+): Record<string, unknown> {
+  const auth = (spec.auth as Record<string, unknown>) ?? {};
+  return (auth[method] as Record<string, unknown>) ?? {};
+}
+
+export function DopplerForm({ spec, errors, onUpdateSpec }: DopplerFormProps) {
+  // Track which auth method's fields are currently shown. Persisted in the
+  // spec itself (via detectMethod) so the form survives Back/Next navigation.
+  const method = useSignal<DopplerAuthMethod | "">(detectMethod(spec));
+
+  function patchTop(field: string, value: string) {
+    const next = { ...spec };
+    if (value === "") delete next[field];
+    else next[field] = value;
+    onUpdateSpec(next);
+  }
+
+  function setMethod(m: DopplerAuthMethod) {
+    if (method.value === m) return;
+    method.value = m;
+    // Clear the auth slate; preserve top-level fields (project, config).
+    onUpdateSpec({
+      ...spec,
+      auth: { [m]: emptyMethodSpec(m) },
+    });
+  }
+
+  function patchAuth(
+    authMethod: DopplerAuthMethod,
+    patch: Record<string, unknown>,
+  ) {
+    const auth = (spec.auth as Record<string, unknown>) ?? {};
+    const block = (auth[authMethod] as Record<string, unknown>) ?? {};
+    onUpdateSpec({
+      ...spec,
+      auth: { ...auth, [authMethod]: { ...block, ...patch } },
+    });
+  }
+
+  function patchSecretRef(
+    authMethod: DopplerAuthMethod,
+    refField: string,
+    patch: SecretRef,
+  ) {
+    const block = getAuthBlock(spec, authMethod);
+    const existing = (block[refField] as SecretRef) ?? {};
+    patchAuth(authMethod, { [refField]: { ...existing, ...patch } });
+  }
+
+  return (
+    <div class="space-y-5">
+      <div class="rounded-md border border-border-primary bg-surface/50 p-4 text-sm text-text-muted">
+        Configure the Doppler provider connection. Doppler credentials must
+        already exist as Kubernetes Secrets in this namespace (for service
+        token) or be available via Workload Identity (for OIDC) — this wizard
+        only references them and never stores credentials directly.
+      </div>
+
+      {/* Top-level Doppler fields */}
+      <div class="grid grid-cols-2 gap-4">
+        <Input
+          id="doppler-project"
+          label="Project"
+          required
+          value={getStr(spec, "project")}
+          onInput={(e) =>
+            patchTop("project", (e.target as HTMLInputElement).value)}
+          placeholder="my-project"
+          description="The Doppler project name."
+          error={errors["project"]}
+        />
+        <Input
+          id="doppler-config"
+          label="Config"
+          required
+          value={getStr(spec, "config")}
+          onInput={(e) =>
+            patchTop("config", (e.target as HTMLInputElement).value)}
+          placeholder="prd"
+          description="The Doppler config (environment) within the project."
+          error={errors["config"]}
+        />
+      </div>
+
+      {/* Auth method picker */}
+      <div class="space-y-3">
+        <h3 class="text-sm font-semibold text-text-primary">
+          Authentication method
+          <span aria-hidden="true" class="text-danger ml-0.5">*</span>
+        </h3>
+        <div class="grid gap-2 sm:grid-cols-2">
+          {AUTH_METHODS.map((m) => {
+            const active = method.value === m.id;
+            return (
+              <button
+                key={m.id}
+                type="button"
+                onClick={() => setMethod(m.id)}
+                class={`text-left rounded-lg border p-3 transition-colors ${
+                  active
+                    ? "border-brand bg-brand/5"
+                    : "border-border-primary bg-surface hover:border-border-emphasis"
+                }`}
+                aria-pressed={active}
+              >
+                <div class="font-medium text-text-primary">{m.label}</div>
+                <p class="mt-1 text-xs text-text-muted">{m.description}</p>
+              </button>
+            );
+          })}
+        </div>
+        {errors["auth"] && <p class="text-sm text-danger">{errors["auth"]}</p>}
+      </div>
+
+      {/* Auth-method-specific fields */}
+      {method.value === "secretRef" && (
+        <ServiceTokenFields
+          block={getAuthBlock(spec, "secretRef")}
+          errors={errors}
+          onPatchRef={(patch) =>
+            patchSecretRef("secretRef", "dopplerToken", patch)}
+        />
+      )}
+      {method.value === "oidcConfig" && (
+        <OIDCAuthFields
+          block={getAuthBlock(spec, "oidcConfig")}
+          errors={errors}
+          onPatch={(patch) => patchAuth("oidcConfig", patch)}
+        />
+      )}
+    </div>
+  );
+}
+
+/** Initial empty block for a freshly-selected auth method. The wizard's
+ *  validator rejects empty blocks so the user must populate before preview. */
+function emptyMethodSpec(m: DopplerAuthMethod): Record<string, unknown> {
+  switch (m) {
+    case "secretRef":
+      return { dopplerToken: {} };
+    case "oidcConfig":
+      return { serviceAccountRef: {} };
+  }
+}
+
+// --- Per-method field components ---------------------------------------
+
+interface ServiceTokenFieldsProps {
+  block: Record<string, unknown>;
+  errors: Record<string, string>;
+  onPatchRef: (patch: SecretRef) => void;
+}
+
+function ServiceTokenFields(
+  { block, errors, onPatchRef }: ServiceTokenFieldsProps,
+) {
+  const ref = (block.dopplerToken as SecretRef) ?? {};
+  return (
+    <div class="rounded-md border border-border-primary p-4 space-y-3">
+      <h4 class="text-sm font-medium text-text-primary">
+        Service token Secret reference
+      </h4>
+      <p class="text-xs text-text-muted">
+        The key defaults to <code class="font-mono">dopplerToken</code>{" "}
+        in ESO when omitted, but an explicit value is required here to produce
+        unambiguous YAML.
+      </p>
+      <div class="grid grid-cols-2 gap-3">
+        <Input
+          id="doppler-token-ref-name"
+          label="Secret name"
+          required
+          value={ref.name ?? ""}
+          onInput={(e) =>
+            onPatchRef({ name: (e.target as HTMLInputElement).value })}
+          placeholder="doppler-token"
+          error={errors["auth.secretRef.dopplerToken.name"]}
+        />
+        <Input
+          id="doppler-token-ref-key"
+          label="Key"
+          required
+          value={ref.key ?? ""}
+          onInput={(e) =>
+            onPatchRef({ key: (e.target as HTMLInputElement).value })}
+          placeholder="serviceToken"
+          error={errors["auth.secretRef.dopplerToken.key"]}
+        />
+      </div>
+    </div>
+  );
+}
+
+interface OIDCAuthFieldsProps {
+  block: Record<string, unknown>;
+  errors: Record<string, string>;
+  onPatch: (patch: Record<string, unknown>) => void;
+}
+
+function OIDCAuthFields({ block, errors, onPatch }: OIDCAuthFieldsProps) {
+  const identity = (block.identity as string) ?? "";
+  const saRef = (block.serviceAccountRef as Record<string, unknown>) ?? {};
+  const saName = (saRef.name as string) ?? "";
+
+  function patchSARef(patch: Record<string, unknown>) {
+    onPatch({ serviceAccountRef: { ...saRef, ...patch } });
+  }
+
+  return (
+    <div class="rounded-md border border-border-primary p-4 space-y-3">
+      <h4 class="text-sm font-medium text-text-primary">
+        OIDC / Workload Identity auth
+      </h4>
+      <Input
+        id="doppler-oidc-identity"
+        label="Doppler Identity ID"
+        required
+        value={identity}
+        onInput={(e) =>
+          onPatch({ identity: (e.target as HTMLInputElement).value })}
+        placeholder="abc123..."
+        description="The Doppler Service Account Identity ID configured for OIDC."
+        error={errors["auth.oidcConfig.identity"]}
+      />
+      <Input
+        id="doppler-oidc-sa-name"
+        label="ServiceAccount name"
+        required
+        value={saName}
+        onInput={(e) =>
+          patchSARef({ name: (e.target as HTMLInputElement).value })}
+        placeholder="my-app"
+        description="Kubernetes ServiceAccount whose token is exchanged for a Doppler credential."
+        error={errors["auth.oidcConfig.serviceAccountRef.name"]}
+      />
+      {errors["auth.oidcConfig.serviceAccountRef"] && (
+        <p class="text-sm text-danger">
+          {errors["auth.oidcConfig.serviceAccountRef"]}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/islands/SecretStoreWizard.tsx
+++ b/frontend/islands/SecretStoreWizard.tsx
@@ -267,7 +267,10 @@ export default function SecretStoreWizard({ scope }: SecretStoreWizardProps) {
         errs.config = "Config is required";
       }
       const auth = ps.auth as Record<string, unknown> | undefined;
-      if (!auth || Object.keys(auth).length === 0) {
+      if (
+        !auth ||
+        !Object.keys(auth).some((k) => ["secretRef", "oidcConfig"].includes(k))
+      ) {
         errs.auth = "Select an authentication method";
       }
     }

--- a/frontend/islands/SecretStoreWizard.tsx
+++ b/frontend/islands/SecretStoreWizard.tsx
@@ -16,6 +16,7 @@ import { AzureKVForm } from "@/components/wizard/secretstore/AzureKVForm.tsx";
 import { AWSPSForm } from "@/components/wizard/secretstore/AWSPSForm.tsx";
 import { GCPSMForm } from "@/components/wizard/secretstore/GCPSMForm.tsx";
 import { KubernetesForm } from "@/components/wizard/secretstore/KubernetesForm.tsx";
+import { DopplerForm } from "@/components/wizard/secretstore/DopplerForm.tsx";
 import { Input } from "@/components/ui/Input.tsx";
 import { NamespaceSelect } from "@/components/ui/NamespaceSelect.tsx";
 import { Button } from "@/components/ui/Button.tsx";
@@ -40,6 +41,7 @@ const PROVIDER_FORMS: Partial<
   awsps: AWSPSForm,
   gcpsm: GCPSMForm,
   kubernetes: KubernetesForm,
+  doppler: DopplerForm,
 };
 
 // Re-export for any downstream consumers that imported from this island.
@@ -250,6 +252,20 @@ export default function SecretStoreWizard({ scope }: SecretStoreWizardProps) {
     // ESO (defaults to "default") so we don't require it client-side.
     if (step === 2 && f.provider === "kubernetes") {
       const ps = f.providerSpec;
+      const auth = ps.auth as Record<string, unknown> | undefined;
+      if (!auth || Object.keys(auth).length === 0) {
+        errs.auth = "Select an authentication method";
+      }
+    }
+
+    if (step === 2 && f.provider === "doppler") {
+      const ps = f.providerSpec;
+      if (!ps.project || (ps.project as string).trim() === "") {
+        errs.project = "Project is required";
+      }
+      if (!ps.config || (ps.config as string).trim() === "") {
+        errs.config = "Config is required";
+      }
       const auth = ps.auth as Record<string, unknown> | undefined;
       if (!auth || Object.keys(auth).length === 0) {
         errs.auth = "Select an authentication method";

--- a/frontend/lib/eso-types.ts
+++ b/frontend/lib/eso-types.ts
@@ -242,6 +242,7 @@ export const READY_SECRET_STORE_PROVIDERS = new Set<SecretStoreProvider>([
   "awsps",
   "gcpsm",
   "kubernetes",
+  "doppler",
 ]);
 
 /**


### PR DESCRIPTION
## Summary

Per-provider sub-PR for Phase H Unit 19. Doppler. Pattern mirrors Vault (PR #217).

(Recreated from #223 — the original PR was stuck in CONFLICTING/DIRTY merge state with no CI runs attached despite a clean local rebase. Re-creating to give it a fresh GitHub PR record.)

## What ships

**Backend (`secretstore_doppler.go`):**
- `validateDopplerSpec` enforces required `project` + `config` fields and an `auth` block with exactly one method.
- Two auth methods (the brief said one — ESO actually has two):
  - **Service Token** — `auth.secretRef.dopplerToken.{name, key}`.
  - **OIDC Workload Identity** — `auth.oidcConfig.{identity, serviceAccountRef.name}`.
- `pickDopplerAuthMethod` iterates a fixed-order slice for deterministic error messages.
- `init()` self-registers under `SecretStoreProviderDoppler`.

**Tests** (19 tests):
- Valid spec, missing/blank project/config, no auth, empty auth, multi-method rejection.
- Per-method happy + missing-required + edge cases.
- Dispatcher integration via `SecretStoreInput.Validate()`.
- Structural ToYAML walk to `spec.provider.doppler.auth.secretRef.dopplerToken.{name, key}`.

**Frontend (`DopplerForm.tsx`):**
- Two-method auth picker (Service Token / OIDC Workload Identity).
- Method switch clears stale auth state.
- Field error keys match Go validator paths exactly.

**`READY_SECRET_STORE_PROVIDERS`** adds `"doppler"`. **`PROVIDER_FORMS`** registers `doppler: DopplerForm`. SecretStoreWizard's client-side step-2 guard checks project + config + auth presence.

## Test plan

- [ ] CI passes.
- [ ] Smoke: `/external-secrets/stores/new` → pick Doppler → form renders project, config, auth-method picker.
- [ ] Smoke: complete a Service-Token Doppler SecretStore → preview YAML → /yaml/apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)