### PR TITLE
feat(mobile): M4 PR-4b — per-resource Metrics tab + MonitoringRepository

### DIFF
--- a/mobile/lib/api/monitoring_repository.dart
+++ b/mobile/lib/api/monitoring_repository.dart
@@ -1,0 +1,333 @@
+// Mobile-side wrapper over the backend monitoring API
+// (`/v1/monitoring/{status,query,query_range,templates,templates/query,
+// resource-dashboard}`).
+//
+// Shape notes worth pinning before reading:
+//
+//   * `query_range` returns Prometheus' raw envelope under `data` —
+//     `{resultType, result, warnings}`. `result` is a list of series,
+//     each carrying `metric` (label map) and `values`
+//     (`[ts_seconds_float, "value_string"]`). PR-4b's chart layer lifts
+//     this into typed `MetricsSeries` records via [QueryRangeResult].
+//
+//   * `resource-dashboard` does NOT return curated PromQL — it returns
+//     Grafana embed metadata (`{available, dashboardUID, varName,
+//     grafanaProxied}`). The plan's "Deferred to Implementation"
+//     section flagged this; the real curated PromQL lives in the
+//     QueryTemplates map mirrored at
+//     `lib/features/observability/metrics/metric_panels.dart`.
+//
+//   * Status endpoint returns `{detected, prometheus, grafana, ...}`.
+//     `detected: false` is the gate for `FeatureUnavailableState
+//     .monitoring()`.
+//
+// Cluster pinning matches `ResourceRepository`: every call accepts
+// `clusterIdOverride` and forwards it as an explicit `X-Cluster-ID`
+// header so the cache slot keyed on cluster id and the wire request
+// always agree, defending against the M3 PR-3c pinned-cluster bug.
+
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../cluster/cluster_provider.dart';
+import 'api_error.dart';
+import 'dio_client.dart';
+
+/// Snapshot of the backend's `/v1/monitoring/status` response.
+/// `detected` drives the `FeatureUnavailableState` gate; the per-engine
+/// flags surface in the metrics tab footer for operators who need to
+/// know whether Grafana embedding is also available.
+class MonitoringStatus {
+  const MonitoringStatus({
+    required this.detected,
+    required this.prometheusAvailable,
+    required this.grafanaAvailable,
+    this.message,
+  });
+
+  final bool detected;
+  final bool prometheusAvailable;
+  final bool grafanaAvailable;
+  final String? message;
+
+  factory MonitoringStatus.fromJson(Map<String, dynamic> json) {
+    final prom = json['prometheus'];
+    final graf = json['grafana'];
+    final promAvail = prom is Map && prom['available'] == true;
+    final grafAvail = graf is Map && graf['available'] == true;
+    final detectedField = json['detected'];
+    // Some discoverer states omit `detected`; fall back to "either side
+    // available" as the activation signal.
+    final detected = detectedField is bool
+        ? detectedField
+        : (promAvail || grafAvail);
+    return MonitoringStatus(
+      detected: detected,
+      prometheusAvailable: promAvail,
+      grafanaAvailable: grafAvail,
+      message: json['message'] as String?,
+    );
+  }
+
+  static const empty = MonitoringStatus(
+    detected: false,
+    prometheusAvailable: false,
+    grafanaAvailable: false,
+  );
+}
+
+/// Single point on a series: timestamp + numeric value.
+typedef MetricsPoint = ({DateTime t, double v});
+
+/// One labelled series — `labels` is the metric's label map (e.g.
+/// `{container: "web"}`), `points` is the time series.
+class MetricsSeriesData {
+  const MetricsSeriesData({required this.labels, required this.points});
+
+  final Map<String, String> labels;
+  final List<MetricsPoint> points;
+}
+
+/// Typed parse of the `query_range` response envelope. `warnings`
+/// surfaces Prometheus admonitions inline; `resultType` is informational
+/// (always `matrix` for range queries) and kept for parity with web.
+class QueryRangeResult {
+  const QueryRangeResult({
+    required this.resultType,
+    required this.series,
+    required this.warnings,
+  });
+
+  final String resultType;
+  final List<MetricsSeriesData> series;
+  final List<String> warnings;
+
+  /// True when no series came back (Prometheus returned `result: []`).
+  /// The chart layer renders a "No data" banner rather than a flat-zero
+  /// chart so operators can distinguish "metric exists with value 0"
+  /// from "metric not collected for this resource".
+  bool get isEmpty => series.isEmpty;
+
+  factory QueryRangeResult.fromJson(Map<String, dynamic> json) {
+    final result = json['result'];
+    final warnings = (json['warnings'] as List?)
+            ?.whereType<String>()
+            .toList() ??
+        const <String>[];
+    final List<MetricsSeriesData> parsed = [];
+    if (result is List) {
+      for (final entry in result) {
+        if (entry is! Map) continue;
+        final metric = entry['metric'];
+        final values = entry['values'];
+        final labels = <String, String>{};
+        if (metric is Map) {
+          for (final mEntry in metric.entries) {
+            final key = mEntry.key;
+            final val = mEntry.value;
+            if (key is String && val is String) {
+              labels[key] = val;
+            }
+          }
+        }
+        final points = <MetricsPoint>[];
+        if (values is List) {
+          for (final pair in values) {
+            if (pair is! List || pair.length < 2) continue;
+            final tRaw = pair[0];
+            final vRaw = pair[1];
+            final tSecs = tRaw is num ? tRaw.toDouble() : double.tryParse('$tRaw');
+            // Prometheus emits the value as a stringified float so very
+            // large counters survive JSON precision; parse defensively.
+            final v = vRaw is num ? vRaw.toDouble() : double.tryParse('$vRaw');
+            if (tSecs == null || v == null) continue;
+            points.add((
+              t: DateTime.fromMillisecondsSinceEpoch(
+                (tSecs * 1000).round(),
+                isUtc: true,
+              ),
+              v: v,
+            ));
+          }
+        }
+        parsed.add(MetricsSeriesData(labels: labels, points: points));
+      }
+    }
+    return QueryRangeResult(
+      resultType: json['resultType'] as String? ?? 'matrix',
+      series: parsed,
+      warnings: warnings,
+    );
+  }
+}
+
+/// Mobile wrapper over the backend monitoring API surface. Stateless —
+/// the active cluster threads in via the Dio interceptor stack unless
+/// the caller explicitly overrides via `clusterIdOverride`.
+class MonitoringRepository {
+  MonitoringRepository(this._dio);
+
+  final Dio _dio;
+
+  /// Ranges and snap presets that mirror the plan's pinned test
+  /// scenarios. See [computeStep] below.
+  static const List<int> _stepPresetSeconds = [
+    15,
+    30,
+    60,
+    300,
+    1800,
+    3600,
+  ];
+
+  /// Computes the `step` (seconds) for a `query_range` call given the
+  /// total range in seconds. Mirrors the plan's pinned values:
+  ///
+  ///   _computeStep(60)     == 15
+  ///   _computeStep(3600)   == 15
+  ///   _computeStep(21600)  == 30
+  ///   _computeStep(86400)  == 300
+  ///   _computeStep(604800) == 1800
+  ///
+  /// Strategy: take `max(ceil(rangeSec / 1000), 15)` — the per-1000-
+  /// datapoint resolution target — then snap up to the nearest preset
+  /// in `{15s, 30s, 1m, 5m, 30m, 1h}`. Snap-up keeps the datapoint
+  /// count at or below 1000 (Prometheus' default cap is ~11000 per
+  /// response, and the 1000-bucket budget keeps charts crisp without
+  /// burning Prometheus query time on points the chart can't render).
+  ///
+  /// Note for cross-stack reviewers: the web's `PromQLQuery.tsx` uses
+  /// `max(round(rangeMs / 200_000), 15)` (~200 datapoints, no preset
+  /// snapping). The plan asserts these match, but they don't — web
+  /// will sit on slightly different `step=` values for the same range
+  /// and the stated "shared Prometheus cache hits" benefit is partial.
+  /// Mobile sticks to the plan's pinned test values; web alignment is a
+  /// follow-up tracked in the plan's risk table.
+  static int computeStep(int rangeSec) {
+    final raw = (rangeSec / 1000).ceil();
+    final clamped = raw < 15 ? 15 : raw;
+    for (final preset in _stepPresetSeconds) {
+      if (clamped <= preset) return preset;
+    }
+    return _stepPresetSeconds.last;
+  }
+
+  /// Fetches the monitoring discovery status. Returns
+  /// [MonitoringStatus.empty] on transport errors so callers can route
+  /// straight to `FeatureUnavailableState.monitoring()` without
+  /// throwing — a network hiccup on a feature gate should surface the
+  /// "not configured" path, not an error card.
+  Future<MonitoringStatus> status({
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) async {
+    try {
+      final res = await _dio.get<Map<String, dynamic>>(
+        '/api/v1/monitoring/status',
+        options: clusterIdOverride == null
+            ? null
+            : Options(headers: {'X-Cluster-ID': clusterIdOverride}),
+        cancelToken: cancelToken,
+      );
+      final data = res.data?['data'];
+      if (data is Map) {
+        return MonitoringStatus.fromJson(Map<String, dynamic>.from(data));
+      }
+      return MonitoringStatus.empty;
+    } on DioException catch (e) {
+      if (CancelToken.isCancel(e)) rethrow;
+      // Treat 503 as a definitive "not configured" signal.
+      if (e.response?.statusCode == 503) {
+        return MonitoringStatus.empty;
+      }
+      final err = e.error;
+      throw err is ApiError ? err : ApiError.fromDio(e);
+    }
+  }
+
+  /// Runs a Prometheus range query. `start` and `end` are wire-encoded
+  /// as RFC3339; `step` is a Go-style duration (`15s`, `1m`, etc.) —
+  /// the backend's `time.ParseDuration` is strict so we format with a
+  /// single unit suffix and avoid composite forms.
+  Future<QueryRangeResult> queryRange({
+    required String query,
+    required DateTime start,
+    required DateTime end,
+    required int stepSeconds,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) async {
+    final step = _formatStep(stepSeconds);
+    try {
+      final res = await _dio.get<Map<String, dynamic>>(
+        '/api/v1/monitoring/query_range',
+        queryParameters: {
+          'query': query,
+          'start': start.toUtc().toIso8601String(),
+          'end': end.toUtc().toIso8601String(),
+          'step': step,
+        },
+        options: clusterIdOverride == null
+            ? null
+            : Options(headers: {'X-Cluster-ID': clusterIdOverride}),
+        cancelToken: cancelToken,
+      );
+      final data = res.data?['data'];
+      if (data is Map) {
+        return QueryRangeResult.fromJson(Map<String, dynamic>.from(data));
+      }
+      return const QueryRangeResult(
+        resultType: 'matrix',
+        series: [],
+        warnings: [],
+      );
+    } on DioException catch (e) {
+      if (CancelToken.isCancel(e)) rethrow;
+      final err = e.error;
+      throw err is ApiError ? err : ApiError.fromDio(e);
+    }
+  }
+
+  /// Formats a step duration for the backend's `time.ParseDuration`.
+  /// Prefers the largest single unit so `3600` becomes `1h` (cleaner
+  /// in logs) while sub-minute durations stay in seconds.
+  String _formatStep(int seconds) {
+    if (seconds <= 0) return '15s';
+    if (seconds % 3600 == 0) return '${seconds ~/ 3600}h';
+    if (seconds % 60 == 0) return '${seconds ~/ 60}m';
+    return '${seconds}s';
+  }
+}
+
+final monitoringRepositoryProvider =
+    Provider<MonitoringRepository>((ref) {
+  return MonitoringRepository(ref.watch(dioProvider));
+});
+
+/// Per-cluster monitoring status. Keyed on the cluster id so cluster
+/// switches key a fresh entry rather than reusing the prior cluster's
+/// gate decision (a false-negative would route every metrics tab into
+/// the FeatureUnavailableState until manual refresh).
+final monitoringStatusProvider = FutureProvider.autoDispose
+    .family<MonitoringStatus, String>((ref, clusterId) async {
+  // Watch active so autoDispose tear-down fires on switch even though
+  // clusterId is in the family key.
+  ref.watch(activeClusterProvider);
+  final cancel = CancelToken();
+  ref.onDispose(() {
+    if (!cancel.isCancelled) cancel.cancel('status invalidated');
+  });
+  try {
+    return await ref.read(monitoringRepositoryProvider).status(
+          clusterIdOverride: clusterId,
+          cancelToken: cancel,
+        );
+  } on DioException catch (e) {
+    if (CancelToken.isCancel(e)) {
+      return Completer<MonitoringStatus>().future;
+    }
+    rethrow;
+  }
+});

--- a/mobile/lib/api/monitoring_repository.dart
+++ b/mobile/lib/api/monitoring_repository.dart
@@ -238,8 +238,15 @@ class MonitoringRepository {
       return MonitoringStatus.empty;
     } on DioException catch (e) {
       if (CancelToken.isCancel(e)) rethrow;
-      // Treat 503 as a definitive "not configured" signal.
-      if (e.response?.statusCode == 503) {
+      // Treat any 5xx as "monitoring not reachable" — operators on a
+      // flaky reverse-proxy shouldn't see a noisy error card when the
+      // feature-unavailable state is more actionable. Backend
+      // distinguishes "Prometheus down" (503 with message) from
+      // "Prometheus errored on a specific query" (502 from
+      // /query_range), and only the latter is operator-actionable;
+      // the status endpoint is purely a probe.
+      final code = e.response?.statusCode ?? 0;
+      if (code >= 500 && code < 600) {
         return MonitoringStatus.empty;
       }
       final err = e.error;
@@ -269,9 +276,12 @@ class MonitoringRepository {
           'end': end.toUtc().toIso8601String(),
           'step': step,
         },
-        options: clusterIdOverride == null
-            ? null
-            : Options(headers: {'X-Cluster-ID': clusterIdOverride}),
+        options: Options(
+          receiveTimeout: const Duration(seconds: 30),
+          headers: clusterIdOverride == null
+              ? null
+              : {'X-Cluster-ID': clusterIdOverride},
+        ),
         cancelToken: cancelToken,
       );
       final data = res.data?['data'];
@@ -325,9 +335,7 @@ final monitoringStatusProvider = FutureProvider.autoDispose
           cancelToken: cancel,
         );
   } on DioException catch (e) {
-    if (CancelToken.isCancel(e)) {
-      return Completer<MonitoringStatus>().future;
-    }
+    if (CancelToken.isCancel(e)) rethrow;
     rethrow;
   }
 });

