### PR TITLE
feat(mobile): M4 PR-4c — LogQL editor + label browser + LokiRepository

### DIFF
--- a/mobile/lib/api/loki_repository.dart
+++ b/mobile/lib/api/loki_repository.dart
@@ -1,0 +1,527 @@
+// Mobile-side wrapper over the backend Loki log API
+// (`/v1/logs/{status,query,labels,labels/{name}/values,volume}`).
+//
+// Shape notes worth pinning before reading:
+//
+//   * `query` returns Loki's raw envelope under `data` —
+//     `{resultType, result: Stream[]}`. Each `Stream` carries a
+//     `stream` label map and a `values` array of `[ns_ts_string, line]`
+//     pairs. The mobile parse lifts this into typed [LogLine] records
+//     so the results list doesn't carry parsing into every render.
+//
+//   * `volume` returns the same envelope shape as Prometheus matrix
+//     queries — `{resultType, result: VolumeEntry[]}` — where each
+//     entry carries a `metric` map and `values: [[ts_seconds, count_str]]`.
+//     The volume histogram aggregates across entries (single bar
+//     series for the whole histogram regardless of how many metrics
+//     match the query) so the parse coalesces buckets by timestamp.
+//
+//   * Status endpoint returns `{detected, url, detectedVia}`. As with
+//     the monitoring status, a 5xx from this probe is treated as
+//     "not detected" rather than an error — the FeatureUnavailableState
+//     route is more actionable than a noisy error card on a flaky
+//     reverse proxy.
+//
+//   * Namespace param threading: the backend hard-403s non-admin
+//     callers that omit `namespace=` on query / labels / volume.
+//     Mobile pre-flights the namespace selection so the UX surfaces
+//     a "Namespace required" prompt instead of letting the operator
+//     submit a query that lands in the network error path.
+//
+//   * 4096-character LogQL limit gated client-side before POST.
+//     Matches the backend's `loki.maxQueryLen` constant — the same
+//     limit also lives there so a runaway query can't burn round-
+//     trip latency just to be rejected at the server.
+
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../cluster/cluster_provider.dart';
+import 'api_error.dart';
+import 'dio_client.dart';
+
+/// Maximum LogQL query length accepted by the backend.
+///
+/// Mirrors `backend/internal/loki/security.go::maxQueryLen`. Mobile
+/// gates this client-side so an operator pasting a multi-megabyte
+/// query into the LogQL textarea sees a "Query exceeds 4096 chars"
+/// inline error before the request leaves the device. The backend
+/// still enforces the limit; the client check is a UX shortcut, not
+/// a security boundary.
+const int kLokiMaxQueryChars = 4096;
+
+/// Snapshot of the backend's `/v1/logs/status` response. `detected`
+/// gates `FeatureUnavailableState.loki()`; `url` and `detectedVia`
+/// surface in the editor footer for operators who need to know
+/// whether Loki was auto-discovered or configured via env var.
+class LokiStatus {
+  const LokiStatus({
+    required this.detected,
+    this.url,
+    this.detectedVia,
+  });
+
+  final bool detected;
+  final String? url;
+  final String? detectedVia;
+
+  factory LokiStatus.fromJson(Map<String, dynamic> json) {
+    return LokiStatus(
+      detected: json['detected'] == true,
+      url: json['url'] as String?,
+      detectedVia: json['detectedVia'] as String?,
+    );
+  }
+
+  static const empty = LokiStatus(detected: false);
+}
+
+/// Single log entry: nanosecond timestamp + raw line + the stream's
+/// label map. Labels are shared across all lines in a `Stream` block
+/// — the mobile parse flattens them onto every LogLine so per-line
+/// rendering doesn't have to thread the stream context around.
+class LogLine {
+  const LogLine({
+    required this.timestampNanos,
+    required this.line,
+    required this.labels,
+  });
+
+  /// Nanosecond timestamp as Loki returns it (string in wire format,
+  /// parsed to int here so the results list can sort + format without
+  /// re-parsing per render).
+  final int timestampNanos;
+
+  /// Raw log line as Loki captured it. May be a JSON object, a plain
+  /// text message, or a stack trace fragment. Mobile renders verbatim
+  /// in monospace; severity detection is best-effort over the prefix.
+  final String line;
+
+  /// Stream labels (e.g. `{namespace, pod, container, app}`). Empty
+  /// when the backend's label set is dropped by the query pipeline.
+  final Map<String, String> labels;
+
+  DateTime get timestamp =>
+      DateTime.fromMicrosecondsSinceEpoch(timestampNanos ~/ 1000, isUtc: true);
+}
+
+/// Typed parse of `query`'s envelope. `lines` is the flattened
+/// stream/values join; `streamCount` carries the Loki-side aggregation
+/// signal (operators occasionally care that "this query matched 47
+/// streams" even if only 12 lines land in the cap).
+class LogQueryResult {
+  const LogQueryResult({
+    required this.lines,
+    required this.streamCount,
+  });
+
+  final List<LogLine> lines;
+  final int streamCount;
+
+  /// True when the response hit the backend's 5000-line cap.
+  /// `LogResultsList` surfaces a banner so the operator knows to
+  /// narrow the query rather than scrolling endlessly.
+  bool get truncated => lines.length >= 5000;
+
+  bool get isEmpty => lines.isEmpty;
+
+  factory LogQueryResult.fromJson(Map<String, dynamic> json) {
+    final result = json['result'];
+    final lines = <LogLine>[];
+    int streamCount = 0;
+    if (result is List) {
+      for (final entry in result) {
+        if (entry is! Map) continue;
+        streamCount++;
+        final streamLabels = <String, String>{};
+        final stream = entry['stream'];
+        if (stream is Map) {
+          for (final mEntry in stream.entries) {
+            final k = mEntry.key;
+            final v = mEntry.value;
+            if (k is String && v is String) {
+              streamLabels[k] = v;
+            }
+          }
+        }
+        final values = entry['values'];
+        if (values is List) {
+          for (final pair in values) {
+            if (pair is! List || pair.length < 2) continue;
+            final tsRaw = pair[0];
+            final lineRaw = pair[1];
+            final tsStr = tsRaw is String ? tsRaw : '$tsRaw';
+            final tsNanos = int.tryParse(tsStr) ?? 0;
+            final line = lineRaw is String ? lineRaw : '$lineRaw';
+            lines.add(LogLine(
+              timestampNanos: tsNanos,
+              line: line,
+              labels: streamLabels,
+            ));
+          }
+        }
+      }
+    }
+    return LogQueryResult(lines: lines, streamCount: streamCount);
+  }
+}
+
+/// One bucket on the log volume histogram. The mobile parse
+/// aggregates across entries so a multi-metric volume response
+/// collapses to a single bar series.
+class LogVolumeBucket {
+  const LogVolumeBucket({required this.timestamp, required this.count});
+
+  final DateTime timestamp;
+  final int count;
+}
+
+/// Typed parse of `volume`'s envelope. Buckets are sorted by
+/// timestamp; histogram render reads them in order.
+class LogVolumeResult {
+  const LogVolumeResult({required this.buckets});
+
+  final List<LogVolumeBucket> buckets;
+
+  bool get isEmpty => buckets.isEmpty;
+
+  int get total => buckets.fold(0, (sum, b) => sum + b.count);
+
+  factory LogVolumeResult.fromJson(Map<String, dynamic> json) {
+    final result = json['result'];
+    // Aggregate counts across entries at each timestamp bucket. The
+    // backend may emit multiple `metric` entries when target labels
+    // are set; a single bar series with summed counts is the
+    // mobile-friendly view.
+    final byTs = <int, int>{};
+    if (result is List) {
+      for (final entry in result) {
+        if (entry is! Map) continue;
+        final values = entry['values'];
+        if (values is! List) continue;
+        for (final pair in values) {
+          if (pair is! List || pair.length < 2) continue;
+          final tsRaw = pair[0];
+          final countRaw = pair[1];
+          // Loki's volume response carries timestamps as numeric
+          // seconds (float), values as stringified counts. Parse
+          // defensively.
+          final tsSecs = tsRaw is num
+              ? tsRaw.toDouble()
+              : double.tryParse('$tsRaw');
+          final countStr = countRaw is String ? countRaw : '$countRaw';
+          final count = int.tryParse(countStr) ??
+              double.tryParse(countStr)?.toInt() ??
+              0;
+          if (tsSecs == null) continue;
+          final tsKey = (tsSecs * 1000).round();
+          byTs[tsKey] = (byTs[tsKey] ?? 0) + count;
+        }
+      }
+    }
+    final buckets = byTs.entries
+        .map((e) => LogVolumeBucket(
+              timestamp:
+                  DateTime.fromMillisecondsSinceEpoch(e.key, isUtc: true),
+              count: e.value,
+            ))
+        .toList()
+      ..sort((a, b) => a.timestamp.compareTo(b.timestamp));
+    return LogVolumeResult(buckets: buckets);
+  }
+}
+
+/// Mobile wrapper over the backend Loki API surface. Stateless — the
+/// active cluster threads in via the Dio interceptor stack unless the
+/// caller explicitly overrides via `clusterIdOverride`.
+class LokiRepository {
+  LokiRepository(this._dio);
+
+  final Dio _dio;
+
+  /// Unwraps the backend's `{data: {data: ...}}` envelope. The outer
+  /// `data` is k8sCenter's response wrapper; the inner `data` is the
+  /// Loki proxy's own envelope. Some shapes flatten onto the outer
+  /// map, so the fallback treats the outer map as the result block —
+  /// keeps the parse resilient to a backend response-shape refactor.
+  Map<String, dynamic>? _unwrapLokiEnvelope(Object? raw) {
+    if (raw is! Map) return null;
+    final asMap = Map<String, dynamic>.from(raw);
+    final nested = asMap['data'];
+    if (nested is Map) {
+      return Map<String, dynamic>.from(nested);
+    }
+    return asMap;
+  }
+
+  /// Fetches the Loki discovery status. Returns [LokiStatus.empty] on
+  /// 5xx transport errors so callers can route straight to
+  /// `FeatureUnavailableState.loki()` without throwing.
+  Future<LokiStatus> status({
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) async {
+    try {
+      final res = await _dio.get<Map<String, dynamic>>(
+        '/api/v1/logs/status',
+        options: clusterIdOverride == null
+            ? null
+            : Options(headers: {'X-Cluster-ID': clusterIdOverride}),
+        cancelToken: cancelToken,
+      );
+      final data = res.data?['data'];
+      if (data is Map) {
+        return LokiStatus.fromJson(Map<String, dynamic>.from(data));
+      }
+      return LokiStatus.empty;
+    } on DioException catch (e) {
+      if (CancelToken.isCancel(e)) rethrow;
+      final code = e.response?.statusCode ?? 0;
+      if (code >= 500 && code < 600) {
+        return LokiStatus.empty;
+      }
+      final err = e.error;
+      throw err is ApiError ? err : ApiError.fromDio(e);
+    }
+  }
+
+  /// Runs a LogQL range query against the backend. `namespace` is
+  /// passed through as a query param; the backend rewrites the query
+  /// to enforce namespace RBAC for non-admin callers.
+  ///
+  /// Throws [ArgumentError] when [query] exceeds [kLokiMaxQueryChars].
+  /// The backend enforces the same limit; the client check is a UX
+  /// shortcut for the 4096-char paste case so the operator sees an
+  /// inline error before waiting on a round-trip.
+  Future<LogQueryResult> query({
+    required String query,
+    required DateTime start,
+    required DateTime end,
+    String? namespace,
+    int limit = 1000,
+    String direction = 'backward',
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) async {
+    if (query.length > kLokiMaxQueryChars) {
+      throw ArgumentError(
+        'LogQL query exceeds $kLokiMaxQueryChars characters '
+        '(${query.length}). Shorten the matcher set or use the search '
+        'mode to construct a more selective query.',
+      );
+    }
+    try {
+      final res = await _dio.get<Map<String, dynamic>>(
+        '/api/v1/logs/query',
+        queryParameters: {
+          'query': query,
+          'start': start.toUtc().toIso8601String(),
+          'end': end.toUtc().toIso8601String(),
+          'limit': '$limit',
+          'direction': direction,
+          if (namespace != null && namespace.isNotEmpty) 'namespace': namespace,
+        },
+        options: Options(
+          receiveTimeout: const Duration(seconds: 60),
+          headers: clusterIdOverride == null
+              ? null
+              : {'X-Cluster-ID': clusterIdOverride},
+        ),
+        cancelToken: cancelToken,
+      );
+      final inner = _unwrapLokiEnvelope(res.data?['data']);
+      if (inner == null) {
+        return const LogQueryResult(lines: [], streamCount: 0);
+      }
+      return LogQueryResult.fromJson(inner);
+    } on DioException catch (e) {
+      if (CancelToken.isCancel(e)) rethrow;
+      final err = e.error;
+      throw err is ApiError ? err : ApiError.fromDio(e);
+    }
+  }
+
+  /// Fetches volume buckets for the histogram. Optional best-effort
+  /// surface — callers swallow 503s and hide the histogram panel
+  /// rather than failing the whole search.
+  Future<LogVolumeResult> volume({
+    required String query,
+    required DateTime start,
+    required DateTime end,
+    required String step,
+    String? namespace,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) async {
+    if (query.length > kLokiMaxQueryChars) {
+      throw ArgumentError(
+        'LogQL query exceeds $kLokiMaxQueryChars characters; '
+        'volume request not sent.',
+      );
+    }
+    try {
+      final res = await _dio.get<Map<String, dynamic>>(
+        '/api/v1/logs/volume',
+        queryParameters: {
+          'query': query,
+          'start': start.toUtc().toIso8601String(),
+          'end': end.toUtc().toIso8601String(),
+          'step': step,
+          if (namespace != null && namespace.isNotEmpty) 'namespace': namespace,
+        },
+        options: Options(
+          receiveTimeout: const Duration(seconds: 30),
+          headers: clusterIdOverride == null
+              ? null
+              : {'X-Cluster-ID': clusterIdOverride},
+        ),
+        cancelToken: cancelToken,
+      );
+      final inner = _unwrapLokiEnvelope(res.data?['data']);
+      if (inner == null) {
+        return const LogVolumeResult(buckets: []);
+      }
+      return LogVolumeResult.fromJson(inner);
+    } on DioException catch (e) {
+      if (CancelToken.isCancel(e)) rethrow;
+      final err = e.error;
+      throw err is ApiError ? err : ApiError.fromDio(e);
+    }
+  }
+
+  /// Lists values for a label (e.g. `pod` values within a namespace).
+  /// `scopeQuery` is the LogQL selector to scope the lookup — when
+  /// non-empty the backend forwards it as a `query=` param so Loki
+  /// returns only labels seen within matching streams.
+  Future<List<String>> labelValues({
+    required String name,
+    DateTime? start,
+    DateTime? end,
+    String? namespace,
+    String? scopeQuery,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) async {
+    final params = <String, String>{};
+    if (start != null) params['start'] = start.toUtc().toIso8601String();
+    if (end != null) params['end'] = end.toUtc().toIso8601String();
+    if (namespace != null && namespace.isNotEmpty) {
+      params['namespace'] = namespace;
+    }
+    if (scopeQuery != null && scopeQuery.isNotEmpty) {
+      params['query'] = scopeQuery;
+    }
+    try {
+      final res = await _dio.get<Map<String, dynamic>>(
+        '/api/v1/logs/labels/${Uri.encodeComponent(name)}/values',
+        queryParameters: params.isEmpty ? null : params,
+        // 15s receiveTimeout caps how long the cascade dropdown sits
+        // on "Loading…" if the Loki label endpoint goes silent
+        // (backend pod restart, TCP half-open). Backend's own
+        // LabelValues context timeout is 10s (loki/client.go) so a
+        // well-behaved backend always responds first; this is the
+        // fallback for crashed/half-open paths.
+        options: Options(
+          receiveTimeout: const Duration(seconds: 15),
+          headers: clusterIdOverride == null
+              ? null
+              : {'X-Cluster-ID': clusterIdOverride},
+        ),
+        cancelToken: cancelToken,
+      );
+      final data = res.data?['data'];
+      if (data is List) {
+        return data.whereType<String>().toList();
+      }
+      return const <String>[];
+    } on DioException catch (e) {
+      if (CancelToken.isCancel(e)) rethrow;
+      // Label lookups are best-effort UX — a 403 (non-admin without
+      // namespace) or 502 (Loki transient) shouldn't crash the
+      // dropdown. Return empty so the picker degrades gracefully and
+      // the operator can still type a value manually.
+      final code = e.response?.statusCode ?? 0;
+      if (code == 403 || code == 502 || code == 503) {
+        return const <String>[];
+      }
+      final err = e.error;
+      throw err is ApiError ? err : ApiError.fromDio(e);
+    }
+  }
+
+  /// Lists all label names. Returns empty list on 5xx so the editor
+  /// label browser degrades gracefully when Loki is briefly
+  /// unavailable mid-session.
+  Future<List<String>> labels({
+    DateTime? start,
+    DateTime? end,
+    String? namespace,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) async {
+    final params = <String, String>{};
+    if (start != null) params['start'] = start.toUtc().toIso8601String();
+    if (end != null) params['end'] = end.toUtc().toIso8601String();
+    if (namespace != null && namespace.isNotEmpty) {
+      params['namespace'] = namespace;
+    }
+    try {
+      final res = await _dio.get<Map<String, dynamic>>(
+        '/api/v1/logs/labels',
+        queryParameters: params.isEmpty ? null : params,
+        options: clusterIdOverride == null
+            ? null
+            : Options(headers: {'X-Cluster-ID': clusterIdOverride}),
+        cancelToken: cancelToken,
+      );
+      final data = res.data?['data'];
+      if (data is List) {
+        return data.whereType<String>().toList();
+      }
+      return const <String>[];
+    } on DioException catch (e) {
+      if (CancelToken.isCancel(e)) rethrow;
+      final code = e.response?.statusCode ?? 0;
+      if (code == 403 || code >= 500) {
+        return const <String>[];
+      }
+      final err = e.error;
+      throw err is ApiError ? err : ApiError.fromDio(e);
+    }
+  }
+}
+
+final lokiRepositoryProvider = Provider<LokiRepository>((ref) {
+  return LokiRepository(ref.watch(dioProvider));
+});
+
+/// Per-cluster Loki status. Keyed on the cluster id so cluster switches
+/// key a fresh entry rather than reusing the prior cluster's gate
+/// decision (a false-negative would route the editor into the
+/// FeatureUnavailableState until manual refresh).
+///
+/// Cancellation handling: when the autoDispose ref is invalidated
+/// mid-fetch (cluster switch, screen pop), the CancelToken fires and
+/// the await throws `DioException(type: cancel)`. We swallow that case
+/// to return `LokiStatus.empty` rather than rethrow — the next-built
+/// provider entry will produce the fresh status, and surfacing a
+/// transient AsyncError briefly flashes an unhelpful error card.
+final lokiStatusProvider =
+    FutureProvider.autoDispose.family<LokiStatus, String>((ref, clusterId) async {
+  ref.watch(activeClusterProvider);
+  final cancel = CancelToken();
+  ref.onDispose(() {
+    if (!cancel.isCancelled) cancel.cancel('status invalidated');
+  });
+  try {
+    return await ref.read(lokiRepositoryProvider).status(
+          clusterIdOverride: clusterId,
+          cancelToken: cancel,
+        );
+  } on DioException catch (e) {
+    if (CancelToken.isCancel(e)) return LokiStatus.empty;
+    rethrow;
+  }
+});

--- a/mobile/lib/features/observability/logs/log_filter_bar.dart
+++ b/mobile/lib/features/observability/logs/log_filter_bar.dart
@@ -1,0 +1,643 @@
+// LogQL editor's form surface — cascading namespace/pod/container
+// dropdowns, severity chips, free-text contains, mode toggle
+// (search/logql), and a Run button. Builds the LogQL string on
+// submit so the controller doesn't have to thread filter state
+// alongside the query body.
+//
+// Cascading dropdown timing (mirrors `frontend/islands/LogFilterBar.tsx`):
+//   * On mount, fetch namespace values from `/v1/logs/labels/namespace/values`.
+//   * When namespace changes, fetch pod values scoped by that namespace.
+//   * When pod changes, fetch container values scoped by namespace+pod.
+//   * Switching modes preserves form state — search → LogQL seeds the
+//     raw text with the constructed query so the operator can edit it
+//     directly; LogQL → search keeps the form fields as they were
+//     (the LogQL-mode raw edits drop, by design — operators who want
+//     to keep their raw edits can stay in LogQL mode).
+//
+// Admin gate: non-admin users MUST pick a namespace before the Run
+// button enables. Admins see an "All namespaces" option which fires
+// a cluster-wide query (backend `enforceQueryNamespaces` permits this
+// path for admins only).
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../api/loki_repository.dart';
+import '../../../auth/auth_repository.dart';
+import '../../../auth/auth_state.dart';
+import '../../../cluster/cluster_provider.dart';
+import '../../../theme/kube_theme_builder.dart';
+import '../../../widgets/time_range_picker.dart';
+import 'log_search_controller.dart';
+
+/// Severity filter values mirrored from web's LogFilterBar — the
+/// backend's `level` label uses a case-insensitive regex match so
+/// the values stay lowercase here and the build path emits the
+/// `(?i)` regex flag.
+enum LogSeverity { error, warn, info, debug }
+
+extension on LogSeverity {
+  String get label => switch (this) {
+        LogSeverity.error => 'Error',
+        LogSeverity.warn => 'Warn',
+        LogSeverity.info => 'Info',
+        LogSeverity.debug => 'Debug',
+      };
+
+  String get value => switch (this) {
+        LogSeverity.error => 'error',
+        LogSeverity.warn => 'warn',
+        LogSeverity.info => 'info',
+        LogSeverity.debug => 'debug',
+      };
+}
+
+/// Callback invoked when the operator presses Run on the filter bar.
+typedef LogSearchSubmit = void Function(LogSearchParams params);
+
+class LogFilterBar extends ConsumerStatefulWidget {
+  const LogFilterBar({
+    required this.onSubmit,
+    this.initialNamespace,
+    this.inFlight = false,
+    super.key,
+  });
+
+  /// Wired to [LogSearchController.submit] from the screen.
+  final LogSearchSubmit onSubmit;
+
+  /// Optional seed when the screen receives a namespace deep-link
+  /// (e.g. notification opens "view logs in namespace X").
+  final String? initialNamespace;
+
+  /// `true` while the parent controller is still resolving a prior
+  /// submission. Disables the Run button so rapid taps cannot stack
+  /// concurrent fetches at the backend — cancellation handles the
+  /// already-fired requests correctly, but the bandwidth + Loki load
+  /// from 10 supersedes per second is wasted regardless.
+  final bool inFlight;
+
+  @override
+  ConsumerState<LogFilterBar> createState() => _LogFilterBarState();
+}
+
+class _LogFilterBarState extends ConsumerState<LogFilterBar> {
+  LogQueryMode _mode = LogQueryMode.search;
+  String? _namespace;
+  String? _pod;
+  String? _container;
+  LogSeverity? _severity;
+  String _freeText = '';
+  String _rawLogql = '';
+  TimeRange _range = timeRangeFromPreset(TimePreset.last1h);
+  final TextEditingController _freeTextCtrl = TextEditingController();
+  final TextEditingController _rawCtrl = TextEditingController();
+
+  List<String> _namespaces = const [];
+  List<String> _pods = const [];
+  List<String> _containers = const [];
+
+  bool _loadingNamespaces = false;
+  bool _loadingPods = false;
+  bool _loadingContainers = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _namespace = widget.initialNamespace;
+    WidgetsBinding.instance.addPostFrameCallback((_) => _fetchNamespaces());
+    if (_namespace != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) => _fetchPods());
+    }
+  }
+
+  @override
+  void dispose() {
+    _freeTextCtrl.dispose();
+    _rawCtrl.dispose();
+    super.dispose();
+  }
+
+  bool get _isAdmin {
+    // ref.watch — not ref.read — so a mid-session auth state change
+    // (token refresh, role promotion via OIDC re-auth) rebuilds the
+    // filter bar with the new admin posture rather than leaving a
+    // stale gate.
+    final auth = ref.watch(authRepositoryProvider);
+    if (auth is AuthAuthenticated) return auth.user.isAdmin;
+    return false;
+  }
+
+  Future<void> _fetchNamespaces() async {
+    if (!mounted) return;
+    setState(() => _loadingNamespaces = true);
+    final clusterId = ref.read(activeClusterProvider);
+    try {
+      final values = await ref
+          .read(lokiRepositoryProvider)
+          .labelValues(name: 'namespace', clusterIdOverride: clusterId);
+      if (!mounted) return;
+      setState(() {
+        _namespaces = values;
+      });
+    } finally {
+      // Reset the loading flag even on non-graceful errors (401, 500,
+      // network timeout). Without this, the repository's narrow
+      // 403/502/503 soft-degrade leaves the dropdown stuck on
+      // "Loading…" indefinitely for any other failure mode.
+      if (mounted) {
+        setState(() => _loadingNamespaces = false);
+      }
+    }
+  }
+
+  Future<void> _fetchPods() async {
+    final ns = _namespace;
+    if (ns == null || ns.isEmpty) {
+      setState(() {
+        _pods = const [];
+        _containers = const [];
+      });
+      return;
+    }
+    if (!mounted) return;
+    setState(() => _loadingPods = true);
+    final clusterId = ref.read(activeClusterProvider);
+    try {
+      final values = await ref.read(lokiRepositoryProvider).labelValues(
+            name: 'pod',
+            namespace: ns,
+            scopeQuery: '{namespace="$ns"}',
+            clusterIdOverride: clusterId,
+          );
+      if (!mounted) return;
+      // Cascade race-protection: if the operator switched namespace
+      // between when we issued the labelValues call and when its
+      // response arrived, drop this result on the floor — the newer
+      // namespace's fetch (already in flight or queued) is authoritative.
+      if (_namespace != ns) return;
+      setState(() {
+        _pods = values;
+        _containers = const [];
+      });
+    } finally {
+      if (mounted && _namespace == ns) {
+        setState(() => _loadingPods = false);
+      }
+    }
+  }
+
+  Future<void> _fetchContainers() async {
+    final ns = _namespace;
+    final pod = _pod;
+    if (ns == null || ns.isEmpty || pod == null || pod.isEmpty) {
+      setState(() => _containers = const []);
+      return;
+    }
+    if (!mounted) return;
+    setState(() => _loadingContainers = true);
+    final clusterId = ref.read(activeClusterProvider);
+    try {
+      final values = await ref.read(lokiRepositoryProvider).labelValues(
+            name: 'container',
+            namespace: ns,
+            scopeQuery: '{namespace="$ns",pod="$pod"}',
+            clusterIdOverride: clusterId,
+          );
+      if (!mounted) return;
+      // Same cascade race-protection as _fetchPods: a fast operator
+      // who switches pod (or namespace) before the container fetch
+      // returns must not see the stale list under the new selection.
+      if (_namespace != ns || _pod != pod) return;
+      setState(() {
+        _containers = values;
+      });
+    } finally {
+      if (mounted && _namespace == ns && _pod == pod) {
+        setState(() => _loadingContainers = false);
+      }
+    }
+  }
+
+  /// Builds the LogQL query string from the current form state.
+  /// In `logql` mode passes the raw textarea contents through.
+  String _buildQuery() {
+    if (_mode == LogQueryMode.logql) return _rawLogql;
+
+    final matchers = <String>[];
+    if (_namespace != null && _namespace!.isNotEmpty) {
+      matchers.add('namespace="${_namespace!}"');
+    }
+    if (_pod != null && _pod!.isNotEmpty) {
+      matchers.add('pod=~"${_pod!}.*"');
+    }
+    if (_container != null && _container!.isNotEmpty) {
+      matchers.add('container="${_container!}"');
+    }
+    var q = '{${matchers.join(',')}}';
+    if (_severity != null) {
+      q += ' | level=~"(?i)${_severity!.value}"';
+    }
+    if (_freeText.isNotEmpty) {
+      q += ' |= "$_freeText"';
+    }
+    return q;
+  }
+
+  void _swapMode(LogQueryMode next) {
+    if (next == _mode) return;
+    setState(() {
+      if (next == LogQueryMode.logql) {
+        // Seed the raw textarea with the current built query so the
+        // operator can edit it directly instead of starting from a
+        // blank prompt.
+        _rawLogql = _buildQuery();
+        _rawCtrl.text = _rawLogql;
+      } else {
+        // Going back to search drops the raw edits; the structured
+        // form fields stay intact so the operator's prior filters
+        // are right where they left them.
+        _rawLogql = '';
+        _rawCtrl.text = '';
+      }
+      _mode = next;
+    });
+  }
+
+  bool get _runEnabled {
+    // While a prior submission is still in flight, gate further taps
+    // so the operator can't stack concurrent queries with a fast double
+    // tap on slow networks.
+    if (widget.inFlight) return false;
+    // Non-admin without a namespace can't submit — backend hard-403s
+    // and the UX is clearer with a disabled button than a
+    // post-submit error card.
+    if (!_isAdmin && (_namespace == null || _namespace!.isEmpty)) {
+      return false;
+    }
+    // LogQL mode requires non-empty query text.
+    if (_mode == LogQueryMode.logql && _rawLogql.trim().isEmpty) {
+      return false;
+    }
+    return true;
+  }
+
+  void _onRunPressed() {
+    if (!_runEnabled) return;
+    widget.onSubmit(LogSearchParams(
+      namespace: _namespace,
+      query: _buildQuery(),
+      range: _range,
+    ));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: colors.bgSurface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colors.borderSubtle),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: TimeRangePicker(
+                  initial: _range,
+                  onChanged: (r) => setState(() => _range = r),
+                ),
+              ),
+              const SizedBox(width: 8),
+              _ModeToggle(
+                mode: _mode,
+                onChanged: _swapMode,
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          if (_mode == LogQueryMode.search) ...[
+            _NamespaceDropdown(
+              namespaces: _namespaces,
+              value: _namespace,
+              loading: _loadingNamespaces,
+              isAdmin: _isAdmin,
+              onChanged: (v) {
+                setState(() {
+                  _namespace = v;
+                  _pod = null;
+                  _container = null;
+                });
+                _fetchPods();
+              },
+            ),
+            const SizedBox(height: 8),
+            _PodDropdown(
+              pods: _pods,
+              value: _pod,
+              loading: _loadingPods,
+              enabled: _namespace != null && _namespace!.isNotEmpty,
+              onChanged: (v) {
+                setState(() {
+                  _pod = v;
+                  _container = null;
+                });
+                _fetchContainers();
+              },
+            ),
+            const SizedBox(height: 8),
+            _ContainerDropdown(
+              containers: _containers,
+              value: _container,
+              loading: _loadingContainers,
+              enabled: _pod != null && _pod!.isNotEmpty,
+              onChanged: (v) => setState(() => _container = v),
+            ),
+            const SizedBox(height: 12),
+            _SeverityChips(
+              value: _severity,
+              onChanged: (v) => setState(() => _severity = v),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _freeTextCtrl,
+              key: const ValueKey('logFilter-freeText'),
+              decoration: InputDecoration(
+                labelText: 'Contains',
+                hintText: 'e.g. timeout',
+                border: const OutlineInputBorder(),
+                isDense: true,
+                fillColor: colors.bgElevated,
+                filled: true,
+              ),
+              onChanged: (v) => setState(() => _freeText = v),
+              onSubmitted: (_) => _onRunPressed(),
+            ),
+          ] else ...[
+            // LogQL mode — single multiline textarea. Submit on Run
+            // button only (no Enter shortcut since LogQL queries
+            // legitimately span lines).
+            TextField(
+              controller: _rawCtrl,
+              key: const ValueKey('logFilter-rawLogql'),
+              maxLines: 4,
+              minLines: 2,
+              decoration: InputDecoration(
+                labelText: 'LogQL',
+                hintText:
+                    '{namespace="app",pod=~"web-.*"} |= "error" | json',
+                border: const OutlineInputBorder(),
+                fillColor: colors.bgElevated,
+                filled: true,
+              ),
+              style: const TextStyle(fontFamily: 'monospace', fontSize: 13),
+              onChanged: (v) => setState(() => _rawLogql = v),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Max ${kLokiMaxQueryChars.toString()} characters · '
+              '${_rawLogql.length} used',
+              style: TextStyle(color: colors.textMuted, fontSize: 11),
+            ),
+          ],
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              if (!_isAdmin &&
+                  (_namespace == null || _namespace!.isEmpty)) ...[
+                Icon(Icons.info_outline, size: 14, color: colors.warning),
+                const SizedBox(width: 4),
+                Expanded(
+                  child: Text(
+                    'Pick a namespace to run a log query.',
+                    style: TextStyle(color: colors.warning, fontSize: 12),
+                  ),
+                ),
+              ] else
+                const Spacer(),
+              FilledButton.icon(
+                key: const ValueKey('logFilter-runButton'),
+                onPressed: _runEnabled ? _onRunPressed : null,
+                icon: const Icon(Icons.search, size: 18),
+                label: const Text('Run'),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Private subwidgets — kept inline so the filter-bar layout is readable
+// without jumping between files.
+// ---------------------------------------------------------------------------
+
+class _ModeToggle extends StatelessWidget {
+  const _ModeToggle({required this.mode, required this.onChanged});
+
+  final LogQueryMode mode;
+  final ValueChanged<LogQueryMode> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return SegmentedButton<LogQueryMode>(
+      segments: const [
+        ButtonSegment(value: LogQueryMode.search, label: Text('Search')),
+        ButtonSegment(value: LogQueryMode.logql, label: Text('LogQL')),
+      ],
+      selected: {mode},
+      onSelectionChanged: (s) => onChanged(s.first),
+      showSelectedIcon: false,
+      style: const ButtonStyle(
+        visualDensity: VisualDensity.compact,
+        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+      ),
+    );
+  }
+}
+
+class _NamespaceDropdown extends StatelessWidget {
+  const _NamespaceDropdown({
+    required this.namespaces,
+    required this.value,
+    required this.loading,
+    required this.isAdmin,
+    required this.onChanged,
+  });
+
+  final List<String> namespaces;
+  final String? value;
+  final bool loading;
+  final bool isAdmin;
+  final ValueChanged<String?> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    // Build the items set — guards against the initial-namespace seed
+    // (e.g. from a deep link) not being in the label-values response
+    // yet, which would otherwise crash DropdownButtonFormField.
+    final items = <String>{
+      ...namespaces,
+      if (value != null && value!.isNotEmpty) value!,
+    }.toList()
+      ..sort();
+    return DropdownButtonFormField<String?>(
+      key: const ValueKey('logFilter-namespace'),
+      initialValue: value,
+      isExpanded: true,
+      decoration: InputDecoration(
+        labelText: 'Namespace${isAdmin ? '' : ' *'}',
+        helperText: loading ? 'Loading…' : null,
+        border: const OutlineInputBorder(),
+        isDense: true,
+      ),
+      hint: Text(isAdmin ? 'All namespaces' : 'Pick a namespace'),
+      items: [
+        if (isAdmin)
+          const DropdownMenuItem<String?>(
+            value: null,
+            child: Text('All namespaces'),
+          ),
+        for (final ns in items)
+          DropdownMenuItem<String?>(value: ns, child: Text(ns)),
+      ],
+      onChanged: onChanged,
+    );
+  }
+}
+
+class _PodDropdown extends StatelessWidget {
+  const _PodDropdown({
+    required this.pods,
+    required this.value,
+    required this.loading,
+    required this.enabled,
+    required this.onChanged,
+  });
+
+  final List<String> pods;
+  final String? value;
+  final bool loading;
+  final bool enabled;
+  final ValueChanged<String?> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final items = <String>{
+      ...pods,
+      if (value != null && value!.isNotEmpty) value!,
+    }.toList()
+      ..sort();
+    return DropdownButtonFormField<String?>(
+      key: const ValueKey('logFilter-pod'),
+      initialValue: value,
+      isExpanded: true,
+      decoration: InputDecoration(
+        labelText: 'Pod (optional)',
+        helperText: loading
+            ? 'Loading…'
+            : (!enabled ? 'Pick a namespace first' : null),
+        border: const OutlineInputBorder(),
+        isDense: true,
+      ),
+      hint: const Text('All pods'),
+      items: [
+        const DropdownMenuItem<String?>(value: null, child: Text('All pods')),
+        for (final p in items)
+          DropdownMenuItem<String?>(value: p, child: Text(p)),
+      ],
+      onChanged: enabled ? onChanged : null,
+    );
+  }
+}
+
+class _ContainerDropdown extends StatelessWidget {
+  const _ContainerDropdown({
+    required this.containers,
+    required this.value,
+    required this.loading,
+    required this.enabled,
+    required this.onChanged,
+  });
+
+  final List<String> containers;
+  final String? value;
+  final bool loading;
+  final bool enabled;
+  final ValueChanged<String?> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final items = <String>{
+      ...containers,
+      if (value != null && value!.isNotEmpty) value!,
+    }.toList()
+      ..sort();
+    return DropdownButtonFormField<String?>(
+      key: const ValueKey('logFilter-container'),
+      initialValue: value,
+      isExpanded: true,
+      decoration: InputDecoration(
+        labelText: 'Container (optional)',
+        helperText:
+            loading ? 'Loading…' : (!enabled ? 'Pick a pod first' : null),
+        border: const OutlineInputBorder(),
+        isDense: true,
+      ),
+      hint: const Text('All containers'),
+      items: [
+        const DropdownMenuItem<String?>(
+            value: null, child: Text('All containers')),
+        for (final c in items)
+          DropdownMenuItem<String?>(value: c, child: Text(c)),
+      ],
+      onChanged: enabled ? onChanged : null,
+    );
+  }
+}
+
+class _SeverityChips extends StatelessWidget {
+  const _SeverityChips({required this.value, required this.onChanged});
+
+  final LogSeverity? value;
+  final ValueChanged<LogSeverity?> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return Wrap(
+      spacing: 6,
+      children: [
+        FilterChip(
+          key: const ValueKey('logFilter-severity-any'),
+          label: const Text('Any'),
+          selected: value == null,
+          onSelected: (_) => onChanged(null),
+        ),
+        for (final s in LogSeverity.values)
+          FilterChip(
+            key: ValueKey('logFilter-severity-${s.value}'),
+            label: Text(s.label),
+            selected: value == s,
+            selectedColor: _severityTone(colors, s).withAlpha(48),
+            onSelected: (_) => onChanged(value == s ? null : s),
+          ),
+      ],
+    );
+  }
+
+  Color _severityTone(KubeColors colors, LogSeverity s) {
+    return switch (s) {
+      LogSeverity.error => colors.error,
+      LogSeverity.warn => colors.warning,
+      LogSeverity.info => colors.accent,
+      LogSeverity.debug => colors.textMuted,
+    };
+  }
+}

