### PR TITLE
docs(mobile): track PR-1d deferred follow-ups in plan files

### DIFF
--- a/plans/mobile-app-m1-pr-sequence.md
+++ b/plans/mobile-app-m1-pr-sequence.md
@@ -524,6 +524,20 @@ The PR graph is mostly linear. The two parallel branches that meet at PR-1g are:
 
 ---
 
+## Carried-Over Issues (post-merge follow-ups)
+
+Surfaced by `/ce:code-review` on PR-1d (#235) and explicitly deferred at fix-up time. Listed here so they survive future plan reads — commit-message-only notes don't.
+
+| Origin | Issue | Target | Notes |
+|---|---|---|---|
+| PR-1d #10 | Tablet `DataTable` has no virtualization; nested `SingleChildScrollView`s materialize every row eagerly. | **PR-1e** | Add `data_table_2: ^2.x` dep and replace `DataTable` with `DataTable2` / `PaginatedDataTable2` in `mobile/lib/widgets/resource_table.dart`. PR-1e adds 6 more kinds and wires Events tab — pulling in DataTable2 at the same time amortizes the dep churn. |
+| PR-1d #11 | ConfigMap key list builds every key as an `ExpansionTile` inside a non-virtualized `Column`. | **PR-1e** | Replace the Column with `SliverList` / `ListView.builder` inside the detail scaffold. 8 KB inline cap shipped in PR-1d's fix-up; full-key viewer already opens a `MaterialPageRoute`. |
+| PR-1d #17 | No `FLAG_SECURE` (Android) or background-blur (iOS) on Secret detail — plaintext visible in app-switcher snapshot when revealed. | **M5 polish** (per master plan) | Master plan's M5 already covers "accessibility audit + perf pass + polish". Add `flutter_windowmanager` for Android FLAG_SECURE and an `AppLifecycleState`-driven blur cover for iOS at that point. |
+| PR-1b carryover | `AuthInterceptor` refresh dedupe `Completer` can leak on synchronous throw inside `_attemptRefresh`. | **PR-1f or PR-1g** | Surfaced as pre-existing in PR-1c and PR-1d reviews. Wrap the `_attemptRefresh` body in try/finally that clears `_refreshing` regardless of outcome. Low-confidence finding — keep an eye on it during PR-1f WS auth integration where the interceptor sees more traffic. |
+| PR-1d #22 | Drawer `onTap` fires `context.go` before `Navigator.pop` completes — visible jank on slow devices, double-tap can throw on deactivated context. | **acknowledged** | Common Flutter idiom; reordering to `go-then-pop` causes other quirks. Re-evaluate only if real users report jank. |
+
+---
+
 ## Documentation / Operational Notes
 
 - `mobile/README.md` — updated by PR-1a with the pinned Flutter version, run-locally instructions, and the Universal Link / FCM caveats.

--- a/plans/mobile-app.md
+++ b/plans/mobile-app.md
@@ -50,3 +50,6 @@ PR-1 begins the Flutter project: `flutter create mobile/`, pubspec deps, theme/a
 - **Apple Watch / Wear OS** — out of scope.
 - **Saved Views & Custom Dashboards** (previous roadmap #9) — still on the roadmap, post-mobile.
 - **Phone-side exec terminal** — tablets only by default. Revisit on operator demand.
+- **Secret-screen screenshot suppression** — `FLAG_SECURE` (Android) + iOS background-blur cover for `SecretDetailScreen`, so revealed plaintext doesn't appear in OS app-switcher snapshots or screen recordings. Surfaced by PR-1d code review (#17). Routed to **M5 polish** — fits naturally with the accessibility + perf pass.
+
+Per-PR carryovers (smaller follow-ups tracked at the M1 plan level rather than here): see the **Carried-Over Issues** section in `plans/mobile-app-m1-pr-sequence.md`.


### PR DESCRIPTION
## Summary

Surface deferred items from PR-1d's \`/ce:code-review\` pass that were only recorded in commit messages (now squashed into 409f079) so anyone reading the plans for PR-1e or M5 sees them.

### Changes

- **\`plans/mobile-app-m1-pr-sequence.md\`** gains a **Carried-Over Issues** table tracking:
  - PR-1d #10 / #11 (DataTable + ConfigMap virtualization → **PR-1e**, with \`data_table_2\` dep)
  - PR-1d #17 (FLAG_SECURE / iOS background blur → **M5 polish**)
  - PR-1b carryover (\`AuthInterceptor\` refresh dedupe completer leak → **PR-1f or PR-1g**)
  - PR-1d #22 (drawer onTap pop+go race — **acknowledged as-is**)

- **\`plans/mobile-app.md\`** Open Deferrals adds the Secret screenshot-suppression item (M5) and points to the M1 plan for the smaller per-PR carryovers.

Doc-only PR — no code, no test, no behavior change.

## Test plan

- [x] Plan files render in GitHub markdown preview without warnings.
- [ ] Reviewers confirm the deferral routing matches expectations (especially the M5 placement of #17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)