--- a/mobile/lib/features/observability/metrics/metric_panels.dart
+++ b/mobile/lib/features/observability/metrics/metric_panels.dart
@@ -1,0 +1,342 @@
+// Per-kind curated PromQL panels for the M4 Metrics tab.
+//
+// The backend's `/v1/monitoring/resource-dashboard?kind=...` endpoint
+// returns only Grafana embed metadata (`{dashboardUID, varName,
+// grafanaProxied}`), NOT the curated PromQL queries the plan describes.
+// The real per-kind queries live in `backend/internal/monitoring/
+// metrics.go` under `QueryTemplates` — exposed via the templates
+// endpoint family but limited to instant queries.
+//
+// PR-4b's "Deferred to Implementation" question delegated this shape
+// to the implementing agent. The cleanest path within the
+// "no backend changes" constraint is to mirror the backend's
+// QueryTemplates queries on mobile, keyed by kind, with explicit
+// variable slots that the controller fills before calling
+// `/v1/monitoring/query_range`. The mobile + backend pair stays in
+// sync the same way mobile-side resource models mirror backend wire
+// types — drift caught at integration test time.
+//
+// Coverage parity with the web's Grafana dashboards:
+//   * pods, nodes — rich coverage (4 panels each)
+//   * persistentvolumeclaims, deployments — one canonical panel each
+//   * statefulsets, daemonsets — workload-shaped panels using a
+//     name-prefix matcher on `pod` labels (mirrors how
+//     `kubectl top` aggregates).
+//
+// PromQL strings here MUST match the backend's QueryTemplates byte-for-
+// byte for any template that exists there. New panels (StatefulSet,
+// DaemonSet) live only here for now; if the backend adds matching
+// templates, prefer those and delete the local copy.
+
+import 'package:flutter/foundation.dart' show immutable;
+
+/// Severity hint the chart layer uses to pick a [KubeColors] token.
+/// Mirrors `KubeChartSeverity` exactly — duplicated as a domain enum so
+/// the registry doesn't import the widget layer (keeps the registry
+/// testable without pulling in Flutter).
+enum PanelSeverity { primary, success, warning, error, info, muted }
+
+/// A single chart panel definition. The PromQL `queryTemplate` is
+/// rendered by substituting `$<name>` tokens against the panel's
+/// declared `variables`. The chart layer takes the rendered string,
+/// hands it to `MonitoringRepository.queryRange`, and routes the result
+/// into a `KubeLineChart`.
+@immutable
+class MetricPanel {
+  const MetricPanel({
+    required this.id,
+    required this.title,
+    required this.queryTemplate,
+    required this.variables,
+    this.severity = PanelSeverity.primary,
+    this.unitHint,
+  });
+
+  /// Stable id used by tests and the controller's per-panel state map.
+  final String id;
+
+  /// Operator-facing chart title (e.g. "CPU usage per container").
+  final String title;
+
+  /// PromQL with `$varname` tokens. The set of required tokens MUST
+  /// equal [variables] — the controller raises an ArgumentError
+  /// otherwise (caught by tests).
+  final String queryTemplate;
+
+  /// Variable names that must appear in the supplied bindings.
+  final List<String> variables;
+
+  /// Color token for the chart line(s) in this panel.
+  final PanelSeverity severity;
+
+  /// Optional unit label rendered above the chart (e.g. "cores", "%",
+  /// "bytes/sec"). Not authoritative — Prometheus values arrive
+  /// unitless; this is purely operator copy.
+  final String? unitHint;
+
+  /// Substitutes `$<varname>` tokens. Throws [ArgumentError] when a
+  /// declared variable is missing from `vars` so the caller sees the
+  /// failure synchronously rather than emitting an empty Prometheus
+  /// query that returns nothing without explanation.
+  String render(Map<String, String> vars) {
+    var q = queryTemplate;
+    for (final v in variables) {
+      final value = vars[v];
+      if (value == null || value.isEmpty) {
+        throw ArgumentError('Missing variable for panel $id: $v');
+      }
+      if (!_isValidK8sName(value)) {
+        throw ArgumentError(
+          'Invalid value for $v on panel $id: '
+          'must be a valid Kubernetes name',
+        );
+      }
+      q = q.replaceAll('\$$v', value);
+    }
+    return q;
+  }
+}
+
+/// Mirrors the backend's `isValidK8sName` so client-side variable
+/// substitution catches injection attempts before they hit the
+/// backend's parser. Lowercase alnum + `-` + `.`, 1..253 chars.
+bool _isValidK8sName(String s) {
+  if (s.isEmpty || s.length > 253) return false;
+  for (final cu in s.codeUnits) {
+    final isLower = cu >= 0x61 && cu <= 0x7A;
+    final isDigit = cu >= 0x30 && cu <= 0x39;
+    final isDash = cu == 0x2D;
+    final isDot = cu == 0x2E;
+    if (!(isLower || isDigit || isDash || isDot)) return false;
+  }
+  return true;
+}
+
+/// Curated panels per resource kind. Keys are the backend-canonical
+/// plural kind strings (matching the route segment and
+/// `ResourceDashboardMap` keys).
+const Map<String, List<MetricPanel>> metricPanelsByKind = {
+  // ---------------- Pod ----------------
+  // Mirrors backend/QueryTemplates entries pod_cpu_usage,
+  // pod_memory_usage, pod_network_rx, pod_network_tx.
+  'pods': [
+    MetricPanel(
+      id: 'pod_cpu_usage',
+      title: 'CPU usage per container',
+      queryTemplate:
+          'sum(rate(container_cpu_usage_seconds_total{container!="",pod="\$pod",namespace="\$namespace"}[5m])) by (container)',
+      variables: ['namespace', 'pod'],
+      severity: PanelSeverity.primary,
+      unitHint: 'cores',
+    ),
+    MetricPanel(
+      id: 'pod_memory_usage',
+      title: 'Memory working set per container',
+      queryTemplate:
+          'sum(container_memory_working_set_bytes{container!="",pod="\$pod",namespace="\$namespace"}) by (container)',
+      variables: ['namespace', 'pod'],
+      severity: PanelSeverity.warning,
+      unitHint: 'bytes',
+    ),
+    MetricPanel(
+      id: 'pod_network_rx',
+      title: 'Network receive',
+      queryTemplate:
+          'sum(rate(container_network_receive_bytes_total{pod="\$pod",namespace="\$namespace"}[5m]))',
+      variables: ['namespace', 'pod'],
+      severity: PanelSeverity.info,
+      unitHint: 'bytes/sec',
+    ),
+    MetricPanel(
+      id: 'pod_network_tx',
+      title: 'Network transmit',
+      queryTemplate:
+          'sum(rate(container_network_transmit_bytes_total{pod="\$pod",namespace="\$namespace"}[5m]))',
+      variables: ['namespace', 'pod'],
+      severity: PanelSeverity.success,
+      unitHint: 'bytes/sec',
+    ),
+  ],
+
+  // ---------------- Node ----------------
+  // Mirrors backend/QueryTemplates node_* entries.
+  'nodes': [
+    MetricPanel(
+      id: 'node_cpu_utilization',
+      title: 'CPU utilization',
+      queryTemplate:
+          '100 - (avg by (instance) (rate(node_cpu_seconds_total{mode="idle",instance=~"\$node.*"}[5m])) * 100)',
+      variables: ['node'],
+      severity: PanelSeverity.primary,
+      unitHint: '%',
+    ),
+    MetricPanel(
+      id: 'node_memory_utilization',
+      title: 'Memory utilization',
+      queryTemplate:
+          '100 * (1 - node_memory_MemAvailable_bytes{instance=~"\$node.*"} / node_memory_MemTotal_bytes{instance=~"\$node.*"})',
+      variables: ['node'],
+      severity: PanelSeverity.warning,
+      unitHint: '%',
+    ),
+    MetricPanel(
+      id: 'node_disk_utilization',
+      title: 'Root disk utilization',
+      queryTemplate:
+          '100 - (node_filesystem_avail_bytes{instance=~"\$node.*",mountpoint="/",fstype!="rootfs"} / node_filesystem_size_bytes{instance=~"\$node.*",mountpoint="/",fstype!="rootfs"} * 100)',
+      variables: ['node'],
+      severity: PanelSeverity.error,
+      unitHint: '%',
+    ),
+    MetricPanel(
+      id: 'node_pod_count',
+      title: 'Pods on node',
+      queryTemplate: 'count(kube_pod_info{node="\$node"})',
+      variables: ['node'],
+      severity: PanelSeverity.info,
+      unitHint: 'pods',
+    ),
+  ],
+
+  // ---------------- Deployment ----------------
+  // Mirrors backend deployment_replica_health and adds per-deployment
+  // CPU/memory roll-ups that aggregate by pod-name prefix — same
+  // matcher `kubectl top` uses when --by-deployment isn't supported.
+  'deployments': [
+    MetricPanel(
+      id: 'deployment_replica_health',
+      title: 'Replica health',
+      queryTemplate:
+          'kube_deployment_status_replicas_available{namespace="\$namespace",deployment="\$deployment"} / kube_deployment_spec_replicas{namespace="\$namespace",deployment="\$deployment"}',
+      variables: ['namespace', 'deployment'],
+      severity: PanelSeverity.success,
+      unitHint: 'ratio',
+    ),
+    MetricPanel(
+      id: 'deployment_pod_cpu',
+      title: 'CPU usage (sum of owned pods)',
+      queryTemplate:
+          'sum(rate(container_cpu_usage_seconds_total{container!="",namespace="\$namespace",pod=~"\$deployment-.*"}[5m]))',
+      variables: ['namespace', 'deployment'],
+      severity: PanelSeverity.primary,
+      unitHint: 'cores',
+    ),
+    MetricPanel(
+      id: 'deployment_pod_memory',
+      title: 'Memory (sum of owned pods)',
+      queryTemplate:
+          'sum(container_memory_working_set_bytes{container!="",namespace="\$namespace",pod=~"\$deployment-.*"})',
+      variables: ['namespace', 'deployment'],
+      severity: PanelSeverity.warning,
+      unitHint: 'bytes',
+    ),
+  ],
+
+  // ---------------- StatefulSet ----------------
+  // No backend QueryTemplates coverage today; the matcher relies on
+  // StatefulSet's predictable `name-<ordinal>` pod naming convention.
+  'statefulsets': [
+    MetricPanel(
+      id: 'statefulset_replica_health',
+      title: 'Ready replicas',
+      queryTemplate:
+          'kube_statefulset_status_replicas_ready{namespace="\$namespace",statefulset="\$statefulset"} / kube_statefulset_status_replicas{namespace="\$namespace",statefulset="\$statefulset"}',
+      variables: ['namespace', 'statefulset'],
+      severity: PanelSeverity.success,
+      unitHint: 'ratio',
+    ),
+    MetricPanel(
+      id: 'statefulset_pod_cpu',
+      title: 'CPU usage (sum of owned pods)',
+      queryTemplate:
+          'sum(rate(container_cpu_usage_seconds_total{container!="",namespace="\$namespace",pod=~"\$statefulset-[0-9]+"}[5m]))',
+      variables: ['namespace', 'statefulset'],
+      severity: PanelSeverity.primary,
+      unitHint: 'cores',
+    ),
+    MetricPanel(
+      id: 'statefulset_pod_memory',
+      title: 'Memory (sum of owned pods)',
+      queryTemplate:
+          'sum(container_memory_working_set_bytes{container!="",namespace="\$namespace",pod=~"\$statefulset-[0-9]+"})',
+      variables: ['namespace', 'statefulset'],
+      severity: PanelSeverity.warning,
+      unitHint: 'bytes',
+    ),
+  ],
+
+  // ---------------- DaemonSet ----------------
+  // Backend has no curated DS templates. The desired/available ratio
+  // catches partial node coverage; per-pod CPU/memory uses the same
+  // prefix matcher as Deployment.
+  'daemonsets': [
+    MetricPanel(
+      id: 'daemonset_ready_ratio',
+      title: 'Ready ratio',
+      queryTemplate:
+          'kube_daemonset_status_number_ready{namespace="\$namespace",daemonset="\$daemonset"} / kube_daemonset_status_desired_number_scheduled{namespace="\$namespace",daemonset="\$daemonset"}',
+      variables: ['namespace', 'daemonset'],
+      severity: PanelSeverity.success,
+      unitHint: 'ratio',
+    ),
+    MetricPanel(
+      id: 'daemonset_pod_cpu',
+      title: 'CPU usage (sum of owned pods)',
+      queryTemplate:
+          'sum(rate(container_cpu_usage_seconds_total{container!="",namespace="\$namespace",pod=~"\$daemonset-.*"}[5m]))',
+      variables: ['namespace', 'daemonset'],
+      severity: PanelSeverity.primary,
+      unitHint: 'cores',
+    ),
+    MetricPanel(
+      id: 'daemonset_pod_memory',
+      title: 'Memory (sum of owned pods)',
+      queryTemplate:
+          'sum(container_memory_working_set_bytes{container!="",namespace="\$namespace",pod=~"\$daemonset-.*"})',
+      variables: ['namespace', 'daemonset'],
+      severity: PanelSeverity.warning,
+      unitHint: 'bytes',
+    ),
+  ],
+
+  // ---------------- PersistentVolumeClaim ----------------
+  // Mirrors backend pvc_usage_percent; capacity/available panels round
+  // out the trio operators want when investigating a "PVC almost full"
+  // alert.
+  'persistentvolumeclaims': [
+    MetricPanel(
+      id: 'pvc_usage_percent',
+      title: 'Used capacity',
+      queryTemplate:
+          'kubelet_volume_stats_used_bytes{namespace="\$namespace",persistentvolumeclaim="\$pvc"} / kubelet_volume_stats_capacity_bytes{namespace="\$namespace",persistentvolumeclaim="\$pvc"} * 100',
+      variables: ['namespace', 'pvc'],
+      severity: PanelSeverity.warning,
+      unitHint: '%',
+    ),
+    MetricPanel(
+      id: 'pvc_used_bytes',
+      title: 'Used bytes',
+      queryTemplate:
+          'kubelet_volume_stats_used_bytes{namespace="\$namespace",persistentvolumeclaim="\$pvc"}',
+      variables: ['namespace', 'pvc'],
+      severity: PanelSeverity.primary,
+      unitHint: 'bytes',
+    ),
+    MetricPanel(
+      id: 'pvc_available_bytes',
+      title: 'Available bytes',
+      queryTemplate:
+          'kubelet_volume_stats_available_bytes{namespace="\$namespace",persistentvolumeclaim="\$pvc"}',
+      variables: ['namespace', 'pvc'],
+      severity: PanelSeverity.success,
+      unitHint: 'bytes',
+    ),
+  ],
+};
+
+/// Convenience for callsites that need an unambiguous "are there panels
+/// for this kind" check before rendering the Metrics tab affordance.
+bool metricsAvailableForKind(String kind) {
+  final panels = metricPanelsByKind[kind];
+  return panels != null && panels.isNotEmpty;
+}

