### PR TITLE
ci(e2e): skip on mobile/docs PRs + fix wizard-flows step-transition race

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,6 +3,16 @@ name: E2E Tests
 on:
   pull_request:
     branches: [main]
+    # E2E exercises only the web frontend + backend + Helm chart against a
+    # kind cluster. Skip when a PR touches none of those — running the
+    # 5–6m suite on mobile-only or docs-only diffs burns CI for no signal.
+    paths-ignore:
+      - 'mobile/**'
+      - 'plans/**'
+      - 'docs/**'
+      - '**/*.md'
+      - 'CLAUDE.md'
+      - '.github/CODEOWNERS'
   workflow_dispatch:
 
 # Deny by default — each job declares minimum permissions

--- a/e2e/tests/wizard-flows.spec.ts
+++ b/e2e/tests/wizard-flows.spec.ts
@@ -84,22 +84,28 @@ for (const w of WIZARDS) {
           name: /next|preview/i,
         });
 
-        // Click Next until review step (submit button visible) — max 5 iterations
+        // Click Next until review step (submit button visible) — max 5 iterations.
+        //
+        // Race fix: do not assert `submitButton.or(nextButton)` between clicks.
+        // During step transition the previous step's button unmounts before
+        // the new step's button mounts, so a momentary "neither visible"
+        // window can stall the assertion. Instead, after each click, wait
+        // for network idle (covers the SSR-island hydration the wizard
+        // does on step swap) and let the next loop iteration poll the
+        // visibility checks — they're already nullable-safe via .catch().
         for (let i = 0; i < 5; i++) {
           if (await submitButton.isVisible().catch(() => false)) break;
           if (await nextButton.isVisible().catch(() => false)) {
             await nextButton.click();
-            // Wait for step transition (actionability of next button or submit button)
-            await expect(
-              submitButton.or(nextButton),
-            ).toBeVisible();
+            await page.waitForLoadState("networkidle").catch(() => {});
           } else {
             break;
           }
         }
 
-        // Submit
-        await expect(submitButton).toBeVisible({ timeout: 5_000 });
+        // Submit. Bumped to 10s — slow CI runners occasionally need more
+        // than 5s to hydrate the review step's island.
+        await expect(submitButton).toBeVisible({ timeout: 10_000 });
         await submitButton.click();
 
         // Assert success — either a success message appears or we navigate away


### PR DESCRIPTION
## Summary

Two fixes targeting CI signal-to-noise on the E2E suite, motivated by PR #237's flake (web NetworkPolicy wizard timing out on a 100% mobile-only PR).

- **Path-filter the workflow.** E2E exercises only the web frontend + backend + Helm chart against a kind cluster. Mobile-only and docs-only diffs cannot regress any of those paths, yet the suite was running for 5–6 minutes per such PR and exposing the run to orthogonal flakes that block merges. Adds \`paths-ignore\` for \`mobile/\`, \`plans/\`, \`docs/\`, all \`*.md\`, and \`CODEOWNERS\`.
- **Fix the wizard-flows step-transition race.** The "click Next until Apply visible" loop in \`wizard-flows.spec.ts\` asserted \`submitButton.or(nextButton).toBeVisible()\` between clicks. During step transition the previous step's button unmounts before the new step's button mounts — a momentary "neither visible" window — and the assertion stalls until its 10s timeout. Replaced with \`page.waitForLoadState('networkidle')\` after each click, letting the next loop iteration's nullable-safe \`isVisible().catch()\` polls handle the transition. Final review-step wait bumped 5s → 10s to absorb slow CI hydration.

## Test plan

- [ ] Confirm path filter: open a docs-only PR after merge, verify E2E does not run
- [ ] Confirm wizard-flows reliability: rerun PR #237 E2E (currently retrying) and watch for the NetworkPolicy step-transition flake
- [ ] Run E2E suite once on this PR (it touches \`e2e/\` so it must run) and confirm the wizard-flows tests pass
- [ ] Verify CI workflow file is YAML-valid (\`actionlint\` if available; otherwise GitHub will reject malformed YAML on push)

## Related

- Triggered by flake on https://github.com/maulepilot117/k8sCenter/pull/237 — the same NetworkPolicy wizard race already retried twice in that run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)