--- a/mobile/lib/features/observability/logs/log_results_list.dart
+++ b/mobile/lib/features/observability/logs/log_results_list.dart
@@ -1,0 +1,270 @@
+// Virtual-scroll log results list. Renders LogQueryResult.lines as a
+// monospace stream with severity color hints + long-press-to-copy.
+//
+// 5000-line cap surfaces as a banner so the operator knows to narrow
+// the query rather than scrolling endlessly. Severity detection mirrors
+// `frontend/islands/LogResults.tsx`'s `parseSeverity` so the same line
+// gets the same color on web and mobile.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:intl/intl.dart';
+
+import '../../../api/loki_repository.dart';
+import '../../../theme/kube_theme_builder.dart';
+
+enum _LineSeverity { error, warn, info, debug }
+
+class LogResultsList extends StatelessWidget {
+  const LogResultsList({
+    required this.result,
+    super.key,
+  });
+
+  final LogQueryResult result;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    if (result.isEmpty) {
+      return Container(
+        padding: const EdgeInsets.all(24),
+        decoration: BoxDecoration(
+          color: colors.bgSurface,
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(color: colors.borderSubtle),
+        ),
+        child: Center(
+          child: Text(
+            'No log lines for this query.',
+            style: TextStyle(color: colors.textMuted, fontSize: 13),
+          ),
+        ),
+      );
+    }
+    return Container(
+      decoration: BoxDecoration(
+        color: colors.bgSurface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colors.borderSubtle),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          if (result.truncated)
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+              color: colors.warningDim,
+              child: Row(
+                children: [
+                  Icon(Icons.info_outline, size: 14, color: colors.warning),
+                  const SizedBox(width: 6),
+                  Expanded(
+                    child: Text(
+                      'Showing 5000 of (truncated) results. Refine the '
+                      'query for the full set.',
+                      style: TextStyle(color: colors.warning, fontSize: 12),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          // Virtual scroll. ListView.builder materializes only visible
+          // rows so a 5000-line response stays under one frame's worth
+          // of work on phone-class GPUs. SizedBox (not
+          // ConstrainedBox + shrinkWrap) is critical: shrinkWrap forces
+          // a full layout pass over every child at first paint, which
+          // negates virtualization for the 5000-line case.
+          SizedBox(
+            height: 600,
+            child: ListView.builder(
+              itemCount: result.lines.length,
+              itemBuilder: (context, i) => _LogLineRow(
+                line: result.lines[i],
+                colors: colors,
+              ),
+            ),
+          ),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+            decoration: BoxDecoration(
+              color: colors.bgElevated,
+              border: Border(top: BorderSide(color: colors.borderSubtle)),
+            ),
+            child: Text(
+              '${result.lines.length} lines · '
+              '${result.streamCount} streams',
+              style: TextStyle(color: colors.textMuted, fontSize: 11),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _LogLineRow extends StatelessWidget {
+  const _LogLineRow({required this.line, required this.colors});
+
+  final LogLine line;
+  final KubeColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    final severity = _parseSeverity(line.line);
+    final tone = _severityColor(severity);
+    final bg = severity == _LineSeverity.error
+        ? colors.errorDim.withAlpha(40)
+        : Colors.transparent;
+    final pod = line.labels['pod'];
+
+    return GestureDetector(
+      onLongPress: () async {
+        await Clipboard.setData(ClipboardData(text: line.line));
+        if (!context.mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Line copied'),
+            duration: Duration(seconds: 1),
+          ),
+        );
+      },
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 2),
+        decoration: BoxDecoration(
+          color: bg,
+          border: Border(bottom: BorderSide(color: colors.borderSubtle)),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SizedBox(
+              width: 86,
+              child: Text(
+                _formatTimestamp(line.timestamp),
+                style: TextStyle(
+                  fontFamily: 'monospace',
+                  fontSize: 10,
+                  color: colors.textMuted,
+                ),
+              ),
+            ),
+            SizedBox(
+              width: 48,
+              child: Text(
+                _severityLabel(severity),
+                style: TextStyle(
+                  fontFamily: 'monospace',
+                  fontSize: 10,
+                  fontWeight: FontWeight.w600,
+                  color: tone,
+                ),
+              ),
+            ),
+            if (pod != null && pod.isNotEmpty)
+              SizedBox(
+                width: 110,
+                child: Text(
+                  pod.length > 18 ? '${pod.substring(0, 18)}…' : pod,
+                  style: TextStyle(
+                    fontFamily: 'monospace',
+                    fontSize: 10,
+                    color: colors.info,
+                  ),
+                ),
+              ),
+            Expanded(
+              child: SelectableText(
+                line.line,
+                style: TextStyle(
+                  fontFamily: 'monospace',
+                  fontSize: 11,
+                  color: colors.textPrimary,
+                  height: 1.3,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Color _severityColor(_LineSeverity s) {
+    return switch (s) {
+      _LineSeverity.error => colors.error,
+      _LineSeverity.warn => colors.warning,
+      _LineSeverity.info => colors.accent,
+      _LineSeverity.debug => colors.textMuted,
+    };
+  }
+
+  String _severityLabel(_LineSeverity s) {
+    return switch (s) {
+      _LineSeverity.error => 'ERROR',
+      _LineSeverity.warn => 'WARN',
+      _LineSeverity.info => 'INFO',
+      _LineSeverity.debug => 'DEBUG',
+    };
+  }
+}
+
+/// Severity heuristic. Mirrors web's `parseSeverity` so the same line
+/// gets the same tone on both surfaces. Inexpensive — only inspects
+/// the prefix of the line rather than the full body.
+_LineSeverity _parseSeverity(String line) {
+  final lower = line.toLowerCase();
+  // Use the full lowercased line for substring checks (matches web
+  // parity for the `level=` / `"level":"X"` JSON / logfmt forms);
+  // restrict the word-boundary scan to the 100-char prefix to keep
+  // the per-row cost bounded on long lines.
+  final prefixLower = lower.length > 100 ? lower.substring(0, 100) : lower;
+
+  if (lower.contains('"level":"error"') ||
+      lower.contains('level=error') ||
+      _wordMatch(prefixLower, 'error')) {
+    return _LineSeverity.error;
+  }
+  if (lower.contains('"level":"warn"') ||
+      lower.contains('level=warn') ||
+      _wordMatch(prefixLower, 'warn') ||
+      _wordMatch(prefixLower, 'warning')) {
+    return _LineSeverity.warn;
+  }
+  if (lower.contains('"level":"debug"') ||
+      lower.contains('level=debug') ||
+      _wordMatch(prefixLower, 'debug')) {
+    return _LineSeverity.debug;
+  }
+  return _LineSeverity.info;
+}
+
+/// Whole-word match. Caller passes pre-lowercased text so the hot
+/// per-row render path doesn't allocate a second lowercased copy.
+/// RegExp would work but creating one per line per render burns
+/// allocations on a long results list; inline scan is cheaper.
+bool _wordMatch(String lower, String word) {
+  var i = lower.indexOf(word);
+  while (i >= 0) {
+    final beforeOk = i == 0 || !_isWordChar(lower.codeUnitAt(i - 1));
+    final afterIdx = i + word.length;
+    final afterOk =
+        afterIdx >= lower.length || !_isWordChar(lower.codeUnitAt(afterIdx));
+    if (beforeOk && afterOk) return true;
+    i = lower.indexOf(word, i + 1);
+  }
+  return false;
+}
+
+bool _isWordChar(int code) {
+  return (code >= 48 && code <= 57) ||
+      (code >= 65 && code <= 90) ||
+      (code >= 97 && code <= 122) ||
+      code == 95;
+}
+
+final DateFormat _tsFormat = DateFormat('HH:mm:ss.SSS');
+
+String _formatTimestamp(DateTime t) {
+  return _tsFormat.format(t.toLocal());
+}

--- a/mobile/lib/features/observability/logs/log_search_controller.dart
+++ b/mobile/lib/features/observability/logs/log_search_controller.dart
@@ -1,0 +1,364 @@
+// Controller behind the LogQL editor screen. Owns the submitted query
+// + range + result + volume buckets; the LogFilterBar manages its own
+// form state and emits a parameter bundle on Run.
+//
+// Race protection comes from the `RefreshableController` mixin —
+//   * supersede() rotates the CancelToken + bumps the dispatch id on
+//     every submit so a fast-tapping operator's prior in-flight fetch
+//     can't write over a fresh result.
+//   * Cluster pin is re-checked at result arrival (postEmission). The
+//     wire request itself was already pinned via `X-Cluster-ID`, so a
+//     post-emission mismatch surfaces the "request landed on pinned
+//     cluster" copy rather than silently writing a different cluster's
+//     log lines under the active cluster's screen.
+//   * isDisposed gates every post-await state write.
+//
+// Query + volume run in parallel (Future.wait). Volume is best-effort —
+// a 5xx surfaces as a hidden volume panel rather than a whole-screen
+// error, mirroring the web's "non-critical" handling in LogExplorer.
+
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../api/api_error.dart';
+import '../../../api/loki_repository.dart';
+import '../../../cluster/cluster_provider.dart';
+import '../../../widgets/refreshable_controller.dart';
+import '../../../widgets/time_range_picker.dart';
+
+/// Editor mode. `search` builds the LogQL string from cascading
+/// dropdowns + free-text contains; `logql` passes the operator's raw
+/// text through verbatim.
+enum LogQueryMode { search, logql }
+
+/// Snapshot of the submitted query's primary result.
+sealed class LogQueryStatus {
+  const LogQueryStatus();
+}
+
+/// Initial state before any query has run. The results panel renders
+/// a "Run a query to see results" prompt; the volume histogram stays
+/// hidden.
+class LogQueryIdle extends LogQueryStatus {
+  const LogQueryIdle();
+}
+
+class LogQueryLoading extends LogQueryStatus {
+  const LogQueryLoading();
+}
+
+class LogQueryLoaded extends LogQueryStatus {
+  const LogQueryLoaded(this.result);
+  final LogQueryResult result;
+}
+
+class LogQueryFailed extends LogQueryStatus {
+  const LogQueryFailed(this.message);
+  final String message;
+}
+
+/// Snapshot of the volume histogram fetch. Hidden when [LogVolumeHidden]
+/// — either because no query has run yet, the volume fetch returned an
+/// error (best-effort surface), or the response was empty.
+sealed class LogVolumeStatus {
+  const LogVolumeStatus();
+}
+
+class LogVolumeHidden extends LogVolumeStatus {
+  const LogVolumeHidden();
+}
+
+class LogVolumeLoading extends LogVolumeStatus {
+  const LogVolumeLoading();
+}
+
+class LogVolumeLoaded extends LogVolumeStatus {
+  const LogVolumeLoaded(this.result);
+  final LogVolumeResult result;
+}
+
+/// Bundled query parameters emitted by the filter bar on Run. Mirrors
+/// the backend's `/v1/logs/query` query-param surface — the controller
+/// passes these straight through.
+class LogSearchParams {
+  const LogSearchParams({
+    required this.namespace,
+    required this.query,
+    required this.range,
+    this.limit = 1000,
+    this.direction = 'backward',
+  });
+
+  final String? namespace;
+  final String query;
+  final TimeRange range;
+  final int limit;
+  final String direction;
+}
+
+/// State the screen consumes. Two AsyncValue-shaped fields (result +
+/// volume) because the two surfaces render independently — a volume
+/// 5xx mustn't blank the results panel.
+class LogSearchState {
+  const LogSearchState({
+    required this.params,
+    required this.result,
+    required this.volume,
+  });
+
+  /// Last submitted params. `null` before the first Run press, used
+  /// only for `refresh()`'s replay path.
+  final LogSearchParams? params;
+
+  final LogQueryStatus result;
+  final LogVolumeStatus volume;
+
+  LogSearchState copyWith({
+    LogSearchParams? params,
+    LogQueryStatus? result,
+    LogVolumeStatus? volume,
+  }) {
+    return LogSearchState(
+      params: params ?? this.params,
+      result: result ?? this.result,
+      volume: volume ?? this.volume,
+    );
+  }
+
+  static const initial = LogSearchState(
+    params: null,
+    result: LogQueryIdle(),
+    volume: LogVolumeHidden(),
+  );
+}
+
+/// Volume step allowlist. The backend's `loki.allowedSteps` rejects
+/// anything outside this set; the mobile picker walks the list to
+/// find the largest step that keeps the bucket count under the cap.
+const List<({String label, int seconds})> _kVolumeSteps = [
+  (label: '15s', seconds: 15),
+  (label: '30s', seconds: 30),
+  (label: '1m', seconds: 60),
+  (label: '5m', seconds: 300),
+  (label: '15m', seconds: 900),
+  (label: '30m', seconds: 1800),
+  (label: '1h', seconds: 3600),
+  (label: '6h', seconds: 21600),
+  (label: '1d', seconds: 86400),
+];
+
+/// Picks the **smallest** volume step that keeps the bucket count
+/// ≤ [maxBuckets] for the selected range — the densest histogram the
+/// cap allows. Walks [_kVolumeSteps] from smallest (15s) to largest
+/// (1d) and returns the first entry that fits.
+///
+/// When the range exceeds what 1d can fit under the cap (multi-month
+/// custom range), falls back to 1d rather than throwing — fl_chart
+/// and the phone GPU can handle a few hundred bars, and the bar count
+/// stays bounded.
+String chooseVolumeStep(int rangeSec, {int maxBuckets = 120}) {
+  for (final step in _kVolumeSteps) {
+    if ((rangeSec / step.seconds).ceil() <= maxBuckets) {
+      return step.label;
+    }
+  }
+  return _kVolumeSteps.last.label;
+}
+
+class LogSearchController
+    extends AutoDisposeFamilyNotifier<LogSearchState, String>
+    with RefreshableController {
+  late String _clusterId;
+
+  @override
+  String get pinnedClusterId => _clusterId;
+
+  @override
+  String currentActiveClusterId(Ref ref) => ref.read(activeClusterProvider);
+
+  @override
+  LogSearchState build(String arg) {
+    _clusterId = arg;
+    initRefreshable(ref);
+    return LogSearchState.initial;
+  }
+
+  /// Operator pressed Run on the filter bar. Cancels any in-flight
+  /// fetch via `supersede()`, marks both panels as loading, and fires
+  /// the query + volume requests in parallel.
+  Future<void> submit(LogSearchParams params) async {
+    if (isDisposed) return;
+
+    // Client-side gate so the operator sees an inline error before
+    // the request hits the wire. Backend enforces the same limit;
+    // this is a UX shortcut for the paste-a-huge-query case.
+    if (params.query.length > kLokiMaxQueryChars) {
+      state = state.copyWith(
+        params: params,
+        result: LogQueryFailed(
+          'Query exceeds $kLokiMaxQueryChars characters '
+          '(${params.query.length}). Shorten the matcher set or use '
+          'search mode to construct a more selective query.',
+        ),
+        volume: const LogVolumeHidden(),
+      );
+      return;
+    }
+
+    state = state.copyWith(
+      params: params,
+      result: const LogQueryLoading(),
+      volume: const LogVolumeLoading(),
+    );
+    supersede('new query submitted');
+    final captured = captureDispatchId();
+    await _runFetches(params, captured);
+  }
+
+  /// Re-fires the last submitted query. Used by pull-to-refresh and
+  /// the error-card retry button. No-op when no query has run yet.
+  Future<void> refresh() async {
+    if (isDisposed) return;
+    final last = state.params;
+    if (last == null) return;
+    await submit(last);
+  }
+
+  Future<void> _runFetches(LogSearchParams params, int captured) async {
+    final repo = ref.read(lokiRepositoryProvider);
+    final rangeSec =
+        params.range.end.difference(params.range.start).inSeconds.clamp(1, 90 * 24 * 3600);
+    final step = chooseVolumeStep(rangeSec);
+
+    // Run query + volume in parallel. Volume is best-effort — its
+    // failure mode falls back to a hidden panel rather than a whole-
+    // screen error.
+    await Future.wait([
+      _runQuery(params, captured, repo),
+      _runVolume(params, step, captured, repo),
+    ]);
+  }
+
+  Future<void> _runQuery(
+    LogSearchParams params,
+    int captured,
+    LokiRepository repo,
+  ) async {
+    try {
+      final result = await repo.query(
+        query: params.query,
+        start: params.range.start,
+        end: params.range.end,
+        namespace: params.namespace,
+        limit: params.limit,
+        direction: params.direction,
+        clusterIdOverride: _clusterId,
+        cancelToken: currentCancelToken,
+      );
+      if (!isFresh(captured)) return;
+      // Pin re-check at result arrival.
+      if (!clusterStillPinned(ref)) {
+        _writeResult(
+          LogQueryFailed(pinnedMismatchMessage(PinPhase.postEmission)),
+          captured,
+        );
+        return;
+      }
+      _writeResult(LogQueryLoaded(result), captured);
+    } on DioException catch (e) {
+      if (RefreshableController.isCancelException(e)) return;
+      final err = e.error;
+      final apiErr = err is ApiError ? err : ApiError.fromDio(e);
+      _writeResult(LogQueryFailed(_humanizeQuery(apiErr)), captured);
+    } on ArgumentError catch (e) {
+      _writeResult(
+        LogQueryFailed(e.message?.toString() ?? '$e'),
+        captured,
+      );
+    } on ApiError catch (e) {
+      _writeResult(LogQueryFailed(_humanizeQuery(e)), captured);
+    } catch (e) {
+      _writeResult(LogQueryFailed(e.toString()), captured);
+    }
+  }
+
+  Future<void> _runVolume(
+    LogSearchParams params,
+    String step,
+    int captured,
+    LokiRepository repo,
+  ) async {
+    try {
+      final result = await repo.volume(
+        query: params.query,
+        start: params.range.start,
+        end: params.range.end,
+        step: step,
+        namespace: params.namespace,
+        clusterIdOverride: _clusterId,
+        cancelToken: currentCancelToken,
+      );
+      if (!isFresh(captured)) return;
+      if (!clusterStillPinned(ref)) {
+        // Volume mismatch is informational — hide the panel rather
+        // than surfacing a duplicate cross-cluster banner alongside
+        // the results panel's mismatch message.
+        _writeVolume(const LogVolumeHidden(), captured);
+        return;
+      }
+      if (result.isEmpty) {
+        _writeVolume(const LogVolumeHidden(), captured);
+      } else {
+        _writeVolume(LogVolumeLoaded(result), captured);
+      }
+    } on DioException catch (e) {
+      if (RefreshableController.isCancelException(e)) return;
+      // Volume failure hides the panel — non-critical surface per web
+      // parity. The query panel is the operator's actual interest.
+      _writeVolume(const LogVolumeHidden(), captured);
+    } on ArgumentError {
+      _writeVolume(const LogVolumeHidden(), captured);
+    } catch (_) {
+      _writeVolume(const LogVolumeHidden(), captured);
+    }
+  }
+
+  void _writeResult(LogQueryStatus status, int captured) {
+    if (!isFresh(captured)) return;
+    state = state.copyWith(result: status);
+  }
+
+  void _writeVolume(LogVolumeStatus status, int captured) {
+    if (!isFresh(captured)) return;
+    state = state.copyWith(volume: status);
+  }
+
+  String _humanizeQuery(ApiError e) {
+    if (e.statusCode == 400) {
+      // Surface the backend's parse-error verbatim — operators
+      // composing LogQL want the original message, not a
+      // generic-rewording.
+      return e.message;
+    }
+    if (e.statusCode == 403) {
+      return 'Namespace required for log queries. Pick a namespace '
+          'or — for cluster-wide reads — open k8sCenter on a '
+          'desktop as an admin.';
+    }
+    if (e.statusCode == 502) {
+      return 'Loki query failed (${e.message}). Retry, or shorten '
+          'the time range.';
+    }
+    if (e.statusCode == 503) {
+      return 'Loki is not available on this cluster.';
+    }
+    return e.message;
+  }
+}
+
+final logSearchControllerProvider = AutoDisposeNotifierProvider.family<
+    LogSearchController, LogSearchState, String>(
+  LogSearchController.new,
+);

--- a/mobile/lib/features/observability/logs/log_search_screen.dart
+++ b/mobile/lib/features/observability/logs/log_search_screen.dart
@@ -1,0 +1,211 @@
+// Top-level LogQL editor screen. Composes the filter bar, volume
+// histogram, and virtual-scroll results list.
+//
+// Status gating routes through `lokiStatusProvider`. When the cluster
+// doesn't have Loki (`detected: false`), the screen renders
+// `FeatureUnavailableState.loki()` — the single-pod live tail under
+// /clusters/.../workloads/pods/.../logs/... still works as the
+// M1-shipped fallback.
+//
+// This surface is separate from the M1 pod log tail. The pod tail's
+// scope is "watch one container live"; this surface's scope is "ad-hoc
+// search across multiple pods in a namespace". The plan keeps both
+// rather than collapsing them so neither has to compromise on UX.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../api/loki_repository.dart';
+import '../../../cluster/cluster_provider.dart';
+import '../../../theme/kube_theme_builder.dart';
+import '../../../widgets/empty_states.dart';
+import '../../../widgets/feature_unavailable_state.dart';
+import 'log_filter_bar.dart';
+import 'log_results_list.dart';
+import 'log_search_controller.dart';
+import 'log_volume_histogram.dart';
+
+class LogSearchScreen extends ConsumerWidget {
+  const LogSearchScreen({
+    this.initialNamespace,
+    super.key,
+  });
+
+  /// Optional deep-link seed (e.g. notification → "view logs in ns X").
+  final String? initialNamespace;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final clusterId = ref.watch(activeClusterProvider);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Log search'),
+      ),
+      body: _LogSearchBody(
+        clusterId: clusterId,
+        initialNamespace: initialNamespace,
+      ),
+    );
+  }
+}
+
+class _LogSearchBody extends ConsumerWidget {
+  const _LogSearchBody({
+    required this.clusterId,
+    this.initialNamespace,
+  });
+
+  final String clusterId;
+  final String? initialNamespace;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final status = ref.watch(lokiStatusProvider(clusterId));
+    return status.when(
+      loading: () => const LoadingState(),
+      error: (e, _) => ErrorStateView(
+        message: 'Failed to query Loki status: $e',
+        onRetry: () => ref.invalidate(lokiStatusProvider(clusterId)),
+      ),
+      data: (s) {
+        if (!s.detected) {
+          return FeatureUnavailableState.loki();
+        }
+        return _LogSearchContent(
+          clusterId: clusterId,
+          initialNamespace: initialNamespace,
+        );
+      },
+    );
+  }
+}
+
+class _LogSearchContent extends ConsumerWidget {
+  const _LogSearchContent({
+    required this.clusterId,
+    this.initialNamespace,
+  });
+
+  final String clusterId;
+  final String? initialNamespace;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(logSearchControllerProvider(clusterId));
+    final notifier =
+        ref.read(logSearchControllerProvider(clusterId).notifier);
+
+    return RefreshIndicator(
+      onRefresh: notifier.refresh,
+      child: ListView(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+        children: [
+          LogFilterBar(
+            initialNamespace: initialNamespace,
+            onSubmit: notifier.submit,
+            inFlight: state.result is LogQueryLoading,
+          ),
+          const SizedBox(height: 12),
+          if (state.volume is LogVolumeLoaded) ...[
+            LogVolumeHistogram(
+              result: (state.volume as LogVolumeLoaded).result,
+            ),
+            const SizedBox(height: 12),
+          ] else if (state.volume is LogVolumeLoading)
+            const _VolumePlaceholder(),
+          _ResultPanel(
+            state: state,
+            onRetry: notifier.refresh,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _VolumePlaceholder extends StatelessWidget {
+  const _VolumePlaceholder();
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return Container(
+      margin: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 18),
+      decoration: BoxDecoration(
+        color: colors.bgSurface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colors.borderSubtle),
+      ),
+      child: Center(
+        child: SizedBox(
+          height: 24,
+          width: 24,
+          child: CircularProgressIndicator(
+            strokeWidth: 2,
+            color: colors.accent,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ResultPanel extends StatelessWidget {
+  const _ResultPanel({required this.state, required this.onRetry});
+
+  final LogSearchState state;
+  final Future<void> Function() onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return switch (state.result) {
+      LogQueryIdle() => const _IdlePanel(),
+      LogQueryLoading() => const SizedBox(
+          height: 120,
+          child: LoadingState(),
+        ),
+      LogQueryFailed(:final message) => ErrorStateView(
+          message: message,
+          onRetry: () => onRetry(),
+        ),
+      LogQueryLoaded(:final result) => LogResultsList(result: result),
+    };
+  }
+}
+
+class _IdlePanel extends StatelessWidget {
+  const _IdlePanel();
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
+      decoration: BoxDecoration(
+        color: colors.bgSurface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colors.borderSubtle),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.search, size: 40, color: colors.textMuted),
+          const SizedBox(height: 12),
+          Text(
+            'Pick a namespace and press Run to search logs.',
+            textAlign: TextAlign.center,
+            style: TextStyle(color: colors.textSecondary, fontSize: 14),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'Single-pod live tail is still available from the pod '
+            'detail screen.',
+            textAlign: TextAlign.center,
+            style: TextStyle(color: colors.textMuted, fontSize: 12),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/observability/logs/log_volume_histogram.dart
+++ b/mobile/lib/features/observability/logs/log_volume_histogram.dart
@@ -1,0 +1,68 @@
+// Log volume histogram. Wraps KubeBarChart over the LogVolumeResult
+// from /v1/logs/volume. Hidden when the volume fetch fails or returns
+// no buckets — best-effort surface; the operator's primary interest is
+// the results list below.
+
+import 'package:flutter/material.dart';
+
+import '../../../api/loki_repository.dart';
+import '../../../theme/kube_theme_builder.dart';
+import '../../../widgets/kube_bar_chart.dart';
+import '../../../widgets/kube_line_chart.dart' show KubeChartSeverity;
+
+class LogVolumeHistogram extends StatelessWidget {
+  const LogVolumeHistogram({
+    required this.result,
+    super.key,
+  });
+
+  final LogVolumeResult result;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    if (result.isEmpty) return const SizedBox.shrink();
+
+    final points = result.buckets
+        .map((b) => (t: b.timestamp, v: b.count.toDouble()))
+        .toList();
+    final series = (
+      label: 'lines',
+      points: points,
+      severity: KubeChartSeverity.info,
+    );
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: colors.bgSurface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colors.borderSubtle),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Text(
+                'Volume',
+                style: TextStyle(
+                  color: colors.textSecondary,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+              const Spacer(),
+              Text(
+                '${result.total.toString()} lines',
+                style: TextStyle(color: colors.textMuted, fontSize: 12),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          KubeBarChart(series: series, height: 80),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/routing/app_router.dart
+++ b/mobile/lib/routing/app_router.dart
@@ -14,6 +14,7 @@ import '../auth/auth_state.dart';
 import '../features/dashboard/dashboard_screen.dart';
 import '../features/login/login_screen.dart';
 import '../features/notifications_center/feed_screen.dart';
+import '../features/observability/logs/log_search_screen.dart';
 import '../features/observability/logs/log_tail_screen.dart';
 import '../notifications/deep_link_handler.dart';
 import '../notifications/fcm_registration.dart';
@@ -78,6 +79,20 @@ final appRouterProvider = Provider<GoRouter>((ref) {
           pod: state.pathParameters['name']!,
           container: state.pathParameters['container']!,
         ),
+      ),
+
+      // --- M4 PR-4c: top-level LogQL editor (multi-pod ad-hoc search).
+      // Separate from the M1 single-pod live tail above so neither
+      // surface has to compromise on UX. `?namespace=` query param
+      // seeds the filter bar for deep links from notifications.
+      GoRoute(
+        path: '/clusters/:clusterId/logs',
+        builder: (context, state) {
+          final ns = state.uri.queryParameters['namespace'];
+          return LogSearchScreen(
+            initialNamespace: ns == null || ns.isEmpty ? null : ns,
+          );
+        },
       ),
 
       // --- Resource list routes (PR-1d: 6 specialized kinds) ---

--- a/mobile/lib/routing/domain_sections.dart
+++ b/mobile/lib/routing/domain_sections.dart
@@ -11,6 +11,7 @@ class DomainKind {
     required this.label,
     required this.icon,
     this.namespaced = true,
+    this.customListPath,
   });
 
   /// URL path segment that maps to the backend's `kind` route param.
@@ -22,6 +23,16 @@ class DomainKind {
   /// to choose between `/clusters/<id>/<section>/<kind>/<ns>/<name>` and
   /// the cluster-scoped `/<kind>/<name>` shape.
   final bool namespaced;
+
+  /// Optional override for the drawer's list-route navigation. Use the
+  /// `{clusterId}` placeholder where the active cluster id should be
+  /// substituted at navigation time. Entries that aren't resource kinds
+  /// (Log search, Observability dashboards) use this so the section
+  /// loop in the drawer doesn't have to special-case them.
+  ///
+  /// Resource kinds leave this null and the drawer falls back to
+  /// `/clusters/<id>/<sectionPath>/<kind>`.
+  final String? customListPath;
 }
 
 class DomainSection {
@@ -134,7 +145,34 @@ const List<DomainSection> domainSections = [
       ),
     ],
   ),
+  // Observability surfaces — log search (PR-4c) and (future) policy /
+  // mesh / cert-manager dashboards. These aren't resource kinds (no
+  // /v1/resources/ endpoint backs them) so they wire through the
+  // customListPath escape hatch rather than the kind/namespace
+  // detail-route construction in `kindDetailPath`.
+  DomainSection(
+    label: 'Observability',
+    pathSegment: 'observability',
+    icon: Icons.insights_outlined,
+    kinds: [
+      DomainKind(
+        kind: 'logs',
+        label: 'Log search',
+        icon: Icons.text_snippet_outlined,
+        namespaced: false,
+        customListPath: '/clusters/{clusterId}/logs',
+      ),
+    ],
+  ),
 ];
+
+/// Substitutes `{clusterId}` (and any future placeholder) in a
+/// [DomainKind.customListPath] template against the active cluster id.
+/// Pulled out as a top-level so the drawer + any future deep-link
+/// builder share one helper.
+String resolveCustomListPath(String template, {required String clusterId}) {
+  return template.replaceAll('{clusterId}', clusterId);
+}
 
 /// Lookup the section that owns a given kind. Used by `kindDetailPath`
 /// so detail-route construction stays in one place rather than each

--- a/mobile/lib/widgets/domain_navigation_drawer.dart
+++ b/mobile/lib/widgets/domain_navigation_drawer.dart
@@ -90,9 +90,13 @@ class DomainNavigationDrawer extends ConsumerWidget {
                 dense: true,
                 onTap: () {
                   Navigator.of(context).pop();
-                  context.go(
-                    '/clusters/$clusterId/${section.pathSegment}/${kind.kind}',
-                  );
+                  final target = kind.customListPath != null
+                      ? resolveCustomListPath(
+                          kind.customListPath!,
+                          clusterId: clusterId,
+                        )
+                      : '/clusters/$clusterId/${section.pathSegment}/${kind.kind}';
+                  context.go(target);
                 },
               ),
           ],

--- a/mobile/test/api/loki_repository_test.dart
+++ b/mobile/test/api/loki_repository_test.dart
@@ -1,0 +1,451 @@
+// Tests for LokiRepository: status, query envelope parsing, volume
+// aggregation, label-values plumbing, namespace param injection,
+// 4096-char query gate, X-Cluster-ID threading.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kubecenter/api/api_error.dart';
+import 'package:kubecenter/api/dio_client.dart';
+import 'package:kubecenter/api/loki_repository.dart';
+import 'package:kubecenter/auth/secure_storage.dart';
+
+import '../support/mock_dio_adapter.dart';
+
+ResponseBody _json(Object body, {int status = 200}) {
+  return ResponseBody.fromBytes(
+    Uint8List.fromList(utf8.encode(jsonEncode(body))),
+    status,
+    headers: {
+      Headers.contentTypeHeader: ['application/json'],
+    },
+  );
+}
+
+({ProviderContainer container, MockDioAdapter mock}) _make() {
+  final mock = MockDioAdapter();
+  final container = ProviderContainer(
+    overrides: [
+      backendUrlProvider.overrideWithValue('http://test'),
+      secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+    ],
+  );
+  container.read(refreshDioProvider).httpClientAdapter = mock;
+  container.read(dioProvider).httpClientAdapter = mock;
+  return (container: container, mock: mock);
+}
+
+void main() {
+  group('LokiRepository.status', () {
+    test('detected: true with url + detectedVia', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/logs/status',
+        body: {
+          'data': {
+            'detected': true,
+            'url': 'http://loki-gateway.loki.svc:3100',
+            'detectedVia': 'service',
+          },
+        },
+      );
+
+      final s = await container.read(lokiRepositoryProvider).status();
+      expect(s.detected, isTrue);
+      expect(s.url, contains('loki-gateway'));
+      expect(s.detectedVia, 'service');
+    });
+
+    test('503 from status endpoint returns LokiStatus.empty', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.on(
+        'GET',
+        '/api/v1/logs/status',
+        (_) => _json({
+          'error': {'code': 503, 'message': 'Loki not configured'},
+        }, status: 503),
+      );
+
+      final s = await container.read(lokiRepositoryProvider).status();
+      expect(s.detected, isFalse);
+      expect(s.url, isNull);
+    });
+  });
+
+  group('LokiRepository.query', () {
+    test('parses streams into flattened LogLine list', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/logs/query',
+        body: {
+          'data': {
+            'data': {
+              'resultType': 'streams',
+              'result': [
+                {
+                  'stream': {'namespace': 'app', 'pod': 'web-abc', 'container': 'web'},
+                  'values': [
+                    ['1700000000000000000', 'first line'],
+                    ['1700000001000000000', 'second line'],
+                  ],
+                },
+                {
+                  'stream': {'namespace': 'app', 'pod': 'web-xyz', 'container': 'web'},
+                  'values': [
+                    ['1700000002000000000', 'third line'],
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      );
+
+      final result =
+          await container.read(lokiRepositoryProvider).query(
+                query: '{namespace="app"}',
+                start: DateTime.utc(2026, 5, 1),
+                end: DateTime.utc(2026, 5, 1, 1),
+                namespace: 'app',
+              );
+
+      expect(result.lines, hasLength(3));
+      expect(result.streamCount, 2);
+      expect(result.lines.first.line, 'first line');
+      expect(result.lines.first.labels['pod'], 'web-abc');
+      expect(result.isEmpty, isFalse);
+      expect(result.truncated, isFalse);
+    });
+
+    test('empty result list surfaces as isEmpty', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/logs/query',
+        body: {
+          'data': {
+            'data': {'resultType': 'streams', 'result': <Object>[]},
+          },
+        },
+      );
+
+      final result =
+          await container.read(lokiRepositoryProvider).query(
+                query: '{namespace="ghosts"}',
+                start: DateTime.utc(2026, 5, 1),
+                end: DateTime.utc(2026, 5, 1, 1),
+                namespace: 'ghosts',
+              );
+      expect(result.isEmpty, isTrue);
+      expect(result.streamCount, 0);
+    });
+
+    test('5000-line result flips truncated', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      // Cheaper to fabricate a synthetic 5000-line stream than to
+      // emit one Map per line. The parse path is value-iteration so
+      // a single stream with 5000 values exercises the cap branch.
+      final values = List.generate(
+        5000,
+        (i) => ['$i', 'line $i'],
+      );
+      mock.onJson(
+        'GET',
+        '/api/v1/logs/query',
+        body: {
+          'data': {
+            'data': {
+              'resultType': 'streams',
+              'result': [
+                {
+                  'stream': {'namespace': 'busy'},
+                  'values': values,
+                },
+              ],
+            },
+          },
+        },
+      );
+
+      final result =
+          await container.read(lokiRepositoryProvider).query(
+                query: '{namespace="busy"}',
+                start: DateTime.utc(2026, 5, 1),
+                end: DateTime.utc(2026, 5, 1, 1),
+                namespace: 'busy',
+              );
+      expect(result.lines, hasLength(5000));
+      expect(result.truncated, isTrue);
+    });
+
+    test('4096-char gate throws ArgumentError before request', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      final huge = '{${'x' * 5000}="y"}';
+      expect(
+        () => container.read(lokiRepositoryProvider).query(
+              query: huge,
+              start: DateTime.utc(2026, 5, 1),
+              end: DateTime.utc(2026, 5, 1, 1),
+              namespace: 'app',
+            ),
+        throwsA(isA<ArgumentError>()),
+      );
+      // No request should have hit the wire.
+      expect(mock.requests, isEmpty);
+    });
+
+    test('403 from backend (missing namespace, non-admin) surfaces as ApiError',
+        () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.on(
+        'GET',
+        '/api/v1/logs/query',
+        (_) => _json({
+          'error': {
+            'code': 403,
+            'message': 'namespace access denied',
+            'detail': 'namespace parameter required for non-admin users',
+          },
+        }, status: 403),
+      );
+
+      expect(
+        () => container.read(lokiRepositoryProvider).query(
+              query: '{job="kubelet"}',
+              start: DateTime.utc(2026, 5, 1),
+              end: DateTime.utc(2026, 5, 1, 1),
+            ),
+        throwsA(isA<ApiError>()
+            .having((e) => e.statusCode, 'statusCode', 403)),
+      );
+    });
+
+    test('400 from backend (invalid LogQL) surfaces ApiError verbatim',
+        () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.on(
+        'GET',
+        '/api/v1/logs/query',
+        (_) => _json({
+          'error': {
+            'code': 400,
+            'message': 'parse error: unexpected token',
+          },
+        }, status: 400),
+      );
+
+      try {
+        await container.read(lokiRepositoryProvider).query(
+              query: '{ this is not logql }',
+              start: DateTime.utc(2026, 5, 1),
+              end: DateTime.utc(2026, 5, 1, 1),
+              namespace: 'app',
+            );
+        fail('expected ApiError');
+      } on ApiError catch (e) {
+        expect(e.statusCode, 400);
+        expect(e.message, contains('parse error'));
+      }
+    });
+
+    test('namespace param is injected when provided', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson('GET', '/api/v1/logs/query', body: {
+        'data': {
+          'data': {'resultType': 'streams', 'result': <Object>[]},
+        },
+      });
+
+      await container.read(lokiRepositoryProvider).query(
+            query: '{namespace="app"}',
+            start: DateTime.utc(2026, 5, 1),
+            end: DateTime.utc(2026, 5, 1, 1),
+            namespace: 'app',
+          );
+
+      final req = mock.requests.single;
+      expect(req.queryParameters['namespace'], 'app');
+      expect(req.queryParameters['query'], '{namespace="app"}');
+      expect(req.queryParameters['direction'], 'backward');
+    });
+
+    test('clusterIdOverride forwards as explicit X-Cluster-ID header',
+        () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson('GET', '/api/v1/logs/query', body: {
+        'data': {
+          'data': {'resultType': 'streams', 'result': <Object>[]},
+        },
+      });
+
+      await container.read(lokiRepositoryProvider).query(
+            query: '{namespace="app"}',
+            start: DateTime.utc(2026, 5, 1),
+            end: DateTime.utc(2026, 5, 1, 1),
+            namespace: 'app',
+            clusterIdOverride: 'cluster-b',
+          );
+
+      expect(mock.requests.single.headers['X-Cluster-ID'], 'cluster-b');
+    });
+  });
+
+  group('LokiRepository.volume', () {
+    test('aggregates counts across entries into sorted buckets', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/logs/volume',
+        body: {
+          'data': {
+            'data': {
+              'resultType': 'matrix',
+              'result': [
+                {
+                  'metric': {'namespace': 'app'},
+                  'values': [
+                    [1700000000.0, '12'],
+                    [1700000060.0, '7'],
+                  ],
+                },
+                {
+                  'metric': {'namespace': 'kube-system'},
+                  'values': [
+                    [1700000000.0, '4'],
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      );
+
+      final result = await container.read(lokiRepositoryProvider).volume(
+            query: '{namespace=~"app|kube-system"}',
+            start: DateTime.utc(2026, 5, 1),
+            end: DateTime.utc(2026, 5, 1, 1),
+            step: '1m',
+            namespace: 'app',
+          );
+
+      expect(result.buckets, hasLength(2));
+      // First bucket = 12 + 4 (timestamps coalesce across entries).
+      expect(result.buckets.first.count, 16);
+      expect(result.buckets[1].count, 7);
+      // Timestamps come out sorted ascending.
+      expect(
+        result.buckets.first.timestamp
+            .isBefore(result.buckets[1].timestamp),
+        isTrue,
+      );
+      expect(result.total, 23);
+    });
+
+    test('4096-char gate also covers volume requests', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      expect(
+        () => container.read(lokiRepositoryProvider).volume(
+              query: '{${'x' * 5000}="y"}',
+              start: DateTime.utc(2026, 5, 1),
+              end: DateTime.utc(2026, 5, 1, 1),
+              step: '1m',
+              namespace: 'app',
+            ),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(mock.requests, isEmpty);
+    });
+  });
+
+  group('LokiRepository.labelValues', () {
+    test('returns label values list from /labels/{name}/values', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/logs/labels/namespace/values',
+        body: {
+          'data': ['app', 'kube-system', 'monitoring'],
+        },
+      );
+
+      final values =
+          await container.read(lokiRepositoryProvider).labelValues(
+                name: 'namespace',
+              );
+      expect(values, ['app', 'kube-system', 'monitoring']);
+    });
+
+    test('threads namespace + scopeQuery as request params', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/logs/labels/pod/values',
+        body: {'data': <String>[]},
+      );
+
+      await container.read(lokiRepositoryProvider).labelValues(
+            name: 'pod',
+            namespace: 'app',
+            scopeQuery: '{namespace="app"}',
+          );
+
+      final req = mock.requests.single;
+      expect(req.queryParameters['namespace'], 'app');
+      expect(req.queryParameters['query'], '{namespace="app"}');
+    });
+
+    test('403 on label values degrades to empty list (graceful UX)',
+        () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.on(
+        'GET',
+        '/api/v1/logs/labels/pod/values',
+        (_) => _json({
+          'error': {'code': 403, 'message': 'namespace access denied'},
+        }, status: 403),
+      );
+
+      final values = await container.read(lokiRepositoryProvider).labelValues(
+            name: 'pod',
+          );
+      // Empty rather than throwing — the dropdown stays operational
+      // and the operator can type a value manually.
+      expect(values, isEmpty);
+    });
+  });
+}

--- a/mobile/test/features/observability/logs/log_filter_bar_test.dart
+++ b/mobile/test/features/observability/logs/log_filter_bar_test.dart
@@ -1,0 +1,258 @@
+// LogFilterBar widget tests — query construction, mode swap, cascade
+// dropdowns, admin-gated namespace requirement.
+
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kubecenter/api/dio_client.dart';
+import 'package:kubecenter/auth/auth_repository.dart';
+import 'package:kubecenter/auth/auth_state.dart';
+import 'package:kubecenter/auth/secure_storage.dart';
+import 'package:kubecenter/auth/user.dart';
+import 'package:kubecenter/features/observability/logs/log_filter_bar.dart';
+import 'package:kubecenter/features/observability/logs/log_search_controller.dart';
+import 'package:kubecenter/theme/kube_theme_builder.dart' show buildKubeTheme;
+
+import '../../../support/mock_dio_adapter.dart';
+
+/// Minimal stub auth controller that resolves to an authenticated user
+/// with the chosen role. Avoids spinning up the real /v1/auth/me flow
+/// for filter-bar widget tests.
+class _StubAuthController extends AuthRepository {
+  _StubAuthController(this._initial);
+  final AuthState _initial;
+  @override
+  AuthState build() => _initial;
+}
+
+AuthState _stubAuth({required bool admin}) {
+  return AuthAuthenticated(
+    user: UserInfo(
+      id: 'u-1',
+      username: admin ? 'root' : 'alice',
+      provider: 'local',
+      roles: admin ? const ['admin'] : const ['operator'],
+    ),
+    rbac: const RBACSummary(),
+  );
+}
+
+Future<LogFilterBarHarness> _pump(
+  WidgetTester tester, {
+  required MockDioAdapter mock,
+  required bool admin,
+}) async {
+  final submitted = <LogSearchParams>[];
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        backendUrlProvider.overrideWithValue('http://test'),
+        secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+        dioProvider.overrideWith((ref) {
+          final dio = Dio(BaseOptions(baseUrl: 'http://test'));
+          dio.httpClientAdapter = mock;
+          return dio;
+        }),
+        refreshDioProvider.overrideWith((ref) {
+          final dio = Dio(BaseOptions(baseUrl: 'http://test'));
+          dio.httpClientAdapter = mock;
+          return dio;
+        }),
+        authRepositoryProvider.overrideWith(
+          () => _StubAuthController(_stubAuth(admin: admin)),
+        ),
+      ],
+      child: MaterialApp(
+        theme: buildKubeTheme('nexus'),
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: LogFilterBar(onSubmit: submitted.add),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 50));
+  return LogFilterBarHarness(tester: tester, submitted: submitted);
+}
+
+class LogFilterBarHarness {
+  LogFilterBarHarness({required this.tester, required this.submitted});
+  final WidgetTester tester;
+  final List<LogSearchParams> submitted;
+}
+
+void main() {
+  group('LogFilterBar.runEnabled', () {
+    testWidgets('non-admin without namespace → Run is disabled',
+        (tester) async {
+      final mock = MockDioAdapter();
+      // Namespace label values come back empty so the dropdown
+      // stays unset.
+      mock.onJson(
+        'GET',
+        '/api/v1/logs/labels/namespace/values',
+        body: {'data': <String>[]},
+      );
+
+      final h = await _pump(tester, mock: mock, admin: false);
+      final runButton = find.byKey(const ValueKey('logFilter-runButton'));
+      // The Run FilledButton renders as disabled when onPressed is
+      // null — Flutter exposes this through the underlying button
+      // state, not as a `disabled` field.
+      final pressedFn = (tester.widget(runButton) as FilledButton).onPressed;
+      expect(pressedFn, isNull);
+      // And the hint text is visible.
+      expect(find.textContaining('Pick a namespace to run'), findsOneWidget);
+      // Sanity: nothing submitted.
+      await tester.tap(runButton, warnIfMissed: false);
+      await tester.pump();
+      expect(h.submitted, isEmpty);
+    });
+
+    testWidgets('admin without namespace → Run is enabled (cluster-wide)',
+        (tester) async {
+      final mock = MockDioAdapter();
+      mock.onJson(
+        'GET',
+        '/api/v1/logs/labels/namespace/values',
+        body: {'data': <String>[]},
+      );
+      // Admin can submit a cluster-wide query. The backend lets this
+      // through; the test confirms the client mirrors the policy.
+      mock.onJson('GET', '/api/v1/logs/query', body: {
+        'data': {
+          'data': {'resultType': 'streams', 'result': <Object>[]},
+        },
+      });
+
+      await _pump(tester, mock: mock, admin: true);
+      final runButton = find.byKey(const ValueKey('logFilter-runButton'));
+      final pressedFn = (tester.widget(runButton) as FilledButton).onPressed;
+      expect(pressedFn, isNotNull);
+      expect(find.textContaining('Pick a namespace to run'), findsNothing);
+    });
+  });
+
+  group('LogFilterBar.search-mode query construction', () {
+    testWidgets('namespace + pod prefix + container + severity + contains',
+        (tester) async {
+      final mock = MockDioAdapter();
+      // Namespace values returned so the dropdown is non-empty.
+      mock.onJson(
+        'GET',
+        '/api/v1/logs/labels/namespace/values',
+        body: {'data': ['app']},
+      );
+      mock.onJson(
+        'GET',
+        '/api/v1/logs/labels/pod/values',
+        body: {'data': ['web-abc']},
+      );
+      mock.onJson(
+        'GET',
+        '/api/v1/logs/labels/container/values',
+        body: {'data': ['web']},
+      );
+
+      final h = await _pump(tester, mock: mock, admin: false);
+
+      // Pick namespace='app'.
+      await tester.tap(find.byKey(const ValueKey('logFilter-namespace')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('app').last);
+      await tester.pumpAndSettle();
+      // Pod cascade resolves.
+      await tester.pump(const Duration(milliseconds: 50));
+
+      // Pick pod='web-abc' (selectable now).
+      await tester.tap(find.byKey(const ValueKey('logFilter-pod')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('web-abc').last);
+      await tester.pumpAndSettle();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      // Pick container='web'.
+      await tester.tap(find.byKey(const ValueKey('logFilter-container')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('web').last);
+      await tester.pumpAndSettle();
+
+      // Pick severity = Error.
+      await tester.tap(find.byKey(const ValueKey('logFilter-severity-error')));
+      await tester.pumpAndSettle();
+
+      // Type free-text.
+      await tester.enterText(
+        find.byKey(const ValueKey('logFilter-freeText')),
+        'timeout',
+      );
+      await tester.pumpAndSettle();
+
+      // Run.
+      await tester.tap(find.byKey(const ValueKey('logFilter-runButton')));
+      await tester.pumpAndSettle();
+
+      expect(h.submitted, hasLength(1));
+      final p = h.submitted.single;
+      expect(p.namespace, 'app');
+      expect(
+        p.query,
+        '{namespace="app",pod=~"web-abc.*",container="web"} '
+        '| level=~"(?i)error" |= "timeout"',
+      );
+    });
+
+    testWidgets('only namespace set → query is `{namespace="X"}`',
+        (tester) async {
+      final mock = MockDioAdapter();
+      mock.onJson('GET', '/api/v1/logs/labels/namespace/values',
+          body: {'data': ['app']});
+      mock.onJson('GET', '/api/v1/logs/labels/pod/values',
+          body: {'data': <String>[]});
+
+      final h2 = await _pump(tester, mock: mock, admin: false);
+      await tester.tap(find.byKey(const ValueKey('logFilter-namespace')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('app').last);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('logFilter-runButton')));
+      await tester.pumpAndSettle();
+
+      expect(h2.submitted.single.query, '{namespace="app"}');
+    });
+  });
+
+  group('LogFilterBar.mode swap', () {
+    testWidgets('search → LogQL seeds raw textarea with built query',
+        (tester) async {
+      final mock = MockDioAdapter();
+      mock.onJson('GET', '/api/v1/logs/labels/namespace/values',
+          body: {'data': ['app']});
+      mock.onJson('GET', '/api/v1/logs/labels/pod/values',
+          body: {'data': <String>[]});
+
+      await _pump(tester, mock: mock, admin: false);
+      // Configure namespace=app + severity=warn.
+      await tester.tap(find.byKey(const ValueKey('logFilter-namespace')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('app').last);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('logFilter-severity-warn')));
+      await tester.pumpAndSettle();
+
+      // Swap to LogQL.
+      await tester.tap(find.text('LogQL'));
+      await tester.pumpAndSettle();
+
+      // Raw textarea is seeded with the built query.
+      final raw = tester.widget<TextField>(
+        find.byKey(const ValueKey('logFilter-rawLogql')),
+      );
+      expect(raw.controller!.text,
+          '{namespace="app"} | level=~"(?i)warn"');
+    });
+  });
+}

--- a/mobile/test/features/observability/logs/log_results_list_test.dart
+++ b/mobile/test/features/observability/logs/log_results_list_test.dart
@@ -1,0 +1,151 @@
+// Widget tests for LogResultsList — verifies severity tinting matches
+// web parity (parseSeverity heuristic), truncation banner, and the
+// empty-state branch.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kubecenter/api/loki_repository.dart';
+import 'package:kubecenter/features/observability/logs/log_results_list.dart';
+import 'package:kubecenter/theme/kube_theme_builder.dart' show buildKubeTheme;
+
+LogLine _ln(String text, {Map<String, String> labels = const {}, int ts = 0}) {
+  return LogLine(timestampNanos: ts, line: text, labels: labels);
+}
+
+Future<void> _pump(WidgetTester tester, LogQueryResult result) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      theme: buildKubeTheme('nexus'),
+      home: Scaffold(
+        body: SingleChildScrollView(
+          child: LogResultsList(result: result),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+void main() {
+  group('LogResultsList severity tinting', () {
+    testWidgets('JSON level=error tints ERROR', (tester) async {
+      await _pump(
+        tester,
+        LogQueryResult(
+          lines: [_ln('{"level":"error","msg":"boom"}', ts: 1)],
+          streamCount: 1,
+        ),
+      );
+      expect(find.text('ERROR'), findsOneWidget);
+    });
+
+    testWidgets('logfmt level=warn tints WARN', (tester) async {
+      await _pump(
+        tester,
+        LogQueryResult(
+          lines: [_ln('ts=2026-05-01 level=warn caller=foo msg="slow"', ts: 2)],
+          streamCount: 1,
+        ),
+      );
+      expect(find.text('WARN'), findsOneWidget);
+    });
+
+    testWidgets('plain-prefix whole-word ERROR tints ERROR', (tester) async {
+      await _pump(
+        tester,
+        LogQueryResult(
+          lines: [_ln('ERROR: connection refused', ts: 3)],
+          streamCount: 1,
+        ),
+      );
+      expect(find.text('ERROR'), findsOneWidget);
+    });
+
+    testWidgets('embedded "xerrorx" must NOT match (whole-word boundary)',
+        (tester) async {
+      // Whole-word logic skips substring matches; xerrorx should fall
+      // through to INFO. Without _isWordChar guarding, this would
+      // falsely color as ERROR and silently mis-tint operational lines
+      // with names like "xerrorxformatter".
+      await _pump(
+        tester,
+        LogQueryResult(
+          lines: [_ln('msg=xerrorxhandler initialized', ts: 4)],
+          streamCount: 1,
+        ),
+      );
+      expect(find.text('ERROR'), findsNothing);
+      expect(find.text('INFO'), findsOneWidget);
+    });
+
+    testWidgets('plain "debug" word tints DEBUG', (tester) async {
+      await _pump(
+        tester,
+        LogQueryResult(
+          lines: [_ln('debug: scheduled tick', ts: 5)],
+          streamCount: 1,
+        ),
+      );
+      expect(find.text('DEBUG'), findsOneWidget);
+    });
+
+    testWidgets('line with no severity keywords defaults to INFO',
+        (tester) async {
+      await _pump(
+        tester,
+        LogQueryResult(
+          lines: [_ln('Started replica on port 9090', ts: 6)],
+          streamCount: 1,
+        ),
+      );
+      expect(find.text('INFO'), findsOneWidget);
+    });
+
+    testWidgets('JSON "level":"error" past column 100 still matches',
+        (tester) async {
+      // Web's parseSeverity scans the FULL line for the JSON / logfmt
+      // level fields; only the word-boundary scan is prefix-bounded.
+      // Mobile must mirror this so a long correlation-ID prefix
+      // doesn't accidentally drop the severity color.
+      final padding = 'x' * 150;
+      await _pump(
+        tester,
+        LogQueryResult(
+          lines: [_ln('$padding "level":"error"', ts: 7)],
+          streamCount: 1,
+        ),
+      );
+      expect(find.text('ERROR'), findsOneWidget);
+    });
+  });
+
+  group('LogResultsList layout states', () {
+    testWidgets('empty result renders "no log lines" message',
+        (tester) async {
+      await _pump(
+        tester,
+        const LogQueryResult(lines: [], streamCount: 0),
+      );
+      expect(find.text('No log lines for this query.'), findsOneWidget);
+    });
+
+    testWidgets('5000-line result shows truncation banner', (tester) async {
+      final lines = List.generate(
+        5000,
+        (i) => _ln('line $i', ts: i),
+      );
+      await _pump(tester, LogQueryResult(lines: lines, streamCount: 1));
+      // The exact banner text uses "5000 of (truncated) results".
+      expect(
+        find.textContaining('5000 of'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('non-truncated result shows footer count', (tester) async {
+      final lines = [_ln('only line', ts: 1)];
+      await _pump(tester, LogQueryResult(lines: lines, streamCount: 1));
+      expect(find.text('1 lines · 1 streams'), findsOneWidget);
+    });
+  });
+}

--- a/mobile/test/features/observability/logs/log_search_controller_test.dart
+++ b/mobile/test/features/observability/logs/log_search_controller_test.dart
@@ -1,0 +1,438 @@
+// Tests for LogSearchController — happy path, 403 namespace missing,
+// 400 backend tokenizer reject, 4096-char client gate, volume best-
+// effort error fallthrough, cluster-pin postEmission, race protection.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kubecenter/api/dio_client.dart';
+import 'package:kubecenter/auth/secure_storage.dart';
+import 'package:kubecenter/cluster/cluster_provider.dart';
+import 'package:kubecenter/features/observability/logs/log_search_controller.dart';
+import 'package:kubecenter/widgets/time_range_picker.dart';
+
+import '../../../support/mock_dio_adapter.dart';
+
+ResponseBody _json(Object body, {int status = 200}) {
+  return ResponseBody.fromBytes(
+    Uint8List.fromList(utf8.encode(jsonEncode(body))),
+    status,
+    headers: {
+      Headers.contentTypeHeader: ['application/json'],
+    },
+  );
+}
+
+ResponseBody _streams(List<Map<String, dynamic>> streams) {
+  return _json({
+    'data': {
+      'data': {
+        'resultType': 'streams',
+        'result': streams,
+      },
+    },
+  });
+}
+
+({ProviderContainer container, MockDioAdapter mock}) _make({
+  String activeClusterId = 'local',
+}) {
+  final mock = MockDioAdapter();
+  final container = ProviderContainer(
+    overrides: [
+      backendUrlProvider.overrideWithValue('http://test'),
+      secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+    ],
+  );
+  container.read(refreshDioProvider).httpClientAdapter = mock;
+  container.read(dioProvider).httpClientAdapter = mock;
+  container.read(activeClusterProvider.notifier).setCluster(activeClusterId);
+  return (container: container, mock: mock);
+}
+
+Future<void> _pumpAsync(ProviderContainer container) async {
+  await pumpEventQueue(times: 30);
+}
+
+LogSearchParams _params({
+  String? namespace = 'app',
+  String query = '{namespace="app"}',
+  TimePreset preset = TimePreset.last1h,
+}) {
+  return LogSearchParams(
+    namespace: namespace,
+    query: query,
+    range: timeRangeFromPreset(preset),
+  );
+}
+
+void main() {
+  group('LogSearchController', () {
+    test('initial state is idle (no panels visible)', () {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      final state = container.read(logSearchControllerProvider('local'));
+      expect(state.result, isA<LogQueryIdle>());
+      expect(state.volume, isA<LogVolumeHidden>());
+      expect(state.params, isNull);
+      // No requests fire until submit is called.
+      expect(mock.requests, isEmpty);
+    });
+
+    test('happy path: submit fires query + volume in parallel', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson('GET', '/api/v1/logs/query', body: {
+        'data': {
+          'data': {
+            'resultType': 'streams',
+            'result': [
+              {
+                'stream': {'namespace': 'app', 'pod': 'web', 'container': 'web'},
+                'values': [
+                  ['1700000000000000000', 'hello world'],
+                ],
+              },
+            ],
+          },
+        },
+      });
+      mock.onJson('GET', '/api/v1/logs/volume', body: {
+        'data': {
+          'data': {
+            'resultType': 'matrix',
+            'result': [
+              {
+                'metric': {'namespace': 'app'},
+                'values': [
+                  [1700000000.0, '1'],
+                ],
+              },
+            ],
+          },
+        },
+      });
+
+      final sub = container.listen(
+        logSearchControllerProvider('local'),
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+      await container
+          .read(logSearchControllerProvider('local').notifier)
+          .submit(_params());
+      await _pumpAsync(container);
+
+      final s = sub.read();
+      expect(s.result, isA<LogQueryLoaded>());
+      expect((s.result as LogQueryLoaded).result.lines, hasLength(1));
+      expect(s.volume, isA<LogVolumeLoaded>());
+    });
+
+    test('4096-char gate marks result as failed without firing requests',
+        () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      final sub = container.listen(
+        logSearchControllerProvider('local'),
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+
+      final huge = '{${'x' * 5000}="y"}';
+      await container
+          .read(logSearchControllerProvider('local').notifier)
+          .submit(_params(query: huge));
+      await _pumpAsync(container);
+
+      final s = sub.read();
+      expect(s.result, isA<LogQueryFailed>());
+      expect(
+        (s.result as LogQueryFailed).message,
+        contains('exceeds'),
+      );
+      // No HTTP calls — the gate fires before submit issues the
+      // first request.
+      expect(mock.requests, isEmpty);
+    });
+
+    test('403 missing-namespace surfaces operator-facing copy', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.on(
+        'GET',
+        '/api/v1/logs/query',
+        (_) => _json({
+          'error': {
+            'code': 403,
+            'message': 'namespace access denied',
+            'detail': 'namespace parameter required for non-admin users',
+          },
+        }, status: 403),
+      );
+      // Volume mirrors the same error path.
+      mock.on(
+        'GET',
+        '/api/v1/logs/volume',
+        (_) => _json({
+          'error': {'code': 403, 'message': 'namespace access denied'},
+        }, status: 403),
+      );
+
+      final sub = container.listen(
+        logSearchControllerProvider('local'),
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+
+      await container
+          .read(logSearchControllerProvider('local').notifier)
+          .submit(_params(namespace: null, query: '{job="kubelet"}'));
+      await _pumpAsync(container);
+
+      final s = sub.read();
+      expect(s.result, isA<LogQueryFailed>());
+      expect(
+        (s.result as LogQueryFailed).message,
+        contains('Namespace required'),
+      );
+      // Volume failure hides the panel rather than surfacing a
+      // duplicate banner.
+      expect(s.volume, isA<LogVolumeHidden>());
+    });
+
+    test('400 backend tokenizer reject surfaces verbatim', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.on(
+        'GET',
+        '/api/v1/logs/query',
+        (_) => _json({
+          'error': {
+            'code': 400,
+            'message': 'parse error: unexpected token at position 5',
+          },
+        }, status: 400),
+      );
+      mock.on(
+        'GET',
+        '/api/v1/logs/volume',
+        (_) => _json({
+          'error': {'code': 400, 'message': 'parse error'},
+        }, status: 400),
+      );
+
+      final sub = container.listen(
+        logSearchControllerProvider('local'),
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+
+      await container
+          .read(logSearchControllerProvider('local').notifier)
+          .submit(_params(query: '{this is not logql}'));
+      await _pumpAsync(container);
+
+      final s = sub.read();
+      expect(s.result, isA<LogQueryFailed>());
+      // Verbatim backend message — operators composing LogQL need
+      // the original error to fix the query.
+      expect(
+        (s.result as LogQueryFailed).message,
+        contains('parse error: unexpected token at position 5'),
+      );
+    });
+
+    test('volume 5xx hides panel without failing the results panel',
+        () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson('GET', '/api/v1/logs/query', body: {
+        'data': {
+          'data': {'resultType': 'streams', 'result': <Object>[]},
+        },
+      });
+      mock.on(
+        'GET',
+        '/api/v1/logs/volume',
+        (_) => _json({
+          'error': {'code': 502, 'message': 'volume backend timeout'},
+        }, status: 502),
+      );
+
+      final sub = container.listen(
+        logSearchControllerProvider('local'),
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+
+      await container
+          .read(logSearchControllerProvider('local').notifier)
+          .submit(_params());
+      await _pumpAsync(container);
+
+      final s = sub.read();
+      // Results panel succeeds (with an empty result set).
+      expect(s.result, isA<LogQueryLoaded>());
+      expect((s.result as LogQueryLoaded).result.isEmpty, isTrue);
+      // Volume panel is hidden — best-effort surface.
+      expect(s.volume, isA<LogVolumeHidden>());
+    });
+
+    test('cluster-pin postEmission mismatch routes result to LogQueryFailed',
+        () async {
+      final (:container, :mock) = _make(activeClusterId: 'cluster-a');
+      addTearDown(container.dispose);
+
+      mock.on('GET', '/api/v1/logs/query', (_) {
+        container
+            .read(activeClusterProvider.notifier)
+            .setCluster('cluster-b');
+        return _streams(const []);
+      });
+      mock.onJson('GET', '/api/v1/logs/volume', body: {
+        'data': {
+          'data': {'resultType': 'matrix', 'result': <Object>[]},
+        },
+      });
+
+      // Persistent subscription so the autoDispose family doesn't
+      // tear the controller down between submit() and the post-pump
+      // read — without this, the await rebuilds the provider and
+      // wipes the failure state.
+      final sub = container.listen(
+        logSearchControllerProvider('cluster-a'),
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+
+      await container
+          .read(logSearchControllerProvider('cluster-a').notifier)
+          .submit(_params());
+      await _pumpAsync(container);
+
+      final s = sub.read();
+      expect(s.result, isA<LogQueryFailed>());
+      final msg = (s.result as LogQueryFailed).message;
+      expect(msg, contains('Cluster changed'));
+      expect(msg, contains('cluster-a'));
+    });
+
+    test('refresh() replays the last submitted params', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      // First submission fails with 502; refresh replays and succeeds.
+      mock.on(
+        'GET',
+        '/api/v1/logs/query',
+        (_) => _json({
+          'error': {'code': 502, 'message': 'Loki upstream timeout'},
+        }, status: 502),
+      );
+      mock.on(
+        'GET',
+        '/api/v1/logs/volume',
+        (_) => _json({
+          'error': {'code': 502, 'message': 'volume backend timeout'},
+        }, status: 502),
+      );
+      // Second batch (after refresh) returns success.
+      mock.on('GET', '/api/v1/logs/query', (_) => _streams([
+            {
+              'stream': {'namespace': 'app'},
+              'values': [
+                ['1700000000000000000', 'recovered'],
+              ],
+            },
+          ]));
+      mock.onJson('GET', '/api/v1/logs/volume', body: {
+        'data': {
+          'data': {'resultType': 'matrix', 'result': <Object>[]},
+        },
+      });
+
+      final sub = container.listen(
+        logSearchControllerProvider('local'),
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+
+      final notifier =
+          container.read(logSearchControllerProvider('local').notifier);
+      await notifier.submit(_params());
+      await _pumpAsync(container);
+      expect(sub.read().result, isA<LogQueryFailed>());
+
+      await notifier.refresh();
+      await _pumpAsync(container);
+      final s = sub.read();
+      expect(s.result, isA<LogQueryLoaded>());
+      expect((s.result as LogQueryLoaded).result.lines.first.line,
+          'recovered');
+    });
+
+    test('refresh() before any submit is a no-op', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      await container
+          .read(logSearchControllerProvider('local').notifier)
+          .refresh();
+      await _pumpAsync(container);
+      // No requests; state stays Idle.
+      expect(mock.requests, isEmpty);
+      expect(
+        container.read(logSearchControllerProvider('local')).result,
+        isA<LogQueryIdle>(),
+      );
+    });
+  });
+
+  group('chooseVolumeStep', () {
+    test('1h range picks 30s (densest step within cap)', () {
+      // 3600 / 30 = 120 buckets, exactly at the 120 cap. Picker
+      // returns the smallest step that fits so the histogram is as
+      // dense as the cap allows.
+      expect(chooseVolumeStep(3600), '30s');
+    });
+
+    test('24h range picks 15m', () {
+      // 86400 / 900 = 96 buckets, under cap.
+      expect(chooseVolumeStep(86400), '15m');
+    });
+
+    test('7d range picks 6h', () {
+      // 604800 / 3600 = 168 buckets > 120; falls to 6h (28 buckets).
+      // The step picker walks the allowlist looking for the first
+      // step that fits, so the answer is the smallest valid step.
+      expect(chooseVolumeStep(604800), '6h');
+    });
+
+    test('30d range picks 6h (still within cap)', () {
+      // 2592000 / 21600 = 120 buckets, exactly at cap. 1d would
+      // suffice too but 6h gives more resolution.
+      expect(chooseVolumeStep(30 * 86400), '6h');
+    });
+
+    test('range too wide to fit in 6h falls back to 1d cap', () {
+      // 200 days × 86400s. 1d step → 200 buckets, over cap, but the
+      // picker falls through to the last entry rather than throwing.
+      expect(chooseVolumeStep(200 * 86400), '1d');
+    });
+
+    test('short 15m range uses 15s', () {
+      // 900 / 15 = 60 buckets.
+      expect(chooseVolumeStep(900), '15s');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Ships PR-4c of the [Mobile M4 sequence](plans/mobile-app-m4-pr-sequence.md#u3-pr-4c--logql-editor--label-browser-lokirepository) — a top-level multi-pod LogQL search surface, separate from the M1 single-pod live tail. Operators tap **Observability → Log search**, pick a namespace (mandatory for non-admin), optionally narrow by pod / container / severity / free-text contains, then run either a structured search-mode query or raw LogQL. Results render as a virtual-scroll monospace list with severity coloring; a volume histogram visualizes line counts over the selected time range.

Implements requirements **R2** (LogQL editor + label browser), **R10** (web/Dart isomorphism), **R11** (cluster pinning), and **R12** (read-only posture) from the M4 plan. No new backend — every endpoint already exists from web phases 7–14.

## What lands

- **`LokiRepository`** wrapping `GET /v1/logs/{status,query,labels,labels/{name}/values,volume}` with `clusterIdOverride` threading, 4096-char client gate matching backend `loki.maxQueryLen`, and graceful 403/5xx degradation on label lookups.
- **`LogSearchController`** extending `AutoDisposeFamilyNotifier` with the `RefreshableController` mixin — `supersede()` rotates the CancelToken and bumps `dispatchId` on every submit, cluster-pin re-checked at result arrival (`PinPhase.postEmission`), volume runs in parallel as a best-effort surface (5xx hides the panel rather than failing the screen).
- **`LogFilterBar`** with cascading namespace → pod → container dropdowns, severity filter chips, mode toggle (search / LogQL), and time-range picker. Builds the LogQL string on submit, mirroring web's `frontend/islands/LogFilterBar.tsx` exactly.
- **`LogResultsList`** virtual-scroll with severity-tinted rows, 5000-line truncation banner, long-press-to-copy, web-parity `parseSeverity`.
- **`LogVolumeHistogram`** wrapping `KubeBarChart` with auto-selected step from the backend allowlist (`15s/30s/1m/5m/15m/30m/1h/6h/1d`) targeting ≤120 buckets per range.
- **`LogSearchScreen`** status-gated via `lokiStatusProvider` — `FeatureUnavailableState.loki()` when Loki isn't detected; pull-to-refresh wiring on the screen body.
- New **`/clusters/:clusterId/logs`** route with optional `?namespace=` seed for deep-link from notifications.
- **Observability drawer section** + new `customListPath` escape hatch on `DomainKind` so non-resource surfaces (future policy/mesh dashboards) can wire their own top-level routes without contorting the resource-kind catalog.

## Code review

Ran `/ce:review mode:autofix plan:plans/mobile-app-m4-pr-sequence.md` (Tier 2, 10 reviewers in parallel). **9 safe_auto fixes applied:**

| # | Severity | File | Fix |
|---|----------|------|-----|
| 1 | P1 | log_results_list.dart | `shrinkWrap:true` on 5000-row ListView defeated virtualization → replaced with `SizedBox(height: 600)` |
| 2 | P2 | loki_repository.dart | `labelValues()` had no `receiveTimeout` → added 15s cap so dropdowns can't hang forever |
| 3 | P2 | loki_repository.dart | `lokiStatusProvider` try/catch was a no-op rethrow → returns `LokiStatus.empty` on cancel so cluster switch doesn't flash an error card |
| 4 | P2 | log_filter_bar.dart | `_fetch*` left loading flag stuck on non-graceful errors → wrapped in try/finally |
| 5 | P3 | log_filter_bar.dart | Cascading label fetches lacked race protection → capture-and-compare args before applying setState |
| 6 | P3 | log_filter_bar.dart | Run button stayed enabled during fetch → new `inFlight` prop wired from `LogQueryLoading` |
| 7 | P3 | log_filter_bar.dart | `_isAdmin` used `ref.read` → switched to `ref.watch` for mid-session auth changes |
| 8 | P3 | log_results_list.dart | `_parseSeverity` re-lowercased prefix per row + scope diverged from web parity → passes pre-lowercased prefix, scans full lowercased line for JSON/logfmt level fields |
| 9 | P3 | log_search_controller.dart | `chooseVolumeStep` docstring inverted return semantics → corrected |

Verified clean: cluster-pin race protection, `_buildQuery` isomorphism, `_unwrapLokiEnvelope` envelope handling, `LogVolumeResult` aggregation, `Future.wait` airtightness, backend trust boundary (`EnforceNamespaces`, `maxQueryLen`, `allowedSteps`), X-Cluster-ID threading on every Loki call, no hardcoded color literals, read-only posture preserved, agent-native parity (7/7 capabilities reachable via existing endpoints).

## Test plan

- [x] `cd mobile && flutter analyze` clean
- [x] `cd mobile && flutter test` — **553/553 passing** (40 new tests for PR-4c across LokiRepository, LogSearchController, LogFilterBar, LogResultsList)
- [x] `make check-themes` in sync
- [ ] Smoke against homelab with Loki installed: open Observability → Log search, run `error` lines in `kube-system` over 6h, verify result count + volume histogram align with `kubectl logs` spot-check
- [ ] Smoke: confirm `FeatureUnavailableState.loki()` renders on a cluster without Loki
- [ ] Smoke: confirm Run button disables during in-flight query (rapid double-tap)
- [ ] Smoke: confirm cluster switch mid-query routes to the pinned-cluster message rather than silently writing wrong-cluster results

## Known Residuals (deferred — manual follow-up)

| Severity | File | Issue |
|----------|------|-------|
| P2 | log_search_screen.dart | `lokiStatusProvider` invalidation mid-search collapses the subtree and wipes the form + in-flight query. Fix would lift form state out of autoDispose; defer to M5 polish. |
| P3 | log_filter_bar.dart | Empty namespace list after Loki labels 5xx-then-empty creates dead-end for non-admin (no recovery affordance distinguishes "no namespaces" from "still loading"). |
| P3 | log_filter_bar.dart | `logql→search` mode swap silently drops raw textarea edits per plan ("by design"). Could add a confirmation snackbar; deferred per plan note. |
| P3 | loki_repository.dart | 4096-char gate uses UTF-16 code units (Dart `String.length`); backend uses UTF-8 bytes. Multibyte LogQL passes client, fails server — marginal since LogQL is overwhelmingly ASCII. |
| P1 | log_results_list.dart + log_filter_bar.dart | Two parallel severity enums (`_LineSeverity`, `LogSeverity`) with overlapping KubeColors mapping. Worth a shared resolver helper; modest refactor deferred to keep PR-4c scope tight. |

## Post-Deploy Monitoring & Validation

Mobile-only change; no backend impact. The screen consumes existing `/v1/logs/*` endpoints unchanged. Monitor:

- **Backend Loki query rate** (Prometheus: `rate(http_requests_total{handler=~"/api/v1/logs/.*"}[5m])`) — sanity-check that mobile traffic doesn't generate runaway query bursts. The `inFlight` Run gate caps per-user submission rate to one-in-flight, but if an operator rapidly switches namespaces, the cascade triggers up to 2 label-value RTTs per change.
- **`backend/internal/loki/handler.go` warn logs** (`loki query failed`, `loki label values query failed`) — expected to surface on transient Loki blips; mobile degrades gracefully via the empty-list pattern.
- **TestFlight / Play Internal crash-free rate** for the next 72h on the mobile builds containing this change — virtual-scroll regressions would surface as OOM crashes on devices submitting 5000-line queries.

**Validation window:** 72h after first deploy. **Owner:** mobile platform.

**Failure signals & rollback:** If mobile users report stuck "Loading…" dropdowns or unresponsive Run buttons on slow networks, revert this PR — the fix-set landed multiple cascade/race protections at once; bisecting the regression would be faster from a clean revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)