--- a/mobile/lib/features/observability/metrics/metric_panels.dart
+++ b/mobile/lib/features/observability/metrics/metric_panels.dart
@@ -85,10 +85,10 @@ class MetricPanel {
       if (value == null || value.isEmpty) {
         throw ArgumentError('Missing variable for panel $id: $v');
       }
-      if (!_isValidK8sName(value)) {
+      if (!_isValidPromQLLabelValue(value)) {
         throw ArgumentError(
           'Invalid value for $v on panel $id: '
-          'must be a valid Kubernetes name',
+          'contains characters that would break the PromQL query',
         );
       }
       q = q.replaceAll('\$$v', value);
@@ -97,17 +97,33 @@ class MetricPanel {
   }
 }
 
-/// Mirrors the backend's `isValidK8sName` so client-side variable
-/// substitution catches injection attempts before they hit the
-/// backend's parser. Lowercase alnum + `-` + `.`, 1..253 chars.
-bool _isValidK8sName(String s) {
+/// Rejects values that would break out of the double-quoted PromQL
+/// label-value string. The strict RFC 1123 subdomain validator is
+/// applied server-side (backend `isValidK8sName`); this client-side
+/// guard exists for defence-in-depth and to fail fast before issuing
+/// the HTTP request — but it must accept any name a Kubernetes
+/// kubelet or controller can register, since legitimate on-prem node
+/// names sometimes contain uppercase or underscores (kubelet's
+/// `--hostname-override` allows them).
+///
+/// Reject only the characters that have semantic meaning inside the
+/// PromQL string context (`"` closes the string, `\` escapes the next
+/// char, `$` triggers another substitution pass in templated query
+/// engines, newline/return/NUL break the wire format) plus the
+/// 253-char Kubernetes name length cap. Anything else is forwarded to
+/// the backend, which applies the strict RFC 1123 check and returns a
+/// 400 with a precise error string for the operator to act on.
+bool _isValidPromQLLabelValue(String s) {
   if (s.isEmpty || s.length > 253) return false;
   for (final cu in s.codeUnits) {
-    final isLower = cu >= 0x61 && cu <= 0x7A;
-    final isDigit = cu >= 0x30 && cu <= 0x39;
-    final isDash = cu == 0x2D;
-    final isDot = cu == 0x2E;
-    if (!(isLower || isDigit || isDash || isDot)) return false;
+    // 0x00 NUL, 0x0A LF, 0x0D CR — control chars that break the wire
+    // format or Prometheus tokenizer.
+    if (cu == 0x00 || cu == 0x0A || cu == 0x0D) return false;
+    // 0x22 " — closes the surrounding label-value string.
+    // 0x5C \ — escape character.
+    // 0x24 $ — variable expansion marker; defence-in-depth, since the
+    //          template engine has already substituted at this point.
+    if (cu == 0x22 || cu == 0x5C || cu == 0x24) return false;
   }
   return true;
 }

--- a/mobile/lib/features/observability/metrics/metrics_controller.dart
+++ b/mobile/lib/features/observability/metrics/metrics_controller.dart
@@ -1,0 +1,296 @@
+// Controller behind the Metrics tab. Owns the time range, fires one
+// `query_range` per panel, and surfaces per-panel state so the chart
+// grid can render partial success (one panel 502s, others render).
+//
+// Race protection comes from the `RefreshableController` mixin:
+//   * supersede() rotates the CancelToken + bumps the dispatch id on
+//     every time-range change so an in-flight 7d fetch can't write
+//     over a fresh 1h selection.
+//   * Cluster pin is re-checked at result arrival (postEmission). The
+//     wire request itself was already pinned via `X-Cluster-ID`, so a
+//     post-emission mismatch surfaces the "request landed on pinned
+//     cluster" copy rather than silently writing a different cluster's
+//     metrics under the active cluster's screen.
+//   * isDisposed gates every post-await state write.
+//
+// The controller is keyed on the full target (cluster + kind + ns +
+// name) so navigating between two pod detail screens doesn't reuse
+// the previous pod's series under the new screen — Riverpod's
+// autoDispose family handles the cache slot, the controller just
+// has to honor the key.
+
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../api/api_error.dart';
+import '../../../api/monitoring_repository.dart';
+import '../../../cluster/cluster_provider.dart';
+import '../../../widgets/refreshable_controller.dart';
+import 'metric_panels.dart';
+
+/// Composite key for the metrics controller family. Mirrors
+/// `ResourceGetKey` shape; carries `clusterId` so cluster swaps don't
+/// reuse the prior cluster's slot.
+class MetricsTarget {
+  const MetricsTarget({
+    required this.clusterId,
+    required this.kind,
+    required this.namespace,
+    required this.name,
+  });
+
+  final String clusterId;
+
+  /// Backend-canonical plural kind (e.g. "pods", "persistentvolumeclaims").
+  final String kind;
+
+  /// Empty for cluster-scoped kinds like "nodes".
+  final String namespace;
+
+  final String name;
+
+  @override
+  bool operator ==(Object other) =>
+      other is MetricsTarget &&
+      other.clusterId == clusterId &&
+      other.kind == kind &&
+      other.namespace == namespace &&
+      other.name == name;
+
+  @override
+  int get hashCode => Object.hash(clusterId, kind, namespace, name);
+}
+
+/// Mirror of the user-facing TimePreset to keep the controller free of
+/// widget imports. The tab translates the picker's enum into this one.
+enum MetricsPreset { last15m, last1h, last6h, last24h, last7d, custom }
+
+/// Initial time window picked when the tab first mounts. 1h matches
+/// the web's `PromQLQuery.tsx` default and covers the median oncall
+/// "is this thing in trouble right now" sweep.
+({DateTime start, DateTime end, MetricsPreset preset}) _defaultRange() {
+  final end = DateTime.now();
+  return (
+    start: end.subtract(const Duration(hours: 1)),
+    end: end,
+    preset: MetricsPreset.last1h,
+  );
+}
+
+/// Snapshot of one panel's fetch status.
+sealed class PanelStatus {
+  const PanelStatus();
+}
+
+class PanelLoading extends PanelStatus {
+  const PanelLoading();
+}
+
+class PanelLoaded extends PanelStatus {
+  const PanelLoaded(this.result);
+  final QueryRangeResult result;
+}
+
+class PanelFailed extends PanelStatus {
+  const PanelFailed(this.message);
+  final String message;
+}
+
+/// State the Metrics tab consumes. `cancelled` flips while a refresh
+/// is in flight so the picker can disable presets until the
+/// supersession resolves (without it, a fast-tapping operator can
+/// queue six concurrent fetches that all land in the wrong order).
+class MetricsState {
+  const MetricsState({
+    required this.range,
+    required this.panels,
+  });
+
+  final ({DateTime start, DateTime end, MetricsPreset preset}) range;
+  final Map<String, PanelStatus> panels;
+
+  MetricsState copyWith({
+    ({DateTime start, DateTime end, MetricsPreset preset})? range,
+    Map<String, PanelStatus>? panels,
+  }) {
+    return MetricsState(
+      range: range ?? this.range,
+      panels: panels ?? this.panels,
+    );
+  }
+}
+
+class MetricsController
+    extends AutoDisposeFamilyNotifier<MetricsState, MetricsTarget>
+    with RefreshableController {
+  late MetricsTarget _target;
+
+  @override
+  String get pinnedClusterId => _target.clusterId;
+
+  @override
+  String currentActiveClusterId(Ref ref) =>
+      ref.read(activeClusterProvider);
+
+  @override
+  MetricsState build(MetricsTarget arg) {
+    _target = arg;
+    initRefreshable(ref);
+    final initialRange = _defaultRange();
+    final panels = metricPanelsByKind[arg.kind] ?? const <MetricPanel>[];
+    final initialStatuses = <String, PanelStatus>{
+      for (final p in panels) p.id: const PanelLoading(),
+    };
+    // Schedule the fetch via microtask so Riverpod has committed the
+    // initial state before `_writePanel` reads it back. Without this
+    // yield, the first await in `_fetchAll` can land before `state` is
+    // observable, and the per-panel writes silently drop.
+    scheduleMicrotask(() {
+      if (isDisposed) return;
+      unawaited(_fetchAll(panels, initialRange));
+    });
+    return MetricsState(range: initialRange, panels: initialStatuses);
+  }
+
+  /// Operator picked a new time range. Cancels every in-flight panel
+  /// fetch via `supersede()` and re-fires with the new range.
+  void setRange(DateTime start, DateTime end, MetricsPreset preset) {
+    if (isDisposed) return;
+    final next = (start: start, end: end, preset: preset);
+    final panels = metricPanelsByKind[_target.kind] ?? const <MetricPanel>[];
+    state = MetricsState(
+      range: next,
+      panels: {for (final p in panels) p.id: const PanelLoading()},
+    );
+    supersede('time-range changed');
+    unawaited(_fetchAll(panels, next));
+  }
+
+  /// Re-fires every panel with the current range. Used by pull-to-
+  /// refresh and the error-card retry button.
+  Future<void> refresh() async {
+    if (isDisposed) return;
+    final range = state.range;
+    final panels = metricPanelsByKind[_target.kind] ?? const <MetricPanel>[];
+    state = MetricsState(
+      range: range,
+      panels: {for (final p in panels) p.id: const PanelLoading()},
+    );
+    supersede('manual refresh');
+    await _fetchAll(panels, range);
+  }
+
+  Future<void> _fetchAll(
+    List<MetricPanel> panels,
+    ({DateTime start, DateTime end, MetricsPreset preset}) range,
+  ) async {
+    if (panels.isEmpty) return;
+    final captured = captureDispatchId();
+    final repo = ref.read(monitoringRepositoryProvider);
+    final rangeSec =
+        range.end.difference(range.start).inSeconds.clamp(1, 365 * 24 * 3600);
+    final step = MonitoringRepository.computeStep(rangeSec);
+    final vars = _resolveVariables();
+
+    await Future.wait(panels.map((panel) async {
+      String query;
+      try {
+        query = panel.render(vars);
+      } on ArgumentError catch (e) {
+        _writePanel(panel.id, PanelFailed(e.message?.toString() ?? '$e'),
+            captured);
+        return;
+      }
+
+      try {
+        final result = await repo.queryRange(
+          query: query,
+          start: range.start,
+          end: range.end,
+          stepSeconds: step,
+          clusterIdOverride: _target.clusterId,
+          cancelToken: currentCancelToken,
+        );
+        // Pin re-check at result arrival — defends against the
+        // cluster-switch-mid-fetch race even though the wire request
+        // already carried the pinned X-Cluster-ID header.
+        if (!clusterStillPinned(ref)) {
+          _writePanel(
+            panel.id,
+            PanelFailed(pinnedMismatchMessage(PinPhase.postEmission)),
+            captured,
+          );
+          return;
+        }
+        _writePanel(panel.id, PanelLoaded(result), captured);
+      } on DioException catch (e) {
+        if (RefreshableController.isCancelException(e)) return;
+        final err = e.error;
+        final apiErr = err is ApiError ? err : ApiError.fromDio(e);
+        _writePanel(
+          panel.id,
+          PanelFailed(_humanize(apiErr)),
+          captured,
+        );
+      } on ApiError catch (e) {
+        _writePanel(panel.id, PanelFailed(_humanize(e)), captured);
+      } catch (e) {
+        _writePanel(panel.id, PanelFailed(e.toString()), captured);
+      }
+    }));
+  }
+
+  /// Translates the controller target into the variable bindings the
+  /// per-kind panels declare. `node` panels read the resource name as
+  /// the node label value; PVC panels read it into `pvc`; workload
+  /// panels follow `<kind-singular>` (deployment / statefulset /
+  /// daemonset).
+  Map<String, String> _resolveVariables() {
+    final base = <String, String>{
+      'namespace': _target.namespace,
+    };
+    switch (_target.kind) {
+      case 'pods':
+        return {...base, 'pod': _target.name};
+      case 'nodes':
+        return {'node': _target.name};
+      case 'deployments':
+        return {...base, 'deployment': _target.name};
+      case 'statefulsets':
+        return {...base, 'statefulset': _target.name};
+      case 'daemonsets':
+        return {...base, 'daemonset': _target.name};
+      case 'persistentvolumeclaims':
+        return {...base, 'pvc': _target.name};
+    }
+    return base;
+  }
+
+  void _writePanel(String panelId, PanelStatus status, int captured) {
+    if (!isFresh(captured)) return;
+    if (isDisposed) return;
+    final current = state;
+    final next = Map<String, PanelStatus>.from(current.panels);
+    next[panelId] = status;
+    state = current.copyWith(panels: next);
+  }
+
+  String _humanize(ApiError e) {
+    if (e.statusCode == 502) {
+      return 'Prometheus query failed (${e.message}). Retry, or shorten '
+          'the time range.';
+    }
+    if (e.statusCode == 503) {
+      return 'Prometheus is not available on this cluster.';
+    }
+    return e.message;
+  }
+}
+
+final metricsControllerProvider = AutoDisposeNotifierProvider.family<
+    MetricsController, MetricsState, MetricsTarget>(
+  MetricsController.new,
+);
+

--- a/mobile/lib/features/observability/metrics/metrics_controller.dart
+++ b/mobile/lib/features/observability/metrics/metrics_controller.dart
@@ -147,9 +147,16 @@ class MetricsController
     // initial state before `_writePanel` reads it back. Without this
     // yield, the first await in `_fetchAll` can land before `state` is
     // observable, and the per-panel writes silently drop.
+    //
+    // Capture the dispatch id eagerly so a same-tick `setRange()` or
+    // `refresh()` call (which bumps `_dispatchId` via `supersede`)
+    // invalidates this build's fetch before it launches — without
+    // this guard, the initial 1h range fetch could still produce the
+    // winning result for a user-selected 24h range.
+    final captured = captureDispatchId();
     scheduleMicrotask(() {
-      if (isDisposed) return;
-      unawaited(_fetchAll(panels, initialRange));
+      if (isDisposed || !isFresh(captured)) return;
+      unawaited(_fetchAll(panels, initialRange, capturedOverride: captured));
     });
     return MetricsState(range: initialRange, panels: initialStatuses);
   }
@@ -184,10 +191,11 @@ class MetricsController
 
   Future<void> _fetchAll(
     List<MetricPanel> panels,
-    ({DateTime start, DateTime end, MetricsPreset preset}) range,
-  ) async {
+    ({DateTime start, DateTime end, MetricsPreset preset}) range, {
+    int? capturedOverride,
+  }) async {
     if (panels.isEmpty) return;
-    final captured = captureDispatchId();
+    final captured = capturedOverride ?? captureDispatchId();
     final repo = ref.read(monitoringRepositoryProvider);
     final rangeSec =
         range.end.difference(range.start).inSeconds.clamp(1, 365 * 24 * 3600);
@@ -269,8 +277,9 @@ class MetricsController
   }
 
   void _writePanel(String panelId, PanelStatus status, int captured) {
+    // `isFresh` already short-circuits when `_disposed` is true, so a
+    // separate `isDisposed` check would be dead code.
     if (!isFresh(captured)) return;
-    if (isDisposed) return;
     final current = state;
     final next = Map<String, PanelStatus>.from(current.panels);
     next[panelId] = status;

--- a/mobile/lib/features/observability/metrics/metrics_tab.dart
+++ b/mobile/lib/features/observability/metrics/metrics_tab.dart
@@ -90,7 +90,7 @@ class _MetricsBody extends ConsumerWidget {
             ),
           ),
           const SizedBox(height: 12),
-          ...metricPanelsByKind[target.kind]!.map((panel) {
+          ...(metricPanelsByKind[target.kind] ?? const <MetricPanel>[]).map((panel) {
             final status =
                 state.panels[panel.id] ?? const PanelLoading();
             return _PanelCard(panel: panel, status: status);
@@ -186,21 +186,19 @@ class _PanelBody extends StatelessWidget {
             ),
           ),
         ),
-      PanelLoaded(:final result) => _renderResult(result),
+      PanelLoaded(:final result) => _renderResult(context, result),
     };
   }
 
-  Widget _renderResult(QueryRangeResult result) {
+  Widget _renderResult(BuildContext context, QueryRangeResult result) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
     if (result.isEmpty) {
-      return Builder(builder: (context) {
-        final colors = Theme.of(context).extension<KubeColors>()!;
-        return Center(
-          child: Text(
-            'No data for this time range',
-            style: TextStyle(color: colors.textMuted, fontSize: 12),
-          ),
-        );
-      });
+      return Center(
+        child: Text(
+          'No data for this time range',
+          style: TextStyle(color: colors.textMuted, fontSize: 12),
+        ),
+      );
     }
     final severity = _toChartSeverity(panel.severity);
     final series = result.series.map((s) {
@@ -211,11 +209,25 @@ class _PanelBody extends StatelessWidget {
         severity: severity,
       );
     }).toList();
-    return KubeLineChart(
+    final chart = KubeLineChart(
       series: series,
       showLegend: result.series.length > 1,
-      // Title is rendered by the card chrome; chart-level title would
-      // duplicate it.
+    );
+    if (result.warnings.isEmpty) return chart;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(bottom: 6),
+          child: Text(
+            result.warnings.length == 1
+                ? result.warnings.first
+                : '${result.warnings.length} warnings: ${result.warnings.first}',
+            style: TextStyle(color: colors.warning, fontSize: 10),
+          ),
+        ),
+        Expanded(child: chart),
+      ],
     );
   }
 

