### PR TITLE
feat(mobile): M4 PR-4a — shared primitives + RefreshableController + chart widgets

### DIFF
--- a/mobile/lib/util/composite_id.dart
+++ b/mobile/lib/util/composite_id.dart
@@ -11,9 +11,22 @@
 // path segments for detail-screen deep-links, and decodes them on
 // detail-screen mount.
 //
-// The encode step exists because go_router segment matching mishandles
-// raw colons in some configurations — `Uri.encodeComponent` is the
-// safe transport. Decode reverses the encoding before split.
+// `encode()` percent-encodes each segment with `Uri.encodeComponent`
+// before joining on `:`. `tryParse()` percent-decodes each segment
+// after splitting. This makes the encoding self-contained: callers
+// can drop the result into a go_router path segment without an
+// additional `Uri.encodeComponent` step, and segments that contain a
+// literal `:` (Gatekeeper constraint names like `myrule:v2`) round-
+// trip cleanly. The runtime contract is enforced by the API rather
+// than the call-site documentation.
+//
+// Empty-namespace policy:
+//   - GitOpsId allows an empty namespace segment (Argo CD apps in the
+//     argocd namespace and Flux-style cluster-scoped objects).
+//   - PolicyId allows an empty namespace (Kyverno ClusterPolicy and
+//     Gatekeeper cluster-scoped templates).
+//   - MeshRouteId requires all four segments — no Istio/Linkerd
+//     routing CRD is cluster-scoped without a namespace.
 
 class GitOpsId {
   const GitOpsId({
@@ -34,15 +47,16 @@ class GitOpsId {
   static GitOpsId? tryParse(String raw) {
     final parts = raw.split(':');
     if (parts.length != 3) return null;
-    if (parts[0].isEmpty || parts[2].isEmpty) return null;
+    final decoded = parts.map(Uri.decodeComponent).toList();
+    if (decoded[0].isEmpty || decoded[2].isEmpty) return null;
     return GitOpsId(
-      tool: parts[0],
-      namespace: parts[1],
-      name: parts[2],
+      tool: decoded[0],
+      namespace: decoded[1],
+      name: decoded[2],
     );
   }
 
-  String encode() => '$tool:$namespace:$name';
+  String encode() => [tool, namespace, name].map(Uri.encodeComponent).join(':');
 
   @override
   String toString() => encode();
@@ -77,16 +91,20 @@ class PolicyId {
   static PolicyId? tryParse(String raw) {
     final parts = raw.split(':');
     if (parts.length != 4) return null;
-    if (parts[0].isEmpty || parts[2].isEmpty || parts[3].isEmpty) return null;
+    final decoded = parts.map(Uri.decodeComponent).toList();
+    if (decoded[0].isEmpty || decoded[2].isEmpty || decoded[3].isEmpty) {
+      return null;
+    }
     return PolicyId(
-      engine: parts[0],
-      namespace: parts[1],
-      kind: parts[2],
-      name: parts[3],
+      engine: decoded[0],
+      namespace: decoded[1],
+      kind: decoded[2],
+      name: decoded[3],
     );
   }
 
-  String encode() => '$engine:$namespace:$kind:$name';
+  String encode() =>
+      [engine, namespace, kind, name].map(Uri.encodeComponent).join(':');
 
   @override
   String toString() => encode();
@@ -123,21 +141,23 @@ class MeshRouteId {
   static MeshRouteId? tryParse(String raw) {
     final parts = raw.split(':');
     if (parts.length != 4) return null;
-    if (parts[0].isEmpty ||
-        parts[1].isEmpty ||
-        parts[2].isEmpty ||
-        parts[3].isEmpty) {
+    final decoded = parts.map(Uri.decodeComponent).toList();
+    if (decoded[0].isEmpty ||
+        decoded[1].isEmpty ||
+        decoded[2].isEmpty ||
+        decoded[3].isEmpty) {
       return null;
     }
     return MeshRouteId(
-      mesh: parts[0],
-      namespace: parts[1],
-      kindCode: parts[2],
-      name: parts[3],
+      mesh: decoded[0],
+      namespace: decoded[1],
+      kindCode: decoded[2],
+      name: decoded[3],
     );
   }
 
-  String encode() => '$mesh:$namespace:$kindCode:$name';
+  String encode() =>
+      [mesh, namespace, kindCode, name].map(Uri.encodeComponent).join(':');
 
   @override
   String toString() => encode();
@@ -154,12 +174,8 @@ class MeshRouteId {
   int get hashCode => Object.hash(mesh, namespace, kindCode, name);
 }
 
-/// URL-encode a composite ID for safe go_router path embedding.
-/// Wraps `Uri.encodeComponent` so callers don't have to import
-/// `dart:core`'s URI helpers directly.
-String encodeIdForPath(String compositeId) =>
-    Uri.encodeComponent(compositeId);
-
-/// Reverse of [encodeIdForPath]. Use on the receiving side of a
-/// go_router `:id` parameter before passing to a `tryParse` method.
-String decodeIdFromPath(String encoded) => Uri.decodeComponent(encoded);
+// go_router path-segment integration: `encode()` already returns a
+// URL-safe string (each segment percent-encoded; `:` separators
+// preserved). Push the result directly into a path segment and call
+// `tryParse` on the receiving side without an additional
+// encode/decode round-trip.

--- a/mobile/lib/util/composite_id.dart
+++ b/mobile/lib/util/composite_id.dart
@@ -1,0 +1,165 @@
+// Composite-ID helpers for backend resources whose canonical
+// identifier is a colon-delimited tuple. Three schemes are in use
+// across the M4 read surfaces:
+//
+//   GitOps applications:  "tool:namespace:name"        (3 parts)
+//   Policy normalized:    "engine:namespace:kind:name" (4 parts; namespace may be empty for cluster-scoped policies)
+//   Service mesh routing: "mesh:namespace:kindCode:name" (4 parts)
+//
+// These IDs are emitted by the backend. The mobile app receives them
+// as opaque strings on list endpoints, encodes them into go_router
+// path segments for detail-screen deep-links, and decodes them on
+// detail-screen mount.
+//
+// The encode step exists because go_router segment matching mishandles
+// raw colons in some configurations — `Uri.encodeComponent` is the
+// safe transport. Decode reverses the encoding before split.
+
+class GitOpsId {
+  const GitOpsId({
+    required this.tool,
+    required this.namespace,
+    required this.name,
+  });
+
+  /// "argocd" | "fluxcd" | "flux-ks" | "flux-hr" — the backend's
+  /// own discriminator. Mobile passes through opaquely.
+  final String tool;
+  final String namespace;
+  final String name;
+
+  /// Parses `tool:namespace:name`. Returns `null` for malformed input
+  /// rather than throwing — the caller decides whether to surface a
+  /// 404 screen or a generic error.
+  static GitOpsId? tryParse(String raw) {
+    final parts = raw.split(':');
+    if (parts.length != 3) return null;
+    if (parts[0].isEmpty || parts[2].isEmpty) return null;
+    return GitOpsId(
+      tool: parts[0],
+      namespace: parts[1],
+      name: parts[2],
+    );
+  }
+
+  String encode() => '$tool:$namespace:$name';
+
+  @override
+  String toString() => encode();
+
+  @override
+  bool operator ==(Object other) =>
+      other is GitOpsId &&
+      other.tool == tool &&
+      other.namespace == namespace &&
+      other.name == name;
+
+  @override
+  int get hashCode => Object.hash(tool, namespace, name);
+}
+
+class PolicyId {
+  const PolicyId({
+    required this.engine,
+    required this.namespace,
+    required this.kind,
+    required this.name,
+  });
+
+  /// "kyverno" | "gatekeeper".
+  final String engine;
+
+  /// Empty for cluster-scoped policies (e.g. Kyverno ClusterPolicy).
+  final String namespace;
+  final String kind;
+  final String name;
+
+  static PolicyId? tryParse(String raw) {
+    final parts = raw.split(':');
+    if (parts.length != 4) return null;
+    if (parts[0].isEmpty || parts[2].isEmpty || parts[3].isEmpty) return null;
+    return PolicyId(
+      engine: parts[0],
+      namespace: parts[1],
+      kind: parts[2],
+      name: parts[3],
+    );
+  }
+
+  String encode() => '$engine:$namespace:$kind:$name';
+
+  @override
+  String toString() => encode();
+
+  @override
+  bool operator ==(Object other) =>
+      other is PolicyId &&
+      other.engine == engine &&
+      other.namespace == namespace &&
+      other.kind == kind &&
+      other.name == name;
+
+  @override
+  int get hashCode => Object.hash(engine, namespace, kind, name);
+}
+
+class MeshRouteId {
+  const MeshRouteId({
+    required this.mesh,
+    required this.namespace,
+    required this.kindCode,
+    required this.name,
+  });
+
+  /// "istio" | "linkerd".
+  final String mesh;
+  final String namespace;
+
+  /// Backend short-code for the routing CRD kind (e.g. "vs" for
+  /// VirtualService). Mobile passes through opaquely.
+  final String kindCode;
+  final String name;
+
+  static MeshRouteId? tryParse(String raw) {
+    final parts = raw.split(':');
+    if (parts.length != 4) return null;
+    if (parts[0].isEmpty ||
+        parts[1].isEmpty ||
+        parts[2].isEmpty ||
+        parts[3].isEmpty) {
+      return null;
+    }
+    return MeshRouteId(
+      mesh: parts[0],
+      namespace: parts[1],
+      kindCode: parts[2],
+      name: parts[3],
+    );
+  }
+
+  String encode() => '$mesh:$namespace:$kindCode:$name';
+
+  @override
+  String toString() => encode();
+
+  @override
+  bool operator ==(Object other) =>
+      other is MeshRouteId &&
+      other.mesh == mesh &&
+      other.namespace == namespace &&
+      other.kindCode == kindCode &&
+      other.name == name;
+
+  @override
+  int get hashCode => Object.hash(mesh, namespace, kindCode, name);
+}
+
+/// URL-encode a composite ID for safe go_router path embedding.
+/// Wraps `Uri.encodeComponent` so callers don't have to import
+/// `dart:core`'s URI helpers directly.
+String encodeIdForPath(String compositeId) =>
+    Uri.encodeComponent(compositeId);
+
+/// Reverse of [encodeIdForPath]. Use on the receiving side of a
+/// go_router `:id` parameter before passing to a `tryParse` method.
+String decodeIdFromPath(String encoded) => Uri.decodeComponent(encoded);

--- a/mobile/lib/widgets/domain_list_scaffold.dart
+++ b/mobile/lib/widgets/domain_list_scaffold.dart
@@ -1,0 +1,126 @@
+// Generic list body used by every M4 CRD-discovered domain screen
+// (cert-manager, ESO, policy, GitOps, mesh, scanning). Mirrors
+// ResourceListScaffold but operates over arbitrary FutureProviders
+// rather than the /v1/resources/ endpoint, so cert lists, violation
+// lists, and app lists can all share the same loading/error/empty UX.
+//
+// The `notDetectedFallback` slot is for "feature not installed" states
+// — callers pass a FeatureUnavailableState when the domain status
+// endpoint returned `detected: false`, keeping the scaffold unaware of
+// the per-domain detection logic.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../theme/kube_theme_builder.dart';
+import 'empty_states.dart';
+
+/// A pull-to-refresh list scaffold for any domain-specific
+/// `FutureProvider<List<T>>`. The provider type is expressed as a
+/// `ProviderBase<AsyncValue<List<T>>>` so callers can pass both
+/// non-family providers and the result of calling a family provider
+/// (e.g. `certListProvider(clusterId)`). `ProviderBase` satisfies both
+/// `ProviderListenable` (for `ref.watch`) and `ProviderOrFamily` (for
+/// `ref.invalidate`), so the scaffold can do both without a separate
+/// invalidation callback.
+class DomainListScaffold<T> extends ConsumerWidget {
+  const DomainListScaffold({
+    required this.listProvider,
+    required this.itemBuilder,
+    this.emptyMessage,
+    this.notDetectedFallback,
+    this.onRefresh,
+    super.key,
+  });
+
+  final ProviderBase<AsyncValue<List<T>>> listProvider;
+  final Widget Function(BuildContext context, T item) itemBuilder;
+
+  /// Text shown in [EmptyState] when the list is empty and
+  /// [notDetectedFallback] is null.
+  final String? emptyMessage;
+
+  /// Widget shown in place of the empty state when the feature is not
+  /// detected on this cluster (callers pass [FeatureUnavailableState]).
+  final Widget? notDetectedFallback;
+
+  /// Custom refresh callback. When null, defaults to
+  /// `ref.invalidate(listProvider)`.
+  final Future<void> Function()? onRefresh;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final async = ref.watch(listProvider);
+
+    Future<void> doRefresh() async {
+      if (onRefresh != null) {
+        await onRefresh!();
+      } else {
+        ref.invalidate(listProvider);
+        // Give the invalidated provider a tick to start fetching so the
+        // RefreshIndicator doesn't dismiss before data arrives.
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+      }
+    }
+
+    return RefreshIndicator(
+      onRefresh: doRefresh,
+      child: async.when(
+        loading: () => const _ScrollableShell(child: LoadingState()),
+        error: (e, _) => _ScrollableShell(
+          child: ErrorStateView(
+            message: e.toString(),
+            onRetry: () => ref.invalidate(listProvider),
+          ),
+        ),
+        data: (items) {
+          if (items.isEmpty) {
+            return _ScrollableShell(
+              child: notDetectedFallback ??
+                  EmptyState(
+                    title: emptyMessage ?? 'No items found',
+                    icon: Icons.inbox_outlined,
+                  ),
+            );
+          }
+          return ListView.builder(
+            physics: const AlwaysScrollableScrollPhysics(),
+            itemCount: items.length,
+            itemBuilder: (context, i) {
+              final item = items[i];
+              return Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  itemBuilder(context, item),
+                  Divider(
+                    color: colors.borderSubtle,
+                    height: 1,
+                    indent: 16,
+                    endIndent: 16,
+                  ),
+                ],
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+
+/// Wraps a non-scrollable child in a ListView so RefreshIndicator has
+/// scroll physics to attach to. Same pattern as ResourceListScaffold.
+class _ScrollableShell extends StatelessWidget {
+  const _ScrollableShell({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      physics: const AlwaysScrollableScrollPhysics(),
+      children: [SizedBox(height: 280, child: child)],
+    );
+  }
+}

--- a/mobile/lib/widgets/domain_list_scaffold.dart
+++ b/mobile/lib/widgets/domain_list_scaffold.dart
@@ -16,14 +16,13 @@ import '../theme/kube_theme_builder.dart';
 import 'empty_states.dart';
 
 /// A pull-to-refresh list scaffold for any domain-specific
-/// `FutureProvider<List<T>>`. The provider type is expressed as a
-/// `ProviderBase<AsyncValue<List<T>>>` so callers can pass both
-/// non-family providers and the result of calling a family provider
-/// (e.g. `certListProvider(clusterId)`). `ProviderBase` satisfies both
-/// `ProviderListenable` (for `ref.watch`) and `ProviderOrFamily` (for
-/// `ref.invalidate`), so the scaffold can do both without a separate
-/// invalidation callback.
-class DomainListScaffold<T> extends ConsumerWidget {
+/// `AutoDisposeFutureProvider<List<T>>`. The autoDispose-typed bound
+/// is what every M4 domain repository emits (their providers are
+/// keyed on `(clusterId, namespace?)` and tear down on screen exit),
+/// and it gives the scaffold access to `.future` so the
+/// RefreshIndicator can `await` the actual fetch completion instead
+/// of guessing with a fixed delay.
+class DomainListScaffold<T> extends ConsumerStatefulWidget {
   const DomainListScaffold({
     required this.listProvider,
     required this.itemBuilder,
@@ -33,7 +32,10 @@ class DomainListScaffold<T> extends ConsumerWidget {
     super.key,
   });
 
-  final ProviderBase<AsyncValue<List<T>>> listProvider;
+  /// AutoDispose-typed so the scaffold can read `.future` for the
+  /// pull-to-refresh wait. Callers pass either a bare provider or a
+  /// family invocation (`certListProvider(clusterId)`).
+  final AutoDisposeFutureProvider<List<T>> listProvider;
   final Widget Function(BuildContext context, T item) itemBuilder;
 
   /// Text shown in [EmptyState] when the list is empty and
@@ -44,42 +46,71 @@ class DomainListScaffold<T> extends ConsumerWidget {
   /// detected on this cluster (callers pass [FeatureUnavailableState]).
   final Widget? notDetectedFallback;
 
-  /// Custom refresh callback. When null, defaults to
-  /// `ref.invalidate(listProvider)`.
+  /// Custom refresh callback. When null, defaults to invalidating the
+  /// provider and awaiting its `.future` so the spinner stays up
+  /// until data actually arrives (or the call errors).
   final Future<void> Function()? onRefresh;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final colors = Theme.of(context).extension<KubeColors>()!;
-    final async = ref.watch(listProvider);
+  ConsumerState<DomainListScaffold<T>> createState() =>
+      _DomainListScaffoldState<T>();
+}
 
-    Future<void> doRefresh() async {
-      if (onRefresh != null) {
-        await onRefresh!();
-      } else {
-        ref.invalidate(listProvider);
-        // Give the invalidated provider a tick to start fetching so the
-        // RefreshIndicator doesn't dismiss before data arrives.
-        await Future<void>.delayed(const Duration(milliseconds: 100));
-      }
+class _DomainListScaffoldState<T>
+    extends ConsumerState<DomainListScaffold<T>> {
+  /// In-flight refresh future. Subsequent pulls await this future
+  /// instead of invalidating again, so chained pulls + retry-button
+  /// taps + navigation-away cannot stack three or four invalidations
+  /// against the same provider while one is mid-flight.
+  Future<void>? _inflight;
+
+  Future<void> _doRefresh() {
+    final pending = _inflight;
+    if (pending != null) return pending;
+    final fut = _runRefresh();
+    _inflight = fut;
+    fut.whenComplete(() {
+      if (mounted && identical(_inflight, fut)) _inflight = null;
+    });
+    return fut;
+  }
+
+  Future<void> _runRefresh() async {
+    final onRefresh = widget.onRefresh;
+    if (onRefresh != null) {
+      await onRefresh();
+      return;
     }
+    ref.invalidate(widget.listProvider);
+    try {
+      await ref.read(widget.listProvider.future);
+    } on Object {
+      // Error state surfaces through the .when branch; swallow here
+      // to keep RefreshIndicator from rethrowing.
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final async = ref.watch(widget.listProvider);
 
     return RefreshIndicator(
-      onRefresh: doRefresh,
+      onRefresh: _doRefresh,
       child: async.when(
         loading: () => const _ScrollableShell(child: LoadingState()),
         error: (e, _) => _ScrollableShell(
           child: ErrorStateView(
             message: e.toString(),
-            onRetry: () => ref.invalidate(listProvider),
+            onRetry: _doRefresh,
           ),
         ),
         data: (items) {
           if (items.isEmpty) {
             return _ScrollableShell(
-              child: notDetectedFallback ??
+              child: widget.notDetectedFallback ??
                   EmptyState(
-                    title: emptyMessage ?? 'No items found',
+                    title: widget.emptyMessage ?? 'No items found',
                     icon: Icons.inbox_outlined,
                   ),
             );
@@ -92,7 +123,7 @@ class DomainListScaffold<T> extends ConsumerWidget {
               return Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  itemBuilder(context, item),
+                  widget.itemBuilder(context, item),
                   Divider(
                     color: colors.borderSubtle,
                     height: 1,

--- a/mobile/lib/widgets/feature_unavailable_state.dart
+++ b/mobile/lib/widgets/feature_unavailable_state.dart
@@ -1,0 +1,153 @@
+// Consistent "feature not installed" empty state shown when a CRD-
+// discovered domain's status endpoint reports `detected: false`. Each
+// domain has its own named factory constructor so call sites are a
+// one-liner and the install message stays close to the domain
+// definition rather than scattered across eight screens.
+
+import 'package:flutter/material.dart';
+
+import '../theme/kube_theme_builder.dart';
+
+/// Full-screen (centered) card shown when an optional cluster feature
+/// is not detected. All eight M4 domains share this widget so the
+/// install-guidance UX is visually consistent.
+class FeatureUnavailableState extends StatelessWidget {
+  const FeatureUnavailableState({
+    required this.featureName,
+    this.helpMessage,
+    this.icon = Icons.extension_off_outlined,
+    super.key,
+  });
+
+  final String featureName;
+  final String? helpMessage;
+  final IconData icon;
+
+  // ---------------------------------------------------------------------------
+  // Named factory constructors — one per CRD-discovered M4 domain
+  // ---------------------------------------------------------------------------
+
+  factory FeatureUnavailableState.monitoring() =>
+      const FeatureUnavailableState(
+        featureName: 'Prometheus monitoring',
+        helpMessage:
+            'Install kube-prometheus-stack on this cluster to enable metrics '
+            'charts. Open k8sCenter on a desktop for installation guidance.',
+        icon: Icons.show_chart_outlined,
+      );
+
+  factory FeatureUnavailableState.loki() => const FeatureUnavailableState(
+        featureName: 'Loki log aggregation',
+        helpMessage:
+            'Install Loki (grafana/loki-stack) on this cluster to enable '
+            'multi-pod log search. Single-pod live tail remains available '
+            'from the pod detail screen.',
+        icon: Icons.text_snippet_outlined,
+      );
+
+  factory FeatureUnavailableState.certManager() =>
+      const FeatureUnavailableState(
+        featureName: 'cert-manager',
+        helpMessage:
+            'Install cert-manager to enable certificate lifecycle management, '
+            'expiry monitoring, and issuer wizards on this cluster.',
+        icon: Icons.verified_outlined,
+      );
+
+  factory FeatureUnavailableState.eso() => const FeatureUnavailableState(
+        featureName: 'External Secrets Operator',
+        helpMessage:
+            'Install the External Secrets Operator to sync secrets from '
+            'Vault, AWS Secrets Manager, and other providers into this cluster.',
+        icon: Icons.lock_person_outlined,
+      );
+
+  factory FeatureUnavailableState.policy() => const FeatureUnavailableState(
+        featureName: 'policy engine (Kyverno or Gatekeeper)',
+        helpMessage:
+            'Install Kyverno or OPA Gatekeeper on this cluster to enable '
+            'compliance scoring and policy violation browsing.',
+        icon: Icons.policy_outlined,
+      );
+
+  factory FeatureUnavailableState.gitops() => const FeatureUnavailableState(
+        featureName: 'GitOps controller (Argo CD or Flux CD)',
+        helpMessage:
+            'Install Argo CD or Flux CD on this cluster to enable application '
+            'sync status, managed resource trees, and revision history.',
+        icon: Icons.account_tree_outlined,
+      );
+
+  factory FeatureUnavailableState.mesh() => const FeatureUnavailableState(
+        featureName: 'service mesh (Istio or Linkerd)',
+        helpMessage:
+            'Install Istio or Linkerd on this cluster to enable mTLS posture, '
+            'traffic routing, and golden signal metrics per service.',
+        icon: Icons.hub_outlined,
+      );
+
+  factory FeatureUnavailableState.scanning() => const FeatureUnavailableState(
+        featureName: 'vulnerability scanner (Trivy or Kubescape)',
+        helpMessage:
+            'Install Trivy Operator or Kubescape on this cluster to enable '
+            'image vulnerability reports and compliance benchmarks.',
+        icon: Icons.security_outlined,
+      );
+
+  // ---------------------------------------------------------------------------
+  // Build
+  // ---------------------------------------------------------------------------
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Card(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(icon, size: 40, color: colors.textMuted),
+                const SizedBox(height: 16),
+                Text(
+                  featureName,
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    color: colors.textPrimary,
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'is not installed on this cluster',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    color: colors.textSecondary,
+                    fontSize: 14,
+                  ),
+                ),
+                if (helpMessage != null) ...[
+                  const SizedBox(height: 12),
+                  Text(
+                    helpMessage!,
+                    textAlign: TextAlign.center,
+                    style: TextStyle(
+                      color: colors.textMuted,
+                      fontSize: 13,
+                      height: 1.4,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/widgets/kube_bar_chart.dart
+++ b/mobile/lib/widgets/kube_bar_chart.dart
@@ -1,14 +1,14 @@
 // Single-series bar chart used for log volume histograms (PR-4c) and
 // ESO sync rate panels (PR-4g). Reuses KubeChartSeverity and the
-// shared _severityColor resolver from kube_line_chart.dart to keep
-// the color contract identical across both chart types.
+// shared kubeChartSeverityColor resolver from kube_line_chart.dart so
+// the color contract is identical across both chart types.
 
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
 import '../theme/kube_theme_builder.dart';
-import 'kube_line_chart.dart' show KubeChartSeverity;
+import 'kube_line_chart.dart' show KubeChartSeverity, kubeChartSeverityColor;
 
 /// A single timestamped bar value.
 typedef BarPoint = ({DateTime t, double v});
@@ -82,7 +82,18 @@ class _BarChartBody extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final points = series.points;
+    // Drop non-finite points (NaN/Infinity from Prometheus rate windows
+    // or stale samples), sort by timestamp, and merge duplicates so the
+    // index-keyed bottom-axis label lookup picks the right bucket.
+    final points = _normalize(series.points);
+    if (points.isEmpty) {
+      return Center(
+        child: Text(
+          'No volume data',
+          style: TextStyle(color: colors.textMuted, fontSize: 13),
+        ),
+      );
+    }
     final minTs = points.map((p) => p.t).reduce((a, b) => a.isBefore(b) ? a : b);
     final maxTs = points.map((p) => p.t).reduce((a, b) => a.isAfter(b) ? a : b);
     final rangeHours = maxTs.difference(minTs).inHours;
@@ -90,7 +101,7 @@ class _BarChartBody extends StatelessWidget {
         ? DateFormat('HH:mm')
         : DateFormat('MM/dd HH:mm');
 
-    final barColor = _resolveColor(series.severity, colors);
+    final barColor = kubeChartSeverityColor(series.severity, colors);
 
     final groups = points.asMap().entries.map((e) {
       return BarChartGroupData(
@@ -166,6 +177,27 @@ class _BarChartBody extends StatelessWidget {
     );
   }
 
+  /// Filters non-finite values, sorts by timestamp, and sums values
+  /// at duplicate timestamps so the histogram shows one bar per
+  /// bucket. Backend merge paths (federated Prometheus, Loki shard
+  /// interleave) can emit duplicates that fl_chart would otherwise
+  /// stack as ambiguous adjacent bars at the same time.
+  List<BarPoint> _normalize(List<BarPoint> raw) {
+    final clean = raw.where((p) => p.v.isFinite).toList()
+      ..sort((a, b) => a.t.compareTo(b.t));
+    if (clean.length <= 1) return clean;
+    final merged = <BarPoint>[];
+    for (final p in clean) {
+      if (merged.isNotEmpty && merged.last.t == p.t) {
+        final prev = merged.removeLast();
+        merged.add((t: prev.t, v: prev.v + p.v));
+      } else {
+        merged.add(p);
+      }
+    }
+    return merged;
+  }
+
   double _barWidth(int count) {
     if (count <= 20) return 8;
     if (count <= 60) return 5;
@@ -178,20 +210,4 @@ class _BarChartBody extends StatelessWidget {
     return v.toStringAsFixed(0);
   }
 
-  Color _resolveColor(KubeChartSeverity severity, KubeColors colors) {
-    switch (severity) {
-      case KubeChartSeverity.primary:
-        return colors.accent;
-      case KubeChartSeverity.success:
-        return colors.success;
-      case KubeChartSeverity.warning:
-        return colors.warning;
-      case KubeChartSeverity.error:
-        return colors.error;
-      case KubeChartSeverity.info:
-        return colors.info;
-      case KubeChartSeverity.muted:
-        return colors.textMuted;
-    }
-  }
 }

--- a/mobile/lib/widgets/kube_bar_chart.dart
+++ b/mobile/lib/widgets/kube_bar_chart.dart
@@ -1,0 +1,197 @@
+// Single-series bar chart used for log volume histograms (PR-4c) and
+// ESO sync rate panels (PR-4g). Reuses KubeChartSeverity and the
+// shared _severityColor resolver from kube_line_chart.dart to keep
+// the color contract identical across both chart types.
+
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../theme/kube_theme_builder.dart';
+import 'kube_line_chart.dart' show KubeChartSeverity;
+
+/// A single timestamped bar value.
+typedef BarPoint = ({DateTime t, double v});
+
+/// One bar series. Single-series only — the bar chart surface is
+/// for "volume over time" reads, not multi-metric comparison.
+typedef BarSeries = ({
+  String label,
+  List<BarPoint> points,
+  KubeChartSeverity severity,
+});
+
+/// Single-series bar chart backed by `fl_chart`. Intended for the
+/// LogQL volume histogram and the ESO sync-rate panel.
+class KubeBarChart extends StatelessWidget {
+  const KubeBarChart({
+    required this.series,
+    this.title,
+    this.height = 160,
+    super.key,
+  });
+
+  final BarSeries series;
+  final String? title;
+  final double height;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (title != null)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 8),
+            child: Text(
+              title!,
+              style: TextStyle(
+                color: colors.textSecondary,
+                fontSize: 13,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+        SizedBox(
+          height: height,
+          child: series.points.isEmpty
+              ? Center(
+                  child: Text(
+                    'No volume data',
+                    style: TextStyle(color: colors.textMuted, fontSize: 13),
+                  ),
+                )
+              : _BarChartBody(series: series, colors: colors),
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Private helper
+// ---------------------------------------------------------------------------
+
+class _BarChartBody extends StatelessWidget {
+  const _BarChartBody({required this.series, required this.colors});
+
+  final BarSeries series;
+  final KubeColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    final points = series.points;
+    final minTs = points.map((p) => p.t).reduce((a, b) => a.isBefore(b) ? a : b);
+    final maxTs = points.map((p) => p.t).reduce((a, b) => a.isAfter(b) ? a : b);
+    final rangeHours = maxTs.difference(minTs).inHours;
+    final labelFmt = rangeHours <= 24
+        ? DateFormat('HH:mm')
+        : DateFormat('MM/dd HH:mm');
+
+    final barColor = _resolveColor(series.severity, colors);
+
+    final groups = points.asMap().entries.map((e) {
+      return BarChartGroupData(
+        x: e.key,
+        barRods: [
+          BarChartRodData(
+            toY: e.value.v,
+            color: barColor,
+            width: _barWidth(points.length),
+            borderRadius: const BorderRadius.vertical(
+              top: Radius.circular(2),
+            ),
+          ),
+        ],
+      );
+    }).toList();
+
+    // Show ~4 evenly-spaced x labels.
+    final step = (points.length / 4).ceil().clamp(1, points.length);
+
+    return BarChart(
+      BarChartData(
+        barGroups: groups,
+        gridData: FlGridData(
+          show: true,
+          drawVerticalLine: false,
+          getDrawingHorizontalLine: (_) => FlLine(
+            color: colors.borderSubtle,
+            strokeWidth: 0.5,
+          ),
+        ),
+        borderData: FlBorderData(show: false),
+        titlesData: FlTitlesData(
+          topTitles:
+              const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+          rightTitles:
+              const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+          bottomTitles: AxisTitles(
+            sideTitles: SideTitles(
+              showTitles: true,
+              reservedSize: 28,
+              getTitlesWidget: (value, meta) {
+                final idx = value.toInt();
+                if (idx % step != 0 || idx >= points.length) {
+                  return const SizedBox.shrink();
+                }
+                return SideTitleWidget(
+                  axisSide: meta.axisSide,
+                  child: Text(
+                    labelFmt.format(points[idx].t),
+                    style: TextStyle(color: colors.textMuted, fontSize: 10),
+                  ),
+                );
+              },
+            ),
+          ),
+          leftTitles: AxisTitles(
+            sideTitles: SideTitles(
+              showTitles: true,
+              reservedSize: 36,
+              getTitlesWidget: (value, meta) => SideTitleWidget(
+                axisSide: meta.axisSide,
+                child: Text(
+                  _formatY(value),
+                  style: TextStyle(color: colors.textMuted, fontSize: 10),
+                ),
+              ),
+            ),
+          ),
+        ),
+        barTouchData: BarTouchData(enabled: false),
+      ),
+    );
+  }
+
+  double _barWidth(int count) {
+    if (count <= 20) return 8;
+    if (count <= 60) return 5;
+    return 3;
+  }
+
+  String _formatY(double v) {
+    if (v >= 1e6) return '${(v / 1e6).toStringAsFixed(1)}M';
+    if (v >= 1e3) return '${(v / 1e3).toStringAsFixed(1)}k';
+    return v.toStringAsFixed(0);
+  }
+
+  Color _resolveColor(KubeChartSeverity severity, KubeColors colors) {
+    switch (severity) {
+      case KubeChartSeverity.primary:
+        return colors.accent;
+      case KubeChartSeverity.success:
+        return colors.success;
+      case KubeChartSeverity.warning:
+        return colors.warning;
+      case KubeChartSeverity.error:
+        return colors.error;
+      case KubeChartSeverity.info:
+        return colors.info;
+      case KubeChartSeverity.muted:
+        return colors.textMuted;
+    }
+  }
+}

--- a/mobile/lib/widgets/kube_gauge_ring.dart
+++ b/mobile/lib/widgets/kube_gauge_ring.dart
@@ -12,7 +12,7 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 
 import '../theme/kube_theme_builder.dart';
-import 'kube_line_chart.dart' show KubeChartSeverity;
+import 'kube_line_chart.dart' show KubeChartSeverity, kubeChartSeverityColor;
 
 /// Returns the appropriate chart severity for a 0–1 percentage.
 /// Thresholds are configurable so callers can tune warn/crit per domain.
@@ -59,14 +59,21 @@ class KubeGaugeRing extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = Theme.of(context).extension<KubeColors>()!;
-    final fillColor = _severityColor(severity, colors);
+    final fillColor = kubeChartSeverityColor(severity, colors);
+
+    // Guard non-finite percentages (e.g. 0/0 from a "0 of 0 policies
+    // evaluated" compliance score). NaN.clamp(0,1) is NaN; the painter
+    // would render a 0% empty ring while the centerLabel showed "NaN%".
+    // Substitute a 0 fill so the operator sees an empty ring with
+    // whatever no-data copy the caller supplies in centerLabel.
+    final safePct = percentage.isFinite ? percentage.clamp(0.0, 1.0) : 0.0;
 
     return SizedBox(
       width: size,
       height: size,
       child: CustomPaint(
         painter: _GaugePainter(
-          percentage: percentage.clamp(0.0, 1.0),
+          percentage: safePct,
           fillColor: fillColor,
           trackColor: colors.bgElevated,
           strokeWidth: 12,
@@ -101,22 +108,6 @@ class KubeGaugeRing extends StatelessWidget {
     );
   }
 
-  Color _severityColor(KubeChartSeverity s, KubeColors c) {
-    switch (s) {
-      case KubeChartSeverity.primary:
-        return c.accent;
-      case KubeChartSeverity.success:
-        return c.success;
-      case KubeChartSeverity.warning:
-        return c.warning;
-      case KubeChartSeverity.error:
-        return c.error;
-      case KubeChartSeverity.info:
-        return c.info;
-      case KubeChartSeverity.muted:
-        return c.textMuted;
-    }
-  }
 }
 
 // ---------------------------------------------------------------------------
@@ -172,8 +163,15 @@ class _GaugePainter extends CustomPainter {
 
   @override
   bool shouldRepaint(_GaugePainter old) =>
-      old.percentage != percentage ||
+      !_pctEquals(old.percentage, percentage) ||
       old.fillColor != fillColor ||
       old.trackColor != trackColor ||
       old.strokeWidth != strokeWidth;
+
+  /// NaN-aware equality. `NaN != NaN` in Dart, which would force a
+  /// repaint on every rebuild for a non-finite percentage.
+  static bool _pctEquals(double a, double b) {
+    if (a.isNaN && b.isNaN) return true;
+    return a == b;
+  }
 }

--- a/mobile/lib/widgets/kube_gauge_ring.dart
+++ b/mobile/lib/widgets/kube_gauge_ring.dart
@@ -1,0 +1,179 @@
+// Donut gauge used for compliance scores (PR-4h policy, PR-4i scanning)
+// and ESO drift summaries (PR-4g). CustomPaint is used instead of
+// fl_chart's PieChart because PieChart doesn't expose a clean API for
+// the thick-stroke / thin-background-ring donut UX — the result would
+// require hacking around its internal padding and clipping math.
+//
+// severityForPercentage is a top-level helper so callers can compute
+// the arc color from a 0–1 ratio without constructing a widget.
+
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import '../theme/kube_theme_builder.dart';
+import 'kube_line_chart.dart' show KubeChartSeverity;
+
+/// Returns the appropriate chart severity for a 0–1 percentage.
+/// Thresholds are configurable so callers can tune warn/crit per domain.
+KubeChartSeverity severityForPercentage(
+  double pct, {
+  double warnBelow = 0.9,
+  double critBelow = 0.7,
+}) {
+  if (pct >= warnBelow) return KubeChartSeverity.success;
+  if (pct >= critBelow) return KubeChartSeverity.warning;
+  return KubeChartSeverity.error;
+}
+
+/// Circular donut gauge with a themed arc and center label.
+///
+/// The filled arc spans `percentage * 2π` starting from the 12 o'clock
+/// position (−π/2). The background ring is drawn first in
+/// [KubeColors.bgElevated] to fill the remaining arc, giving a
+/// continuous ring appearance.
+class KubeGaugeRing extends StatelessWidget {
+  const KubeGaugeRing({
+    required this.percentage,
+    required this.centerLabel,
+    this.subtitle,
+    this.severity = KubeChartSeverity.success,
+    this.size = 120,
+    super.key,
+  });
+
+  /// Fraction filled, clamped to [0.0, 1.0].
+  final double percentage;
+
+  /// Large bold text in the centre (e.g. "87%").
+  final String centerLabel;
+
+  /// Optional small muted text below [centerLabel].
+  final String? subtitle;
+
+  final KubeChartSeverity severity;
+
+  /// Outer diameter of the ring widget in logical pixels.
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final fillColor = _severityColor(severity, colors);
+
+    return SizedBox(
+      width: size,
+      height: size,
+      child: CustomPaint(
+        painter: _GaugePainter(
+          percentage: percentage.clamp(0.0, 1.0),
+          fillColor: fillColor,
+          trackColor: colors.bgElevated,
+          strokeWidth: 12,
+        ),
+        child: Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                centerLabel,
+                style: TextStyle(
+                  color: colors.textPrimary,
+                  fontSize: size * 0.18,
+                  fontWeight: FontWeight.bold,
+                  height: 1.1,
+                ),
+              ),
+              if (subtitle != null)
+                Text(
+                  subtitle!,
+                  style: TextStyle(
+                    color: colors.textMuted,
+                    fontSize: size * 0.11,
+                    height: 1.2,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Color _severityColor(KubeChartSeverity s, KubeColors c) {
+    switch (s) {
+      case KubeChartSeverity.primary:
+        return c.accent;
+      case KubeChartSeverity.success:
+        return c.success;
+      case KubeChartSeverity.warning:
+        return c.warning;
+      case KubeChartSeverity.error:
+        return c.error;
+      case KubeChartSeverity.info:
+        return c.info;
+      case KubeChartSeverity.muted:
+        return c.textMuted;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Painter
+// ---------------------------------------------------------------------------
+
+class _GaugePainter extends CustomPainter {
+  _GaugePainter({
+    required this.percentage,
+    required this.fillColor,
+    required this.trackColor,
+    required this.strokeWidth,
+  });
+
+  final double percentage;
+  final Color fillColor;
+  final Color trackColor;
+  final double strokeWidth;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = Offset(size.width / 2, size.height / 2);
+    final radius = (size.shortestSide / 2) - (strokeWidth / 2);
+
+    final trackPaint = Paint()
+      ..color = trackColor
+      ..strokeWidth = strokeWidth
+      ..style = PaintingStyle.stroke
+      ..strokeCap = StrokeCap.round;
+
+    final fillPaint = Paint()
+      ..color = fillColor
+      ..strokeWidth = strokeWidth
+      ..style = PaintingStyle.stroke
+      ..strokeCap = StrokeCap.round;
+
+    final rect = Rect.fromCircle(center: center, radius: radius);
+
+    // Background full ring.
+    canvas.drawArc(rect, 0, 2 * math.pi, false, trackPaint);
+
+    // Filled arc: start at 12 o'clock (−π/2), sweep clockwise.
+    if (percentage > 0) {
+      canvas.drawArc(
+        rect,
+        -math.pi / 2,
+        2 * math.pi * percentage,
+        false,
+        fillPaint,
+      );
+    }
+  }
+
+  @override
+  bool shouldRepaint(_GaugePainter old) =>
+      old.percentage != percentage ||
+      old.fillColor != fillColor ||
+      old.trackColor != trackColor ||
+      old.strokeWidth != strokeWidth;
+}

--- a/mobile/lib/widgets/kube_line_chart.dart
+++ b/mobile/lib/widgets/kube_line_chart.dart
@@ -1,0 +1,296 @@
+// Themed multi-series line chart used by the per-resource Metrics tab
+// (PR-4b) and golden signals surface (PR-4e). All colors route through
+// KubeColors so the chart adapts to the operator's active theme without
+// any hardcoded hex literals.
+//
+// X-axis label strategy mirrors the web frontend: ranges ≤ 24 h show
+// HH:mm; longer ranges show MM/dd HH:mm. This keeps the axis readable
+// on a 360dp phone screen without truncation.
+
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../theme/kube_theme_builder.dart';
+
+/// Severity → KubeColors mapping that drives line colors. Kept in one
+/// enum so the caller declares intent ("this series is an error metric")
+/// and the chart resolves the token, avoiding per-callsite color
+/// decision fatigue.
+enum KubeChartSeverity { primary, success, warning, error, info, muted }
+
+/// A single timestamped data point.
+typedef MetricsPoint = ({DateTime t, double v});
+
+/// One named line in the chart, associated with a display color via
+/// [severity].
+typedef MetricsSeries = ({
+  String label,
+  List<MetricsPoint> points,
+  KubeChartSeverity severity,
+});
+
+/// Multi-series line chart backed by `fl_chart`. Intended for
+/// CPU/memory/network/latency time-series from
+/// `GET /v1/monitoring/query_range`.
+class KubeLineChart extends StatelessWidget {
+  const KubeLineChart({
+    required this.series,
+    this.title,
+    this.showGrid = true,
+    this.showLegend = true,
+    this.height = 200,
+    super.key,
+  });
+
+  final List<MetricsSeries> series;
+  final String? title;
+  final bool showGrid;
+  final bool showLegend;
+  final double height;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final hasData = series.any((s) => s.points.isNotEmpty);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (title != null) _ChartTitle(title: title!, colors: colors),
+        SizedBox(
+          height: height,
+          child: hasData
+              ? _LineChartBody(
+                  series: series,
+                  colors: colors,
+                  showGrid: showGrid,
+                )
+              : _NoDataPlaceholder(colors: colors),
+        ),
+        if (showLegend && hasData)
+          _Legend(series: series, colors: colors),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+class _ChartTitle extends StatelessWidget {
+  const _ChartTitle({required this.title, required this.colors});
+
+  final String title;
+  final KubeColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Text(
+        title,
+        style: TextStyle(
+          color: colors.textSecondary,
+          fontSize: 13,
+          fontWeight: FontWeight.w500,
+        ),
+      ),
+    );
+  }
+}
+
+class _NoDataPlaceholder extends StatelessWidget {
+  const _NoDataPlaceholder({required this.colors});
+
+  final KubeColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Text(
+        'No data for this time range',
+        style: TextStyle(color: colors.textMuted, fontSize: 13),
+      ),
+    );
+  }
+}
+
+class _Legend extends StatelessWidget {
+  const _Legend({required this.series, required this.colors});
+
+  final List<MetricsSeries> series;
+  final KubeColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 8),
+      child: Wrap(
+        spacing: 16,
+        runSpacing: 4,
+        children: series.map((s) {
+          final color = _severityColor(s.severity, colors);
+          return Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Container(
+                width: 12,
+                height: 3,
+                decoration: BoxDecoration(
+                  color: color,
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+              const SizedBox(width: 4),
+              Text(
+                s.label,
+                style: TextStyle(color: colors.textMuted, fontSize: 11),
+              ),
+            ],
+          );
+        }).toList(),
+      ),
+    );
+  }
+}
+
+class _LineChartBody extends StatelessWidget {
+  const _LineChartBody({
+    required this.series,
+    required this.colors,
+    required this.showGrid,
+  });
+
+  final List<MetricsSeries> series;
+  final KubeColors colors;
+  final bool showGrid;
+
+  @override
+  Widget build(BuildContext context) {
+    final allPoints = series.expand((s) => s.points).toList();
+    final minTs = allPoints.map((p) => p.t).reduce(
+      (a, b) => a.isBefore(b) ? a : b,
+    );
+    final maxTs = allPoints.map((p) => p.t).reduce(
+      (a, b) => a.isAfter(b) ? a : b,
+    );
+    final rangeHours = maxTs.difference(minTs).inHours;
+    // Short ranges: show HH:mm; longer ranges: include date.
+    final labelFmt = rangeHours <= 24
+        ? DateFormat('HH:mm')
+        : DateFormat('MM/dd HH:mm');
+
+    final barData = series.map((s) {
+      final color = _severityColor(s.severity, colors);
+      final spots = s.points
+          .map((p) => FlSpot(
+                p.t.millisecondsSinceEpoch.toDouble(),
+                p.v,
+              ))
+          .toList();
+      return LineChartBarData(
+        spots: spots,
+        color: color,
+        barWidth: 1.5,
+        dotData: const FlDotData(show: false),
+        belowBarData: BarAreaData(
+          show: true,
+          color: color.withValues(alpha: 0.08),
+        ),
+      );
+    }).toList();
+
+    return LineChart(
+      LineChartData(
+        lineBarsData: barData,
+        gridData: FlGridData(
+          show: showGrid,
+          drawVerticalLine: false,
+          getDrawingHorizontalLine: (_) => FlLine(
+            color: colors.borderSubtle,
+            strokeWidth: 0.5,
+          ),
+        ),
+        borderData: FlBorderData(show: false),
+        titlesData: FlTitlesData(
+          topTitles:
+              const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+          rightTitles:
+              const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+          bottomTitles: AxisTitles(
+            sideTitles: SideTitles(
+              showTitles: true,
+              reservedSize: 28,
+              interval: _xInterval(minTs, maxTs),
+              getTitlesWidget: (value, meta) {
+                final dt =
+                    DateTime.fromMillisecondsSinceEpoch(value.toInt());
+                return SideTitleWidget(
+                  axisSide: meta.axisSide,
+                  child: Text(
+                    labelFmt.format(dt),
+                    style: TextStyle(
+                      color: colors.textMuted,
+                      fontSize: 10,
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+          leftTitles: AxisTitles(
+            sideTitles: SideTitles(
+              showTitles: true,
+              reservedSize: 40,
+              getTitlesWidget: (value, meta) => SideTitleWidget(
+                axisSide: meta.axisSide,
+                child: Text(
+                  _formatY(value),
+                  style: TextStyle(
+                    color: colors.textMuted,
+                    fontSize: 10,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  // Target ~4 x-axis labels regardless of range.
+  double _xInterval(DateTime min, DateTime max) {
+    final rangeMs = max.millisecondsSinceEpoch - min.millisecondsSinceEpoch;
+    return (rangeMs / 4).clamp(1, double.infinity);
+  }
+
+  String _formatY(double v) {
+    if (v >= 1e9) return '${(v / 1e9).toStringAsFixed(1)}G';
+    if (v >= 1e6) return '${(v / 1e6).toStringAsFixed(1)}M';
+    if (v >= 1e3) return '${(v / 1e3).toStringAsFixed(1)}k';
+    return v.toStringAsFixed(v.truncate() == v ? 0 : 1);
+  }
+}
+
+/// Maps a [KubeChartSeverity] to the corresponding [KubeColors] token.
+/// Kept as a top-level function so both the line chart and bar chart
+/// can share the same mapping without duplication.
+Color _severityColor(KubeChartSeverity severity, KubeColors colors) {
+  switch (severity) {
+    case KubeChartSeverity.primary:
+      return colors.accent;
+    case KubeChartSeverity.success:
+      return colors.success;
+    case KubeChartSeverity.warning:
+      return colors.warning;
+    case KubeChartSeverity.error:
+      return colors.error;
+    case KubeChartSeverity.info:
+      return colors.info;
+    case KubeChartSeverity.muted:
+      return colors.textMuted;
+  }
+}

--- a/mobile/lib/widgets/kube_line_chart.dart
+++ b/mobile/lib/widgets/kube_line_chart.dart
@@ -131,7 +131,7 @@ class _Legend extends StatelessWidget {
         spacing: 16,
         runSpacing: 4,
         children: series.map((s) {
-          final color = _severityColor(s.severity, colors);
+          final color = kubeChartSeverityColor(s.severity, colors);
           return Row(
             mainAxisSize: MainAxisSize.min,
             children: [
@@ -169,7 +169,22 @@ class _LineChartBody extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final allPoints = series.expand((s) => s.points).toList();
+    // Filter out NaN/Infinity points up front. Prometheus emits NaN
+    // for division-by-zero rate windows and stale-for-N samples; a
+    // single NaN poisons fl_chart's reduce(min/max) axis computation
+    // and blanks the entire chart with no operator hint.
+    final cleanedSeries = series
+        .map((s) => (
+              label: s.label,
+              points: _sortByTime(
+                  s.points.where((p) => p.v.isFinite).toList()),
+              severity: s.severity,
+            ))
+        .toList();
+    final allPoints = cleanedSeries.expand((s) => s.points).toList();
+    if (allPoints.isEmpty) {
+      return _NoDataPlaceholder(colors: colors);
+    }
     final minTs = allPoints.map((p) => p.t).reduce(
       (a, b) => a.isBefore(b) ? a : b,
     );
@@ -182,8 +197,23 @@ class _LineChartBody extends StatelessWidget {
         ? DateFormat('HH:mm')
         : DateFormat('MM/dd HH:mm');
 
-    final barData = series.map((s) {
-      final color = _severityColor(s.severity, colors);
+    // Pad zero-range axes (single-point series). Without explicit
+    // min/max, fl_chart's default interval for a zero range collapses
+    // toward zero and SideTitlesWidget tries to emit millions of axis
+    // labels, OOMing the UI thread. The pad values are arbitrary —
+    // fl_chart only needs a non-zero range to compute a sane interval.
+    final rawMinX = minTs.millisecondsSinceEpoch.toDouble();
+    final rawMaxX = maxTs.millisecondsSinceEpoch.toDouble();
+    final minX = rawMinX == rawMaxX ? rawMinX - 1 : rawMinX;
+    final maxX = rawMinX == rawMaxX ? rawMaxX + 1 : rawMaxX;
+    final yValues = allPoints.map((p) => p.v);
+    final rawMinY = yValues.reduce((a, b) => a < b ? a : b);
+    final rawMaxY = yValues.reduce((a, b) => a > b ? a : b);
+    final minY = rawMinY == rawMaxY ? rawMinY - 1 : rawMinY;
+    final maxY = rawMinY == rawMaxY ? rawMaxY + 1 : rawMaxY;
+
+    final barData = cleanedSeries.map((s) {
+      final color = kubeChartSeverityColor(s.severity, colors);
       final spots = s.points
           .map((p) => FlSpot(
                 p.t.millisecondsSinceEpoch.toDouble(),
@@ -204,6 +234,10 @@ class _LineChartBody extends StatelessWidget {
 
     return LineChart(
       LineChartData(
+        minX: minX,
+        maxX: maxX,
+        minY: minY,
+        maxY: maxY,
         lineBarsData: barData,
         gridData: FlGridData(
           show: showGrid,
@@ -223,7 +257,7 @@ class _LineChartBody extends StatelessWidget {
             sideTitles: SideTitles(
               showTitles: true,
               reservedSize: 28,
-              interval: _xInterval(minTs, maxTs),
+              interval: (maxX - minX) / 4,
               getTitlesWidget: (value, meta) {
                 final dt =
                     DateTime.fromMillisecondsSinceEpoch(value.toInt());
@@ -244,6 +278,7 @@ class _LineChartBody extends StatelessWidget {
             sideTitles: SideTitles(
               showTitles: true,
               reservedSize: 40,
+              interval: (maxY - minY) / 4,
               getTitlesWidget: (value, meta) => SideTitleWidget(
                 axisSide: meta.axisSide,
                 child: Text(
@@ -261,10 +296,13 @@ class _LineChartBody extends StatelessWidget {
     );
   }
 
-  // Target ~4 x-axis labels regardless of range.
-  double _xInterval(DateTime min, DateTime max) {
-    final rangeMs = max.millisecondsSinceEpoch - min.millisecondsSinceEpoch;
-    return (rangeMs / 4).clamp(1, double.infinity);
+  /// Sorts points by timestamp ascending. fl_chart connects spots in
+  /// array order — out-of-order timestamps (Prometheus federated merge,
+  /// Loki shard interleave) render as visible "backwards" segments.
+  List<MetricsPoint> _sortByTime(List<MetricsPoint> points) {
+    if (points.length <= 1) return points;
+    final sorted = [...points]..sort((a, b) => a.t.compareTo(b.t));
+    return sorted;
   }
 
   String _formatY(double v) {
@@ -278,7 +316,7 @@ class _LineChartBody extends StatelessWidget {
 /// Maps a [KubeChartSeverity] to the corresponding [KubeColors] token.
 /// Kept as a top-level function so both the line chart and bar chart
 /// can share the same mapping without duplication.
-Color _severityColor(KubeChartSeverity severity, KubeColors colors) {
+Color kubeChartSeverityColor(KubeChartSeverity severity, KubeColors colors) {
   switch (severity) {
     case KubeChartSeverity.primary:
       return colors.accent;

--- a/mobile/lib/widgets/refreshable_controller.dart
+++ b/mobile/lib/widgets/refreshable_controller.dart
@@ -1,70 +1,73 @@
 // Race-protection mixin lifted from `wizards/wizard_controller.dart` for
-// per-domain read controllers in M4 (metrics, logs, diagnostics, gitops,
-// mesh, certificates, ESO, policy, scanning).
+// per-domain read controllers in M4.
 //
 // Why a mixin and not a base class: per-domain controllers extend
 // `AutoDisposeFamilyNotifier<TState, TKey>` (Riverpod-typed). Single
 // inheritance forces them to extend AutoDispose first; the race-
-// protection patterns then mix in here without claiming the only
-// extension slot.
-//
-// What it carries:
-//   * `_dispatchId` — bumped by `refresh()` and any other action that
-//     should invalidate an in-flight fetch. Async paths capture the id
-//     at start and drop the result on mismatch. Prevents the late-200
-//     from a back-out fetch re-routing state forward.
-//   * `_disposed` — set by `ref.onDispose`. Every post-await state
-//     setter checks via [safeSet] so writing to a torn-down notifier
-//     doesn't throw `StateError`.
-//   * `_clusterStillPinned(phase)` — pre/post-emission cluster check.
-//     Pre-emission mismatches abort cleanly; post-emission mismatches
-//     happen *after* a request landed on the pinned cluster's
-//     `X-Cluster-ID`, so the failure copy says "the request landed on
-//     the pinned cluster" rather than "aborted."
-//   * `cancelInflight()` — cancels the active `CancelToken` so cluster
-//     switches mid-fetch don't write stale state. Subclasses are
-//     responsible for passing `currentCancelToken` to Dio calls.
+// protection patterns mix in here without claiming the only extension
+// slot. The mixin cannot reach `state` from a generic location (the
+// Notifier's `state` setter type depends on `TState`), so the
+// dispose-guarded write is implemented at the call site — either as
+// `if (!isDisposed) state = next;` or via the static
+// `RefreshableController.safeSetIfAlive` helper below.
 //
 // Subclass contract:
 //   1. Override `pinnedClusterId` to return the cluster id this
 //      controller is keyed on (typically `arg.clusterId`).
-//   2. Override `activeClusterId(WidgetRef-equivalent)` — typically
-//      `ref.read(activeClusterProvider)`.
+//   2. Override `currentActiveClusterId(ref)` to read the active
+//      cluster (typically `ref.read(activeClusterProvider)`).
 //   3. Call `initRefreshable(ref)` exactly once from `build()` so the
-//      `onDispose` hook registers.
-//   4. Wrap every state setter in `safeSet(next)`.
+//      `onDispose` hook registers and `_refreshableInitialized` flips.
+//      Calling it again is a no-op (idempotent guard).
+//   4. Wrap every post-await state write as
+//      `if (!isDisposed) state = next;` or
+//      `RefreshableController.safeSetIfAlive<TState>(isDisposed,
+//      (s) => state = s, next);`. Without the guard, Riverpod throws
+//      `StateError` when an async result lands after the notifier has
+//      been disposed.
 //   5. Pass `currentCancelToken` to every Dio call so disposal cancels
-//      in-flight HTTP.
+//      in-flight HTTP. Catch `DioException` BEFORE any generic catch
+//      and short-circuit on `RefreshableController.isCancelException`
+//      so cancelled fetches are silent rather than surfacing as
+//      operator-visible errors.
+//   6. After every `await` in a fetch path, re-check cluster pin with
+//      `clusterStillPinned(ref)`. On mismatch, call
+//      `pinnedMismatchMessage(phase)` to get the operator-facing copy
+//      and write it into your failure state.
 
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-/// Phase used to tailor the cluster-mismatch surfaced message.
+/// Phase used to tailor the cluster-mismatch message.
 enum PinPhase {
   /// Mismatch detected before the HTTP request was emitted.
   preEmission,
 
   /// Mismatch detected after the request returned. The request was
-  /// pinned via `X-Cluster-ID` so any cluster-side mutation already
-  /// landed on the pinned cluster.
+  /// pinned via `X-Cluster-ID` so any cluster-side data already
+  /// reflects the pinned cluster.
   postEmission,
 }
 
 mixin RefreshableController {
   int _dispatchId = 0;
   bool _disposed = false;
+  bool _refreshableInitialized = false;
   CancelToken? _cancelToken;
 
-  /// Cluster id this controller is keyed on. Subclass returns
-  /// `arg.clusterId` (or equivalent family-key field).
+  /// Cluster id this controller is keyed on.
   String get pinnedClusterId;
 
-  /// Live cluster id from the active cluster provider. Subclass reads
-  /// `ref.read(activeClusterProvider)` (or equivalent).
+  /// Live cluster id from the active cluster provider.
   String currentActiveClusterId(Ref ref);
 
-  /// Register the dispose hook. Call once from `build()`.
+  /// Register the dispose hook. Idempotent: calling more than once is a
+  /// no-op so a second `build()` invocation (or accidental copy-paste in
+  /// a subclass) cannot stack a second `onDispose` callback that would
+  /// double-cancel `_cancelToken` after disposal.
   void initRefreshable(Ref ref) {
+    if (_refreshableInitialized) return;
+    _refreshableInitialized = true;
     ref.onDispose(() {
       _disposed = true;
       _cancelToken?.cancel('controller disposed');
@@ -74,52 +77,93 @@ mixin RefreshableController {
   /// True after the controller's `ref.onDispose` has fired.
   bool get isDisposed => _disposed;
 
+  /// True after `initRefreshable` has run. Subclasses can assert on
+  /// this in their fetch helpers.
+  bool get isInitialized => _refreshableInitialized;
+
   /// Captures a fresh dispatch id for an async operation. The async
   /// path stores this and compares before writing back state on
-  /// completion. Bumping the id elsewhere (via [bumpDispatch]) makes
-  /// the captured id stale.
+  /// completion.
   int captureDispatchId() => ++_dispatchId;
 
   /// Returns `true` when [captured] still matches the live dispatch
-  /// id and the controller hasn't been disposed. Async result
-  /// handlers gate state writes on this.
+  /// id and the controller hasn't been disposed.
   bool isFresh(int captured) => !_disposed && captured == _dispatchId;
 
   /// Bumps `_dispatchId` so any in-flight async result is dropped on
-  /// arrival. Call from `refresh()`, `back()`, form-edit handlers,
-  /// or any input change that invalidates a pending fetch.
+  /// arrival. Call from `refresh()`, form-edit handlers, or any input
+  /// change that invalidates a pending fetch.
   void bumpDispatch() {
     _dispatchId++;
   }
 
   /// CancelToken for in-flight Dio calls. Subclass passes this to
-  /// every `dio.get/post(...)` so disposal cancels HTTP cleanly.
+  /// every Dio call so disposal cancels HTTP cleanly.
   CancelToken get currentCancelToken {
     _cancelToken ??= CancelToken();
     return _cancelToken!;
   }
 
-  /// Cancels the active CancelToken and replaces it with a fresh one.
-  /// Called by [refresh] before re-firing a fetch so the previous
-  /// request doesn't compete with the new one for state.
-  void cancelInflight([String? reason]) {
+  /// Supersedes any in-flight fetch by cancelling the active
+  /// CancelToken, rotating a fresh one, and bumping `_dispatchId`. The
+  /// two operations are paired: cancelling without bumping leaves a
+  /// window where a stale response (already in the socket buffer when
+  /// the cancel arrives) can write back to state; bumping without
+  /// cancelling leaves the HTTP request on the wire wasting bandwidth
+  /// and backend load.
+  ///
+  /// Call from `refresh()`, form-edit handlers, or any input change
+  /// that invalidates a pending fetch. This is the canonical entry
+  /// point — prefer it over calling [bumpDispatch] or [cancelInflight]
+  /// directly.
+  void supersede([String? reason]) {
     _cancelToken?.cancel(reason ?? 'superseded by new request');
     _cancelToken = CancelToken();
+    _dispatchId++;
   }
 
-  /// Pre/post-emission cluster pin check. Returns `true` when the
-  /// pinned cluster still matches the active cluster. On mismatch,
-  /// returns `false` and surfaces a phase-specific message via
-  /// [onClusterMismatch] (subclass-defined — see [pinnedMismatchMessage]).
-  bool clusterStillPinned(Ref ref, {PinPhase phase = PinPhase.preEmission}) {
-    final active = currentActiveClusterId(ref);
-    if (active == pinnedClusterId) return true;
-    return false;
+
+  /// Returns `true` when the pinned cluster still matches the active
+  /// cluster. On mismatch returns `false`; the caller must then call
+  /// [pinnedMismatchMessage] with the appropriate [PinPhase] and write
+  /// that message into the failure state. The boolean form is
+  /// intentional — the mixin cannot type-safely reach the subclass's
+  /// `state` setter, so the action half lives at the call site.
+  ///
+  /// The phase is supplied to [pinnedMismatchMessage], not to this
+  /// check, because the data-correctness question (does pinned still
+  /// match active?) is phase-independent; only the operator-facing
+  /// copy differs.
+  bool clusterStillPinned(Ref ref) {
+    return currentActiveClusterId(ref) == pinnedClusterId;
   }
 
-  /// Phase-specific message body for cluster mismatch. Subclass uses
-  /// this in its failure-state setter when [clusterStillPinned]
-  /// returns false.
+  /// Dispose-guarded state writer for subclasses. The mixin cannot
+  /// reach `state` from a generic location (the Notifier's `state`
+  /// setter type depends on the subclass's `TState` parameter), so the
+  /// caller passes a [setter] closure that captures the live setter.
+  ///
+  /// Usage in a subclass:
+  /// ```dart
+  /// RefreshableController.safeSetIfAlive<MyState>(
+  ///   isDisposed,
+  ///   (s) => state = s,
+  ///   computedNext,
+  /// );
+  /// ```
+  ///
+  /// No-op when [isDisposed] is true. Equivalent to
+  /// `if (!isDisposed) setter(value);` and offered as a single static
+  /// call so subclass hot paths can keep one line per state write.
+  static void safeSetIfAlive<S>(
+    bool isDisposed,
+    void Function(S value) setter,
+    S value,
+  ) {
+    if (!isDisposed) setter(value);
+  }
+
+  /// Phase-specific message body for cluster mismatch.
   String pinnedMismatchMessage(PinPhase phase) {
     return switch (phase) {
       PinPhase.preEmission =>
@@ -131,4 +175,12 @@ mixin RefreshableController {
             'from the active cluster to refresh.',
     };
   }
+
+  /// True when [e] is a `DioException` of type `cancel`. Catch
+  /// blocks in fetch helpers should short-circuit on this so cancelled
+  /// fetches are silent (no error surface) rather than visible as a
+  /// failure card. Static so tests and per-domain controllers can
+  /// reference it without an instance.
+  static bool isCancelException(Object e) =>
+      e is DioException && e.type == DioExceptionType.cancel;
 }

--- a/mobile/lib/widgets/refreshable_controller.dart
+++ b/mobile/lib/widgets/refreshable_controller.dart
@@ -1,0 +1,134 @@
+// Race-protection mixin lifted from `wizards/wizard_controller.dart` for
+// per-domain read controllers in M4 (metrics, logs, diagnostics, gitops,
+// mesh, certificates, ESO, policy, scanning).
+//
+// Why a mixin and not a base class: per-domain controllers extend
+// `AutoDisposeFamilyNotifier<TState, TKey>` (Riverpod-typed). Single
+// inheritance forces them to extend AutoDispose first; the race-
+// protection patterns then mix in here without claiming the only
+// extension slot.
+//
+// What it carries:
+//   * `_dispatchId` — bumped by `refresh()` and any other action that
+//     should invalidate an in-flight fetch. Async paths capture the id
+//     at start and drop the result on mismatch. Prevents the late-200
+//     from a back-out fetch re-routing state forward.
+//   * `_disposed` — set by `ref.onDispose`. Every post-await state
+//     setter checks via [safeSet] so writing to a torn-down notifier
+//     doesn't throw `StateError`.
+//   * `_clusterStillPinned(phase)` — pre/post-emission cluster check.
+//     Pre-emission mismatches abort cleanly; post-emission mismatches
+//     happen *after* a request landed on the pinned cluster's
+//     `X-Cluster-ID`, so the failure copy says "the request landed on
+//     the pinned cluster" rather than "aborted."
+//   * `cancelInflight()` — cancels the active `CancelToken` so cluster
+//     switches mid-fetch don't write stale state. Subclasses are
+//     responsible for passing `currentCancelToken` to Dio calls.
+//
+// Subclass contract:
+//   1. Override `pinnedClusterId` to return the cluster id this
+//      controller is keyed on (typically `arg.clusterId`).
+//   2. Override `activeClusterId(WidgetRef-equivalent)` — typically
+//      `ref.read(activeClusterProvider)`.
+//   3. Call `initRefreshable(ref)` exactly once from `build()` so the
+//      `onDispose` hook registers.
+//   4. Wrap every state setter in `safeSet(next)`.
+//   5. Pass `currentCancelToken` to every Dio call so disposal cancels
+//      in-flight HTTP.
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Phase used to tailor the cluster-mismatch surfaced message.
+enum PinPhase {
+  /// Mismatch detected before the HTTP request was emitted.
+  preEmission,
+
+  /// Mismatch detected after the request returned. The request was
+  /// pinned via `X-Cluster-ID` so any cluster-side mutation already
+  /// landed on the pinned cluster.
+  postEmission,
+}
+
+mixin RefreshableController {
+  int _dispatchId = 0;
+  bool _disposed = false;
+  CancelToken? _cancelToken;
+
+  /// Cluster id this controller is keyed on. Subclass returns
+  /// `arg.clusterId` (or equivalent family-key field).
+  String get pinnedClusterId;
+
+  /// Live cluster id from the active cluster provider. Subclass reads
+  /// `ref.read(activeClusterProvider)` (or equivalent).
+  String currentActiveClusterId(Ref ref);
+
+  /// Register the dispose hook. Call once from `build()`.
+  void initRefreshable(Ref ref) {
+    ref.onDispose(() {
+      _disposed = true;
+      _cancelToken?.cancel('controller disposed');
+    });
+  }
+
+  /// True after the controller's `ref.onDispose` has fired.
+  bool get isDisposed => _disposed;
+
+  /// Captures a fresh dispatch id for an async operation. The async
+  /// path stores this and compares before writing back state on
+  /// completion. Bumping the id elsewhere (via [bumpDispatch]) makes
+  /// the captured id stale.
+  int captureDispatchId() => ++_dispatchId;
+
+  /// Returns `true` when [captured] still matches the live dispatch
+  /// id and the controller hasn't been disposed. Async result
+  /// handlers gate state writes on this.
+  bool isFresh(int captured) => !_disposed && captured == _dispatchId;
+
+  /// Bumps `_dispatchId` so any in-flight async result is dropped on
+  /// arrival. Call from `refresh()`, `back()`, form-edit handlers,
+  /// or any input change that invalidates a pending fetch.
+  void bumpDispatch() {
+    _dispatchId++;
+  }
+
+  /// CancelToken for in-flight Dio calls. Subclass passes this to
+  /// every `dio.get/post(...)` so disposal cancels HTTP cleanly.
+  CancelToken get currentCancelToken {
+    _cancelToken ??= CancelToken();
+    return _cancelToken!;
+  }
+
+  /// Cancels the active CancelToken and replaces it with a fresh one.
+  /// Called by [refresh] before re-firing a fetch so the previous
+  /// request doesn't compete with the new one for state.
+  void cancelInflight([String? reason]) {
+    _cancelToken?.cancel(reason ?? 'superseded by new request');
+    _cancelToken = CancelToken();
+  }
+
+  /// Pre/post-emission cluster pin check. Returns `true` when the
+  /// pinned cluster still matches the active cluster. On mismatch,
+  /// returns `false` and surfaces a phase-specific message via
+  /// [onClusterMismatch] (subclass-defined — see [pinnedMismatchMessage]).
+  bool clusterStillPinned(Ref ref, {PinPhase phase = PinPhase.preEmission}) {
+    final active = currentActiveClusterId(ref);
+    if (active == pinnedClusterId) return true;
+    return false;
+  }
+
+  /// Phase-specific message body for cluster mismatch. Subclass uses
+  /// this in its failure-state setter when [clusterStillPinned]
+  /// returns false.
+  String pinnedMismatchMessage(PinPhase phase) {
+    return switch (phase) {
+      PinPhase.preEmission =>
+        'Cluster changed during this fetch. Aborted to avoid loading '
+            "the wrong cluster's data. Refresh from the new cluster.",
+      PinPhase.postEmission =>
+        'Cluster changed mid-request. The data was loaded from the '
+            'pinned cluster ($pinnedClusterId); re-open this surface '
+            'from the active cluster to refresh.',
+    };
+  }
+}

--- a/mobile/lib/widgets/resource_detail_scaffold.dart
+++ b/mobile/lib/widgets/resource_detail_scaffold.dart
@@ -1,10 +1,16 @@
 // Detail-screen chrome for any kind. Header (kind icon + name + namespace
-// + status pill) + tabbed body (Overview, YAML, Events).
+// + status pill) + tabbed body (Overview, YAML, Events) plus optional
+// extra tabs supplied by the caller (M4: Metrics, Logs, Diagnose).
 //
 // PR-1d ships YAML as a read-only SelectableText render of the raw
 // resource map (toJson then JsonEncoder.withIndent). Syntax highlighting
 // (code_text_field) lands in PR-1e or M2 to keep this PR's surface area
 // reviewable. Events tab is a stub pending PR-1e's events fetch.
+//
+// `extraTabs` (M4 PR-4a): callers append tabs to the right of Events.
+// Order is operator-meaningful — typical M4 layout is Overview / YAML /
+// Events / Metrics / Logs. The TabBar becomes scrollable when the
+// total tab count exceeds the screen's horizontal capacity.
 
 import 'dart:convert';
 
@@ -18,6 +24,17 @@ import '../features/resources/k8s_helpers.dart';
 import '../theme/kube_theme_builder.dart';
 import 'empty_states.dart';
 import 'yaml_editor_panel.dart';
+
+/// One extra tab entry callers append to the scaffold's default
+/// Overview / YAML / Events triplet. Held as a class (not a record)
+/// so callers can compare instances and so the type is stable across
+/// future field additions.
+class DetailExtraTab {
+  const DetailExtraTab({required this.label, required this.body});
+
+  final String label;
+  final Widget body;
+}
 
 class ResourceDetailScaffold extends StatelessWidget {
   const ResourceDetailScaffold({
@@ -36,6 +53,7 @@ class ResourceDetailScaffold extends StatelessWidget {
     this.trailingAction,
     this.editableYaml = false,
     this.applyKey,
+    this.extraTabs = const <DetailExtraTab>[],
   }) : assert(!editableYaml || applyKey != null,
             'editableYaml requires applyKey for the YAML editor panel');
 
@@ -56,6 +74,7 @@ class ResourceDetailScaffold extends StatelessWidget {
     Widget? trailingAction,
     bool editableYaml = false,
     YamlApplyKey? applyKey,
+    List<DetailExtraTab> extraTabs = const <DetailExtraTab>[],
   }) : this(
           key: key,
           kindLabel: 'Secret',
@@ -71,6 +90,7 @@ class ResourceDetailScaffold extends StatelessWidget {
           trailingAction: trailingAction,
           editableYaml: editableYaml,
           applyKey: applyKey,
+          extraTabs: extraTabs,
         );
 
   final String kindLabel;
@@ -123,11 +143,17 @@ class ResourceDetailScaffold extends StatelessWidget {
   /// [editableYaml] is true.
   final YamlApplyKey? applyKey;
 
+  /// Caller-appended tabs rendered after Events. Empty by default —
+  /// the M1 detail screens render the canonical 3-tab layout. M4
+  /// per-resource Metrics + Logs tabs land here.
+  final List<DetailExtraTab> extraTabs;
+
   @override
   Widget build(BuildContext context) {
     final colors = Theme.of(context).extension<KubeColors>()!;
+    final extraCount = extraTabs.length;
     return DefaultTabController(
-      length: 3,
+      length: 3 + extraCount,
       child: Scaffold(
         appBar: AppBar(
           title: Column(
@@ -161,11 +187,17 @@ class ResourceDetailScaffold extends StatelessWidget {
                 ),
               ),
           ],
-          bottom: const TabBar(
+          bottom: TabBar(
+            // Becomes scrollable when extra tabs push the row past
+            // the screen's horizontal capacity. Default 3-tab layout
+            // stays non-scrollable (extraCount == 0).
+            isScrollable: extraCount > 0,
+            tabAlignment: extraCount > 0 ? TabAlignment.start : null,
             tabs: [
-              Tab(text: 'Overview'),
-              Tab(text: 'YAML'),
-              Tab(text: 'Events'),
+              const Tab(text: 'Overview'),
+              const Tab(text: 'YAML'),
+              const Tab(text: 'Events'),
+              for (final t in extraTabs) Tab(text: t.label),
             ],
           ),
         ),
@@ -225,6 +257,7 @@ class ResourceDetailScaffold extends StatelessWidget {
               name: name,
               uid: uid,
             ),
+            for (final t in extraTabs) t.body,
           ],
         ),
       ),

--- a/mobile/lib/widgets/resource_detail_scaffold.dart
+++ b/mobile/lib/widgets/resource_detail_scaffold.dart
@@ -355,9 +355,13 @@ class _YamlTab extends StatelessWidget {
 }
 
 /// Returns a deep copy of the resource map with sensitive payload fields
-/// redacted. Currently scrubs `data` and `stringData` (Secret + a few
-/// adjacent kinds with similar shapes); preserves metadata, type, and
-/// non-sensitive fields so the operator can still verify the structure.
+/// redacted. Scope: top-level `data` and `stringData` only — designed
+/// for the core/v1 Secret kind. Does not walk into nested maps. Kinds
+/// whose sensitive payload nests deeper (ExternalSecret status, sealed
+/// secrets at `spec.encryptedData`, vault paths under `spec`) need
+/// their own redaction layer; do not reuse `isSensitive: true` for
+/// those without first extending this helper or adding a kind-specific
+/// scrubber.
 Map<String, dynamic> _redactSensitive(Map<String, dynamic> input) {
   final out = <String, dynamic>{};
   for (final entry in input.entries) {
@@ -572,16 +576,21 @@ class EventsTab extends ConsumerWidget {
 
   int _byLastTimestampDesc(
       Map<String, dynamic> a, Map<String, dynamic> b) {
-    final ta = _eventTimestamp(a);
-    final tb = _eventTimestamp(b);
-    return tb.compareTo(ta);
+    return _eventDateTime(b).compareTo(_eventDateTime(a));
   }
 
-  String _eventTimestamp(Map<String, dynamic> e) {
-    return (e['lastTimestamp'] as String?) ??
+  /// Parses the event timestamp to a real `DateTime` so events emitted
+  /// in the same second still sort by sub-second precision. The Event
+  /// v1.events.k8s.io resource carries microsecond precision in
+  /// `eventTime`; the legacy core/v1 `lastTimestamp` is second-precision.
+  /// Lexicographic string compare misorders them when they share a
+  /// second because `Z` (0x5A) > `.` (0x2E).
+  DateTime _eventDateTime(Map<String, dynamic> e) {
+    final raw = (e['lastTimestamp'] as String?) ??
         (e['eventTime'] as String?) ??
-        ((e['metadata'] as Map?)?['creationTimestamp'] as String?) ??
-        '';
+        ((e['metadata'] as Map?)?['creationTimestamp'] as String?);
+    if (raw == null) return DateTime.fromMillisecondsSinceEpoch(0);
+    return DateTime.tryParse(raw) ?? DateTime.fromMillisecondsSinceEpoch(0);
   }
 }
 

--- a/mobile/lib/widgets/time_range_picker.dart
+++ b/mobile/lib/widgets/time_range_picker.dart
@@ -9,8 +9,6 @@
 
 import 'package:flutter/material.dart';
 
-import '../theme/kube_theme_builder.dart';
-
 /// The six time-window options surfaced in the picker.
 enum TimePreset { last15m, last1h, last6h, last24h, last7d, custom }
 
@@ -35,8 +33,15 @@ TimeRange timeRangeFromPreset(TimePreset p, {DateTime? now}) {
     case TimePreset.last7d:
       delta = const Duration(days: 7);
     case TimePreset.custom:
-      // Caller must supply explicit start/end for custom; fall back to 1h.
-      delta = const Duration(hours: 1);
+      // `custom` has no implicit duration — callers must construct
+      // the TimeRange directly from operator-picked dates. Throwing
+      // here prevents the silent 1h fallback from masking
+      // provider-seed paths that mistakenly call this helper for a
+      // restored custom range.
+      throw ArgumentError(
+        'timeRangeFromPreset does not support TimePreset.custom — '
+        'construct the TimeRange directly from operator-picked dates.',
+      );
   }
   return (start: end.subtract(delta), end: end, preset: p);
 }
@@ -69,20 +74,52 @@ class _TimeRangePickerState extends State<TimeRangePicker> {
   }
 
   Future<void> _openCustomPicker() async {
+    final firstDate = DateTime.now().subtract(const Duration(days: 365));
+    final lastDate = DateTime.now();
+    // Clamp the restored initial range to [firstDate, lastDate].
+    // showDateRangePicker asserts initialDateRange is in-range and
+    // crashes the route otherwise — reachable via saved-views with a
+    // 400-day-old range, a manual clock reset, or a wizard reusing a
+    // TimeRange from outside the 365-day cap.
+    final clampedStart = widget.initial.start.isBefore(firstDate)
+        ? firstDate
+        : (widget.initial.start.isAfter(lastDate)
+            ? lastDate
+            : widget.initial.start);
+    final clampedEnd = widget.initial.end.isAfter(lastDate)
+        ? lastDate
+        : (widget.initial.end.isBefore(firstDate)
+            ? firstDate
+            : widget.initial.end);
+    final initialRange = clampedStart.isAfter(clampedEnd)
+        ? DateTimeRange(start: clampedEnd, end: clampedEnd)
+        : DateTimeRange(start: clampedStart, end: clampedEnd);
     final result = await showDateRangePicker(
       context: context,
-      firstDate: DateTime.now().subtract(const Duration(days: 365)),
-      lastDate: DateTime.now(),
-      initialDateRange: DateTimeRange(
-        start: widget.initial.start,
-        end: widget.initial.end,
-      ),
+      firstDate: firstDate,
+      lastDate: lastDate,
+      initialDateRange: initialRange,
     );
     if (result == null || !mounted) return;
+    // showDateRangePicker returns date-precision values: start at
+    // 00:00 of the chosen day and end at 00:00 of the chosen day.
+    // Without the +1 day extension the trailing day is silently
+    // dropped from every metrics / logs / policy-compliance custom
+    // range — operators querying "May 6 to May 8" would lose May 8
+    // entirely. Snap end to 23:59:59.999 of the picked day instead.
+    final endOfDay = DateTime(
+      result.end.year,
+      result.end.month,
+      result.end.day,
+      23,
+      59,
+      59,
+      999,
+    );
     setState(() => _selected = TimePreset.custom);
     widget.onChanged((
       start: result.start,
-      end: result.end,
+      end: endOfDay,
       preset: TimePreset.custom,
     ));
   }
@@ -98,10 +135,6 @@ class _TimeRangePickerState extends State<TimeRangePicker> {
 
   @override
   Widget build(BuildContext context) {
-    // Read colors to style the button; actual coloring is driven by
-    // Material's SegmentedButton theme which inherits ColorScheme.primary.
-    Theme.of(context).extension<KubeColors>()!;
-
     return SingleChildScrollView(
       scrollDirection: Axis.horizontal,
       child: SegmentedButton<TimePreset>(

--- a/mobile/lib/widgets/time_range_picker.dart
+++ b/mobile/lib/widgets/time_range_picker.dart
@@ -1,0 +1,126 @@
+// Time-range selector shared across every M4 observability surface
+// (metrics, logs, policy compliance). Uses a SegmentedButton for
+// the six preset slots; "Custom" opens the Material date-range picker
+// so operators can investigate a specific incident window.
+//
+// `timeRangeFromPreset` is a pure top-level function so it can be
+// called from provider code without a BuildContext (e.g. to seed the
+// initial query key on first load).
+
+import 'package:flutter/material.dart';
+
+import '../theme/kube_theme_builder.dart';
+
+/// The six time-window options surfaced in the picker.
+enum TimePreset { last15m, last1h, last6h, last24h, last7d, custom }
+
+/// Typed time window emitted by [TimeRangePicker] and accepted by
+/// every chart and query provider in M4.
+typedef TimeRange = ({DateTime start, DateTime end, TimePreset preset});
+
+/// Converts a [TimePreset] to a concrete [TimeRange]. [now] defaults
+/// to `DateTime.now()` and is injectable for tests.
+TimeRange timeRangeFromPreset(TimePreset p, {DateTime? now}) {
+  final end = now ?? DateTime.now();
+  final Duration delta;
+  switch (p) {
+    case TimePreset.last15m:
+      delta = const Duration(minutes: 15);
+    case TimePreset.last1h:
+      delta = const Duration(hours: 1);
+    case TimePreset.last6h:
+      delta = const Duration(hours: 6);
+    case TimePreset.last24h:
+      delta = const Duration(hours: 24);
+    case TimePreset.last7d:
+      delta = const Duration(days: 7);
+    case TimePreset.custom:
+      // Caller must supply explicit start/end for custom; fall back to 1h.
+      delta = const Duration(hours: 1);
+  }
+  return (start: end.subtract(delta), end: end, preset: p);
+}
+
+/// Compact time-range picker rendered as a [SegmentedButton] row.
+/// "Custom" opens [showDateRangePicker] and emits a [TimeRange] with
+/// [TimePreset.custom] so callers can detect the operator chose an
+/// explicit window rather than a rolling preset.
+class TimeRangePicker extends StatefulWidget {
+  const TimeRangePicker({
+    required this.initial,
+    required this.onChanged,
+    super.key,
+  });
+
+  final TimeRange initial;
+  final ValueChanged<TimeRange> onChanged;
+
+  @override
+  State<TimeRangePicker> createState() => _TimeRangePickerState();
+}
+
+class _TimeRangePickerState extends State<TimeRangePicker> {
+  late TimePreset _selected;
+
+  @override
+  void initState() {
+    super.initState();
+    _selected = widget.initial.preset;
+  }
+
+  Future<void> _openCustomPicker() async {
+    final result = await showDateRangePicker(
+      context: context,
+      firstDate: DateTime.now().subtract(const Duration(days: 365)),
+      lastDate: DateTime.now(),
+      initialDateRange: DateTimeRange(
+        start: widget.initial.start,
+        end: widget.initial.end,
+      ),
+    );
+    if (result == null || !mounted) return;
+    setState(() => _selected = TimePreset.custom);
+    widget.onChanged((
+      start: result.start,
+      end: result.end,
+      preset: TimePreset.custom,
+    ));
+  }
+
+  void _selectPreset(TimePreset p) {
+    if (p == TimePreset.custom) {
+      _openCustomPicker();
+      return;
+    }
+    setState(() => _selected = p);
+    widget.onChanged(timeRangeFromPreset(p));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Read colors to style the button; actual coloring is driven by
+    // Material's SegmentedButton theme which inherits ColorScheme.primary.
+    Theme.of(context).extension<KubeColors>()!;
+
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: SegmentedButton<TimePreset>(
+        segments: const [
+          ButtonSegment(value: TimePreset.last15m, label: Text('15m')),
+          ButtonSegment(value: TimePreset.last1h, label: Text('1h')),
+          ButtonSegment(value: TimePreset.last6h, label: Text('6h')),
+          ButtonSegment(value: TimePreset.last24h, label: Text('24h')),
+          ButtonSegment(value: TimePreset.last7d, label: Text('7d')),
+          ButtonSegment(value: TimePreset.custom, label: Text('Custom')),
+        ],
+        selected: {_selected},
+        onSelectionChanged: (s) => _selectPreset(s.first),
+        showSelectedIcon: false,
+        style: const ButtonStyle(
+          visualDensity: VisualDensity.compact,
+          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/test/util/composite_id_test.dart
+++ b/mobile/test/util/composite_id_test.dart
@@ -1,0 +1,109 @@
+// Tests for the three composite-ID encoders + the URL-encoding
+// transport pair. These IDs flow through go_router path segments,
+// so the encode/decode round-trip is the load-bearing invariant.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kubecenter/util/composite_id.dart';
+
+void main() {
+  group('GitOpsId', () {
+    test('parses tool:ns:name and round-trips through encode', () {
+      final id = GitOpsId.tryParse('argocd:argocd:my-app')!;
+      expect(id.tool, 'argocd');
+      expect(id.namespace, 'argocd');
+      expect(id.name, 'my-app');
+      expect(id.encode(), 'argocd:argocd:my-app');
+    });
+
+    test('parses fluxcd Kustomization id', () {
+      final id = GitOpsId.tryParse('flux-ks:flux-system:my-ks')!;
+      expect(id.tool, 'flux-ks');
+      expect(id.namespace, 'flux-system');
+      expect(id.name, 'my-ks');
+    });
+
+    test('returns null on wrong part count', () {
+      expect(GitOpsId.tryParse('argocd:my-app'), isNull);
+      expect(GitOpsId.tryParse('argocd:argocd:my-app:extra'), isNull);
+    });
+
+    test('returns null when tool or name is empty', () {
+      expect(GitOpsId.tryParse(':argocd:my-app'), isNull);
+      expect(GitOpsId.tryParse('argocd:argocd:'), isNull);
+    });
+
+    test('equality holds across re-parses of the same encoded id', () {
+      final a = GitOpsId.tryParse('argocd:argocd:my-app');
+      final b = GitOpsId.tryParse('argocd:argocd:my-app');
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+  });
+
+  group('PolicyId', () {
+    test('parses 4-part engine:ns:kind:name', () {
+      final id = PolicyId.tryParse('kyverno:app:Pod:disallow-privileged')!;
+      expect(id.engine, 'kyverno');
+      expect(id.namespace, 'app');
+      expect(id.kind, 'Pod');
+      expect(id.name, 'disallow-privileged');
+    });
+
+    test('accepts empty namespace for cluster-scoped policies', () {
+      final id =
+          PolicyId.tryParse('kyverno::ClusterPolicy:disallow-root')!;
+      expect(id.namespace, isEmpty);
+      expect(id.kind, 'ClusterPolicy');
+    });
+
+    test('returns null when engine, kind, or name is empty', () {
+      expect(PolicyId.tryParse(':app:Pod:foo'), isNull);
+      expect(PolicyId.tryParse('kyverno:app::foo'), isNull);
+      expect(PolicyId.tryParse('kyverno:app:Pod:'), isNull);
+    });
+
+    test('returns null on wrong part count', () {
+      expect(PolicyId.tryParse('kyverno:Pod:foo'), isNull);
+      expect(PolicyId.tryParse('kyverno:app:Pod:foo:extra'), isNull);
+    });
+  });
+
+  group('MeshRouteId', () {
+    test('parses mesh:ns:kindCode:name', () {
+      final id = MeshRouteId.tryParse('istio:bookinfo:vs:reviews')!;
+      expect(id.mesh, 'istio');
+      expect(id.namespace, 'bookinfo');
+      expect(id.kindCode, 'vs');
+      expect(id.name, 'reviews');
+    });
+
+    test('returns null on any empty part', () {
+      expect(MeshRouteId.tryParse(':bookinfo:vs:reviews'), isNull);
+      expect(MeshRouteId.tryParse('istio::vs:reviews'), isNull);
+      expect(MeshRouteId.tryParse('istio:bookinfo::reviews'), isNull);
+      expect(MeshRouteId.tryParse('istio:bookinfo:vs:'), isNull);
+    });
+  });
+
+  group('encodeIdForPath / decodeIdFromPath', () {
+    test('round-trips a colon-bearing GitOpsId encode through both', () {
+      final id = GitOpsId(tool: 'argocd', namespace: 'argocd', name: 'my-app');
+      final encoded = encodeIdForPath(id.encode());
+      // Colons are URL-encoded so go_router path segment matching is
+      // safe.
+      expect(encoded.contains(':'), isFalse);
+      expect(encoded, contains('%3A'));
+      final decoded = decodeIdFromPath(encoded);
+      expect(decoded, id.encode());
+      expect(GitOpsId.tryParse(decoded), id);
+    });
+
+    test('round-trips a PolicyId with empty namespace', () {
+      const raw = 'kyverno::ClusterPolicy:disallow-root';
+      final encoded = encodeIdForPath(raw);
+      final decoded = decodeIdFromPath(encoded);
+      expect(decoded, raw);
+      expect(PolicyId.tryParse(decoded)!.namespace, isEmpty);
+    });
+  });
+}

--- a/mobile/test/util/composite_id_test.dart
+++ b/mobile/test/util/composite_id_test.dart
@@ -41,12 +41,13 @@ void main() {
   });
 
   group('PolicyId', () {
-    test('parses 4-part engine:ns:kind:name', () {
+    test('parses 4-part engine:ns:kind:name and round-trips encode', () {
       final id = PolicyId.tryParse('kyverno:app:Pod:disallow-privileged')!;
       expect(id.engine, 'kyverno');
       expect(id.namespace, 'app');
       expect(id.kind, 'Pod');
       expect(id.name, 'disallow-privileged');
+      expect(id.encode(), 'kyverno:app:Pod:disallow-privileged');
     });
 
     test('accepts empty namespace for cluster-scoped policies', () {
@@ -54,6 +55,7 @@ void main() {
           PolicyId.tryParse('kyverno::ClusterPolicy:disallow-root')!;
       expect(id.namespace, isEmpty);
       expect(id.kind, 'ClusterPolicy');
+      expect(id.encode(), 'kyverno::ClusterPolicy:disallow-root');
     });
 
     test('returns null when engine, kind, or name is empty', () {
@@ -69,12 +71,13 @@ void main() {
   });
 
   group('MeshRouteId', () {
-    test('parses mesh:ns:kindCode:name', () {
+    test('parses mesh:ns:kindCode:name and round-trips encode', () {
       final id = MeshRouteId.tryParse('istio:bookinfo:vs:reviews')!;
       expect(id.mesh, 'istio');
       expect(id.namespace, 'bookinfo');
       expect(id.kindCode, 'vs');
       expect(id.name, 'reviews');
+      expect(id.encode(), 'istio:bookinfo:vs:reviews');
     });
 
     test('returns null on any empty part', () {
@@ -85,25 +88,36 @@ void main() {
     });
   });
 
-  group('encodeIdForPath / decodeIdFromPath', () {
-    test('round-trips a colon-bearing GitOpsId encode through both', () {
+  group('Uri.encodeComponent round-trip (go_router transport)', () {
+    test('GitOpsId encode survives encode/decode round-trip', () {
       final id = GitOpsId(tool: 'argocd', namespace: 'argocd', name: 'my-app');
-      final encoded = encodeIdForPath(id.encode());
-      // Colons are URL-encoded so go_router path segment matching is
-      // safe.
+      final encoded = Uri.encodeComponent(id.encode());
+      // Colons are encoded so go_router segment matching is safe.
       expect(encoded.contains(':'), isFalse);
       expect(encoded, contains('%3A'));
-      final decoded = decodeIdFromPath(encoded);
+      final decoded = Uri.decodeComponent(encoded);
       expect(decoded, id.encode());
       expect(GitOpsId.tryParse(decoded), id);
     });
 
-    test('round-trips a PolicyId with empty namespace', () {
+    test('PolicyId with empty namespace round-trips', () {
       const raw = 'kyverno::ClusterPolicy:disallow-root';
-      final encoded = encodeIdForPath(raw);
-      final decoded = decodeIdFromPath(encoded);
+      final encoded = Uri.encodeComponent(raw);
+      final decoded = Uri.decodeComponent(encoded);
       expect(decoded, raw);
       expect(PolicyId.tryParse(decoded)!.namespace, isEmpty);
+    });
+
+    test('MeshRouteId encode survives round-trip', () {
+      final id = MeshRouteId(
+        mesh: 'istio',
+        namespace: 'bookinfo',
+        kindCode: 'vs',
+        name: 'reviews',
+      );
+      expect(id.encode(), 'istio:bookinfo:vs:reviews');
+      final decoded = Uri.decodeComponent(Uri.encodeComponent(id.encode()));
+      expect(MeshRouteId.tryParse(decoded), id);
     });
   });
 }

--- a/mobile/test/widgets/kube_line_chart_test.dart
+++ b/mobile/test/widgets/kube_line_chart_test.dart
@@ -1,0 +1,113 @@
+// Tests for the chart-color contract. The plan's Mobile M4
+// Banned-pattern rule says every fl_chart series color MUST resolve
+// from `KubeColors`, not from a hardcoded literal. The shared
+// `kubeChartSeverityColor` mapping is the only color path; verify
+// each severity slot maps to the right token, and that the chart
+// widget renders without exceptions for the documented inputs.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kubecenter/theme/kube_theme_builder.dart';
+import 'package:kubecenter/widgets/kube_line_chart.dart';
+
+void main() {
+  group('kubeChartSeverityColor', () {
+    final colors = buildKubeTheme('nexus').extension<KubeColors>()!;
+
+    test('maps each severity to the corresponding KubeColors token', () {
+      expect(kubeChartSeverityColor(KubeChartSeverity.primary, colors),
+          colors.accent);
+      expect(kubeChartSeverityColor(KubeChartSeverity.success, colors),
+          colors.success);
+      expect(kubeChartSeverityColor(KubeChartSeverity.warning, colors),
+          colors.warning);
+      expect(kubeChartSeverityColor(KubeChartSeverity.error, colors),
+          colors.error);
+      expect(kubeChartSeverityColor(KubeChartSeverity.info, colors),
+          colors.info);
+      expect(kubeChartSeverityColor(KubeChartSeverity.muted, colors),
+          colors.textMuted);
+    });
+
+    test('all 6 severity slots resolve to distinct colors', () {
+      // Catches a future regression where two severities collapse to
+      // the same token (e.g. error and warning) — the chart contract
+      // assumes each severity is visually distinct.
+      final resolved = {
+        for (final s in KubeChartSeverity.values)
+          s: kubeChartSeverityColor(s, colors),
+      };
+      expect(resolved.values.toSet().length, KubeChartSeverity.values.length,
+          reason: 'each severity must map to a distinct color token');
+    });
+  });
+
+  group('KubeLineChart widget', () {
+    testWidgets('renders no-data placeholder for an empty series list',
+        (tester) async {
+      await tester.pumpWidget(_wrap(const KubeLineChart(series: [])));
+      expect(find.text('No data for this time range'), findsOneWidget);
+    });
+
+    testWidgets('renders no-data placeholder when every series has 0 points',
+        (tester) async {
+      await tester.pumpWidget(_wrap(const KubeLineChart(series: [
+        (
+          label: 'cpu',
+          points: <MetricsPoint>[],
+          severity: KubeChartSeverity.success,
+        ),
+      ])));
+      expect(find.text('No data for this time range'), findsOneWidget);
+    });
+
+    testWidgets('renders the chart body when at least one series has points',
+        (tester) async {
+      final now = DateTime(2026, 5, 9, 12);
+      await tester.pumpWidget(_wrap(KubeLineChart(series: [
+        (
+          label: 'cpu',
+          points: [
+            (t: now, v: 0.1),
+            (t: now.add(const Duration(minutes: 1)), v: 0.2),
+            (t: now.add(const Duration(minutes: 2)), v: 0.3),
+          ],
+          severity: KubeChartSeverity.success,
+        ),
+      ])));
+      // No placeholder; chart rendered without exception.
+      expect(find.text('No data for this time range'), findsNothing);
+    });
+
+    testWidgets('survives a single-point series without hanging on x-axis '
+        'label computation (zero-range guard)', (tester) async {
+      // The plan's reliability finding: when min == max, _xInterval
+      // must return double.infinity so fl_chart renders at most one
+      // axis label. A 1ms interval would attempt millions of labels
+      // and hang the UI thread. We wrap in a fixed-size SizedBox so
+      // fl_chart has bounded constraints during layout.
+      final t = DateTime(2026, 5, 9, 12);
+      await tester.pumpWidget(_wrap(SizedBox(
+        width: 400,
+        height: 240,
+        child: KubeLineChart(series: [
+          (
+            label: 'cpu',
+            points: [(t: t, v: 0.42)],
+            severity: KubeChartSeverity.success,
+          ),
+        ]),
+      )));
+      // pumpWidget completes without hanging or throwing — the only
+      // assertion the zero-range guard makes is "don't blow up".
+      await tester.pump();
+    });
+  });
+}
+
+Widget _wrap(Widget child) {
+  return MaterialApp(
+    theme: buildKubeTheme('nexus'),
+    home: Scaffold(body: child),
+  );
+}

--- a/mobile/test/widgets/refreshable_controller_test.dart
+++ b/mobile/test/widgets/refreshable_controller_test.dart
@@ -1,10 +1,9 @@
 // Tests for the RefreshableController mixin's race-protection
-// state — captureDispatchId / isFresh / bumpDispatch / cancelInflight
-// / pinnedMismatchMessage. These are the bits that don't require a
-// real Riverpod Ref. End-to-end cluster-pin behavior is validated by
-// the per-domain controller tests in PR-4b onward, where a real
-// ProviderContainer + Notifier composition is available.
+// state — captureDispatchId / isFresh / bumpDispatch / supersede
+// / pinnedMismatchMessage / isCancelException — plus an end-to-end
+// dispose-path test backed by a real ProviderContainer.
 
+import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kubecenter/widgets/refreshable_controller.dart';
@@ -41,16 +40,67 @@ void main() {
       expect(h.isFresh(captured), isFalse);
     });
 
-    test('cancelInflight cancels the current token and rotates a new one',
+    test('supersede cancels the current token and rotates a new one',
         () {
       final h = _Harness(pinnedClusterId: 'a', activeClusterId: 'a');
       final tokenA = h.currentCancelToken;
       expect(tokenA.isCancelled, isFalse);
-      h.cancelInflight();
+      h.supersede();
       expect(tokenA.isCancelled, isTrue);
       final tokenB = h.currentCancelToken;
       expect(tokenB, isNot(same(tokenA)));
       expect(tokenB.isCancelled, isFalse);
+    });
+
+    test('supersede bumps dispatch id so late results are dropped', () {
+      // A response that lands after the socket-buffer race is captured
+      // before supersede fires. After the cancel, isFresh on the
+      // captured id must return false even though the controller is
+      // not disposed.
+      final h = _Harness(pinnedClusterId: 'a', activeClusterId: 'a');
+      final captured = h.captureDispatchId();
+      expect(h.isFresh(captured), isTrue);
+      h.supersede();
+      expect(h.isFresh(captured), isFalse);
+    });
+
+    test('clusterStillPinned: true when active matches pinned, false otherwise',
+        () {
+      final h = _Harness(pinnedClusterId: 'cluster-a', activeClusterId: 'cluster-a');
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      // Use a no-op provider to materialize a Ref the harness can read
+      // through. The harness ignores the Ref and reads activeClusterId
+      // directly, so any Ref is fine.
+      final probe = Provider<int>((ref) {
+        expect(h.clusterStillPinned(ref), isTrue);
+        h.activeClusterId = 'cluster-b';
+        expect(h.clusterStillPinned(ref), isFalse);
+        return 0;
+      });
+      container.read(probe);
+    });
+
+    test('initRefreshable is idempotent — second call is a no-op', () {
+      // After the first init, _refreshableInitialized flips true and a
+      // dispose hook is registered. A second call must not register a
+      // second hook (which would double-cancel the CancelToken and
+      // double-set _disposed). We can't directly count onDispose
+      // registrations, so we verify the public surface stays consistent
+      // and the call does not throw.
+      final provider = AutoDisposeNotifierProvider<_TinyNotifier, int>(
+        _TinyNotifier.new,
+      );
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final notifier = container.read(provider.notifier);
+      expect(notifier.isInitialized, isTrue);
+      // Re-invoking initRefreshable inside the same notifier instance
+      // must be safe.
+      expect(() => notifier.callInitAgain(), returnsNormally);
+      expect(notifier.isInitialized, isTrue);
+      expect(notifier.isDisposed, isFalse);
     });
 
     test('pinnedMismatchMessage differs between pre/post-emission phases',
@@ -69,5 +119,62 @@ void main() {
       final h = _Harness(pinnedClusterId: 'a', activeClusterId: 'a');
       expect(h.isDisposed, isFalse);
     });
+
+    test('isCancelException true only for DioException(cancel)', () {
+      final cancel = DioException(
+        requestOptions: RequestOptions(path: '/'),
+        type: DioExceptionType.cancel,
+      );
+      final connTimeout = DioException(
+        requestOptions: RequestOptions(path: '/'),
+        type: DioExceptionType.connectionTimeout,
+      );
+      expect(RefreshableController.isCancelException(cancel), isTrue);
+      expect(RefreshableController.isCancelException(connTimeout), isFalse);
+      expect(RefreshableController.isCancelException(StateError('x')), isFalse);
+    });
   });
+
+  group('RefreshableController dispose path (ProviderContainer-backed)', () {
+    test('isDisposed flips true after the provider is invalidated; '
+        'CancelToken cancels in flight', () {
+      final provider = AutoDisposeNotifierProvider<_TinyNotifier, int>(
+        _TinyNotifier.new,
+      );
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final notifier = container.read(provider.notifier);
+      expect(notifier.isInitialized, isTrue);
+      expect(notifier.isDisposed, isFalse);
+      // Acquire the token before disposal so we can verify cancellation.
+      final token = notifier.currentCancelToken;
+      expect(token.isCancelled, isFalse);
+
+      // Disposing the container fires the autoDispose lifecycle which
+      // runs every `ref.onDispose` callback registered in
+      // `initRefreshable`.
+      container.dispose();
+      expect(notifier.isDisposed, isTrue);
+      expect(token.isCancelled, isTrue);
+    });
+  });
+}
+
+class _TinyNotifier extends AutoDisposeNotifier<int> with RefreshableController {
+  @override
+  String get pinnedClusterId => 'pinned';
+
+  @override
+  String currentActiveClusterId(Ref ref) => 'pinned';
+
+  @override
+  int build() {
+    initRefreshable(ref);
+    return 0;
+  }
+
+  /// Test hook: re-invoke initRefreshable on the same instance to
+  /// exercise the idempotent guard.
+  void callInitAgain() => initRefreshable(ref);
 }

--- a/mobile/test/widgets/refreshable_controller_test.dart
+++ b/mobile/test/widgets/refreshable_controller_test.dart
@@ -1,0 +1,73 @@
+// Tests for the RefreshableController mixin's race-protection
+// state — captureDispatchId / isFresh / bumpDispatch / cancelInflight
+// / pinnedMismatchMessage. These are the bits that don't require a
+// real Riverpod Ref. End-to-end cluster-pin behavior is validated by
+// the per-domain controller tests in PR-4b onward, where a real
+// ProviderContainer + Notifier composition is available.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kubecenter/widgets/refreshable_controller.dart';
+
+class _Harness with RefreshableController {
+  _Harness({required this.pinnedClusterId, required this.activeClusterId});
+
+  @override
+  final String pinnedClusterId;
+
+  String activeClusterId;
+
+  @override
+  String currentActiveClusterId(Ref ref) => activeClusterId;
+}
+
+void main() {
+  group('RefreshableController', () {
+    test('captureDispatchId returns increasing ids; isFresh tracks them',
+        () {
+      final h = _Harness(pinnedClusterId: 'a', activeClusterId: 'a');
+      final id1 = h.captureDispatchId();
+      final id2 = h.captureDispatchId();
+      expect(id1 < id2, isTrue);
+      expect(h.isFresh(id1), isFalse);
+      expect(h.isFresh(id2), isTrue);
+    });
+
+    test('bumpDispatch invalidates a previously captured id', () {
+      final h = _Harness(pinnedClusterId: 'a', activeClusterId: 'a');
+      final captured = h.captureDispatchId();
+      expect(h.isFresh(captured), isTrue);
+      h.bumpDispatch();
+      expect(h.isFresh(captured), isFalse);
+    });
+
+    test('cancelInflight cancels the current token and rotates a new one',
+        () {
+      final h = _Harness(pinnedClusterId: 'a', activeClusterId: 'a');
+      final tokenA = h.currentCancelToken;
+      expect(tokenA.isCancelled, isFalse);
+      h.cancelInflight();
+      expect(tokenA.isCancelled, isTrue);
+      final tokenB = h.currentCancelToken;
+      expect(tokenB, isNot(same(tokenA)));
+      expect(tokenB.isCancelled, isFalse);
+    });
+
+    test('pinnedMismatchMessage differs between pre/post-emission phases',
+        () {
+      final h = _Harness(pinnedClusterId: 'cluster-a', activeClusterId: 'cluster-b');
+      final pre = h.pinnedMismatchMessage(PinPhase.preEmission);
+      final post = h.pinnedMismatchMessage(PinPhase.postEmission);
+      expect(pre, contains('Aborted'));
+      expect(post, contains('was loaded from the'));
+      expect(post, contains('cluster-a'));
+      expect(pre, isNot(equals(post)));
+    });
+
+    test('isDisposed reads false until dispose hook fires (state default)',
+        () {
+      final h = _Harness(pinnedClusterId: 'a', activeClusterId: 'a');
+      expect(h.isDisposed, isFalse);
+    });
+  });
+}

--- a/mobile/test/widgets/resource_detail_scaffold_test.dart
+++ b/mobile/test/widgets/resource_detail_scaffold_test.dart
@@ -1,0 +1,78 @@
+// Backwards-compat tests for the M4 PR-4a `extraTabs` parameter on
+// `ResourceDetailScaffold`. Two invariants matter:
+//
+//   1. With no extraTabs passed, the scaffold renders the canonical
+//      Overview / YAML / Events triplet exactly as M1/M2/M3 ship today.
+//      Length-mismatch with `DefaultTabController` would throw.
+//   2. With extraTabs passed, length is `3 + extras.length`, the TabBar
+//      becomes scrollable, and the extra labels + bodies render.
+//
+// These two cases together prove the wire-up of every PR-4b+ caller.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kubecenter/theme/kube_theme_builder.dart';
+import 'package:kubecenter/widgets/resource_detail_scaffold.dart';
+
+void main() {
+  group('ResourceDetailScaffold extraTabs', () {
+    testWidgets('default 3-tab layout when extraTabs is empty (backwards-compat)',
+        (tester) async {
+      await _pump(tester, extraTabs: const []);
+      expect(find.text('Overview'), findsOneWidget);
+      expect(find.text('YAML'), findsOneWidget);
+      expect(find.text('Events'), findsOneWidget);
+      // Default 3-tab layout uses non-scrollable TabBar.
+      final tabBar = tester.widget<TabBar>(find.byType(TabBar));
+      expect(tabBar.isScrollable, isFalse);
+    });
+
+    testWidgets('appends extra tabs after Events; TabBar becomes scrollable',
+        (tester) async {
+      const extra = [
+        DetailExtraTab(
+            label: 'Metrics', body: Center(child: Text('metrics-body'))),
+        DetailExtraTab(
+            label: 'Logs', body: Center(child: Text('logs-body'))),
+      ];
+      await _pump(tester, extraTabs: extra);
+      expect(find.text('Overview'), findsOneWidget);
+      expect(find.text('Metrics'), findsOneWidget);
+      expect(find.text('Logs'), findsOneWidget);
+      final tabBar = tester.widget<TabBar>(find.byType(TabBar));
+      expect(tabBar.isScrollable, isTrue,
+          reason: 'TabBar must be scrollable when extraTabs are present so '
+              'tabs do not clip on phone-sized AppBar widths');
+      // Tap the Metrics tab and verify the body renders.
+      await tester.tap(find.text('Metrics'));
+      await tester.pumpAndSettle();
+      expect(find.text('metrics-body'), findsOneWidget);
+    });
+  });
+}
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required List<DetailExtraTab> extraTabs,
+}) async {
+  await tester.pumpWidget(ProviderScope(
+    child: MaterialApp(
+      theme: buildKubeTheme('nexus'),
+      home: ResourceDetailScaffold(
+        kindLabel: 'Pod',
+        name: 'test-pod',
+        namespace: 'default',
+        resource: const <String, dynamic>{
+          'metadata': {'name': 'test-pod', 'namespace': 'default'},
+        },
+        overview: const Center(child: Text('overview-body')),
+        extraTabs: extraTabs,
+      ),
+    ),
+  ));
+  // Allow the EventsTab's resourceListProvider to settle (loading
+  // state — no fetch fires because no Dio override is configured;
+  // EventsTab renders a LoadingState which is fine for this test).
+  await tester.pump();
+}

--- a/mobile/test/widgets/time_range_picker_test.dart
+++ b/mobile/test/widgets/time_range_picker_test.dart
@@ -1,0 +1,53 @@
+// Tests for the TimeRangePicker preset → range conversion plus the
+// pure helper used by callers that want presets without a widget.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kubecenter/widgets/time_range_picker.dart';
+
+void main() {
+  group('timeRangeFromPreset', () {
+    final fixedNow = DateTime(2026, 5, 9, 12, 0, 0);
+
+    test('last15m yields a 15-minute window ending at now', () {
+      final r = timeRangeFromPreset(TimePreset.last15m, now: fixedNow);
+      expect(r.end, fixedNow);
+      expect(r.start, fixedNow.subtract(const Duration(minutes: 15)));
+      expect(r.preset, TimePreset.last15m);
+    });
+
+    test('last1h yields a 1-hour window', () {
+      final r = timeRangeFromPreset(TimePreset.last1h, now: fixedNow);
+      expect(r.end.difference(r.start), const Duration(hours: 1));
+      expect(r.preset, TimePreset.last1h);
+    });
+
+    test('last6h yields a 6-hour window', () {
+      final r = timeRangeFromPreset(TimePreset.last6h, now: fixedNow);
+      expect(r.end.difference(r.start), const Duration(hours: 6));
+    });
+
+    test('last24h yields a 24-hour window', () {
+      final r = timeRangeFromPreset(TimePreset.last24h, now: fixedNow);
+      expect(r.end.difference(r.start), const Duration(hours: 24));
+    });
+
+    test('last7d yields a 7-day window', () {
+      final r = timeRangeFromPreset(TimePreset.last7d, now: fixedNow);
+      expect(r.end.difference(r.start), const Duration(days: 7));
+    });
+
+    test('all preset windows end at the supplied now', () {
+      for (final p in [
+        TimePreset.last15m,
+        TimePreset.last1h,
+        TimePreset.last6h,
+        TimePreset.last24h,
+        TimePreset.last7d,
+      ]) {
+        final r = timeRangeFromPreset(p, now: fixedNow);
+        expect(r.end, fixedNow,
+            reason: 'preset $p should end at now (no future-date drift)');
+      }
+    });
+  });
+}

--- a/mobile/test/widgets/time_range_picker_test.dart
+++ b/mobile/test/widgets/time_range_picker_test.dart
@@ -1,6 +1,9 @@
 // Tests for the TimeRangePicker preset → range conversion plus the
-// pure helper used by callers that want presets without a widget.
+// pure helper used by callers that want presets without a widget,
+// and a widget-level test that the SegmentedButton tap path emits
+// the expected typed range.
 
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kubecenter/widgets/time_range_picker.dart';
 
@@ -47,6 +50,57 @@ void main() {
         final r = timeRangeFromPreset(p, now: fixedNow);
         expect(r.end, fixedNow,
             reason: 'preset $p should end at now (no future-date drift)');
+      }
+    });
+
+    test('custom preset throws — caller must construct TimeRange directly',
+        () {
+      // Catches the silent 1h-fallback regression. The custom preset
+      // has no implicit duration; provider-seed paths that mistakenly
+      // call this helper for a restored custom range should fail loud.
+      expect(
+        () => timeRangeFromPreset(TimePreset.custom, now: fixedNow),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('TimeRangePicker widget', () {
+    testWidgets('tapping a preset emits a typed TimeRange via onChanged',
+        (tester) async {
+      TimeRange? emitted;
+      final now = DateTime.now();
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: TimeRangePicker(
+            initial: timeRangeFromPreset(TimePreset.last1h, now: now),
+            onChanged: (r) => emitted = r,
+          ),
+        ),
+      ));
+      // Tap the '6h' segment.
+      await tester.tap(find.text('6h'));
+      await tester.pumpAndSettle();
+      expect(emitted, isNotNull);
+      expect(emitted!.preset, TimePreset.last6h);
+      expect(
+        emitted!.end.difference(emitted!.start),
+        const Duration(hours: 6),
+      );
+    });
+
+    testWidgets('renders all 6 preset segments', (tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: TimeRangePicker(
+            initial: timeRangeFromPreset(TimePreset.last1h),
+            onChanged: (_) {},
+          ),
+        ),
+      ));
+      for (final label in ['15m', '1h', '6h', '24h', '7d', 'Custom']) {
+        expect(find.text(label), findsOneWidget,
+            reason: 'preset $label segment should render');
       }
     });
   });


### PR DESCRIPTION
## Summary

First PR of M4 per [plans/mobile-app-m4-pr-sequence.md](plans/mobile-app-m4-pr-sequence.md) U1. Lands the foundation that PR-4b through PR-4j depend on so subsequent PRs are pure feature ports.

**Race-protection mixin** — `lib/widgets/refreshable_controller.dart`. Lifts \`_dispatchId\`, \`_disposed\`, cluster-pin re-check, and CancelToken management out of \`WizardController\` into a reusable mixin so M4 read controllers (metrics, logs, diagnostics, gitops, mesh, certificates, ESO, policy, scanning) inherit the same defenses without re-deriving them.

**Composite-ID helpers** — \`lib/util/composite_id.dart\`. Typed encode/decode for the three backend ID schemes (\`tool:ns:name\` for GitOps, \`engine:ns:kind:name\` for Policy, \`mesh:ns:kindCode:name\` for service mesh routing) plus URL-encoding wrappers for go_router path segments.

**Chart + widget batch** (6 widgets):
- \`time_range_picker.dart\` — SegmentedButton over \`{15m, 1h, 6h, 24h, 7d, custom}\`. Pure \`timeRangeFromPreset\` helper for non-widget callers.
- \`kube_line_chart.dart\` — \`fl_chart\` LineChart wrapper over typed \`MetricsSeries\` records, severity → \`KubeColors\` mapping.
- \`kube_bar_chart.dart\` — single-series BarChart (log volume + ESO sync rate).
- \`kube_gauge_ring.dart\` — custom-painted donut gauge (ESO drift dashboard + policy compliance score).
- \`domain_list_scaffold.dart\` — generic \`<T>\` list scaffold for non-/v1/resources/ endpoints.
- \`feature_unavailable_state.dart\` — shared empty state for the 8 status-driven surfaces with named factory constructors.

**Detail scaffold extension** — \`lib/widgets/resource_detail_scaffold.dart\` adds optional \`extraTabs: List<DetailExtraTab>\` parameter so PR-4b/c/d can append Metrics/Logs/Diagnose tabs without forking the scaffold. TabBar becomes scrollable when extraCount > 0.

**Tests** (3 files, +24 cases) — composite_id_test, refreshable_controller_test, time_range_picker_test.

## Files
- 8 new \`lib/\` files (mixin + util + 6 widgets)
- 1 modify (\`resource_detail_scaffold.dart\`)
- 3 new test files

## Verification
- [x] \`cd mobile && flutter analyze\` clean repo-wide
- [x] \`cd mobile && flutter test\` — 457 tests pass (was 433 — +24 new)
- [x] \`make check-themes\` clean

## Test plan
- [ ] Visual smoke: open any resource detail screen, confirm the existing 3-tab layout (Overview/YAML/Events) renders unchanged (extraTabs defaults to empty list, behavior should be identical to pre-PR).
- [ ] Code review: race-protection mixin matches the WizardController invariants; CancelToken disposal hooks correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)