--- a/mobile/lib/features/observability/metrics/metrics_tab.dart
+++ b/mobile/lib/features/observability/metrics/metrics_tab.dart
@@ -1,0 +1,330 @@
+// Body widget for the per-resource Metrics tab. Composes the
+// `TimeRangePicker` and a vertical scroll of `KubeLineChart` cards —
+// one per panel defined in `metric_panels.dart` for the target kind.
+//
+// Status gating runs through `monitoringStatusProvider`. When the
+// cluster doesn't have Prometheus (`detected: false`), the entire tab
+// renders `FeatureUnavailableState.monitoring()`. Empty per-panel
+// results render a "No data for this time range" banner rather than a
+// flat-zero chart so operators can distinguish "metric missing" from
+// "metric is zero".
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../api/monitoring_repository.dart';
+import '../../../theme/kube_theme_builder.dart';
+import '../../../widgets/empty_states.dart';
+import '../../../widgets/feature_unavailable_state.dart';
+import '../../../widgets/kube_line_chart.dart';
+import '../../../widgets/time_range_picker.dart';
+import 'metric_panels.dart';
+import 'metrics_controller.dart';
+
+class MetricsTab extends ConsumerWidget {
+  const MetricsTab({
+    super.key,
+    required this.clusterId,
+    required this.kind,
+    required this.namespace,
+    required this.name,
+  });
+
+  final String clusterId;
+  final String kind;
+  final String namespace;
+  final String name;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final status = ref.watch(monitoringStatusProvider(clusterId));
+    return status.when(
+      loading: () => const LoadingState(),
+      error: (e, _) => ErrorStateView(
+        message: 'Failed to query monitoring status: $e',
+        onRetry: () => ref.invalidate(monitoringStatusProvider(clusterId)),
+      ),
+      data: (s) {
+        if (!s.detected) {
+          return FeatureUnavailableState.monitoring();
+        }
+        if (!metricsAvailableForKind(kind)) {
+          return const _NoPanelsState();
+        }
+        final target = MetricsTarget(
+          clusterId: clusterId,
+          kind: kind,
+          namespace: namespace,
+          name: name,
+        );
+        return _MetricsBody(target: target);
+      },
+    );
+  }
+}
+
+class _MetricsBody extends ConsumerWidget {
+  const _MetricsBody({required this.target});
+
+  final MetricsTarget target;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(metricsControllerProvider(target));
+    final notifier = ref.read(metricsControllerProvider(target).notifier);
+
+    return RefreshIndicator(
+      onRefresh: notifier.refresh,
+      child: ListView(
+        padding: const EdgeInsets.symmetric(
+          horizontal: 12,
+          vertical: 12,
+        ),
+        children: [
+          _TimeRangeBar(
+            state: state,
+            onChanged: (range) => notifier.setRange(
+              range.start,
+              range.end,
+              _mapPreset(range.preset),
+            ),
+          ),
+          const SizedBox(height: 12),
+          ...metricPanelsByKind[target.kind]!.map((panel) {
+            final status =
+                state.panels[panel.id] ?? const PanelLoading();
+            return _PanelCard(panel: panel, status: status);
+          }),
+        ],
+      ),
+    );
+  }
+}
+
+class _TimeRangeBar extends StatelessWidget {
+  const _TimeRangeBar({required this.state, required this.onChanged});
+
+  final MetricsState state;
+  final ValueChanged<TimeRange> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final initial = (
+      start: state.range.start,
+      end: state.range.end,
+      preset: _toWidgetPreset(state.range.preset),
+    );
+    return TimeRangePicker(initial: initial, onChanged: onChanged);
+  }
+}
+
+class _PanelCard extends StatelessWidget {
+  const _PanelCard({required this.panel, required this.status});
+
+  final MetricPanel panel;
+  final PanelStatus status;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return Container(
+      margin: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: colors.bgSurface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colors.borderSubtle),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  panel.title,
+                  style: TextStyle(
+                    color: colors.textPrimary,
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+              if (panel.unitHint != null)
+                Text(
+                  panel.unitHint!,
+                  style: TextStyle(color: colors.textMuted, fontSize: 11),
+                ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          SizedBox(height: 200, child: _PanelBody(panel: panel, status: status)),
+        ],
+      ),
+    );
+  }
+}
+
+class _PanelBody extends StatelessWidget {
+  const _PanelBody({required this.panel, required this.status});
+
+  final MetricPanel panel;
+  final PanelStatus status;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return switch (status) {
+      PanelLoading() => const LoadingState(),
+      PanelFailed(:final message) => Center(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            child: Text(
+              message,
+              textAlign: TextAlign.center,
+              style: TextStyle(color: colors.error, fontSize: 12),
+            ),
+          ),
+        ),
+      PanelLoaded(:final result) => _renderResult(result),
+    };
+  }
+
+  Widget _renderResult(QueryRangeResult result) {
+    if (result.isEmpty) {
+      return Builder(builder: (context) {
+        final colors = Theme.of(context).extension<KubeColors>()!;
+        return Center(
+          child: Text(
+            'No data for this time range',
+            style: TextStyle(color: colors.textMuted, fontSize: 12),
+          ),
+        );
+      });
+    }
+    final severity = _toChartSeverity(panel.severity);
+    final series = result.series.map((s) {
+      final label = _labelFor(s.labels);
+      return (
+        label: label,
+        points: s.points,
+        severity: severity,
+      );
+    }).toList();
+    return KubeLineChart(
+      series: series,
+      showLegend: result.series.length > 1,
+      // Title is rendered by the card chrome; chart-level title would
+      // duplicate it.
+    );
+  }
+
+  /// Picks the most operator-meaningful label key from a Prometheus
+  /// series. Pods/containers expose `container`; network panels return
+  /// no labels (single series) so fall back to the panel id.
+  String _labelFor(Map<String, String> labels) {
+    for (final key in const [
+      'container',
+      'pod',
+      'instance',
+      'node',
+      'deployment',
+      'statefulset',
+      'daemonset',
+    ]) {
+      final v = labels[key];
+      if (v != null && v.isNotEmpty) return v;
+    }
+    return panel.id;
+  }
+}
+
+class _NoPanelsState extends StatelessWidget {
+  const _NoPanelsState();
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.show_chart_outlined,
+                size: 40, color: colors.textMuted),
+            const SizedBox(height: 12),
+            Text(
+              'No curated metrics for this resource kind',
+              textAlign: TextAlign.center,
+              style: TextStyle(color: colors.textSecondary, fontSize: 14),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              'Open Grafana on a desktop for ad-hoc PromQL.',
+              textAlign: TextAlign.center,
+              style: TextStyle(color: colors.textMuted, fontSize: 12),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Cross-layer enum bridges. The widget's TimePreset and the controller's
+// MetricsPreset are intentionally separate to keep the controller free of
+// widget imports; these helpers translate between the two.
+// ---------------------------------------------------------------------------
+
+MetricsPreset _mapPreset(TimePreset p) {
+  switch (p) {
+    case TimePreset.last15m:
+      return MetricsPreset.last15m;
+    case TimePreset.last1h:
+      return MetricsPreset.last1h;
+    case TimePreset.last6h:
+      return MetricsPreset.last6h;
+    case TimePreset.last24h:
+      return MetricsPreset.last24h;
+    case TimePreset.last7d:
+      return MetricsPreset.last7d;
+    case TimePreset.custom:
+      return MetricsPreset.custom;
+  }
+}
+
+TimePreset _toWidgetPreset(MetricsPreset p) {
+  switch (p) {
+    case MetricsPreset.last15m:
+      return TimePreset.last15m;
+    case MetricsPreset.last1h:
+      return TimePreset.last1h;
+    case MetricsPreset.last6h:
+      return TimePreset.last6h;
+    case MetricsPreset.last24h:
+      return TimePreset.last24h;
+    case MetricsPreset.last7d:
+      return TimePreset.last7d;
+    case MetricsPreset.custom:
+      return TimePreset.custom;
+  }
+}
+
+KubeChartSeverity _toChartSeverity(PanelSeverity s) {
+  switch (s) {
+    case PanelSeverity.primary:
+      return KubeChartSeverity.primary;
+    case PanelSeverity.success:
+      return KubeChartSeverity.success;
+    case PanelSeverity.warning:
+      return KubeChartSeverity.warning;
+    case PanelSeverity.error:
+      return KubeChartSeverity.error;
+    case PanelSeverity.info:
+      return KubeChartSeverity.info;
+    case PanelSeverity.muted:
+      return KubeChartSeverity.muted;
+  }
+}

--- a/mobile/lib/features/resources/daemonset_screens.dart
+++ b/mobile/lib/features/resources/daemonset_screens.dart
@@ -16,6 +16,7 @@ import '../../widgets/resource_actions_button.dart';
 import '../../widgets/resource_detail_scaffold.dart';
 import '../../widgets/resource_list_scaffold.dart';
 import '../../widgets/resource_table.dart';
+import '../observability/metrics/metrics_tab.dart';
 import 'k8s_helpers.dart';
 
 class _DaemonSetRow {
@@ -153,6 +154,17 @@ class DaemonSetDetailScreen extends ConsumerWidget {
             name: d.meta.name,
             resource: raw,
           ),
+          extraTabs: [
+            DetailExtraTab(
+              label: 'Metrics',
+              body: MetricsTab(
+                clusterId: clusterId,
+                kind: 'daemonsets',
+                namespace: d.meta.namespace,
+                name: d.meta.name,
+              ),
+            ),
+          ],
           overview: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [

--- a/mobile/lib/features/resources/deployment_screens.dart
+++ b/mobile/lib/features/resources/deployment_screens.dart
@@ -13,6 +13,7 @@ import '../../widgets/resource_actions_button.dart';
 import '../../widgets/resource_detail_scaffold.dart';
 import '../../widgets/resource_list_scaffold.dart';
 import '../../widgets/resource_table.dart';
+import '../observability/metrics/metrics_tab.dart';
 import 'k8s_helpers.dart';
 
 class _DeploymentRow {
@@ -133,6 +134,17 @@ class DeploymentDetailScreen extends ConsumerWidget {
             name: d.meta.name,
             resource: raw,
           ),
+          extraTabs: [
+            DetailExtraTab(
+              label: 'Metrics',
+              body: MetricsTab(
+                clusterId: clusterId,
+                kind: 'deployments',
+                namespace: d.meta.namespace,
+                name: d.meta.name,
+              ),
+            ),
+          ],
           overview: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [

--- a/mobile/lib/features/resources/node_screens.dart
+++ b/mobile/lib/features/resources/node_screens.dart
@@ -12,6 +12,7 @@ import '../../widgets/empty_states.dart';
 import '../../widgets/resource_detail_scaffold.dart';
 import '../../widgets/resource_list_scaffold.dart';
 import '../../widgets/resource_table.dart';
+import '../observability/metrics/metrics_tab.dart';
 import 'k8s_helpers.dart';
 
 class _NodeRow {
@@ -157,6 +158,17 @@ class NodeDetailScreen extends ConsumerWidget {
           statusLabel: n.ready ? 'Ready' : 'NotReady',
           statusColor: n.ready ? colors.success : colors.error,
           resource: raw,
+          extraTabs: [
+            DetailExtraTab(
+              label: 'Metrics',
+              body: MetricsTab(
+                clusterId: clusterId,
+                kind: 'nodes',
+                namespace: '',
+                name: n.meta.name,
+              ),
+            ),
+          ],
           overview: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [

--- a/mobile/lib/features/resources/pod_screens.dart
+++ b/mobile/lib/features/resources/pod_screens.dart
@@ -15,6 +15,7 @@ import '../../widgets/resource_actions_button.dart';
 import '../../widgets/resource_detail_scaffold.dart';
 import '../../widgets/resource_list_scaffold.dart';
 import '../../widgets/resource_table.dart';
+import '../observability/metrics/metrics_tab.dart';
 import 'k8s_helpers.dart';
 
 /// Read-only thin view over the unstructured Pod map.
@@ -244,6 +245,17 @@ class PodDetailScreen extends ConsumerWidget {
             name: pod.meta.name,
             resource: raw,
           ),
+          extraTabs: [
+            DetailExtraTab(
+              label: 'Metrics',
+              body: MetricsTab(
+                clusterId: clusterId,
+                kind: 'pods',
+                namespace: pod.meta.namespace,
+                name: pod.meta.name,
+              ),
+            ),
+          ],
           overview: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [

--- a/mobile/lib/features/resources/pvc_screens.dart
+++ b/mobile/lib/features/resources/pvc_screens.dart
@@ -15,6 +15,7 @@ import '../../widgets/resource_actions_button.dart';
 import '../../widgets/resource_detail_scaffold.dart';
 import '../../widgets/resource_list_scaffold.dart';
 import '../../widgets/resource_table.dart';
+import '../observability/metrics/metrics_tab.dart';
 import 'k8s_helpers.dart';
 
 class _PvcRow {
@@ -159,6 +160,17 @@ class PvcDetailScreen extends ConsumerWidget {
             name: p.meta.name,
             resource: raw,
           ),
+          extraTabs: [
+            DetailExtraTab(
+              label: 'Metrics',
+              body: MetricsTab(
+                clusterId: clusterId,
+                kind: 'persistentvolumeclaims',
+                namespace: p.meta.namespace,
+                name: p.meta.name,
+              ),
+            ),
+          ],
           overview: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [

--- a/mobile/lib/features/resources/statefulset_screens.dart
+++ b/mobile/lib/features/resources/statefulset_screens.dart
@@ -15,6 +15,7 @@ import '../../widgets/resource_actions_button.dart';
 import '../../widgets/resource_detail_scaffold.dart';
 import '../../widgets/resource_list_scaffold.dart';
 import '../../widgets/resource_table.dart';
+import '../observability/metrics/metrics_tab.dart';
 import 'k8s_helpers.dart';
 
 class _StatefulSetRow {
@@ -141,6 +142,17 @@ class StatefulSetDetailScreen extends ConsumerWidget {
             name: s.meta.name,
             resource: raw,
           ),
+          extraTabs: [
+            DetailExtraTab(
+              label: 'Metrics',
+              body: MetricsTab(
+                clusterId: clusterId,
+                kind: 'statefulsets',
+                namespace: s.meta.namespace,
+                name: s.meta.name,
+              ),
+            ),
+          ],
           overview: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [

--- a/mobile/test/api/monitoring_repository_test.dart
+++ b/mobile/test/api/monitoring_repository_test.dart
@@ -1,0 +1,277 @@
+// Tests for MonitoringRepository: step formula pinned to plan values,
+// status endpoint parsing, query_range envelope decoding, 503 fallthrough.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kubecenter/api/api_error.dart';
+import 'package:kubecenter/api/dio_client.dart';
+import 'package:kubecenter/api/monitoring_repository.dart';
+import 'package:kubecenter/auth/secure_storage.dart';
+
+import '../support/mock_dio_adapter.dart';
+
+ResponseBody _json(Object body, {int status = 200}) {
+  return ResponseBody.fromBytes(
+    Uint8List.fromList(utf8.encode(jsonEncode(body))),
+    status,
+    headers: {
+      Headers.contentTypeHeader: ['application/json'],
+    },
+  );
+}
+
+({ProviderContainer container, MockDioAdapter mock}) _make() {
+  final mock = MockDioAdapter();
+  final container = ProviderContainer(
+    overrides: [
+      backendUrlProvider.overrideWithValue('http://test'),
+      secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+    ],
+  );
+  container.read(refreshDioProvider).httpClientAdapter = mock;
+  container.read(dioProvider).httpClientAdapter = mock;
+  return (container: container, mock: mock);
+}
+
+void main() {
+  group('MonitoringRepository.computeStep', () {
+    // The five plan-pinned values. Drift here means web/mobile
+    // Prometheus cache slots stop aligning — at minimum the same
+    // (start, end) tuple should produce a deterministic step on
+    // mobile so chart frames look the same across launches.
+    test('60s range → 15s step', () {
+      expect(MonitoringRepository.computeStep(60), 15);
+    });
+
+    test('1h range → 15s step', () {
+      expect(MonitoringRepository.computeStep(3600), 15);
+    });
+
+    test('6h range → 30s step', () {
+      expect(MonitoringRepository.computeStep(21600), 30);
+    });
+
+    test('24h range → 5m step (300s)', () {
+      expect(MonitoringRepository.computeStep(86400), 300);
+    });
+
+    test('7d range → 30m step (1800s)', () {
+      expect(MonitoringRepository.computeStep(604800), 1800);
+    });
+
+    test('intermediate ranges snap UP to next preset', () {
+      // 22 raw → 30 (next preset above)
+      expect(MonitoringRepository.computeStep(22000), 30);
+      // 87 raw → 300 (next preset above 60)
+      expect(MonitoringRepository.computeStep(86001), 300);
+    });
+
+    test('ranges past 1h preset clamp to 3600 (largest preset)', () {
+      // 10x 7d range, would compute step 6048 — clamps to 3600.
+      expect(MonitoringRepository.computeStep(604800 * 10), 3600);
+    });
+
+    test('zero or negative range falls back to 15s', () {
+      expect(MonitoringRepository.computeStep(0), 15);
+      expect(MonitoringRepository.computeStep(-5), 15);
+    });
+  });
+
+  group('MonitoringRepository.status', () {
+    test('detected: true with both engines available', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/monitoring/status',
+        body: {
+          'data': {
+            'detected': true,
+            'prometheus': {'available': true},
+            'grafana': {'available': true},
+          },
+        },
+      );
+
+      final s = await container
+          .read(monitoringRepositoryProvider)
+          .status();
+      expect(s.detected, isTrue);
+      expect(s.prometheusAvailable, isTrue);
+      expect(s.grafanaAvailable, isTrue);
+    });
+
+    test('503 from status endpoint returns MonitoringStatus.empty', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.on(
+        'GET',
+        '/api/v1/monitoring/status',
+        (_) => _json({
+          'error': {'code': 503, 'message': 'monitoring not configured'},
+        }, status: 503),
+      );
+
+      final s = await container
+          .read(monitoringRepositoryProvider)
+          .status();
+      expect(s.detected, isFalse);
+      expect(s.prometheusAvailable, isFalse);
+    });
+
+    test('missing detected field falls back to OR of engine flags', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      // Some discoverer paths omit `detected` and just expose the per-
+      // engine availability. The factory falls back to OR rather than
+      // surfacing a confusing "detected: false but Prom: true" state.
+      mock.onJson(
+        'GET',
+        '/api/v1/monitoring/status',
+        body: {
+          'data': {
+            'prometheus': {'available': true},
+            'grafana': {'available': false},
+          },
+        },
+      );
+
+      final s = await container
+          .read(monitoringRepositoryProvider)
+          .status();
+      expect(s.detected, isTrue);
+      expect(s.prometheusAvailable, isTrue);
+      expect(s.grafanaAvailable, isFalse);
+    });
+  });
+
+  group('MonitoringRepository.queryRange', () {
+    test('parses matrix result into typed series + points', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/monitoring/query_range',
+        body: {
+          'data': {
+            'resultType': 'matrix',
+            'result': [
+              {
+                'metric': {'container': 'web'},
+                'values': [
+                  [1700000000.0, '0.5'],
+                  [1700000060.0, '0.6'],
+                ],
+              },
+              {
+                'metric': {'container': 'sidecar'},
+                'values': [
+                  [1700000000.0, '0.1'],
+                ],
+              },
+            ],
+            'warnings': ['high cardinality result'],
+          },
+        },
+      );
+
+      final result =
+          await container.read(monitoringRepositoryProvider).queryRange(
+                query: 'up',
+                start: DateTime.utc(2026, 5, 1),
+                end: DateTime.utc(2026, 5, 1, 1),
+                stepSeconds: 15,
+              );
+
+      expect(result.series, hasLength(2));
+      expect(result.series.first.labels['container'], 'web');
+      expect(result.series.first.points, hasLength(2));
+      expect(result.series.first.points.first.v, 0.5);
+      expect(result.warnings, contains('high cardinality result'));
+      expect(result.isEmpty, isFalse);
+    });
+
+    test('empty result list surfaces as isEmpty', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/monitoring/query_range',
+        body: {
+          'data': {
+            'resultType': 'matrix',
+            'result': <Object>[],
+          },
+        },
+      );
+
+      final result =
+          await container.read(monitoringRepositoryProvider).queryRange(
+                query: 'up',
+                start: DateTime.utc(2026, 5, 1),
+                end: DateTime.utc(2026, 5, 1, 1),
+                stepSeconds: 15,
+              );
+
+      expect(result.isEmpty, isTrue);
+      expect(result.series, isEmpty);
+    });
+
+    test('502 from Prometheus surfaces as ApiError(502)', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.on(
+        'GET',
+        '/api/v1/monitoring/query_range',
+        (_) => _json({
+          'error': {'code': 502, 'message': 'Prometheus query failed'},
+        }, status: 502),
+      );
+
+      expect(
+        () => container.read(monitoringRepositoryProvider).queryRange(
+              query: 'up',
+              start: DateTime.utc(2026, 5, 1),
+              end: DateTime.utc(2026, 5, 1, 1),
+              stepSeconds: 15,
+            ),
+        throwsA(isA<ApiError>()
+            .having((e) => e.statusCode, 'statusCode', 502)),
+      );
+    });
+
+    test('clusterIdOverride forwards as explicit X-Cluster-ID header',
+        () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/monitoring/query_range',
+        body: {
+          'data': {'resultType': 'matrix', 'result': <Object>[]},
+        },
+      );
+
+      await container.read(monitoringRepositoryProvider).queryRange(
+            query: 'up',
+            start: DateTime.utc(2026, 5, 1),
+            end: DateTime.utc(2026, 5, 1, 1),
+            stepSeconds: 15,
+            clusterIdOverride: 'cluster-b',
+          );
+
+      expect(mock.requests.single.headers['X-Cluster-ID'], 'cluster-b');
+    });
+  });
+}

--- a/mobile/test/api/monitoring_repository_test.dart
+++ b/mobile/test/api/monitoring_repository_test.dart
@@ -150,6 +150,34 @@ void main() {
       expect(s.prometheusAvailable, isTrue);
       expect(s.grafanaAvailable, isFalse);
     });
+
+    test('prometheus: null in status response → prometheusAvailable: false',
+        () async {
+      // A discoverer that explicitly emits `prometheus: null` (vs.
+      // absent) must not coerce to "available". The `prom is Map`
+      // check defends this; locking it down with a test prevents a
+      // future refactor from regressing the null case.
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/monitoring/status',
+        body: {
+          'data': {
+            'detected': true,
+            'prometheus': null,
+            'grafana': {'available': false},
+          },
+        },
+      );
+
+      final s = await container
+          .read(monitoringRepositoryProvider)
+          .status();
+      expect(s.detected, isTrue);
+      expect(s.prometheusAvailable, isFalse);
+    });
   });
 
   group('MonitoringRepository.queryRange', () {

--- a/mobile/test/features/observability/metrics/metric_panels_test.dart
+++ b/mobile/test/features/observability/metrics/metric_panels_test.dart
@@ -1,0 +1,93 @@
+// Tests for the per-kind MetricPanel registry — variable substitution,
+// injection guards, and coverage for the six R1-required kinds.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kubecenter/features/observability/metrics/metric_panels.dart';
+
+void main() {
+  group('metricPanelsByKind coverage', () {
+    test('every R1 kind has at least one panel', () {
+      const requiredKinds = [
+        'pods',
+        'deployments',
+        'statefulsets',
+        'daemonsets',
+        'nodes',
+        'persistentvolumeclaims',
+      ];
+      for (final k in requiredKinds) {
+        expect(metricPanelsByKind[k], isNotNull,
+            reason: 'kind $k must have at least one MetricPanel');
+        expect(metricPanelsByKind[k]!, isNotEmpty,
+            reason: 'kind $k must have at least one MetricPanel');
+      }
+    });
+
+    test('metricsAvailableForKind returns true for supported kinds', () {
+      expect(metricsAvailableForKind('pods'), isTrue);
+      expect(metricsAvailableForKind('nodes'), isTrue);
+    });
+
+    test('metricsAvailableForKind returns false for unsupported kinds', () {
+      expect(metricsAvailableForKind('configmaps'), isFalse);
+      expect(metricsAvailableForKind('ingresses'), isFalse);
+    });
+
+    test('every panel id is unique within its kind', () {
+      for (final entry in metricPanelsByKind.entries) {
+        final ids = entry.value.map((p) => p.id).toList();
+        final unique = ids.toSet();
+        expect(unique.length, ids.length,
+            reason: 'duplicate panel id under ${entry.key}: $ids');
+      }
+    });
+  });
+
+  group('MetricPanel.render', () {
+    test('substitutes declared variables', () {
+      final panel = metricPanelsByKind['pods']!
+          .firstWhere((p) => p.id == 'pod_cpu_usage');
+      final rendered = panel.render({
+        'namespace': 'default',
+        'pod': 'web-abc',
+      });
+      expect(rendered, contains('namespace="default"'));
+      expect(rendered, contains('pod="web-abc"'));
+      // No leftover variables.
+      expect(rendered, isNot(contains(r'$pod')));
+      expect(rendered, isNot(contains(r'$namespace')));
+    });
+
+    test('throws ArgumentError on missing variable', () {
+      final panel = metricPanelsByKind['pods']!.first;
+      expect(
+        () => panel.render(const {'namespace': 'default'}),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects values that would break the Kubernetes name regex '
+        '(PromQL injection defense)', () {
+      final panel = metricPanelsByKind['pods']!.first;
+      // The backend's `isValidK8sName` rejects values with quotes,
+      // braces, or whitespace — these are the exact characters an
+      // attacker would use to break out of the PromQL label-value
+      // string. The client-side guard catches them before they hit the
+      // wire.
+      expect(
+        () => panel.render({
+          'namespace': 'default',
+          'pod': 'evil"} ; drop_metrics()',
+        }),
+        throwsArgumentError,
+      );
+      expect(
+        () => panel.render({
+          'namespace': 'default',
+          'pod': '', // empty value
+        }),
+        throwsArgumentError,
+      );
+    });
+  });
+}

--- a/mobile/test/features/observability/metrics/metric_panels_test.dart
+++ b/mobile/test/features/observability/metrics/metric_panels_test.dart
@@ -66,27 +66,65 @@ void main() {
       );
     });
 
-    test('rejects values that would break the Kubernetes name regex '
-        '(PromQL injection defense)', () {
+    test('accepts legitimate names that the backend may still RFC-1123-reject '
+        '(uppercase, underscore) — defers strict validation to backend',
+        () {
+      // Kubelet's --hostname-override historically allowed uppercase and
+      // underscore on on-prem nodes. The client-side guard should not
+      // dead-end such names; backend returns a 400 with a precise error
+      // if the value is actually invalid per RFC 1123.
+      final panel = metricPanelsByKind['nodes']!.first;
+      expect(
+        () => panel.render({'node': 'WORKER_01.corp.local'}),
+        returnsNormally,
+      );
+    });
+
+    test('rejects values containing PromQL-breaking characters', () {
       final panel = metricPanelsByKind['pods']!.first;
-      // The backend's `isValidK8sName` rejects values with quotes,
-      // braces, or whitespace — these are the exact characters an
-      // attacker would use to break out of the PromQL label-value
-      // string. The client-side guard catches them before they hit the
-      // wire.
+      // Double-quote closes the label-value string — direct injection.
+      expect(
+        () => panel.render({'namespace': 'default', 'pod': 'evil"; up'}),
+        throwsArgumentError,
+      );
+      // Backslash escapes the next char — escape-chain injection.
+      expect(
+        () => panel.render({'namespace': 'default', 'pod': 'a\\b'}),
+        throwsArgumentError,
+      );
+      // Dollar — defence-in-depth against double-substitution.
+      expect(
+        () => panel.render({'namespace': 'default', 'pod': 'a\$b'}),
+        throwsArgumentError,
+      );
+      // Newline — breaks the wire format.
+      expect(
+        () => panel.render({'namespace': 'default', 'pod': 'a\nb'}),
+        throwsArgumentError,
+      );
+      // Empty — still rejected (no substitution target).
+      expect(
+        () => panel.render({'namespace': 'default', 'pod': ''}),
+        throwsArgumentError,
+      );
+      // 254-char name — over length cap.
       expect(
         () => panel.render({
           'namespace': 'default',
-          'pod': 'evil"} ; drop_metrics()',
+          'pod': 'a' * 254,
         }),
         throwsArgumentError,
       );
+    });
+
+    test('accepts boundary-valid 253-char name', () {
+      final panel = metricPanelsByKind['pods']!.first;
       expect(
         () => panel.render({
           'namespace': 'default',
-          'pod': '', // empty value
+          'pod': 'a' * 253,
         }),
-        throwsArgumentError,
+        returnsNormally,
       );
     });
   });

--- a/mobile/test/features/observability/metrics/metrics_controller_test.dart
+++ b/mobile/test/features/observability/metrics/metrics_controller_test.dart
@@ -300,5 +300,60 @@ void main() {
         isEmpty,
       );
     });
+
+    test('refresh() re-fires panel fetches after a previous failure', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      // First batch fails with 502 for every panel.
+      for (var i = 0; i < 4; i++) {
+        mock.on(
+          'GET',
+          '/api/v1/monitoring/query_range',
+          (_) => _json({
+            'error': {'code': 502, 'message': 'Prometheus query failed'},
+          }, status: 502),
+        );
+      }
+      // Second batch (after refresh) returns success.
+      for (var i = 0; i < 4; i++) {
+        mock.on(
+          'GET',
+          '/api/v1/monitoring/query_range',
+          (_) => _matrix([
+            {
+              'metric': {'container': 'web'},
+              'values': [
+                [1700000000.0, '0.5'],
+              ],
+            },
+          ]),
+        );
+      }
+
+      final target = const MetricsTarget(
+        clusterId: 'local',
+        kind: 'pods',
+        namespace: 'default',
+        name: 'web-pod',
+      );
+      final sub = container.listen(
+        metricsControllerProvider(target),
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+      sub.read();
+      await _pumpAsync(container);
+      // First batch landed as PanelFailed.
+      expect(sub.read().panels.values, everyElement(isA<PanelFailed>()));
+
+      // refresh() supersedes and re-fires.
+      await container
+          .read(metricsControllerProvider(target).notifier)
+          .refresh();
+      await _pumpAsync(container);
+      // Second batch lands as PanelLoaded.
+      expect(sub.read().panels.values, everyElement(isA<PanelLoaded>()));
+    });
   });
 }

--- a/mobile/test/features/observability/metrics/metrics_controller_test.dart
+++ b/mobile/test/features/observability/metrics/metrics_controller_test.dart
@@ -1,0 +1,304 @@
+// Tests for the MetricsController: per-panel happy path, 502 error
+// path, time-range swap mid-fetch (race), cluster-pin postEmission
+// guard.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kubecenter/api/dio_client.dart';
+import 'package:kubecenter/auth/secure_storage.dart';
+import 'package:kubecenter/cluster/cluster_provider.dart';
+import 'package:kubecenter/features/observability/metrics/metrics_controller.dart';
+
+import '../../../support/mock_dio_adapter.dart';
+
+ResponseBody _json(Object body, {int status = 200}) {
+  return ResponseBody.fromBytes(
+    Uint8List.fromList(utf8.encode(jsonEncode(body))),
+    status,
+    headers: {
+      Headers.contentTypeHeader: ['application/json'],
+    },
+  );
+}
+
+ResponseBody _matrix(List<Map<String, dynamic>> result) {
+  return _json({
+    'data': {'resultType': 'matrix', 'result': result},
+  });
+}
+
+({ProviderContainer container, MockDioAdapter mock}) _make({
+  String activeClusterId = 'local',
+}) {
+  final mock = MockDioAdapter();
+  final container = ProviderContainer(
+    overrides: [
+      backendUrlProvider.overrideWithValue('http://test'),
+      secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+    ],
+  );
+  container.read(refreshDioProvider).httpClientAdapter = mock;
+  container.read(dioProvider).httpClientAdapter = mock;
+  // Seed the active cluster so the controller's pin check has a value.
+  container.read(activeClusterProvider.notifier).setCluster(activeClusterId);
+  return (container: container, mock: mock);
+}
+
+Future<void> _pumpAsync(ProviderContainer container) async {
+  // Dio's async chain (5 interceptors × ~2 microtasks each, plus
+  // response transformer + onResponse loop) needs more than three
+  // hops. Flutter's pumpEventQueue cycles a generous 20 turns and
+  // covers the worst case (auth retry + refresh + main response).
+  await pumpEventQueue(times: 30);
+}
+
+void main() {
+  group('MetricsController', () {
+    test(
+        'happy path: fetches all panels for a Pod target and renders Loaded',
+        () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      // Status gate (the tab queries this; the controller itself doesn't,
+      // but we keep the mock simple by allowing it).
+      mock.onJson('GET', '/api/v1/monitoring/status', body: {
+        'data': {'detected': true, 'prometheus': {'available': true}},
+      });
+
+      // Every panel hits query_range; respond with one series for each.
+      for (var i = 0; i < 4; i++) {
+        mock.on(
+          'GET',
+          '/api/v1/monitoring/query_range',
+          (_) => _matrix([
+            {
+              'metric': {'container': 'web'},
+              'values': [
+                [1700000000.0, '0.5'],
+              ],
+            },
+          ]),
+        );
+      }
+
+      final target = const MetricsTarget(
+        clusterId: 'local',
+        kind: 'pods',
+        namespace: 'default',
+        name: 'web-pod',
+      );
+
+      // Persistent subscription so autoDispose doesn't tear the
+      // provider down between the two reads — without it the second
+      // read rebuilds from scratch and loses the in-flight state.
+      final sub = container.listen(
+        metricsControllerProvider(target),
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+
+      final initial = sub.read();
+      expect(initial.panels.values, everyElement(isA<PanelLoading>()));
+      await _pumpAsync(container);
+      final after = sub.read();
+      expect(after.range.preset, MetricsPreset.last1h);
+      for (final panel in after.panels.values) {
+        expect(panel, isA<PanelLoaded>(),
+            reason: 'every panel should land Loaded; got $panel');
+      }
+    });
+
+    test('502 from Prometheus surfaces as PanelFailed with a clear message',
+        () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      for (var i = 0; i < 4; i++) {
+        mock.on(
+          'GET',
+          '/api/v1/monitoring/query_range',
+          (_) => _json({
+            'error': {'code': 502, 'message': 'Prometheus query failed'},
+          }, status: 502),
+        );
+      }
+
+      final target = const MetricsTarget(
+        clusterId: 'local',
+        kind: 'pods',
+        namespace: 'default',
+        name: 'web-pod',
+      );
+      final sub = container.listen(
+        metricsControllerProvider(target),
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+      sub.read();
+      await _pumpAsync(container);
+
+      final s = sub.read();
+      for (final panel in s.panels.values) {
+        expect(panel, isA<PanelFailed>());
+        expect(
+          (panel as PanelFailed).message,
+          contains('Prometheus query failed'),
+        );
+      }
+    });
+
+    test('time-range swap mid-fetch drops stale results via supersede',
+        () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      // Each panel returns marker-distinguished payloads so the assertion
+      // can verify which fetch landed. The first batch (initial 1h fetch)
+      // would resolve to value 0.5; the second batch (after 24h swap)
+      // resolves to value 0.99.
+      final initialCompleters = List.generate(4, (_) => Completer<void>());
+      var phase = 0;
+      mock.on('GET', '/api/v1/monitoring/query_range', (req) {
+        // First 4 calls — phase 0.
+        if (phase < 4) {
+          final i = phase++;
+          // Force the initial fetches to block on completer so we can
+          // swap range before they resolve.
+          // (we can't actually block sync; emulate by returning fast
+          // then asserting supersede via dispatch id behavior below)
+          initialCompleters[i].complete();
+          return _matrix([
+            {
+              'metric': {'container': 'old'},
+              'values': [
+                [1700000000.0, '0.5'],
+              ],
+            },
+          ]);
+        }
+        return _matrix([
+          {
+            'metric': {'container': 'new'},
+            'values': [
+              [1700000000.0, '0.99'],
+            ],
+          },
+        ]);
+      });
+
+      final target = const MetricsTarget(
+        clusterId: 'local',
+        kind: 'pods',
+        namespace: 'default',
+        name: 'web-pod',
+      );
+      final sub = container.listen(
+        metricsControllerProvider(target),
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+      sub.read();
+      // Let the build's scheduled microtask fire first, then swap
+      // range. The post-swap fetches dominate the in-flight write
+      // race via `supersede()` (bumps the dispatch id so prior
+      // captures fail `isFresh`).
+      await _pumpAsync(container);
+      final notifier =
+          container.read(metricsControllerProvider(target).notifier);
+      final now = DateTime.now();
+      notifier.setRange(
+        now.subtract(const Duration(hours: 24)),
+        now,
+        MetricsPreset.last24h,
+      );
+      await _pumpAsync(container);
+      await _pumpAsync(container);
+
+      final after = sub.read();
+      expect(after.range.preset, MetricsPreset.last24h);
+      // All panels should reflect the second-batch payload now.
+      for (final p in after.panels.values) {
+        if (p is PanelLoaded) {
+          expect(p.result.series.first.labels['container'], 'new');
+        }
+      }
+    });
+
+    test('cluster-pin postEmission mismatch routes to PanelFailed', () async {
+      final (:container, :mock) = _make(activeClusterId: 'cluster-a');
+      addTearDown(container.dispose);
+
+      // Switch active cluster after the controller pins on 'cluster-a',
+      // before the query_range mock returns. The mock returns a valid
+      // body so we exercise the post-emission re-check rather than the
+      // happy path or a Dio error path.
+      for (var i = 0; i < 4; i++) {
+        mock.on(
+          'GET',
+          '/api/v1/monitoring/query_range',
+          (_) {
+            container
+                .read(activeClusterProvider.notifier)
+                .setCluster('cluster-b');
+            return _matrix(const []);
+          },
+        );
+      }
+
+      final target = const MetricsTarget(
+        clusterId: 'cluster-a',
+        kind: 'pods',
+        namespace: 'default',
+        name: 'web-pod',
+      );
+      final sub = container.listen(
+        metricsControllerProvider(target),
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+      sub.read();
+      await _pumpAsync(container);
+
+      final s = sub.read();
+      // Every panel should fail with the post-emission mismatch copy.
+      for (final p in s.panels.values) {
+        expect(p, isA<PanelFailed>());
+        final msg = (p as PanelFailed).message;
+        expect(msg, contains('Cluster changed'));
+        expect(msg, contains('cluster-a'));
+      }
+    });
+
+    test('kind with no panel registry stays at empty Loaded state', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      final target = const MetricsTarget(
+        clusterId: 'local',
+        kind: 'configmaps', // no panels registered
+        namespace: 'default',
+        name: 'cm',
+      );
+      final sub = container.listen(
+        metricsControllerProvider(target),
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+      final state = sub.read();
+      await _pumpAsync(container);
+      expect(state.panels, isEmpty);
+      // The mock never gets a request because no panels are scheduled.
+      expect(
+        mock.requests
+            .where((r) => r.path == '/api/v1/monitoring/query_range'),
+        isEmpty,
+      );
+    });
+  });
+}

--- a/mobile/test/features/observability/metrics/metrics_tab_test.dart
+++ b/mobile/test/features/observability/metrics/metrics_tab_test.dart
@@ -1,0 +1,157 @@
+// Widget tests for MetricsTab — status gate routing, panel grid render
+// for the happy path, and the "no curated panels for this kind" state.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kubecenter/api/dio_client.dart';
+import 'package:kubecenter/auth/secure_storage.dart';
+import 'package:kubecenter/features/observability/metrics/metrics_tab.dart';
+import 'package:kubecenter/theme/kube_theme_builder.dart' show buildKubeTheme;
+import 'package:kubecenter/widgets/feature_unavailable_state.dart';
+
+import '../../../support/mock_dio_adapter.dart';
+
+ResponseBody _json(Object body, {int status = 200}) {
+  return ResponseBody.fromBytes(
+    Uint8List.fromList(utf8.encode(jsonEncode(body))),
+    status,
+    headers: {
+      Headers.contentTypeHeader: ['application/json'],
+    },
+  );
+}
+
+Future<void> _pumpTab(
+  WidgetTester tester, {
+  required MockDioAdapter mock,
+  required String kind,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        backendUrlProvider.overrideWithValue('http://test'),
+        secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+        // Replace the Dio adapters with the mock under test before
+        // any provider that depends on dioProvider materializes.
+        dioProvider.overrideWith((ref) {
+          final dio = Dio(BaseOptions(baseUrl: 'http://test'));
+          dio.httpClientAdapter = mock;
+          return dio;
+        }),
+        refreshDioProvider.overrideWith((ref) {
+          final dio = Dio(BaseOptions(baseUrl: 'http://test'));
+          dio.httpClientAdapter = mock;
+          return dio;
+        }),
+      ],
+      child: MaterialApp(
+        theme: buildKubeTheme('nexus'),
+        home: Scaffold(
+          body: MetricsTab(
+            clusterId: 'local',
+            kind: kind,
+            namespace: 'default',
+            name: 'web-pod',
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('MetricsTab status gate', () {
+    testWidgets('Prometheus not detected → FeatureUnavailableState.monitoring',
+        (tester) async {
+      final mock = MockDioAdapter();
+      mock.onJson(
+        'GET',
+        '/api/v1/monitoring/status',
+        body: {
+          'data': {
+            'detected': false,
+            'prometheus': {'available': false},
+            'grafana': {'available': false},
+          },
+        },
+      );
+
+      await _pumpTab(tester, mock: mock, kind: 'pods');
+      // Pump until the status future resolves.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      // The feature-unavailable card carries the canonical wording.
+      expect(find.byType(FeatureUnavailableState), findsOneWidget);
+      expect(find.textContaining('Prometheus monitoring'), findsOneWidget);
+    });
+
+    testWidgets('detected + supported kind renders the panel grid',
+        (tester) async {
+      final mock = MockDioAdapter();
+      mock.onJson(
+        'GET',
+        '/api/v1/monitoring/status',
+        body: {
+          'data': {
+            'detected': true,
+            'prometheus': {'available': true},
+          },
+        },
+      );
+      // Every panel call returns one empty matrix so panels land in
+      // PanelLoaded(isEmpty) — the "No data" branch — without needing
+      // realistic Prometheus payloads.
+      mock.on(
+        'GET',
+        '/api/v1/monitoring/query_range',
+        (_) => _json({
+          'data': {'resultType': 'matrix', 'result': <Object>[]},
+        }),
+      );
+
+      await _pumpTab(tester, mock: mock, kind: 'pods');
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.pump(const Duration(milliseconds: 100));
+
+      // The TimeRangePicker's segment labels are unambiguous evidence
+      // the body widget rendered.
+      expect(find.text('1h'), findsOneWidget);
+      expect(find.text('6h'), findsOneWidget);
+      // First two pod-kind panel titles render in the visible viewport;
+      // the remaining two live below the fold (ListView.builder lazy).
+      expect(find.text('CPU usage per container'), findsOneWidget);
+      expect(find.text('Memory working set per container'), findsOneWidget);
+    });
+
+    testWidgets('kind with no panels renders the "no curated metrics" state',
+        (tester) async {
+      final mock = MockDioAdapter();
+      mock.onJson(
+        'GET',
+        '/api/v1/monitoring/status',
+        body: {
+          'data': {
+            'detected': true,
+            'prometheus': {'available': true},
+          },
+        },
+      );
+
+      await _pumpTab(tester, mock: mock, kind: 'configmaps');
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(
+        find.text('No curated metrics for this resource kind'),
+        findsOneWidget,
+      );
+    });
+  });
+}

--- a/mobile/test/features/observability/metrics/metrics_tab_test.dart
+++ b/mobile/test/features/observability/metrics/metrics_tab_test.dart
@@ -128,6 +128,11 @@ void main() {
       // the remaining two live below the fold (ListView.builder lazy).
       expect(find.text('CPU usage per container'), findsOneWidget);
       expect(find.text('Memory working set per container'), findsOneWidget);
+      // The empty-vector mock should route each panel through the
+      // _renderResult `result.isEmpty` branch, surfacing the "No data"
+      // banner. Without this assertion the empty-state copy could
+      // regress silently when _renderResult is refactored.
+      expect(find.text('No data for this time range'), findsWidgets);
     });
 
     testWidgets('kind with no panels renders the "no curated metrics" state',


### PR DESCRIPTION
## Summary

Lands the per-resource Metrics tab on Pod / Deployment / StatefulSet / DaemonSet / Node / PVC detail screens — the first M4 PR after PR-4a's shared primitives. An oncall who taps a workload from a notification now sees CPU / memory / network charts over a selectable time range (15m / 1h / 6h / 24h / 7d / custom) without opening Grafana on a desktop.

**Implements:** plan `plans/mobile-app-m4-pr-sequence.md` U2 (R1, R10, R11, R12).

## What's new

- **`MonitoringRepository`** wraps `/v1/monitoring/{status,query_range}`. Static `computeStep(rangeSec)` snaps to the plan-pinned presets `{15s, 30s, 1m, 5m, 30m, 1h}` keeping chart frames deterministic.
- **`metric_panels.dart`** — per-kind curated PromQL registry. Mirrors backend `QueryTemplates` client-side; the plan's "Deferred to Implementation" question on the resource-dashboard endpoint resolved at implementation time (backend returns Grafana embed metadata, not curated PromQL).
- **`MetricsController`** — `AutoDisposeFamilyNotifier<MetricsState, MetricsTarget>` with `RefreshableController` mixin. Eager dispatch-id capture in `build()` guards against same-tick `setRange` / `refresh` races; per-panel state lets partial failures render alongside successes.
- **`MetricsTab`** — `TimeRangePicker` + per-panel `KubeLineChart` grid, status-gated via `monitoringStatusProvider` → `FeatureUnavailableState.monitoring()`. Prometheus warnings (high-cardinality, truncation) render as inline banners above the chart.
- **Detail screens (6)** — `extraTabs: [DetailExtraTab(label: 'Metrics', body: MetricsTab(...))]` wired into pod / deployment / statefulset / daemonset / node / pvc.

## Review pass

`/ce:code-review` ran 9 reviewer personas (correctness, testing, maintainability, project-standards, agent-native, learnings, security, reliability, adversarial). 11 fixes applied in commit `c33ac69`:

- **Reliability:** rethrow on cancel (was a never-completing Future); 30s receive timeout on `queryRange`; 5xx fallback for status (was 503-only); null-bang guard on `_MetricsBody`.
- **Correctness:** eager dispatch-id capture in `build()` closes the same-tick race; warnings banner surfaces Prometheus admonitions.
- **Security:** validator narrowed from strict RFC 1123 to actual PromQL-injection vectors (`"`, `\`, `$`, NUL, LF, CR + length cap) — accepts legitimate uppercase / underscore names; backend still applies strict check server-side.
- **Tests:** +4 cases (refresh() round-trip, `prometheus: null`, "No data" banner, narrowed-validator boundaries).

**Residual** (tracked in `c33ac69` commit body): unanchored prefix regex on Deployment/SS/DS/Node panels (silent cross-resource metric aggregation; backend mirrors the node defect — needs coordinated fix); enum/typedef dedup crossing PR-4a code; test redesigns needing a Completer-gated mock pattern.

## Test plan

- [ ] `cd mobile && flutter analyze` — clean
- [ ] `cd mobile && flutter test` — 508 / 508 passing
- [ ] `make check-themes` — themes in sync
- [ ] Smoke against homelab: open a busy Pod's Metrics tab, verify CPU/memory chart renders with non-zero data over 1h; switch to 7d, confirm step is 30m (=1800s) on the wire
- [ ] Smoke against homelab: open a Pod in a namespace where Prometheus is not detected (or temporarily 503 the discoverer), verify `FeatureUnavailableState.monitoring()` renders
- [ ] Smoke against homelab: confirm pull-to-refresh re-fires panel fetches; confirm time-range chip taps work without flicker

🤖 Generated with [Claude Code](https://claude.com/claude-code)