### PR TITLE
feat(mobile): M4 PR-4f — service mesh (dashboard + routing + mTLS + golden signals)

### DIFF
--- a/mobile/lib/api/mesh_repository.dart
+++ b/mobile/lib/api/mesh_repository.dart
@@ -1,0 +1,958 @@
+// Mobile-side wrapper over the backend service mesh API
+// (`/v1/mesh/{status,routing,routing/{id},policies,mtls,golden-signals}`).
+// Wire types mirror `backend/internal/servicemesh/types.go` exactly.
+// Web parallel: `frontend/islands/Mesh*.tsx` + `frontend/lib/mesh-types.ts`.
+//
+// Read surfaces only — verb actions are not part of mesh and there are no
+// writes here. cert-manager wizards landed in PR-3e; mesh has no wizards.
+//
+// Composite ID:
+//   The backend emits each routing / policy resource as
+//   `{mesh}:{namespace}:{kindCode}:{name}` (URL-encoded). Mobile uses
+//   [MeshRouteId] / [PolicyId equivalent] from `util/composite_id.dart`
+//   for parse/encode but stores the raw string on the wire so opaque
+//   round-trips never re-encode.
+//
+// Cluster pinning: every call accepts `clusterIdOverride` and forwards
+// it as an explicit `X-Cluster-ID` header. The PR-3c interceptor
+// invariant (`only injects header when absent`) is the live contract.
+//
+// Backend partial-failure pattern:
+//   `RoutingResponse.errors` and `PoliciesResponse.errors` carry a
+//   per-CRD failure map alongside successful results. The detail
+//   screens surface these as inline banners — they are NOT fatal.
+//   Cf. PR-3f's `_PartialFetchWarning` carry-over.
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../cluster/cluster_provider.dart';
+import 'api_error.dart';
+import 'dio_client.dart';
+
+/// Per-engine availability flags from `/v1/mesh/status`. Mirrors
+/// `backend/internal/servicemesh/types.go::MeshInfo` exactly.
+class MeshInfo {
+  const MeshInfo({
+    required this.installed,
+    this.namespace,
+    this.version,
+    this.mode,
+  });
+
+  final bool installed;
+
+  /// Control-plane namespace (e.g. `istio-system`, `linkerd`). Empty for
+  /// non-admin users — backend redacts before serialising.
+  final String? namespace;
+  final String? version;
+
+  /// Istio-only: "sidecar" or "ambient". Empty for Linkerd.
+  final String? mode;
+
+  factory MeshInfo.fromJson(Map<String, dynamic> json) {
+    String? s(Object? v) => v is String && v.isNotEmpty ? v : null;
+    return MeshInfo(
+      installed: json['installed'] as bool? ?? false,
+      namespace: s(json['namespace']),
+      version: s(json['version']),
+      mode: s(json['mode']),
+    );
+  }
+
+  static const empty = MeshInfo(installed: false);
+}
+
+/// Decoded `/v1/mesh/status` response. `detected` is one of `""`,
+/// `"istio"`, `"linkerd"`, `"both"`. `isInstalled` is the gate for
+/// `FeatureUnavailableState.mesh()`.
+class MeshStatus {
+  const MeshStatus({
+    required this.detected,
+    required this.istio,
+    required this.linkerd,
+    this.lastChecked,
+  });
+
+  /// `""` when neither mesh is detected.
+  final String detected;
+  final MeshInfo istio;
+  final MeshInfo linkerd;
+  final String? lastChecked;
+
+  bool get isInstalled => detected.isNotEmpty;
+  bool get hasIstio => detected == 'istio' || detected == 'both';
+  bool get hasLinkerd => detected == 'linkerd' || detected == 'both';
+  bool get hasBoth => detected == 'both';
+
+  factory MeshStatus.fromJson(Map<String, dynamic> json) {
+    final istio = json['istio'];
+    final linkerd = json['linkerd'];
+    return MeshStatus(
+      detected: json['detected'] as String? ?? '',
+      istio: istio is Map
+          ? MeshInfo.fromJson(Map<String, dynamic>.from(istio))
+          : MeshInfo.empty,
+      linkerd: linkerd is Map
+          ? MeshInfo.fromJson(Map<String, dynamic>.from(linkerd))
+          : MeshInfo.empty,
+      lastChecked: json['lastChecked'] as String?,
+    );
+  }
+
+  static const empty = MeshStatus(
+    detected: '',
+    istio: MeshInfo.empty,
+    linkerd: MeshInfo.empty,
+  );
+}
+
+/// One HTTP match rule on a routing CRD (Istio VirtualService /
+/// Linkerd HTTPRoute / etc.). Backend tag names mirrored exactly.
+class RouteMatcher {
+  const RouteMatcher({
+    this.name,
+    this.method,
+    this.pathExact,
+    this.pathPrefix,
+    this.pathRegex,
+  });
+
+  final String? name;
+  final String? method;
+  final String? pathExact;
+  final String? pathPrefix;
+  final String? pathRegex;
+
+  factory RouteMatcher.fromJson(Map<String, dynamic> json) {
+    String? s(Object? v) => v is String && v.isNotEmpty ? v : null;
+    return RouteMatcher(
+      name: s(json['name']),
+      method: s(json['method']),
+      pathExact: s(json['pathExact']),
+      pathPrefix: s(json['pathPrefix']),
+      pathRegex: s(json['pathRegex']),
+    );
+  }
+}
+
+/// One destination in a route's traffic split.
+class RouteDestination {
+  const RouteDestination({
+    this.host,
+    this.subset,
+    this.port,
+    this.weight,
+  });
+
+  final String? host;
+  final String? subset;
+  final int? port;
+  final int? weight;
+
+  factory RouteDestination.fromJson(Map<String, dynamic> json) {
+    String? s(Object? v) => v is String && v.isNotEmpty ? v : null;
+    int? n(Object? v) => (v as num?)?.toInt();
+    return RouteDestination(
+      host: s(json['host']),
+      subset: s(json['subset']),
+      port: n(json['port']),
+      weight: n(json['weight']),
+    );
+  }
+}
+
+/// One row on the routing list / one detail response.
+/// `raw` is the full unstructured spec from the CRD — used for the
+/// YAML sub-panel on the detail screen.
+class TrafficRoute {
+  const TrafficRoute({
+    required this.id,
+    required this.mesh,
+    required this.kind,
+    required this.name,
+    this.namespace = '',
+    this.hosts = const <String>[],
+    this.gateways = const <String>[],
+    this.subsets = const <String>[],
+    this.selector,
+    this.matchers = const <RouteMatcher>[],
+    this.destinations = const <RouteDestination>[],
+    this.raw,
+  });
+
+  /// Backend-issued composite id, `mesh:namespace:kindCode:name`,
+  /// URL-encoded. Round-trips through [MeshRouteId.tryParse].
+  final String id;
+
+  /// `"istio"` or `"linkerd"`. Display-only — branch tab visibility
+  /// on the id prefix, not this field.
+  final String mesh;
+
+  /// Canonical CRD kind (`VirtualService`, `DestinationRule`,
+  /// `ServiceProfile`, `HTTPRoute`, etc.).
+  final String kind;
+
+  final String name;
+  final String namespace;
+
+  final List<String> hosts;
+  final List<String> gateways;
+  final List<String> subsets;
+
+  /// Stringified `matchLabels` for Server-like resources. Empty for
+  /// VirtualService / HTTPRoute (which carry no selector).
+  final String? selector;
+
+  final List<RouteMatcher> matchers;
+  final List<RouteDestination> destinations;
+
+  /// Full unstructured spec for the YAML panel on the detail screen.
+  /// Detail responses populate this; list responses leave it null.
+  final Map<String, Object?>? raw;
+
+  factory TrafficRoute.fromJson(Map<String, dynamic> json) {
+    List<String> strs(Object? v) =>
+        v is List ? v.whereType<String>().toList() : const <String>[];
+    List<T> objs<T>(
+      Object? v,
+      T Function(Map<String, dynamic>) parse,
+    ) {
+      if (v is! List) return <T>[];
+      return v
+          .whereType<Map<dynamic, dynamic>>()
+          .map((m) => parse(Map<String, dynamic>.from(m)))
+          .toList();
+    }
+
+    final raw = json['raw'];
+    return TrafficRoute(
+      id: json['id'] as String? ?? '',
+      mesh: json['mesh'] as String? ?? '',
+      kind: json['kind'] as String? ?? '',
+      name: json['name'] as String? ?? '',
+      namespace: json['namespace'] as String? ?? '',
+      hosts: strs(json['hosts']),
+      gateways: strs(json['gateways']),
+      subsets: strs(json['subsets']),
+      selector: json['selector'] is String &&
+              (json['selector'] as String).isNotEmpty
+          ? json['selector'] as String
+          : null,
+      matchers: objs(json['matchers'], RouteMatcher.fromJson),
+      destinations: objs(json['destinations'], RouteDestination.fromJson),
+      raw: raw is Map ? Map<String, Object?>.from(raw) : null,
+    );
+  }
+}
+
+/// Decoded `/v1/mesh/routing` response envelope. `errors` carries
+/// per-CRD partial fetch failures.
+class RoutingResponse {
+  const RoutingResponse({
+    required this.status,
+    required this.routes,
+    required this.errors,
+  });
+
+  final MeshStatus status;
+  final List<TrafficRoute> routes;
+
+  /// Per-CRD failure map keyed by `"mesh/Kind"` (e.g.
+  /// `"istio/VirtualService": "forbidden"`). Empty when every CRD list
+  /// call succeeded. Renders as a banner on the list screen; never
+  /// surfaces as a whole-screen error.
+  final Map<String, String> errors;
+
+  factory RoutingResponse.fromJson(Map<String, dynamic> json) {
+    final status = json['status'];
+    final routes = json['routes'];
+    final errors = json['errors'];
+    return RoutingResponse(
+      status: status is Map
+          ? MeshStatus.fromJson(Map<String, dynamic>.from(status))
+          : MeshStatus.empty,
+      routes: routes is List
+          ? routes
+              .whereType<Map<dynamic, dynamic>>()
+              .map((m) => TrafficRoute.fromJson(Map<String, dynamic>.from(m)))
+              .toList()
+          : const <TrafficRoute>[],
+      errors: errors is Map
+          ? errors.map((k, v) => MapEntry(k.toString(), v?.toString() ?? ''))
+          : const <String, String>{},
+    );
+  }
+
+  static const empty = RoutingResponse(
+    status: MeshStatus.empty,
+    routes: <TrafficRoute>[],
+    errors: <String, String>{},
+  );
+}
+
+/// One mesh policy row (PeerAuthentication, AuthorizationPolicy,
+/// Server, MeshTLSAuthentication, etc.).
+class MeshedPolicy {
+  const MeshedPolicy({
+    required this.id,
+    required this.mesh,
+    required this.kind,
+    required this.name,
+    this.namespace = '',
+    this.action,
+    this.effect,
+    this.mtlsMode,
+    this.selector,
+    this.ruleCount = 0,
+    this.raw,
+  });
+
+  final String id;
+  final String mesh;
+  final String kind;
+  final String name;
+  final String namespace;
+
+  /// AuthorizationPolicy: `ALLOW`, `DENY`, `AUDIT`.
+  final String? action;
+
+  /// Backend-computed disposition: `deny_all`, `allow_all`, or empty.
+  final String? effect;
+
+  /// PeerAuthentication: `STRICT`, `PERMISSIVE`, `DISABLE`, `UNSET`.
+  final String? mtlsMode;
+
+  /// Stringified matchLabels selector.
+  final String? selector;
+
+  final int ruleCount;
+  final Map<String, Object?>? raw;
+
+  factory MeshedPolicy.fromJson(Map<String, dynamic> json) {
+    String? s(Object? v) => v is String && v.isNotEmpty ? v : null;
+    final raw = json['raw'];
+    return MeshedPolicy(
+      id: json['id'] as String? ?? '',
+      mesh: json['mesh'] as String? ?? '',
+      kind: json['kind'] as String? ?? '',
+      name: json['name'] as String? ?? '',
+      namespace: json['namespace'] as String? ?? '',
+      action: s(json['action']),
+      effect: s(json['effect']),
+      mtlsMode: s(json['mtlsMode']),
+      selector: s(json['selector']),
+      ruleCount: (json['ruleCount'] as num?)?.toInt() ?? 0,
+      raw: raw is Map ? Map<String, Object?>.from(raw) : null,
+    );
+  }
+}
+
+class PoliciesResponse {
+  const PoliciesResponse({
+    required this.status,
+    required this.policies,
+    required this.errors,
+  });
+
+  final MeshStatus status;
+  final List<MeshedPolicy> policies;
+  final Map<String, String> errors;
+
+  factory PoliciesResponse.fromJson(Map<String, dynamic> json) {
+    final status = json['status'];
+    final policies = json['policies'];
+    final errors = json['errors'];
+    return PoliciesResponse(
+      status: status is Map
+          ? MeshStatus.fromJson(Map<String, dynamic>.from(status))
+          : MeshStatus.empty,
+      policies: policies is List
+          ? policies
+              .whereType<Map<dynamic, dynamic>>()
+              .map((m) => MeshedPolicy.fromJson(Map<String, dynamic>.from(m)))
+              .toList()
+          : const <MeshedPolicy>[],
+      errors: errors is Map
+          ? errors.map((k, v) => MapEntry(k.toString(), v?.toString() ?? ''))
+          : const <String, String>{},
+    );
+  }
+
+  static const empty = PoliciesResponse(
+    status: MeshStatus.empty,
+    policies: <MeshedPolicy>[],
+    errors: <String, String>{},
+  );
+}
+
+/// Per-workload mTLS posture row.
+class WorkloadMTLS {
+  const WorkloadMTLS({
+    required this.namespace,
+    required this.workload,
+    required this.mesh,
+    required this.state,
+    required this.source,
+    this.workloadKind,
+    this.istioMode,
+    this.sourceDetail,
+    this.workloadKindConfident = true,
+  });
+
+  final String namespace;
+  final String workload;
+
+  /// `"Deployment"`, `"StatefulSet"`, etc. Empty when unmeshed or when
+  /// the backend's owner-reference walk found no owning workload.
+  final String? workloadKind;
+  final String mesh;
+
+  /// `"active" | "inactive" | "mixed" | "unmeshed"`. Mobile renders this
+  /// verbatim — unknown values fall back to the muted text colour.
+  final String state;
+
+  /// `"policy" | "metric" | "default"`. Drives which of the three
+  /// attribution sources lit up.
+  final String source;
+
+  /// Istio-only PeerAuthentication mode after resolution.
+  final String? istioMode;
+
+  /// `"workload" | "namespace" | "mesh"` — which PeerAuthentication
+  /// scope ultimately won. Empty for Linkerd or metric-driven rows.
+  final String? sourceDetail;
+
+  /// `false` when the kind was inferred from a ReplicaSet name heuristic
+  /// (no owner-reference lookup landed). Surface with an asterisk +
+  /// tooltip on the detail screen.
+  final bool workloadKindConfident;
+
+  factory WorkloadMTLS.fromJson(Map<String, dynamic> json) {
+    String? s(Object? v) => v is String && v.isNotEmpty ? v : null;
+    return WorkloadMTLS(
+      namespace: json['namespace'] as String? ?? '',
+      workload: json['workload'] as String? ?? '',
+      workloadKind: s(json['workloadKind']),
+      mesh: json['mesh'] as String? ?? '',
+      state: json['state'] as String? ?? '',
+      source: json['source'] as String? ?? '',
+      istioMode: s(json['istioMode']),
+      sourceDetail: s(json['sourceDetail']),
+      workloadKindConfident: json['workloadKindConfident'] as bool? ?? true,
+    );
+  }
+}
+
+class MTLSPostureResponse {
+  const MTLSPostureResponse({
+    required this.status,
+    required this.workloads,
+    required this.errors,
+  });
+
+  final MeshStatus status;
+  final List<WorkloadMTLS> workloads;
+
+  /// Partial-failure map. Keys to watch for:
+  ///   `prometheus-cross-check` / `truncated` — warning-level (yellow);
+  ///   `pods` / `policies` / `istio/...` / `linkerd/...` — error-level.
+  final Map<String, String> errors;
+
+  factory MTLSPostureResponse.fromJson(Map<String, dynamic> json) {
+    final status = json['status'];
+    final workloads = json['workloads'];
+    final errors = json['errors'];
+    return MTLSPostureResponse(
+      status: status is Map
+          ? MeshStatus.fromJson(Map<String, dynamic>.from(status))
+          : MeshStatus.empty,
+      workloads: workloads is List
+          ? workloads
+              .whereType<Map<dynamic, dynamic>>()
+              .map((m) => WorkloadMTLS.fromJson(Map<String, dynamic>.from(m)))
+              .toList()
+          : const <WorkloadMTLS>[],
+      errors: errors is Map
+          ? errors.map((k, v) => MapEntry(k.toString(), v?.toString() ?? ''))
+          : const <String, String>{},
+    );
+  }
+
+  static const empty = MTLSPostureResponse(
+    status: MeshStatus.empty,
+    workloads: <WorkloadMTLS>[],
+    errors: <String, String>{},
+  );
+}
+
+/// Point-in-time golden-signal scalars for a single service.
+///
+/// The backend exposes scalars, NOT time series — the chart renderer
+/// on mobile is a tile grid, not a LineChart. The plan's "4-up
+/// LineChart" wording predates the backend audit; this struct is the
+/// source of truth.
+class GoldenSignals {
+  const GoldenSignals({
+    required this.mesh,
+    required this.namespace,
+    required this.service,
+    required this.available,
+    this.reason,
+    this.missingQueries = const <String>[],
+    this.rps = 0.0,
+    this.errorRate = 0.0,
+    this.p50Ms = 0.0,
+    this.p95Ms = 0.0,
+    this.p99Ms = 0.0,
+  });
+
+  final String mesh;
+  final String namespace;
+  final String service;
+
+  /// `false` when Prometheus is offline. [reason] carries the operator-
+  /// visible explanation in that case.
+  final bool available;
+  final String? reason;
+
+  /// Names of failed PromQL queries (e.g. `["p99", "errorRate"]`).
+  /// Non-empty when partial-success — surfaced as a banner above the
+  /// tile grid; the failed tiles render an em-dash.
+  final List<String> missingQueries;
+
+  /// Requests per second.
+  final double rps;
+
+  /// Error rate as a fraction in `[0, 1]`. UI multiplies by 100.
+  final double errorRate;
+
+  final double p50Ms;
+  final double p95Ms;
+  final double p99Ms;
+
+  bool isMetricMissing(String name) => missingQueries.contains(name);
+
+  factory GoldenSignals.fromJson(Map<String, dynamic> json) {
+    double n(Object? v) => (v as num?)?.toDouble() ?? 0.0;
+    return GoldenSignals(
+      mesh: json['mesh'] as String? ?? '',
+      namespace: json['namespace'] as String? ?? '',
+      service: json['service'] as String? ?? '',
+      available: json['available'] as bool? ?? false,
+      reason: json['reason'] is String && (json['reason'] as String).isNotEmpty
+          ? json['reason'] as String
+          : null,
+      missingQueries: json['missingQueries'] is List
+          ? (json['missingQueries'] as List).whereType<String>().toList()
+          : const <String>[],
+      rps: n(json['rps']),
+      errorRate: n(json['errorRate']),
+      p50Ms: n(json['p50Ms']),
+      p95Ms: n(json['p95Ms']),
+      p99Ms: n(json['p99Ms']),
+    );
+  }
+}
+
+class GoldenSignalsResponse {
+  const GoldenSignalsResponse({
+    required this.status,
+    required this.signals,
+  });
+
+  final MeshStatus status;
+  final GoldenSignals signals;
+
+  factory GoldenSignalsResponse.fromJson(Map<String, dynamic> json) {
+    final status = json['status'];
+    final signals = json['signals'];
+    return GoldenSignalsResponse(
+      status: status is Map
+          ? MeshStatus.fromJson(Map<String, dynamic>.from(status))
+          : MeshStatus.empty,
+      signals: signals is Map
+          ? GoldenSignals.fromJson(Map<String, dynamic>.from(signals))
+          : GoldenSignals(
+              mesh: '',
+              namespace: '',
+              service: '',
+              available: false,
+            ),
+    );
+  }
+}
+
+/// Mobile wrapper over `/v1/mesh/*`. Stateless — cluster pinning
+/// threads through `clusterIdOverride` so the wire header always
+/// matches the family-key slot the caller writes back into.
+class MeshRepository {
+  MeshRepository(this._dio);
+
+  final Dio _dio;
+
+  /// Fetches mesh discovery status. Returns [MeshStatus.empty] on 5xx
+  /// so callers route straight to `FeatureUnavailableState.mesh()` —
+  /// a flaky reverse-proxy probe should not surface as an error card.
+  Future<MeshStatus> status({
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) async {
+    try {
+      final res = await _dio.get<Map<String, dynamic>>(
+        '/api/v1/mesh/status',
+        options: clusterIdOverride == null
+            ? null
+            : Options(headers: {'X-Cluster-ID': clusterIdOverride}),
+        cancelToken: cancelToken,
+      );
+      final data = res.data?['data'];
+      if (data is Map) {
+        // Backend wraps the response payload as `{"status": {...}}` on
+        // top of the standard `{"data": {...}}` envelope. The
+        // routing/policies/mtls endpoints all share the same shape.
+        final inner = data['status'];
+        if (inner is Map) {
+          return MeshStatus.fromJson(Map<String, dynamic>.from(inner));
+        }
+        // Some test harnesses skip the inner envelope. Tolerate.
+        return MeshStatus.fromJson(Map<String, dynamic>.from(data));
+      }
+      return MeshStatus.empty;
+    } on DioException catch (e) {
+      if (CancelToken.isCancel(e)) rethrow;
+      final code = e.response?.statusCode ?? 0;
+      if (code >= 500 && code < 600) return MeshStatus.empty;
+      final err = e.error;
+      throw err is ApiError ? err : ApiError.fromDio(e);
+    }
+  }
+
+  Future<RoutingResponse> listRouting({
+    String? namespace,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) async {
+    return _fetchEnvelope<RoutingResponse>(
+      path: '/api/v1/mesh/routing',
+      query: namespace == null || namespace.isEmpty
+          ? null
+          : {'namespace': namespace},
+      parse: RoutingResponse.fromJson,
+      empty: RoutingResponse.empty,
+      clusterIdOverride: clusterIdOverride,
+      cancelToken: cancelToken,
+    );
+  }
+
+  /// Fetches a single routing CRD by composite id. The id is
+  /// URL-encoded here once — callers pass the raw
+  /// `mesh:ns:kindCode:name` string. Double-encoding via
+  /// [MeshRouteId.encode] on the caller side would corrupt the path.
+  Future<TrafficRoute> getRoute({
+    required String id,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) async {
+    try {
+      final res = await _dio.get<Map<String, dynamic>>(
+        '/api/v1/mesh/routing/${Uri.encodeComponent(id)}',
+        options: clusterIdOverride == null
+            ? null
+            : Options(headers: {'X-Cluster-ID': clusterIdOverride}),
+        cancelToken: cancelToken,
+      );
+      final data = res.data?['data'];
+      if (data is Map) {
+        // Detail handler returns either `{"route": {...}}` or the raw
+        // TrafficRoute object depending on the route. Tolerate both.
+        final inner = data['route'];
+        final src = inner is Map ? inner : data;
+        return TrafficRoute.fromJson(Map<String, dynamic>.from(src));
+      }
+      throw ApiError(
+        statusCode: 500,
+        code: 500,
+        message: 'Empty response for route $id',
+      );
+    } on DioException catch (e) {
+      if (CancelToken.isCancel(e)) rethrow;
+      final err = e.error;
+      throw err is ApiError ? err : ApiError.fromDio(e);
+    }
+  }
+
+  Future<PoliciesResponse> listPolicies({
+    String? namespace,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) async {
+    return _fetchEnvelope<PoliciesResponse>(
+      path: '/api/v1/mesh/policies',
+      query: namespace == null || namespace.isEmpty
+          ? null
+          : {'namespace': namespace},
+      parse: PoliciesResponse.fromJson,
+      empty: PoliciesResponse.empty,
+      clusterIdOverride: clusterIdOverride,
+      cancelToken: cancelToken,
+    );
+  }
+
+  /// Fetches mTLS posture for a namespace. Backend hard-requires
+  /// `?namespace=`; passing empty produces a 400 which surfaces as an
+  /// inline error on the namespace selector.
+  Future<MTLSPostureResponse> mtlsPosture({
+    required String namespace,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) async {
+    return _fetchEnvelope<MTLSPostureResponse>(
+      path: '/api/v1/mesh/mtls',
+      query: {'namespace': namespace},
+      parse: MTLSPostureResponse.fromJson,
+      empty: MTLSPostureResponse.empty,
+      clusterIdOverride: clusterIdOverride,
+      cancelToken: cancelToken,
+    );
+  }
+
+  /// Fetches golden signals for a single service. `mesh` is required
+  /// when both meshes are installed; otherwise the backend infers it.
+  /// Backend timeout is 2s — partial-success (some missing queries) is
+  /// the common case, not the exceptional one.
+  Future<GoldenSignalsResponse> goldenSignals({
+    required String namespace,
+    required String service,
+    String? mesh,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) async {
+    final query = <String, String>{
+      'namespace': namespace,
+      'service': service,
+      if (mesh != null && mesh.isNotEmpty) 'mesh': mesh,
+    };
+    try {
+      final res = await _dio.get<Map<String, dynamic>>(
+        '/api/v1/mesh/golden-signals',
+        queryParameters: query,
+        options: clusterIdOverride == null
+            ? null
+            : Options(headers: {'X-Cluster-ID': clusterIdOverride}),
+        cancelToken: cancelToken,
+      );
+      final data = res.data?['data'];
+      if (data is Map) {
+        return GoldenSignalsResponse.fromJson(Map<String, dynamic>.from(data));
+      }
+      throw ApiError(
+        statusCode: 500,
+        code: 500,
+        message: 'Empty golden-signals response',
+      );
+    } on DioException catch (e) {
+      if (CancelToken.isCancel(e)) rethrow;
+      final err = e.error;
+      throw err is ApiError ? err : ApiError.fromDio(e);
+    }
+  }
+
+  /// Shared envelope unwrapping for the four list-style endpoints
+  /// (routing, policies, mtls — and any future addition that follows
+  /// the `{"data": {...}}` shape). Centralised so a backend envelope
+  /// change touches one place instead of four.
+  Future<T> _fetchEnvelope<T>({
+    required String path,
+    Map<String, String>? query,
+    required T Function(Map<String, dynamic>) parse,
+    required T empty,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) async {
+    try {
+      final res = await _dio.get<Map<String, dynamic>>(
+        path,
+        queryParameters: query,
+        options: clusterIdOverride == null
+            ? null
+            : Options(headers: {'X-Cluster-ID': clusterIdOverride}),
+        cancelToken: cancelToken,
+      );
+      final data = res.data?['data'];
+      if (data is Map) {
+        return parse(Map<String, dynamic>.from(data));
+      }
+      return empty;
+    } on DioException catch (e) {
+      if (CancelToken.isCancel(e)) rethrow;
+      final err = e.error;
+      throw err is ApiError ? err : ApiError.fromDio(e);
+    }
+  }
+}
+
+final meshRepositoryProvider = Provider<MeshRepository>((ref) {
+  return MeshRepository(ref.watch(dioProvider));
+});
+
+/// Per-cluster mesh discovery status. Drives `FeatureUnavailableState
+/// .mesh()` and decides which engine cards render on the dashboard.
+final meshStatusProvider = FutureProvider.autoDispose
+    .family<MeshStatus, String>((ref, clusterId) async {
+  ref.watch(activeClusterProvider);
+  final cancel = CancelToken();
+  ref.onDispose(() {
+    if (!cancel.isCancelled) cancel.cancel('mesh status invalidated');
+  });
+  return ref.read(meshRepositoryProvider).status(
+        clusterIdOverride: clusterId,
+        cancelToken: cancel,
+      );
+});
+
+/// Family key for the routing list provider. Carries both cluster id
+/// (so cluster switches force a fresh slot) and namespace (so two open
+/// routing-list screens with different namespace filters don't share
+/// state).
+class MeshRoutingKey {
+  const MeshRoutingKey({required this.clusterId, this.namespace});
+
+  final String clusterId;
+
+  /// Empty / null → cluster-wide list. The handler enforces RBAC.
+  final String? namespace;
+
+  @override
+  bool operator ==(Object other) =>
+      other is MeshRoutingKey &&
+      other.clusterId == clusterId &&
+      other.namespace == namespace;
+
+  @override
+  int get hashCode => Object.hash(clusterId, namespace);
+}
+
+final meshRoutingProvider = FutureProvider.autoDispose
+    .family<RoutingResponse, MeshRoutingKey>((ref, key) async {
+  ref.watch(activeClusterProvider);
+  final cancel = CancelToken();
+  ref.onDispose(() {
+    if (!cancel.isCancelled) cancel.cancel('mesh routing invalidated');
+  });
+  return ref.read(meshRepositoryProvider).listRouting(
+        namespace: key.namespace,
+        clusterIdOverride: key.clusterId,
+        cancelToken: cancel,
+      );
+});
+
+class MeshRouteDetailKey {
+  const MeshRouteDetailKey({required this.clusterId, required this.id});
+
+  final String clusterId;
+  final String id;
+
+  @override
+  bool operator ==(Object other) =>
+      other is MeshRouteDetailKey &&
+      other.clusterId == clusterId &&
+      other.id == id;
+
+  @override
+  int get hashCode => Object.hash(clusterId, id);
+}
+
+final meshRouteDetailProvider = FutureProvider.autoDispose
+    .family<TrafficRoute, MeshRouteDetailKey>((ref, key) async {
+  ref.watch(activeClusterProvider);
+  final cancel = CancelToken();
+  ref.onDispose(() {
+    if (!cancel.isCancelled) cancel.cancel('mesh route detail invalidated');
+  });
+  return ref.read(meshRepositoryProvider).getRoute(
+        id: key.id,
+        clusterIdOverride: key.clusterId,
+        cancelToken: cancel,
+      );
+});
+
+/// Family key for the mTLS posture provider. Namespace is required
+/// (mTLS posture is only meaningful per namespace) so the key carries
+/// it as a non-nullable field.
+class MeshMtlsKey {
+  const MeshMtlsKey({required this.clusterId, required this.namespace});
+
+  final String clusterId;
+  final String namespace;
+
+  @override
+  bool operator ==(Object other) =>
+      other is MeshMtlsKey &&
+      other.clusterId == clusterId &&
+      other.namespace == namespace;
+
+  @override
+  int get hashCode => Object.hash(clusterId, namespace);
+}
+
+final meshMtlsPostureProvider = FutureProvider.autoDispose
+    .family<MTLSPostureResponse, MeshMtlsKey>((ref, key) async {
+  ref.watch(activeClusterProvider);
+  final cancel = CancelToken();
+  ref.onDispose(() {
+    if (!cancel.isCancelled) cancel.cancel('mesh mtls invalidated');
+  });
+  return ref.read(meshRepositoryProvider).mtlsPosture(
+        namespace: key.namespace,
+        clusterIdOverride: key.clusterId,
+        cancelToken: cancel,
+      );
+});
+
+/// Family key for the golden-signals provider. Carries every parameter
+/// the wire request needs so a service swap on the same screen produces
+/// a fresh cache slot rather than overwriting the prior one.
+class MeshGoldenSignalsKey {
+  const MeshGoldenSignalsKey({
+    required this.clusterId,
+    required this.namespace,
+    required this.service,
+    this.mesh,
+  });
+
+  final String clusterId;
+  final String namespace;
+  final String service;
+
+  /// `"istio"` or `"linkerd"` when both meshes are installed. Null
+  /// when only one is installed (backend infers it).
+  final String? mesh;
+
+  @override
+  bool operator ==(Object other) =>
+      other is MeshGoldenSignalsKey &&
+      other.clusterId == clusterId &&
+      other.namespace == namespace &&
+      other.service == service &&
+      other.mesh == mesh;
+
+  @override
+  int get hashCode => Object.hash(clusterId, namespace, service, mesh);
+}
+
+final meshGoldenSignalsProvider = FutureProvider.autoDispose
+    .family<GoldenSignalsResponse, MeshGoldenSignalsKey>((ref, key) async {
+  ref.watch(activeClusterProvider);
+  final cancel = CancelToken();
+  ref.onDispose(() {
+    if (!cancel.isCancelled) cancel.cancel('mesh golden-signals invalidated');
+  });
+  return ref.read(meshRepositoryProvider).goldenSignals(
+        namespace: key.namespace,
+        service: key.service,
+        mesh: key.mesh,
+        clusterIdOverride: key.clusterId,
+        cancelToken: cancel,
+      );
+});

--- a/mobile/lib/api/mesh_repository.dart
+++ b/mobile/lib/api/mesh_repository.dart
@@ -71,14 +71,18 @@ class MeshStatus {
     required this.detected,
     required this.istio,
     required this.linkerd,
-    this.lastChecked,
+    this.lastChecked = '',
   });
 
   /// `""` when neither mesh is detected.
   final String detected;
   final MeshInfo istio;
   final MeshInfo linkerd;
-  final String? lastChecked;
+
+  /// ISO-8601 timestamp of the last mesh discovery probe. Empty string
+  /// when not yet available (e.g. the first poll hasn't completed).
+  /// The backend always populates this field once a probe has run.
+  final String lastChecked;
 
   bool get isInstalled => detected.isNotEmpty;
   bool get hasIstio => detected == 'istio' || detected == 'both';
@@ -96,7 +100,7 @@ class MeshStatus {
       linkerd: linkerd is Map
           ? MeshInfo.fromJson(Map<String, dynamic>.from(linkerd))
           : MeshInfo.empty,
-      lastChecked: json['lastChecked'] as String?,
+      lastChecked: json['lastChecked'] as String? ?? '',
     );
   }
 
@@ -397,7 +401,7 @@ class WorkloadMTLS {
     this.workloadKind,
     this.istioMode,
     this.sourceDetail,
-    this.workloadKindConfident = true,
+    this.workloadKindConfident = false,
   });
 
   final String namespace;
@@ -439,7 +443,7 @@ class WorkloadMTLS {
       source: json['source'] as String? ?? '',
       istioMode: s(json['istioMode']),
       sourceDetail: s(json['sourceDetail']),
-      workloadKindConfident: json['workloadKindConfident'] as bool? ?? true,
+      workloadKindConfident: json['workloadKindConfident'] as bool? ?? false,
     );
   }
 }
@@ -581,6 +585,16 @@ class GoldenSignalsResponse {
             ),
     );
   }
+
+  static const empty = GoldenSignalsResponse(
+    status: MeshStatus.empty,
+    signals: GoldenSignals(
+      mesh: '',
+      namespace: '',
+      service: '',
+      available: false,
+    ),
+  );
 }
 
 /// Mobile wrapper over `/v1/mesh/*`. Stateless — cluster pinning
@@ -664,11 +678,9 @@ class MeshRepository {
       );
       final data = res.data?['data'];
       if (data is Map) {
-        // Detail handler returns either `{"route": {...}}` or the raw
-        // TrafficRoute object depending on the route. Tolerate both.
-        final inner = data['route'];
-        final src = inner is Map ? inner : data;
-        return TrafficRoute.fromJson(Map<String, dynamic>.from(src));
+        // HandleGetRoute (handler.go) writes a flat TrafficRoute into the
+        // standard `{"data": {...}}` envelope — no inner "route" key.
+        return TrafficRoute.fromJson(Map<String, dynamic>.from(data));
       }
       throw ApiError(
         statusCode: 500,
@@ -699,9 +711,13 @@ class MeshRepository {
     );
   }
 
-  /// Fetches mTLS posture for a namespace. Backend hard-requires
-  /// `?namespace=`; passing empty produces a 400 which surfaces as an
-  /// inline error on the namespace selector.
+  /// Fetches mTLS posture for a namespace.
+  ///
+  /// The backend actually supports cluster-wide posture when `?namespace=`
+  /// is omitted — it does NOT 400 on an empty namespace parameter. The
+  /// mobile UI always passes a namespace because per-namespace posture is
+  /// the only UX this screen exposes; the constraint is a product-layer
+  /// choice, not enforced by the backend.
   Future<MTLSPostureResponse> mtlsPosture({
     required String namespace,
     String? clusterIdOverride,
@@ -746,22 +762,28 @@ class MeshRepository {
       if (data is Map) {
         return GoldenSignalsResponse.fromJson(Map<String, dynamic>.from(data));
       }
-      throw ApiError(
-        statusCode: 500,
-        code: 500,
-        message: 'Empty golden-signals response',
-      );
+      return GoldenSignalsResponse.empty;
     } on DioException catch (e) {
       if (CancelToken.isCancel(e)) rethrow;
+      final code = e.response?.statusCode ?? 0;
+      if (code >= 500 && code < 600) return GoldenSignalsResponse.empty;
       final err = e.error;
       throw err is ApiError ? err : ApiError.fromDio(e);
     }
   }
 
-  /// Shared envelope unwrapping for the four list-style endpoints
-  /// (routing, policies, mtls — and any future addition that follows
-  /// the `{"data": {...}}` shape). Centralised so a backend envelope
-  /// change touches one place instead of four.
+  /// Shared envelope unwrapping for the three list-style endpoints that
+  /// follow the `{"data": {...}}` envelope: routing ([listRouting]),
+  /// policies ([listPolicies]), and mtls posture ([mtlsPosture]).
+  ///
+  /// [status()] and [getRoute()] are excluded — status() nests an inner
+  /// `{"status": {...}}` key, and getRoute() may return a flat
+  /// TrafficRoute or a nested `{"route": {...}}` depending on the detail
+  /// handler revision; both parse themselves.
+  ///
+  /// Unlike [status()], a 5xx here is rethrown — list endpoints should
+  /// not silently empty on backend errors; the screen surfaces the
+  /// failure via an error state so operators see the problem.
   Future<T> _fetchEnvelope<T>({
     required String path,
     Map<String, String>? query,
@@ -816,11 +838,15 @@ final meshStatusProvider = FutureProvider.autoDispose
 /// routing-list screens with different namespace filters don't share
 /// state).
 class MeshRoutingKey {
-  const MeshRoutingKey({required this.clusterId, this.namespace});
+  /// Normalise [namespace]: empty string is treated as null so that
+  /// `MeshRoutingKey(clusterId: 'c', namespace: '')` and
+  /// `MeshRoutingKey(clusterId: 'c')` resolve to the same provider slot.
+  MeshRoutingKey({required this.clusterId, String? namespace})
+      : namespace = (namespace != null && namespace.isEmpty) ? null : namespace;
 
   final String clusterId;
 
-  /// Empty / null → cluster-wide list. The handler enforces RBAC.
+  /// null → cluster-wide list. The handler enforces RBAC.
   final String? namespace;
 
   @override

--- a/mobile/lib/features/mesh/golden_signals_tab.dart
+++ b/mobile/lib/features/mesh/golden_signals_tab.dart
@@ -1,0 +1,444 @@
+// Golden signals tile grid for a single Service. Surfaces under
+// the Service detail screen as an `extraTabs` entry when mesh is
+// detected on the cluster.
+//
+// **Tile grid, not LineCharts.** The backend exposes point-in-time
+// scalars (rps / errorRate / p50 / p95 / p99), not time series — the
+// plan's "4-up LineChart" wording predates the backend audit. Mobile
+// renders five tiles in a responsive Wrap layout.
+//
+// Mesh disambiguation: when both Istio and Linkerd are installed the
+// service's mesh is ambiguous (the backend can't auto-detect from the
+// Service object alone). The tab presents a SegmentedButton so the
+// operator picks; until they do, the body renders a prompt rather
+// than 503-ing on every refresh.
+//
+// Missing queries: a non-empty `signals.missingQueries` is normal —
+// the backend's PromQL timeout is 2s, and any failed sub-query lands
+// here. The tab renders a banner naming the failed metrics; the
+// associated tiles render an em-dash rather than `0.0`.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../api/api_error.dart';
+import '../../api/mesh_repository.dart';
+import '../../cluster/cluster_provider.dart';
+import '../../theme/kube_theme_builder.dart';
+import 'mesh_widgets.dart';
+
+/// Body of the Metrics-style tab on Service detail. The host
+/// [Widget.build] is reached only when `meshStatus.isInstalled`
+/// — the Service detail screen gates the tab visibility.
+class GoldenSignalsTab extends ConsumerStatefulWidget {
+  const GoldenSignalsTab({
+    super.key,
+    required this.namespace,
+    required this.service,
+    required this.status,
+  });
+
+  final String namespace;
+  final String service;
+
+  /// Resolved mesh status; carries `detected` so the tab knows
+  /// whether to render the mesh picker (both installed) or auto-
+  /// select the single installed mesh.
+  final MeshStatus status;
+
+  @override
+  ConsumerState<GoldenSignalsTab> createState() => _GoldenSignalsTabState();
+}
+
+class _GoldenSignalsTabState extends ConsumerState<GoldenSignalsTab> {
+  String? _mesh;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.status.hasIstio && !widget.status.hasLinkerd) {
+      _mesh = 'istio';
+    } else if (widget.status.hasLinkerd && !widget.status.hasIstio) {
+      _mesh = 'linkerd';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final clusterId = ref.watch(activeClusterProvider);
+
+    return Column(
+      children: [
+        if (widget.status.hasBoth)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+            child: Row(
+              children: [
+                Text(
+                  'Mesh',
+                  style: TextStyle(color: colors.textMuted, fontSize: 12),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: SegmentedButton<String>(
+                    style: const ButtonStyle(visualDensity: VisualDensity.compact),
+                    segments: const [
+                      ButtonSegment(value: 'istio', label: Text('Istio')),
+                      ButtonSegment(value: 'linkerd', label: Text('Linkerd')),
+                    ],
+                    selected: _mesh == null ? <String>{} : <String>{_mesh!},
+                    emptySelectionAllowed: true,
+                    onSelectionChanged: (s) => setState(
+                      () => _mesh = s.isEmpty ? null : s.first,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        Expanded(
+          child: _mesh == null && widget.status.hasBoth
+              ? _MeshPickerPrompt()
+              : _SignalsBody(
+                  clusterId: clusterId,
+                  namespace: widget.namespace,
+                  service: widget.service,
+                  mesh: _mesh,
+                ),
+        ),
+      ],
+    );
+  }
+}
+
+class _MeshPickerPrompt extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Text(
+          'Both meshes are installed. Pick one above to compute golden '
+          'signals for this service — Istio and Linkerd publish '
+          'different Prometheus series.',
+          textAlign: TextAlign.center,
+          style: TextStyle(color: colors.textMuted, fontSize: 13),
+        ),
+      ),
+    );
+  }
+}
+
+class _SignalsBody extends ConsumerWidget {
+  const _SignalsBody({
+    required this.clusterId,
+    required this.namespace,
+    required this.service,
+    required this.mesh,
+  });
+
+  final String clusterId;
+  final String namespace;
+  final String service;
+  final String? mesh;
+
+  MeshGoldenSignalsKey get _key => MeshGoldenSignalsKey(
+        clusterId: clusterId,
+        namespace: namespace,
+        service: service,
+        mesh: mesh,
+      );
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final async = ref.watch(meshGoldenSignalsProvider(_key));
+
+    Future<void> handleRefresh() async {
+      ref.invalidate(meshGoldenSignalsProvider(_key));
+      try {
+        await ref.read(meshGoldenSignalsProvider(_key).future);
+      } on Object {
+        // surfaces via error branch
+      }
+    }
+
+    return RefreshIndicator(
+      onRefresh: handleRefresh,
+      child: async.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => _errorShell(e, handleRefresh, colors),
+        data: (response) {
+          final s = response.signals;
+          return ListView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            padding: const EdgeInsets.fromLTRB(0, 8, 0, 24),
+            children: [
+              if (!s.available)
+                _Banner(
+                  color: colors.warning,
+                  icon: Icons.warning_amber_outlined,
+                  title: 'Metrics unavailable',
+                  body: s.reason ?? 'Prometheus did not respond within 2s.',
+                ),
+              if (s.available && s.missingQueries.isNotEmpty)
+                _Banner(
+                  color: colors.warning,
+                  icon: Icons.info_outline,
+                  title:
+                      '${s.missingQueries.length} metric(s) unavailable',
+                  body: s.missingQueries.join(', '),
+                ),
+              _TileGrid(signals: s),
+              const SizedBox(height: 12),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Text(
+                  'Mesh: ${meshDisplayName(s.mesh)}  ·  '
+                  'service=${s.service}  ·  namespace=${s.namespace}',
+                  style: TextStyle(color: colors.textMuted, fontSize: 11),
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _errorShell(Object e, Future<void> Function() retry, KubeColors c) {
+    final body = e is ApiError && e.statusCode == 400
+        ? 'Service or namespace missing. This tab is rendered with '
+            'invalid arguments — please re-open this Service from the '
+            'list.'
+        : e is ApiError && e.statusCode == 403
+            ? 'You lack permission to read mesh metrics for this '
+                'namespace.'
+            : e is ApiError
+                ? e.message
+                : e.toString();
+    return ListView(
+      physics: const AlwaysScrollableScrollPhysics(),
+      children: [
+        SizedBox(
+          height: 280,
+          child: Center(
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    body,
+                    style: TextStyle(color: c.textPrimary),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 12),
+                  OutlinedButton(
+                    onPressed: retry,
+                    child: const Text('Retry'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _Banner extends StatelessWidget {
+  const _Banner({
+    required this.color,
+    required this.icon,
+    required this.title,
+    required this.body,
+  });
+
+  final Color color;
+  final IconData icon;
+  final String title;
+  final String body;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: color.withValues(alpha: 0.3)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(icon, color: color, size: 16),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: TextStyle(
+                    color: color,
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                if (body.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 2),
+                    child: Text(
+                      body,
+                      style: TextStyle(
+                        color: colors.textSecondary,
+                        fontSize: 11,
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TileGrid extends StatelessWidget {
+  const _TileGrid({required this.signals});
+
+  final GoldenSignals signals;
+
+  String _format(double v, String unit) {
+    if (v.isNaN || v.isInfinite) return '—';
+    if (unit == '%') return '${(v * 100).toStringAsFixed(2)} %';
+    if (unit == 'ms') return '${v.toStringAsFixed(1)} ms';
+    return v.toStringAsFixed(2);
+  }
+
+  String _value(String key, double raw, String unit) {
+    if (signals.isMetricMissing(key)) return '—';
+    return _format(raw, unit);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    // Backend's missing-query keys match the JSON tag basenames; we
+    // pre-compute one source-of-truth bag here.
+    final tiles = <_TileData>[
+      _TileData(
+        label: 'Requests / s',
+        value: _value('rps', signals.rps, ''),
+        color: colors.info,
+        missing: signals.isMetricMissing('rps'),
+      ),
+      _TileData(
+        label: 'Error rate',
+        value: _value('errorRate', signals.errorRate, '%'),
+        color: signals.errorRate > 0.05 ? colors.error : colors.success,
+        missing: signals.isMetricMissing('errorRate') ||
+            signals.isMetricMissing('errorNum') ||
+            signals.isMetricMissing('errorDen'),
+      ),
+      _TileData(
+        label: 'p50 latency',
+        value: _value('p50', signals.p50Ms, 'ms'),
+        color: colors.accent,
+        missing: signals.isMetricMissing('p50'),
+      ),
+      _TileData(
+        label: 'p95 latency',
+        value: _value('p95', signals.p95Ms, 'ms'),
+        color: colors.accent,
+        missing: signals.isMetricMissing('p95'),
+      ),
+      _TileData(
+        label: 'p99 latency',
+        value: _value('p99', signals.p99Ms, 'ms'),
+        color: signals.p99Ms > 1000 ? colors.warning : colors.accent,
+        missing: signals.isMetricMissing('p99'),
+      ),
+    ];
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final tileWidth = constraints.maxWidth < 540
+              ? (constraints.maxWidth - 24) / 2
+              : (constraints.maxWidth - 32) / 3;
+          return Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              for (final t in tiles)
+                SizedBox(
+                  width: tileWidth,
+                  child: _Tile(data: t),
+                ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _TileData {
+  const _TileData({
+    required this.label,
+    required this.value,
+    required this.color,
+    required this.missing,
+  });
+
+  final String label;
+  final String value;
+  final Color color;
+  final bool missing;
+}
+
+class _Tile extends StatelessWidget {
+  const _Tile({required this.data});
+
+  final _TileData data;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: colors.bgSurface,
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: colors.borderSubtle),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            data.label,
+            style: TextStyle(color: colors.textMuted, fontSize: 11),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            data.value,
+            style: TextStyle(
+              color: data.missing ? colors.textMuted : data.color,
+              fontSize: 20,
+              fontWeight: FontWeight.w700,
+              fontFamily: 'monospace',
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/mesh/golden_signals_tab.dart
+++ b/mobile/lib/features/mesh/golden_signals_tab.dart
@@ -56,17 +56,50 @@ class _GoldenSignalsTabState extends ConsumerState<GoldenSignalsTab> {
   @override
   void initState() {
     super.initState();
-    if (widget.status.hasIstio && !widget.status.hasLinkerd) {
-      _mesh = 'istio';
-    } else if (widget.status.hasLinkerd && !widget.status.hasIstio) {
-      _mesh = 'linkerd';
+    _mesh = _deriveMesh(widget.status, null);
+  }
+
+  @override
+  void didUpdateWidget(GoldenSignalsTab oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.status.detected == widget.status.detected) return;
+    // Re-derive preferred mesh from the new status. If the currently
+    // selected mesh is still installed, keep it; otherwise fall back to
+    // the auto-derived choice (or null when both are still installed).
+    final auto = _deriveMesh(widget.status, null);
+    if (_mesh != null && !_isMeshInstalled(_mesh!, widget.status)) {
+      // Previously selected mesh is no longer detected — clear.
+      setState(() => _mesh = auto);
+    } else if (auto != null && _mesh == null) {
+      // Transitioned from both→one installed: auto-select.
+      setState(() => _mesh = auto);
     }
+  }
+
+  /// Returns the auto-selected mesh when exactly one is installed, or
+  /// null when both (or neither) are installed.
+  static String? _deriveMesh(MeshStatus status, String? current) {
+    if (status.hasIstio && !status.hasLinkerd) return 'istio';
+    if (status.hasLinkerd && !status.hasIstio) return 'linkerd';
+    return null;
+  }
+
+  static bool _isMeshInstalled(String mesh, MeshStatus status) {
+    return mesh == 'istio' ? status.hasIstio : status.hasLinkerd;
   }
 
   @override
   Widget build(BuildContext context) {
     final colors = Theme.of(context).extension<KubeColors>()!;
     final clusterId = ref.watch(activeClusterProvider);
+    // Reset mesh selection when the user switches clusters so the tab
+    // re-derives from the new cluster's installed meshes instead of
+    // carrying over the previous selection.
+    ref.listen<String>(activeClusterProvider, (previous, next) {
+      if (previous != next) {
+        setState(() => _mesh = _deriveMesh(widget.status, null));
+      }
+    });
 
     return Column(
       children: [
@@ -177,19 +210,24 @@ class _SignalsBody extends ConsumerWidget {
             padding: const EdgeInsets.fromLTRB(0, 8, 0, 24),
             children: [
               if (!s.available)
-                _Banner(
-                  color: colors.warning,
-                  icon: Icons.warning_amber_outlined,
-                  title: 'Metrics unavailable',
-                  body: s.reason ?? 'Prometheus did not respond within 2s.',
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 12),
+                  child: MeshBanner(
+                    color: colors.warning,
+                    icon: Icons.warning_amber_outlined,
+                    title: 'Metrics unavailable',
+                    body: s.reason ?? 'Prometheus did not respond within 2s.',
+                  ),
                 ),
               if (s.available && s.missingQueries.isNotEmpty)
-                _Banner(
-                  color: colors.warning,
-                  icon: Icons.info_outline,
-                  title:
-                      '${s.missingQueries.length} metric(s) unavailable',
-                  body: s.missingQueries.join(', '),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 12),
+                  child: MeshBanner(
+                    color: colors.warning,
+                    icon: Icons.info_outline,
+                    title: '${s.missingQueries.length} metric(s) unavailable',
+                    body: s.missingQueries.join(', '),
+                  ),
                 ),
               _TileGrid(signals: s),
               const SizedBox(height: 12),
@@ -250,67 +288,6 @@ class _SignalsBody extends ConsumerWidget {
   }
 }
 
-class _Banner extends StatelessWidget {
-  const _Banner({
-    required this.color,
-    required this.icon,
-    required this.title,
-    required this.body,
-  });
-
-  final Color color;
-  final IconData icon;
-  final String title;
-  final String body;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = Theme.of(context).extension<KubeColors>()!;
-    return Container(
-      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-      padding: const EdgeInsets.all(10),
-      decoration: BoxDecoration(
-        color: color.withValues(alpha: 0.08),
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: color.withValues(alpha: 0.3)),
-      ),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Icon(icon, color: color, size: 16),
-          const SizedBox(width: 8),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  title,
-                  style: TextStyle(
-                    color: color,
-                    fontSize: 12,
-                    fontWeight: FontWeight.w600,
-                  ),
-                ),
-                if (body.isNotEmpty)
-                  Padding(
-                    padding: const EdgeInsets.only(top: 2),
-                    child: Text(
-                      body,
-                      style: TextStyle(
-                        color: colors.textSecondary,
-                        fontSize: 11,
-                      ),
-                    ),
-                  ),
-              ],
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
 class _TileGrid extends StatelessWidget {
   const _TileGrid({required this.signals});
 
@@ -323,8 +300,8 @@ class _TileGrid extends StatelessWidget {
     return v.toStringAsFixed(2);
   }
 
-  String _value(String key, double raw, String unit) {
-    if (signals.isMetricMissing(key)) return '—';
+  String _value(String key, double raw, String unit, {bool missing = false}) {
+    if (missing || signals.isMetricMissing(key)) return '—';
     return _format(raw, unit);
   }
 
@@ -342,8 +319,21 @@ class _TileGrid extends StatelessWidget {
       ),
       _TileData(
         label: 'Error rate',
-        value: _value('errorRate', signals.errorRate, '%'),
-        color: signals.errorRate > 0.05 ? colors.error : colors.success,
+        value: _value(
+          'errorRate',
+          signals.errorRate,
+          '%',
+          missing: signals.isMetricMissing('errorRate') ||
+              signals.isMetricMissing('errorNum') ||
+              signals.isMetricMissing('errorDen'),
+        ),
+        color: signals.isMetricMissing('errorRate') ||
+                signals.isMetricMissing('errorNum') ||
+                signals.isMetricMissing('errorDen')
+            ? colors.textMuted
+            : signals.errorRate > 0.05
+                ? colors.error
+                : colors.success,
         missing: signals.isMetricMissing('errorRate') ||
             signals.isMetricMissing('errorNum') ||
             signals.isMetricMissing('errorDen'),
@@ -363,7 +353,11 @@ class _TileGrid extends StatelessWidget {
       _TileData(
         label: 'p99 latency',
         value: _value('p99', signals.p99Ms, 'ms'),
-        color: signals.p99Ms > 1000 ? colors.warning : colors.accent,
+        color: signals.isMetricMissing('p99')
+            ? colors.textMuted
+            : signals.p99Ms > 1000
+                ? colors.warning
+                : colors.accent,
         missing: signals.isMetricMissing('p99'),
       ),
     ];

--- a/mobile/lib/features/mesh/mesh_dashboard_screen.dart
+++ b/mobile/lib/features/mesh/mesh_dashboard_screen.dart
@@ -87,10 +87,10 @@ class MeshDashboardScreen extends ConsumerWidget {
                 ),
                 const SizedBox(height: 16),
                 _Actions(clusterId: clusterId),
-                if (status.lastChecked != null)
+                if (status.lastChecked.isNotEmpty)
                   Padding(
                     padding: const EdgeInsets.only(top: 12, left: 4),
-                    child: _LastCheckedLine(timestamp: status.lastChecked!),
+                    child: _LastCheckedLine(timestamp: status.lastChecked),
                   ),
               ],
             );

--- a/mobile/lib/features/mesh/mesh_dashboard_screen.dart
+++ b/mobile/lib/features/mesh/mesh_dashboard_screen.dart
@@ -1,0 +1,237 @@
+// Top-level mesh dashboard. Two side-by-side cards (Istio / Linkerd)
+// with installed status, control-plane namespace, version, and mode
+// for Istio. When neither mesh is installed renders the standard
+// `FeatureUnavailableState.mesh()`.
+//
+// Navigation: each card carries CTAs to the routing list and the
+// mTLS posture screen. The mTLS screen requires a namespace; on tap
+// without an active namespace the user lands on the screen and
+// receives the namespace prompt.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../api/api_error.dart';
+import '../../api/mesh_repository.dart';
+import '../../cluster/cluster_provider.dart';
+import '../../theme/kube_theme_builder.dart';
+import '../../widgets/feature_unavailable_state.dart';
+import 'mesh_widgets.dart';
+
+class MeshDashboardScreen extends ConsumerWidget {
+  const MeshDashboardScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final clusterId = ref.watch(activeClusterProvider);
+    final statusAsync = ref.watch(meshStatusProvider(clusterId));
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Service Mesh')),
+      body: RefreshIndicator(
+        onRefresh: () async {
+          ref.invalidate(meshStatusProvider(clusterId));
+          try {
+            await ref.read(meshStatusProvider(clusterId).future);
+          } on Object {
+            // surfaces via .when error branch
+          }
+        },
+        child: statusAsync.when(
+          loading: () =>
+              const _ScrollableShell(child: Center(child: CircularProgressIndicator())),
+          error: (e, _) {
+            if (e is ApiError && (e.statusCode == 401 || e.statusCode == 403)) {
+              return _ScrollableShell(
+                child: Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(24),
+                    child: Text(
+                      'Access denied: ${e.message}',
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                ),
+              );
+            }
+            return _ScrollableShell(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Text(e.toString(), textAlign: TextAlign.center),
+              ),
+            );
+          },
+          data: (status) {
+            if (!status.isInstalled) {
+              return _ScrollableShell(child: FeatureUnavailableState.mesh());
+            }
+            return ListView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              padding: const EdgeInsets.fromLTRB(12, 12, 12, 24),
+              children: [
+                _EngineCard(
+                  name: 'Istio',
+                  info: status.istio,
+                  accentIcon: Icons.hub_outlined,
+                  clusterId: clusterId,
+                  meshKey: 'istio',
+                ),
+                const SizedBox(height: 12),
+                _EngineCard(
+                  name: 'Linkerd',
+                  info: status.linkerd,
+                  accentIcon: Icons.linked_camera_outlined,
+                  clusterId: clusterId,
+                  meshKey: 'linkerd',
+                ),
+                const SizedBox(height: 16),
+                _Actions(clusterId: clusterId),
+                if (status.lastChecked != null)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 12, left: 4),
+                    child: _LastCheckedLine(timestamp: status.lastChecked!),
+                  ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _EngineCard extends StatelessWidget {
+  const _EngineCard({
+    required this.name,
+    required this.info,
+    required this.accentIcon,
+    required this.clusterId,
+    required this.meshKey,
+  });
+
+  final String name;
+  final MeshInfo info;
+  final IconData accentIcon;
+  final String clusterId;
+
+  /// `"istio"` | `"linkerd"` — drives the routing list deep-link's
+  /// `mesh=` filter so taps on the Istio card pre-filter the list.
+  final String meshKey;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final accent = info.installed ? colors.success : colors.textMuted;
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(accentIcon, color: accent),
+                const SizedBox(width: 8),
+                Text(
+                  name,
+                  style: TextStyle(
+                    color: colors.textPrimary,
+                    fontWeight: FontWeight.w700,
+                    fontSize: 16,
+                  ),
+                ),
+                const Spacer(),
+                MeshPill(
+                  label: info.installed ? 'Installed' : 'Not installed',
+                  color: accent,
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            if (info.installed) ...[
+              if (info.namespace != null)
+                MeshKvLine(label: 'Namespace', value: info.namespace!),
+              if (info.version != null)
+                MeshKvLine(label: 'Version', value: info.version!),
+              if (info.mode != null) MeshKvLine(label: 'Mode', value: info.mode!),
+              if (info.namespace == null &&
+                  info.version == null &&
+                  info.mode == null)
+                Text(
+                  'Details hidden for non-admin users.',
+                  style: TextStyle(color: colors.textMuted, fontSize: 12),
+                ),
+            ] else
+              Text(
+                '$name is not installed on this cluster. The routing, mTLS, '
+                'and golden-signal surfaces will be empty.',
+                style: TextStyle(color: colors.textMuted, fontSize: 12),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Actions extends StatelessWidget {
+  const _Actions({required this.clusterId});
+
+  final String clusterId;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 4),
+      child: Wrap(
+        spacing: 8,
+        runSpacing: 8,
+        children: [
+          OutlinedButton.icon(
+            onPressed: () =>
+                context.push('/clusters/$clusterId/mesh/routing'),
+            icon: const Icon(Icons.alt_route),
+            label: const Text('Routing rules'),
+          ),
+          OutlinedButton.icon(
+            onPressed: () => context.push('/clusters/$clusterId/mesh/mtls'),
+            icon: const Icon(Icons.lock_outline),
+            label: const Text('mTLS posture'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _LastCheckedLine extends StatelessWidget {
+  const _LastCheckedLine({required this.timestamp});
+
+  final String timestamp;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return Text(
+      'Last checked: $timestamp',
+      style: TextStyle(color: colors.textMuted, fontSize: 11),
+    );
+  }
+}
+
+/// Same scrollable wrapper trick as DomainListScaffold — gives the
+/// RefreshIndicator scroll physics when the data branch is empty.
+class _ScrollableShell extends StatelessWidget {
+  const _ScrollableShell({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      physics: const AlwaysScrollableScrollPhysics(),
+      children: [SizedBox(height: 320, child: child)],
+    );
+  }
+}

--- a/mobile/lib/features/mesh/mesh_widgets.dart
+++ b/mobile/lib/features/mesh/mesh_widgets.dart
@@ -1,0 +1,260 @@
+// Shared widget primitives + colour helpers for the M4 service-mesh
+// surfaces. Centralising these mirrors the precedent set by
+// `features/gitops/gitops_widgets.dart` so list / detail / dashboard
+// screens don't each carry a private `_StatusPill` copy.
+
+import 'package:flutter/material.dart';
+
+import '../../theme/kube_theme_builder.dart';
+
+/// Coloured rounded pill — sync/mtls/state badges across all mesh
+/// screens use this. Visually identical to `gitops.StatusPill` but
+/// kept separate so future tweaks can diverge without coupling the
+/// two domains.
+class MeshPill extends StatelessWidget {
+  const MeshPill({super.key, required this.label, required this.color});
+
+  final String label;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(10),
+        color: color.withValues(alpha: 0.15),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          color: color,
+          fontSize: 11,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+/// Maps a mesh state / mTLS state string → KubeColors token.
+/// Backend values are case-canonical (e.g. `"active"`, `"STRICT"`) but
+/// we lowercase before matching so any backend casing tweak doesn't
+/// produce silent color drift.
+Color meshStateColor(KubeColors colors, String? raw) {
+  return switch (raw?.toLowerCase() ?? '') {
+    'active' || 'strict' || 'allow' || 'allow_all' || 'healthy' || 'synced' =>
+      colors.success,
+    'mixed' || 'permissive' || 'audit' || 'outofsync' => colors.warning,
+    'inactive' || 'disable' || 'deny' || 'deny_all' || 'failed' => colors.error,
+    'unmeshed' || 'unset' || 'suspended' || '' => colors.textMuted,
+    _ => colors.textMuted,
+  };
+}
+
+/// "Warn"-tier keys in a partial-failure errors map. Anything outside
+/// this set surfaces as an error-coloured banner. Mirrors the web's
+/// `WARN_KEYS = {"prometheus-cross-check", "truncated"}` exactly.
+const Set<String> kMeshErrorWarnKeys = {
+  'prometheus-cross-check',
+  'truncated',
+};
+
+/// Renders the per-CRD partial-failure map as a stack of inline
+/// banners. Warn-tier keys get a yellow background; everything else
+/// is error-coloured. Returns an empty SizedBox when [errors] is empty
+/// so callers can drop it into a Column without a conditional.
+class MeshErrorsBanner extends StatelessWidget {
+  const MeshErrorsBanner({super.key, required this.errors});
+
+  final Map<String, String> errors;
+
+  @override
+  Widget build(BuildContext context) {
+    if (errors.isEmpty) return const SizedBox.shrink();
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final entries = errors.entries.toList();
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          for (final entry in entries)
+            _BannerRow(
+              icon: kMeshErrorWarnKeys.contains(entry.key)
+                  ? Icons.info_outline
+                  : Icons.warning_amber_outlined,
+              color: kMeshErrorWarnKeys.contains(entry.key)
+                  ? colors.warning
+                  : colors.error,
+              label: entry.key,
+              message: entry.value,
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _BannerRow extends StatelessWidget {
+  const _BannerRow({
+    required this.icon,
+    required this.color,
+    required this.label,
+    required this.message,
+  });
+
+  final IconData icon;
+  final Color color;
+  final String label;
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: 4),
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: color.withValues(alpha: 0.3)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(icon, color: color, size: 16),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  label,
+                  style: TextStyle(
+                    color: color,
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                if (message.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 2),
+                    child: Text(
+                      message,
+                      style: TextStyle(
+                        color: colors.textSecondary,
+                        fontSize: 11,
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Key/value line for the metadata panels on detail screens. Same
+/// shape as `gitops.KvLine` but with a tighter label column — mesh
+/// labels run short ("Mesh", "Kind", "Host") so we don't need the
+/// 132px width that GitOps uses for "Destination cluster" etc.
+class MeshKvLine extends StatelessWidget {
+  const MeshKvLine({
+    super.key,
+    required this.label,
+    required this.value,
+    this.valueColor,
+    this.monospace = false,
+  });
+
+  final String label;
+  final String value;
+  final Color? valueColor;
+  final bool monospace;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 96,
+            child: Text(
+              label,
+              style: TextStyle(color: colors.textMuted, fontSize: 13),
+            ),
+          ),
+          Expanded(
+            child: SelectableText(
+              value,
+              style: TextStyle(
+                color: valueColor ?? colors.textPrimary,
+                fontSize: 13,
+                fontFamily: monospace ? 'monospace' : null,
+                fontWeight:
+                    valueColor == null ? FontWeight.w400 : FontWeight.w600,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Section card used across the mesh screens to group related fields.
+/// Same chrome as the resource_detail_scaffold DetailSection but
+/// re-implemented here to avoid pulling that file into the mesh
+/// feature dependency surface (it carries YAML editor imports).
+class MeshSection extends StatelessWidget {
+  const MeshSection({super.key, required this.title, required this.child});
+
+  final String title;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: TextStyle(
+              color: colors.textMuted,
+              fontSize: 11,
+              fontWeight: FontWeight.w700,
+              letterSpacing: 0.6,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Card(
+            margin: EdgeInsets.zero,
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(12, 10, 12, 10),
+              child: child,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Human-readable label for a mesh discriminator. `"both"` reads as
+/// `"Istio + Linkerd"` for operator clarity.
+String meshDisplayName(String mesh) => switch (mesh) {
+      'istio' => 'Istio',
+      'linkerd' => 'Linkerd',
+      'both' => 'Istio + Linkerd',
+      '' => 'Unknown',
+      _ => mesh,
+    };

--- a/mobile/lib/features/mesh/mesh_widgets.dart
+++ b/mobile/lib/features/mesh/mesh_widgets.dart
@@ -80,15 +80,15 @@ class MeshErrorsBanner extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           for (final entry in entries)
-            _BannerRow(
+            MeshBanner(
               icon: kMeshErrorWarnKeys.contains(entry.key)
                   ? Icons.info_outline
                   : Icons.warning_amber_outlined,
               color: kMeshErrorWarnKeys.contains(entry.key)
                   ? colors.warning
                   : colors.error,
-              label: entry.key,
-              message: entry.value,
+              title: entry.key,
+              body: entry.value,
             ),
         ],
       ),
@@ -96,18 +96,26 @@ class MeshErrorsBanner extends StatelessWidget {
   }
 }
 
-class _BannerRow extends StatelessWidget {
-  const _BannerRow({
+/// Inline banner used across mesh screens to surface warnings and
+/// partial-failure messages. [MeshErrorsBanner] uses this internally;
+/// golden signals and other screens can reference it directly.
+///
+/// Named parameters follow the [_Banner] convention from
+/// `golden_signals_tab.dart` (pre-consolidation) so callers do not
+/// need to map `label`/`message` → `title`/`body`.
+class MeshBanner extends StatelessWidget {
+  const MeshBanner({
+    super.key,
     required this.icon,
     required this.color,
-    required this.label,
-    required this.message,
+    required this.title,
+    required this.body,
   });
 
   final IconData icon;
   final Color color;
-  final String label;
-  final String message;
+  final String title;
+  final String body;
 
   @override
   Widget build(BuildContext context) {
@@ -130,18 +138,18 @@ class _BannerRow extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
-                  label,
+                  title,
                   style: TextStyle(
                     color: color,
                     fontSize: 12,
                     fontWeight: FontWeight.w600,
                   ),
                 ),
-                if (message.isNotEmpty)
+                if (body.isNotEmpty)
                   Padding(
                     padding: const EdgeInsets.only(top: 2),
                     child: Text(
-                      message,
+                      body,
                       style: TextStyle(
                         color: colors.textSecondary,
                         fontSize: 11,
@@ -244,6 +252,32 @@ class MeshSection extends StatelessWidget {
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+/// Muted rounded badge — destination-count and scope labels across the
+/// mesh routing and mTLS screens. Unlike [MeshPill], this badge uses a
+/// plain background rather than a tinted colour fill, signalling that
+/// the content is metadata rather than a status value.
+class MeshMutedBadge extends StatelessWidget {
+  const MeshMutedBadge({super.key, required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(10),
+        color: colors.bgElevated,
+      ),
+      child: Text(
+        label,
+        style: TextStyle(color: colors.textMuted, fontSize: 11),
       ),
     );
   }

--- a/mobile/lib/features/mesh/mtls_posture_screen.dart
+++ b/mobile/lib/features/mesh/mtls_posture_screen.dart
@@ -1,0 +1,492 @@
+// mTLS posture per namespace. Namespace is required — backend hard-
+// requires `?namespace=` (400 without it) so the screen presents a
+// namespace prompt first, and only fetches once one is selected.
+//
+// Three-source attribution per row (Policy / Metric / Default) lives
+// in the `WorkloadMTLS.source` field. The detail expansion shows
+// `istioMode` and `sourceDetail` (workload / namespace / mesh scope)
+// for Istio rows; Linkerd rows show only state + source.
+//
+// Workloads with `workloadKindConfident == false` carry an asterisk +
+// tooltip explaining the kind was inferred from a ReplicaSet name
+// heuristic — not a real owner-reference walk.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../api/api_error.dart';
+import '../../api/mesh_repository.dart';
+import '../../api/resource_repository.dart';
+import '../../cluster/cluster_provider.dart';
+import '../../theme/kube_theme_builder.dart';
+import '../../widgets/feature_unavailable_state.dart';
+import 'mesh_widgets.dart';
+
+class MeshMtlsPostureScreen extends ConsumerStatefulWidget {
+  const MeshMtlsPostureScreen({super.key, this.initialNamespace});
+
+  /// Drawer / deep-link seed value for the namespace.
+  final String? initialNamespace;
+
+  @override
+  ConsumerState<MeshMtlsPostureScreen> createState() =>
+      _MeshMtlsPostureScreenState();
+}
+
+class _MeshMtlsPostureScreenState
+    extends ConsumerState<MeshMtlsPostureScreen> {
+  String? _namespace;
+
+  @override
+  void initState() {
+    super.initState();
+    _namespace = widget.initialNamespace;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final clusterId = ref.watch(activeClusterProvider);
+    final statusAsync = ref.watch(meshStatusProvider(clusterId));
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('mTLS posture'),
+      ),
+      body: statusAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Text(e.toString()),
+          ),
+        ),
+        data: (status) {
+          if (!status.isInstalled) return FeatureUnavailableState.mesh();
+          return Column(
+            children: [
+              _NamespaceBar(
+                clusterId: clusterId,
+                value: _namespace,
+                onChanged: (v) => setState(() => _namespace = v),
+              ),
+              const Divider(height: 1),
+              Expanded(
+                child: _namespace == null || _namespace!.isEmpty
+                    ? const _NamespacePrompt()
+                    : _PostureBody(
+                        clusterId: clusterId,
+                        namespace: _namespace!,
+                      ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _NamespaceBar extends ConsumerWidget {
+  const _NamespaceBar({
+    required this.clusterId,
+    required this.value,
+    required this.onChanged,
+  });
+
+  final String clusterId;
+  final String? value;
+  final ValueChanged<String?> onChanged;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final listAsync = ref.watch(resourceListProvider(
+      ResourceListKey(clusterId: clusterId, kind: 'namespaces'),
+    ));
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
+      child: Row(
+        children: [
+          Icon(Icons.folder_outlined, color: colors.textMuted, size: 18),
+          const SizedBox(width: 8),
+          Expanded(
+            child: listAsync.when(
+              loading: () => Text(
+                'Loading namespaces…',
+                style: TextStyle(color: colors.textMuted, fontSize: 13),
+              ),
+              error: (_, _) => DropdownButton<String?>(
+                value: value,
+                isExpanded: true,
+                hint: const Text('Namespaces unavailable — type manually'),
+                onChanged: (_) {},
+                items: const [],
+              ),
+              data: (list) {
+                final names = <String>{};
+                for (final item in list.items) {
+                  final meta = item['metadata'];
+                  if (meta is Map) {
+                    final n = meta['name'];
+                    if (n is String && n.isNotEmpty) names.add(n);
+                  }
+                }
+                final sorted = names.toList()..sort();
+                return DropdownButton<String?>(
+                  value: sorted.contains(value) ? value : null,
+                  isExpanded: true,
+                  hint: const Text('Select namespace'),
+                  onChanged: onChanged,
+                  items: [
+                    for (final name in sorted)
+                      DropdownMenuItem(value: name, child: Text(name)),
+                  ],
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _NamespacePrompt extends StatelessWidget {
+  const _NamespacePrompt();
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.lock_outline, size: 40, color: colors.textMuted),
+            const SizedBox(height: 12),
+            Text(
+              'Choose a namespace',
+              style: TextStyle(
+                color: colors.textPrimary,
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 6),
+            Text(
+              'mTLS posture is computed per namespace. Pick one above to '
+              'see workload-level encryption state, source attribution, '
+              'and Istio mode.',
+              textAlign: TextAlign.center,
+              style: TextStyle(color: colors.textMuted, fontSize: 13),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PostureBody extends ConsumerWidget {
+  const _PostureBody({required this.clusterId, required this.namespace});
+
+  final String clusterId;
+  final String namespace;
+
+  MeshMtlsKey get _key =>
+      MeshMtlsKey(clusterId: clusterId, namespace: namespace);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final async = ref.watch(meshMtlsPostureProvider(_key));
+
+    Future<void> handleRefresh() async {
+      ref.invalidate(meshMtlsPostureProvider(_key));
+      try {
+        await ref.read(meshMtlsPostureProvider(_key).future);
+      } on Object {
+        // surfaces via .when error branch
+      }
+    }
+
+    return RefreshIndicator(
+      onRefresh: handleRefresh,
+      child: async.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => _errorShell(e, handleRefresh, colors),
+        data: (response) {
+          final workloads = response.workloads;
+          final summary = _summarise(workloads);
+          return ListView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            padding: const EdgeInsets.symmetric(vertical: 8),
+            children: [
+              MeshErrorsBanner(errors: response.errors),
+              _SummaryStrip(summary: summary),
+              if (workloads.isEmpty)
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: 32,
+                  ),
+                  child: Center(
+                    child: Text(
+                      'No workloads found in namespace `$namespace`. '
+                      'The namespace may be empty or you may lack '
+                      'pod-read permission.',
+                      style: TextStyle(color: colors.textMuted),
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                )
+              else ...[
+                for (final w in workloads) _WorkloadRow(workload: w),
+              ],
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  _PostureSummary _summarise(List<WorkloadMTLS> rows) {
+    int active = 0, inactive = 0, mixed = 0, unmeshed = 0;
+    for (final w in rows) {
+      switch (w.state.toLowerCase()) {
+        case 'active':
+          active++;
+          break;
+        case 'inactive':
+          inactive++;
+          break;
+        case 'mixed':
+          mixed++;
+          break;
+        case 'unmeshed':
+          unmeshed++;
+          break;
+      }
+    }
+    return _PostureSummary(
+      active: active,
+      inactive: inactive,
+      mixed: mixed,
+      unmeshed: unmeshed,
+    );
+  }
+
+  Widget _errorShell(Object e, Future<void> Function() retry, KubeColors c) {
+    final body = e is ApiError && e.statusCode == 400
+        ? 'mTLS posture requires a namespace. Re-select above.'
+        : e is ApiError && e.statusCode == 403
+            ? 'You lack permission to view mTLS posture in this namespace.'
+            : e is ApiError
+                ? e.message
+                : e.toString();
+    return ListView(
+      physics: const AlwaysScrollableScrollPhysics(),
+      children: [
+        SizedBox(
+          height: 280,
+          child: Center(
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    body,
+                    style: TextStyle(color: c.textPrimary),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 12),
+                  OutlinedButton(
+                    onPressed: retry,
+                    child: const Text('Retry'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _PostureSummary {
+  const _PostureSummary({
+    required this.active,
+    required this.inactive,
+    required this.mixed,
+    required this.unmeshed,
+  });
+
+  final int active;
+  final int inactive;
+  final int mixed;
+  final int unmeshed;
+}
+
+class _SummaryStrip extends StatelessWidget {
+  const _SummaryStrip({required this.summary});
+
+  final _PostureSummary summary;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Wrap(
+        spacing: 8,
+        runSpacing: 8,
+        children: [
+          MeshPill(label: '${summary.active} Active', color: colors.success),
+          MeshPill(label: '${summary.mixed} Mixed', color: colors.warning),
+          MeshPill(label: '${summary.inactive} Inactive', color: colors.error),
+          MeshPill(
+              label: '${summary.unmeshed} Unmeshed', color: colors.textMuted),
+        ],
+      ),
+    );
+  }
+}
+
+class _WorkloadRow extends StatelessWidget {
+  const _WorkloadRow({required this.workload});
+
+  final WorkloadMTLS workload;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final kind = workload.workloadKind;
+    final showAsterisk = kind != null && !workload.workloadKindConfident;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      workload.workload,
+                      style: TextStyle(
+                        color: colors.textPrimary,
+                        fontWeight: FontWeight.w600,
+                        fontSize: 14,
+                      ),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    if (kind != null)
+                      Row(
+                        children: [
+                          Text(
+                            kind,
+                            style:
+                                TextStyle(color: colors.textMuted, fontSize: 12),
+                          ),
+                          if (showAsterisk)
+                            Tooltip(
+                              message:
+                                  'Workload kind inferred from ReplicaSet '
+                                  'name (no owner-reference lookup).',
+                              child: Padding(
+                                padding: const EdgeInsets.only(left: 2),
+                                child: Text(
+                                  '*',
+                                  style: TextStyle(
+                                    color: colors.warning,
+                                    fontSize: 12,
+                                    fontWeight: FontWeight.w700,
+                                  ),
+                                ),
+                              ),
+                            ),
+                        ],
+                      ),
+                  ],
+                ),
+              ),
+              MeshPill(
+                label: workload.state,
+                color: meshStateColor(colors, workload.state),
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Wrap(
+            spacing: 6,
+            runSpacing: 4,
+            children: [
+              MeshPill(
+                label: meshDisplayName(workload.mesh),
+                color: colors.accent,
+              ),
+              _SourceBadge(source: workload.source),
+              if (workload.istioMode != null)
+                MeshPill(
+                  label: 'Mode: ${workload.istioMode}',
+                  color: meshStateColor(colors, workload.istioMode),
+                ),
+              if (workload.sourceDetail != null)
+                _MutedBadge(
+                  label: 'Scope: ${workload.sourceDetail}',
+                  colors: colors,
+                ),
+            ],
+          ),
+          Divider(color: colors.borderSubtle, height: 18),
+        ],
+      ),
+    );
+  }
+}
+
+class _SourceBadge extends StatelessWidget {
+  const _SourceBadge({required this.source});
+
+  final String source;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final color = switch (source) {
+      'policy' => colors.info,
+      'metric' => colors.accent,
+      'default' => colors.textMuted,
+      _ => colors.textMuted,
+    };
+    return MeshPill(label: 'Source: $source', color: color);
+  }
+}
+
+class _MutedBadge extends StatelessWidget {
+  const _MutedBadge({required this.label, required this.colors});
+
+  final String label;
+  final KubeColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(10),
+        color: colors.bgElevated,
+      ),
+      child: Text(
+        label,
+        style: TextStyle(color: colors.textMuted, fontSize: 11),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/mesh/mtls_posture_screen.dart
+++ b/mobile/lib/features/mesh/mtls_posture_screen.dart
@@ -46,6 +46,12 @@ class _MeshMtlsPostureScreenState
   @override
   Widget build(BuildContext context) {
     final clusterId = ref.watch(activeClusterProvider);
+    // Reset namespace selection when the user switches clusters so stale
+    // namespace state from the previous cluster doesn't contaminate the
+    // new cluster's mTLS fetch.
+    ref.listen<String>(activeClusterProvider, (previous, next) {
+      if (previous != next) setState(() => _namespace = null);
+    });
     final statusAsync = ref.watch(meshStatusProvider(clusterId));
 
     return Scaffold(
@@ -115,12 +121,32 @@ class _NamespaceBar extends ConsumerWidget {
                 'Loading namespaces…',
                 style: TextStyle(color: colors.textMuted, fontSize: 13),
               ),
-              error: (_, _) => DropdownButton<String?>(
-                value: value,
-                isExpanded: true,
-                hint: const Text('Namespaces unavailable — type manually'),
-                onChanged: (_) {},
-                items: const [],
+              error: (e, _) => Row(
+                children: [
+                  Expanded(
+                    child: TextField(
+                      decoration: const InputDecoration(
+                        isDense: true,
+                        hintText: 'Namespace unavailable — type manually',
+                        hintStyle: TextStyle(fontSize: 13),
+                      ),
+                      onSubmitted: onChanged,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  IconButton(
+                    icon: const Icon(Icons.refresh, size: 20),
+                    tooltip: 'Retry namespace list',
+                    onPressed: () => ref.invalidate(
+                      resourceListProvider(
+                        ResourceListKey(
+                          clusterId: clusterId,
+                          kind: 'namespaces',
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
               ),
               data: (list) {
                 final names = <String>{};
@@ -252,7 +278,7 @@ class _PostureBody extends ConsumerWidget {
   }
 
   _PostureSummary _summarise(List<WorkloadMTLS> rows) {
-    int active = 0, inactive = 0, mixed = 0, unmeshed = 0;
+    int active = 0, inactive = 0, mixed = 0, unmeshed = 0, unknown = 0;
     for (final w in rows) {
       switch (w.state.toLowerCase()) {
         case 'active':
@@ -267,6 +293,9 @@ class _PostureBody extends ConsumerWidget {
         case 'unmeshed':
           unmeshed++;
           break;
+        default:
+          unknown++;
+          break;
       }
     }
     return _PostureSummary(
@@ -274,6 +303,7 @@ class _PostureBody extends ConsumerWidget {
       inactive: inactive,
       mixed: mixed,
       unmeshed: unmeshed,
+      unknown: unknown,
     );
   }
 
@@ -322,12 +352,17 @@ class _PostureSummary {
     required this.inactive,
     required this.mixed,
     required this.unmeshed,
+    this.unknown = 0,
   });
 
   final int active;
   final int inactive;
   final int mixed;
   final int unmeshed;
+
+  /// Count of workloads with a state value not in the known vocabulary.
+  /// Shown when non-zero so unknown backend states surface visibly.
+  final int unknown;
 }
 
 class _SummaryStrip extends StatelessWidget {
@@ -349,6 +384,9 @@ class _SummaryStrip extends StatelessWidget {
           MeshPill(label: '${summary.inactive} Inactive', color: colors.error),
           MeshPill(
               label: '${summary.unmeshed} Unmeshed', color: colors.textMuted),
+          if (summary.unknown > 0)
+            MeshPill(
+                label: '${summary.unknown} Unknown', color: colors.textMuted),
         ],
       ),
     );
@@ -438,9 +476,8 @@ class _WorkloadRow extends StatelessWidget {
                   color: meshStateColor(colors, workload.istioMode),
                 ),
               if (workload.sourceDetail != null)
-                _MutedBadge(
+                MeshMutedBadge(
                   label: 'Scope: ${workload.sourceDetail}',
-                  colors: colors,
                 ),
             ],
           ),
@@ -469,24 +506,3 @@ class _SourceBadge extends StatelessWidget {
   }
 }
 
-class _MutedBadge extends StatelessWidget {
-  const _MutedBadge({required this.label, required this.colors});
-
-  final String label;
-  final KubeColors colors;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(10),
-        color: colors.bgElevated,
-      ),
-      child: Text(
-        label,
-        style: TextStyle(color: colors.textMuted, fontSize: 11),
-      ),
-    );
-  }
-}

--- a/mobile/lib/features/mesh/route_detail_screen.dart
+++ b/mobile/lib/features/mesh/route_detail_screen.dart
@@ -62,6 +62,15 @@ class MeshRouteDetailScreen extends ConsumerWidget {
     final key = MeshRouteDetailKey(clusterId: clusterId, id: id);
     final async = ref.watch(meshRouteDetailProvider(key));
 
+    Future<void> handleRefresh() async {
+      ref.invalidate(meshRouteDetailProvider(key));
+      try {
+        await ref.read(meshRouteDetailProvider(key).future);
+      } on Object {
+        // surfaces via .when error branch
+      }
+    }
+
     return Scaffold(
       appBar: AppBar(
         title: Text(parsed.name),
@@ -69,37 +78,56 @@ class MeshRouteDetailScreen extends ConsumerWidget {
           IconButton(
             tooltip: 'Refresh',
             icon: const Icon(Icons.refresh),
-            onPressed: () => ref.invalidate(meshRouteDetailProvider(key)),
+            onPressed: handleRefresh,
           ),
         ],
       ),
-      body: async.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) {
-          if (e is ApiError && e.statusCode == 404) {
-            return Center(
-              child: Padding(
-                padding: const EdgeInsets.all(24),
-                child: Text(
-                  'Route ${parsed.name} not found in namespace '
-                  '${parsed.namespace}. It may have been deleted.',
-                  textAlign: TextAlign.center,
+      body: RefreshIndicator(
+        onRefresh: handleRefresh,
+        child: async.when(
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (e, _) {
+            if (e is ApiError && e.statusCode == 404) {
+              return ListView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                children: [
+                  SizedBox(
+                    height: 280,
+                    child: Center(
+                      child: Padding(
+                        padding: const EdgeInsets.all(24),
+                        child: Text(
+                          'Route ${parsed.name} not found in namespace '
+                          '${parsed.namespace}. It may have been deleted.',
+                          textAlign: TextAlign.center,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              );
+            }
+            return ListView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              children: [
+                SizedBox(
+                  height: 280,
+                  child: Center(
+                    child: Padding(
+                      padding: const EdgeInsets.all(24),
+                      child: Text(
+                        e is ApiError ? e.message : e.toString(),
+                        style: TextStyle(color: colors.error),
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                  ),
                 ),
-              ),
+              ],
             );
-          }
-          return Center(
-            child: Padding(
-              padding: const EdgeInsets.all(24),
-              child: Text(
-                e is ApiError ? e.message : e.toString(),
-                style: TextStyle(color: colors.error),
-                textAlign: TextAlign.center,
-              ),
-            ),
-          );
-        },
-        data: (route) => _Body(route: route, parsed: parsed),
+          },
+          data: (route) => _Body(route: route, parsed: parsed),
+        ),
       ),
     );
   }
@@ -115,6 +143,7 @@ class _Body extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = Theme.of(context).extension<KubeColors>()!;
     return ListView(
+      physics: const AlwaysScrollableScrollPhysics(),
       padding: const EdgeInsets.fromLTRB(0, 8, 0, 24),
       children: [
         _Header(route: route, parsed: parsed),
@@ -247,10 +276,18 @@ class _DestinationRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = Theme.of(context).extension<KubeColors>()!;
+    // Build host+port as a single token so the display reads
+    // "web.app.svc:80" rather than "web.app.svc : 80".
+    final hostPort = dest.host != null
+        ? dest.port != null
+            ? '${dest.host}:${dest.port}'
+            : dest.host!
+        : dest.port != null
+            ? ':${dest.port}'
+            : null;
     final segments = <String>[
-      if (dest.host != null) dest.host!,
+      ?hostPort,
       if (dest.subset != null) 'subset=${dest.subset}',
-      if (dest.port != null) ':${dest.port}',
       if (dest.weight != null) 'weight=${dest.weight}',
     ];
     return Padding(

--- a/mobile/lib/features/mesh/route_detail_screen.dart
+++ b/mobile/lib/features/mesh/route_detail_screen.dart
@@ -1,0 +1,398 @@
+// Routing CRD detail. Composite-ID-driven — the URL path segment is
+// `Uri.encodeComponent(route.id)` where the id has the shape
+// `mesh:namespace:kindCode:name`. The id round-trips through
+// [MeshRouteId.tryParse] so an invalid path produces a 404-style
+// error screen instead of a stack trace.
+//
+// Body layout:
+//   Header card    — name + Mesh pill + Kind label
+//   Metadata       — name / namespace / mesh / kind
+//   Routing panel  — hosts / gateways / subsets (collapses empty lists)
+//   Destinations   — numbered list with host + subset + port + weight
+//   Matchers       — indexed list with method + path
+//   Raw spec       — JSON-encoded raw map for operators who want the
+//                    full unstructured payload (mobile doesn't ship the
+//                    full YAML editor here; the desktop covers that
+//                    case with a real CodeMirror-class surface).
+//
+// Effect annotations (Istio AuthorizationPolicy `effect: deny_all`)
+// are part of `policies`, not `routing`, so they don't render here.
+
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../api/api_error.dart';
+import '../../api/mesh_repository.dart';
+import '../../cluster/cluster_provider.dart';
+import '../../theme/kube_theme_builder.dart';
+import '../../util/composite_id.dart';
+import 'mesh_widgets.dart';
+
+class MeshRouteDetailScreen extends ConsumerWidget {
+  const MeshRouteDetailScreen({super.key, required this.id});
+
+  /// Raw composite id as it arrived in the route path (already
+  /// decoded one layer by go_router). Form: `mesh:ns:kindCode:name`.
+  final String id;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final parsed = MeshRouteId.tryParse(id);
+
+    if (parsed == null) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('Route')),
+        body: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Text(
+              'Invalid route ID: $id',
+              style: TextStyle(color: colors.error),
+              textAlign: TextAlign.center,
+            ),
+          ),
+        ),
+      );
+    }
+
+    final clusterId = ref.watch(activeClusterProvider);
+    final key = MeshRouteDetailKey(clusterId: clusterId, id: id);
+    final async = ref.watch(meshRouteDetailProvider(key));
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(parsed.name),
+        actions: [
+          IconButton(
+            tooltip: 'Refresh',
+            icon: const Icon(Icons.refresh),
+            onPressed: () => ref.invalidate(meshRouteDetailProvider(key)),
+          ),
+        ],
+      ),
+      body: async.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) {
+          if (e is ApiError && e.statusCode == 404) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Text(
+                  'Route ${parsed.name} not found in namespace '
+                  '${parsed.namespace}. It may have been deleted.',
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            );
+          }
+          return Center(
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Text(
+                e is ApiError ? e.message : e.toString(),
+                style: TextStyle(color: colors.error),
+                textAlign: TextAlign.center,
+              ),
+            ),
+          );
+        },
+        data: (route) => _Body(route: route, parsed: parsed),
+      ),
+    );
+  }
+}
+
+class _Body extends StatelessWidget {
+  const _Body({required this.route, required this.parsed});
+
+  final TrafficRoute route;
+  final MeshRouteId parsed;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(0, 8, 0, 24),
+      children: [
+        _Header(route: route, parsed: parsed),
+        MeshSection(
+          title: 'METADATA',
+          child: Column(
+            children: [
+              MeshKvLine(label: 'Name', value: route.name),
+              MeshKvLine(label: 'Namespace', value: route.namespace),
+              MeshKvLine(
+                label: 'Mesh',
+                value: meshDisplayName(route.mesh),
+                valueColor: colors.accent,
+              ),
+              MeshKvLine(label: 'Kind', value: route.kind),
+              if (route.selector != null)
+                MeshKvLine(
+                  label: 'Selector',
+                  value: route.selector!,
+                  monospace: true,
+                ),
+            ],
+          ),
+        ),
+        if (route.hosts.isNotEmpty ||
+            route.gateways.isNotEmpty ||
+            route.subsets.isNotEmpty)
+          MeshSection(
+            title: 'ROUTING',
+            child: Column(
+              children: [
+                if (route.hosts.isNotEmpty)
+                  MeshKvLine(
+                    label: 'Hosts',
+                    value: route.hosts.join('\n'),
+                    monospace: true,
+                  ),
+                if (route.gateways.isNotEmpty)
+                  MeshKvLine(
+                    label: 'Gateways',
+                    value: route.gateways.join('\n'),
+                    monospace: true,
+                  ),
+                if (route.subsets.isNotEmpty)
+                  MeshKvLine(
+                    label: 'Subsets',
+                    value: route.subsets.join(', '),
+                  ),
+              ],
+            ),
+          ),
+        if (route.destinations.isNotEmpty)
+          MeshSection(
+            title: 'DESTINATIONS (${route.destinations.length})',
+            child: Column(
+              children: [
+                for (var i = 0; i < route.destinations.length; i++)
+                  _DestinationRow(index: i + 1, dest: route.destinations[i]),
+              ],
+            ),
+          ),
+        if (route.matchers.isNotEmpty)
+          MeshSection(
+            title: 'MATCHERS (${route.matchers.length})',
+            child: Column(
+              children: [
+                for (var i = 0; i < route.matchers.length; i++)
+                  _MatcherRow(index: i + 1, matcher: route.matchers[i]),
+              ],
+            ),
+          ),
+        if (route.raw != null) _RawPanel(raw: route.raw!),
+      ],
+    );
+  }
+}
+
+class _Header extends StatelessWidget {
+  const _Header({required this.route, required this.parsed});
+
+  final TrafficRoute route;
+  final MeshRouteId parsed;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+      child: Row(
+        children: [
+          Icon(Icons.alt_route, color: colors.accent),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  route.name,
+                  style: TextStyle(
+                    color: colors.textPrimary,
+                    fontWeight: FontWeight.w700,
+                    fontSize: 18,
+                  ),
+                  overflow: TextOverflow.ellipsis,
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  '${route.kind} · ${route.namespace}',
+                  style: TextStyle(color: colors.textMuted, fontSize: 12),
+                ),
+              ],
+            ),
+          ),
+          MeshPill(
+            label: meshDisplayName(route.mesh),
+            color: colors.accent,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DestinationRow extends StatelessWidget {
+  const _DestinationRow({required this.index, required this.dest});
+
+  final int index;
+  final RouteDestination dest;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final segments = <String>[
+      if (dest.host != null) dest.host!,
+      if (dest.subset != null) 'subset=${dest.subset}',
+      if (dest.port != null) ':${dest.port}',
+      if (dest.weight != null) 'weight=${dest.weight}',
+    ];
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 3),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 24,
+            child: Text(
+              '$index.',
+              style: TextStyle(color: colors.textMuted, fontSize: 12),
+            ),
+          ),
+          Expanded(
+            child: SelectableText(
+              segments.join(' '),
+              style: TextStyle(
+                color: colors.textPrimary,
+                fontSize: 13,
+                fontFamily: 'monospace',
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MatcherRow extends StatelessWidget {
+  const _MatcherRow({required this.index, required this.matcher});
+
+  final int index;
+  final RouteMatcher matcher;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final path = matcher.pathExact ??
+        (matcher.pathPrefix != null ? '${matcher.pathPrefix}* (prefix)' : null) ??
+        (matcher.pathRegex != null ? '${matcher.pathRegex} (regex)' : null) ??
+        '—';
+    final method = matcher.method ?? 'ANY';
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 3),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 24,
+            child: Text(
+              '$index.',
+              style: TextStyle(color: colors.textMuted, fontSize: 12),
+            ),
+          ),
+          MeshPill(label: method, color: colors.info),
+          const SizedBox(width: 6),
+          Expanded(
+            child: SelectableText(
+              path,
+              style: TextStyle(
+                color: colors.textPrimary,
+                fontSize: 13,
+                fontFamily: 'monospace',
+              ),
+            ),
+          ),
+          if (matcher.name != null)
+            Padding(
+              padding: const EdgeInsets.only(left: 8),
+              child: Text(
+                matcher.name!,
+                style: TextStyle(color: colors.textMuted, fontSize: 11),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _RawPanel extends StatefulWidget {
+  const _RawPanel({required this.raw});
+
+  final Map<String, Object?> raw;
+
+  @override
+  State<_RawPanel> createState() => _RawPanelState();
+}
+
+class _RawPanelState extends State<_RawPanel> {
+  bool _expanded = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final encoded =
+        const JsonEncoder.withIndent('  ').convert(widget.raw);
+    return MeshSection(
+      title: 'RAW SPEC',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          InkWell(
+            onTap: () => setState(() => _expanded = !_expanded),
+            child: Row(
+              children: [
+                Icon(
+                  _expanded ? Icons.expand_less : Icons.expand_more,
+                  size: 18,
+                  color: colors.textMuted,
+                ),
+                const SizedBox(width: 4),
+                Text(
+                  _expanded ? 'Hide' : 'Show',
+                  style: TextStyle(color: colors.textMuted, fontSize: 12),
+                ),
+              ],
+            ),
+          ),
+          if (_expanded) ...[
+            const SizedBox(height: 6),
+            Container(
+              decoration: BoxDecoration(
+                color: colors.bgSurface,
+                borderRadius: BorderRadius.circular(6),
+                border: Border.all(color: colors.borderSubtle),
+              ),
+              padding: const EdgeInsets.all(8),
+              child: SelectableText(
+                encoded,
+                style: TextStyle(
+                  color: colors.textPrimary,
+                  fontSize: 11,
+                  fontFamily: 'monospace',
+                ),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/mesh/routing_list_screen.dart
+++ b/mobile/lib/features/mesh/routing_list_screen.dart
@@ -62,6 +62,17 @@ class _MeshRoutingListScreenState
   Widget build(BuildContext context) {
     final clusterId = ref.watch(activeClusterProvider);
     final statusAsync = ref.watch(meshStatusProvider(clusterId));
+    // Reset mesh filter and namespace text when the user switches clusters
+    // so stale filter state from the previous cluster is cleared.
+    ref.listen<String>(activeClusterProvider, (previous, next) {
+      if (previous != next) {
+        setState(() {
+          _mesh = _MeshFilter.all;
+          _namespace = '';
+          _namespaceCtl.clear();
+        });
+      }
+    });
 
     return Scaffold(
       appBar: AppBar(title: const Text('Mesh Routing')),
@@ -132,44 +143,55 @@ class _RoutingBody extends ConsumerWidget {
         error: (e, _) => _errorShell(e, handleRefresh, colors),
         data: (response) {
           final filtered = _applyMeshFilter(response.routes);
-          return ListView(
+          return CustomScrollView(
             physics: const AlwaysScrollableScrollPhysics(),
-            padding: const EdgeInsets.symmetric(vertical: 8),
-            children: [
-              _FilterStrip(
-                mesh: mesh,
-                namespaceCtl: namespaceCtl,
-                onMeshChanged: onMeshChanged,
-                onNamespaceChanged: onNamespaceChanged,
+            slivers: [
+              SliverToBoxAdapter(
+                child: Column(
+                  children: [
+                    _FilterStrip(
+                      mesh: mesh,
+                      namespaceCtl: namespaceCtl,
+                      onMeshChanged: onMeshChanged,
+                      onNamespaceChanged: onNamespaceChanged,
+                    ),
+                    MeshErrorsBanner(errors: response.errors),
+                  ],
+                ),
               ),
-              MeshErrorsBanner(errors: response.errors),
               if (filtered.isEmpty)
-                Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 16,
-                    vertical: 32,
-                  ),
-                  child: Center(
-                    child: Text(
-                      response.routes.isEmpty
-                          ? 'No routing rules. Apply a VirtualService, '
-                              'HTTPRoute, or similar to see entries here.'
-                          : 'No routes match the current filters.',
-                      style: TextStyle(color: colors.textMuted),
-                      textAlign: TextAlign.center,
+                SliverToBoxAdapter(
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 16,
+                      vertical: 32,
+                    ),
+                    child: Center(
+                      child: Text(
+                        response.routes.isEmpty
+                            ? 'No routing rules. Apply a VirtualService, '
+                                'HTTPRoute, or similar to see entries here.'
+                            : 'No routes match the current filters.',
+                        style: TextStyle(color: colors.textMuted),
+                        textAlign: TextAlign.center,
+                      ),
                     ),
                   ),
                 )
-              else ...[
-                for (final route in filtered)
-                  _RouteRow(
-                    route: route,
-                    onTap: () => context.push(
-                      '/clusters/$clusterId/mesh/routing/'
-                      '${Uri.encodeComponent(route.id)}',
+              else
+                SliverList(
+                  delegate: SliverChildBuilderDelegate(
+                    (context, index) => _RouteRow(
+                      route: filtered[index],
+                      onTap: () => context.push(
+                        '/clusters/$clusterId/mesh/routing/'
+                        '${Uri.encodeComponent(filtered[index].id)}',
+                      ),
                     ),
+                    childCount: filtered.length,
                   ),
-              ],
+                ),
+              const SliverPadding(padding: EdgeInsets.only(bottom: 8)),
             ],
           );
         },
@@ -336,9 +358,8 @@ class _RouteRow extends StatelessWidget {
                 ),
                 if (destCount > 0) ...[
                   const SizedBox(width: 8),
-                  _MutedBadge(
+                  MeshMutedBadge(
                     label: '$destCount destination${destCount == 1 ? '' : 's'}',
-                    colors: colors,
                   ),
                 ],
               ],
@@ -363,27 +384,3 @@ class _RouteRow extends StatelessWidget {
   }
 }
 
-class _MutedBadge extends StatelessWidget {
-  const _MutedBadge({required this.label, required this.colors});
-
-  final String label;
-  final KubeColors colors;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(10),
-        color: colors.bgElevated,
-      ),
-      child: Text(
-        label,
-        style: TextStyle(
-          color: colors.textMuted,
-          fontSize: 11,
-        ),
-      ),
-    );
-  }
-}

--- a/mobile/lib/features/mesh/routing_list_screen.dart
+++ b/mobile/lib/features/mesh/routing_list_screen.dart
@@ -1,0 +1,389 @@
+// Routing list — every TrafficRoute the active user can read across
+// both meshes. Filter chips for mesh (Both / Istio / Linkerd) and a
+// free-text namespace filter at the top. Partial-fetch error map
+// surfaces as a banner above the list. Mirrors the web's
+// `MeshRoutingList.tsx` filter and banner strategy.
+//
+// Status gating: `meshStatusProvider` gates the surface — when neither
+// mesh is detected the operator sees `FeatureUnavailableState.mesh()`
+// rather than an empty list with no explanation.
+//
+// Tap row → `/clusters/<id>/mesh/routing/<encoded-id>`. The composite
+// id round-trips through [MeshRouteId.tryParse] in the detail screen.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../api/api_error.dart';
+import '../../api/mesh_repository.dart';
+import '../../cluster/cluster_provider.dart';
+import '../../theme/kube_theme_builder.dart';
+import '../../widgets/feature_unavailable_state.dart';
+import 'mesh_widgets.dart';
+
+enum _MeshFilter { all, istio, linkerd }
+
+class MeshRoutingListScreen extends ConsumerStatefulWidget {
+  const MeshRoutingListScreen({super.key, this.initialMesh});
+
+  /// Pre-filter the mesh chip on mount. Drawer deep-links don't seed
+  /// this; the dashboard cards do (Istio card → `?mesh=istio`).
+  final String? initialMesh;
+
+  @override
+  ConsumerState<MeshRoutingListScreen> createState() =>
+      _MeshRoutingListScreenState();
+}
+
+class _MeshRoutingListScreenState
+    extends ConsumerState<MeshRoutingListScreen> {
+  late _MeshFilter _mesh;
+  String _namespace = '';
+  final _namespaceCtl = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _mesh = switch (widget.initialMesh) {
+      'istio' => _MeshFilter.istio,
+      'linkerd' => _MeshFilter.linkerd,
+      _ => _MeshFilter.all,
+    };
+  }
+
+  @override
+  void dispose() {
+    _namespaceCtl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final clusterId = ref.watch(activeClusterProvider);
+    final statusAsync = ref.watch(meshStatusProvider(clusterId));
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Mesh Routing')),
+      body: statusAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Text(e.toString()),
+          ),
+        ),
+        data: (status) {
+          if (!status.isInstalled) return FeatureUnavailableState.mesh();
+          return _RoutingBody(
+            clusterId: clusterId,
+            mesh: _mesh,
+            namespace: _namespace,
+            namespaceCtl: _namespaceCtl,
+            onMeshChanged: (v) => setState(() => _mesh = v),
+            onNamespaceChanged: (v) => setState(() => _namespace = v),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _RoutingBody extends ConsumerWidget {
+  const _RoutingBody({
+    required this.clusterId,
+    required this.mesh,
+    required this.namespace,
+    required this.namespaceCtl,
+    required this.onMeshChanged,
+    required this.onNamespaceChanged,
+  });
+
+  final String clusterId;
+  final _MeshFilter mesh;
+  final String namespace;
+  final TextEditingController namespaceCtl;
+  final ValueChanged<_MeshFilter> onMeshChanged;
+  final ValueChanged<String> onNamespaceChanged;
+
+  MeshRoutingKey get _key => MeshRoutingKey(
+        clusterId: clusterId,
+        namespace: namespace.isEmpty ? null : namespace,
+      );
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final async = ref.watch(meshRoutingProvider(_key));
+
+    Future<void> handleRefresh() async {
+      ref.invalidate(meshRoutingProvider(_key));
+      try {
+        await ref.read(meshRoutingProvider(_key).future);
+      } on Object {
+        // surfaces via .when error branch
+      }
+    }
+
+    return RefreshIndicator(
+      onRefresh: handleRefresh,
+      child: async.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => _errorShell(e, handleRefresh, colors),
+        data: (response) {
+          final filtered = _applyMeshFilter(response.routes);
+          return ListView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            padding: const EdgeInsets.symmetric(vertical: 8),
+            children: [
+              _FilterStrip(
+                mesh: mesh,
+                namespaceCtl: namespaceCtl,
+                onMeshChanged: onMeshChanged,
+                onNamespaceChanged: onNamespaceChanged,
+              ),
+              MeshErrorsBanner(errors: response.errors),
+              if (filtered.isEmpty)
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: 32,
+                  ),
+                  child: Center(
+                    child: Text(
+                      response.routes.isEmpty
+                          ? 'No routing rules. Apply a VirtualService, '
+                              'HTTPRoute, or similar to see entries here.'
+                          : 'No routes match the current filters.',
+                      style: TextStyle(color: colors.textMuted),
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                )
+              else ...[
+                for (final route in filtered)
+                  _RouteRow(
+                    route: route,
+                    onTap: () => context.push(
+                      '/clusters/$clusterId/mesh/routing/'
+                      '${Uri.encodeComponent(route.id)}',
+                    ),
+                  ),
+              ],
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  List<TrafficRoute> _applyMeshFilter(List<TrafficRoute> routes) {
+    return routes.where((r) {
+      if (mesh == _MeshFilter.istio && r.mesh != 'istio') return false;
+      if (mesh == _MeshFilter.linkerd && r.mesh != 'linkerd') return false;
+      return true;
+    }).toList();
+  }
+
+  Widget _errorShell(Object e, Future<void> Function() retry, KubeColors c) {
+    return ListView(
+      physics: const AlwaysScrollableScrollPhysics(),
+      children: [
+        SizedBox(
+          height: 280,
+          child: Center(
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    'Failed to load routing rules',
+                    style: TextStyle(
+                      color: c.textPrimary,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    e is ApiError ? e.message : e.toString(),
+                    style: TextStyle(color: c.textMuted),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 12),
+                  OutlinedButton(
+                    onPressed: retry,
+                    child: const Text('Retry'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _FilterStrip extends StatelessWidget {
+  const _FilterStrip({
+    required this.mesh,
+    required this.namespaceCtl,
+    required this.onMeshChanged,
+    required this.onNamespaceChanged,
+  });
+
+  final _MeshFilter mesh;
+  final TextEditingController namespaceCtl;
+  final ValueChanged<_MeshFilter> onMeshChanged;
+  final ValueChanged<String> onNamespaceChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Wrap(
+            spacing: 6,
+            runSpacing: 4,
+            children: [
+              for (final value in _MeshFilter.values)
+                ChoiceChip(
+                  label: Text(switch (value) {
+                    _MeshFilter.all => 'Both meshes',
+                    _MeshFilter.istio => 'Istio',
+                    _MeshFilter.linkerd => 'Linkerd',
+                  }),
+                  selected: value == mesh,
+                  onSelected: (_) => onMeshChanged(value),
+                ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          TextField(
+            controller: namespaceCtl,
+            decoration: InputDecoration(
+              prefixIcon: const Icon(Icons.folder_outlined, size: 18),
+              labelText: 'Namespace filter',
+              hintText: 'Empty = all namespaces',
+              hintStyle: TextStyle(color: colors.textMuted, fontSize: 12),
+              isDense: true,
+            ),
+            onSubmitted: onNamespaceChanged,
+            onChanged: (v) {
+              // Debounce-light: only refetch on Enter via onSubmitted.
+              // Free-text edits update local state but don't refire the
+              // provider; otherwise every keystroke would trigger a fetch.
+              if (v.isEmpty) onNamespaceChanged('');
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _RouteRow extends StatelessWidget {
+  const _RouteRow({required this.route, required this.onTap});
+
+  final TrafficRoute route;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final destCount = route.destinations.length;
+    final hostPreview = route.hosts.isEmpty
+        ? null
+        : route.hosts.length <= 2
+            ? route.hosts.join(', ')
+            : '${route.hosts.take(2).join(', ')} (+${route.hosts.length - 2})';
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    route.name,
+                    style: TextStyle(
+                      color: colors.textPrimary,
+                      fontWeight: FontWeight.w600,
+                      fontSize: 15,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                MeshPill(
+                  label: meshDisplayName(route.mesh),
+                  color: colors.accent,
+                ),
+              ],
+            ),
+            const SizedBox(height: 4),
+            Row(
+              children: [
+                Text(
+                  '${route.kind} · ${route.namespace}',
+                  style: TextStyle(color: colors.textMuted, fontSize: 12),
+                ),
+                if (destCount > 0) ...[
+                  const SizedBox(width: 8),
+                  _MutedBadge(
+                    label: '$destCount destination${destCount == 1 ? '' : 's'}',
+                    colors: colors,
+                  ),
+                ],
+              ],
+            ),
+            if (hostPreview != null) ...[
+              const SizedBox(height: 4),
+              Text(
+                hostPreview,
+                style: TextStyle(color: colors.textSecondary, fontSize: 11),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
+            Divider(
+              color: colors.borderSubtle,
+              height: 18,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MutedBadge extends StatelessWidget {
+  const _MutedBadge({required this.label, required this.colors});
+
+  final String label;
+  final KubeColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(10),
+        color: colors.bgElevated,
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          color: colors.textMuted,
+          fontSize: 11,
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/resources/service_screens.dart
+++ b/mobile/lib/features/resources/service_screens.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../api/mesh_repository.dart';
 import '../../api/resource_repository.dart';
 import '../../cluster/cluster_provider.dart';
 import '../../routing/domain_sections.dart';
@@ -13,6 +14,7 @@ import '../../widgets/resource_actions_button.dart';
 import '../../widgets/resource_detail_scaffold.dart';
 import '../../widgets/resource_list_scaffold.dart';
 import '../../widgets/resource_table.dart';
+import '../mesh/golden_signals_tab.dart';
 import 'k8s_helpers.dart';
 
 class _ServiceRow {
@@ -142,6 +144,23 @@ class ServiceDetailScreen extends ConsumerWidget {
       data: (raw) {
         final s = _ServiceRow(raw);
         final colors = Theme.of(context).extension<KubeColors>()!;
+        // M4 PR-4f: surface golden signals as an extra tab when a mesh
+        // is installed on the cluster. The mesh status drives both tab
+        // visibility and (in the tab itself) the mesh disambiguation
+        // when both Istio and Linkerd are present.
+        final meshStatus =
+            ref.watch(meshStatusProvider(clusterId)).valueOrNull;
+        final extraTabs = <DetailExtraTab>[
+          if (meshStatus != null && meshStatus.isInstalled)
+            DetailExtraTab(
+              label: 'Golden signals',
+              body: GoldenSignalsTab(
+                namespace: s.meta.namespace,
+                service: s.meta.name,
+                status: meshStatus,
+              ),
+            ),
+        ];
         return ResourceDetailScaffold(
           kindLabel: 'Service',
           name: s.meta.name,
@@ -151,6 +170,7 @@ class ServiceDetailScreen extends ConsumerWidget {
           statusLabel: s.type,
           statusColor: colors.accent,
           resource: raw,
+          extraTabs: extraTabs,
           trailingAction: ResourceActionsButton(
             kind: 'services',
             namespace: s.meta.namespace,

--- a/mobile/lib/features/resources/service_screens.dart
+++ b/mobile/lib/features/resources/service_screens.dart
@@ -14,6 +14,10 @@ import '../../widgets/resource_actions_button.dart';
 import '../../widgets/resource_detail_scaffold.dart';
 import '../../widgets/resource_list_scaffold.dart';
 import '../../widgets/resource_table.dart';
+// Intentional cross-feature import: Service detail surfaces a golden
+// signals tab from the mesh feature when a service mesh is detected on
+// the cluster (added in PR-4f). This is the only mesh dependency in the
+// resources feature.
 import '../mesh/golden_signals_tab.dart';
 import 'k8s_helpers.dart';
 

--- a/mobile/lib/routing/app_router.dart
+++ b/mobile/lib/routing/app_router.dart
@@ -18,6 +18,10 @@ import '../features/gitops/application_detail_screen.dart';
 import '../features/gitops/applications_list_screen.dart';
 import '../features/gitops/applicationset_detail_screen.dart';
 import '../features/gitops/applicationsets_list_screen.dart';
+import '../features/mesh/mesh_dashboard_screen.dart';
+import '../features/mesh/mtls_posture_screen.dart';
+import '../features/mesh/route_detail_screen.dart';
+import '../features/mesh/routing_list_screen.dart';
 import '../features/observability/diagnostics/diagnostics_screen.dart';
 import '../features/observability/diagnostics/namespace_summary_screen.dart';
 import '../features/observability/logs/log_search_screen.dart';
@@ -159,6 +163,50 @@ final appRouterProvider = Provider<GoRouter>((ref) {
             path: ':id',
             builder: (context, state) => ApplicationSetDetailScreen(
               id: state.pathParameters['id']!,
+            ),
+          ),
+        ],
+      ),
+
+      // --- M4 PR-4f: service-mesh surfaces (Istio + Linkerd) ---
+      // /clusters/<id>/mesh                       → dashboard
+      // /clusters/<id>/mesh/routing[?mesh=istio]  → routing list
+      // /clusters/<id>/mesh/routing/<encoded-id>  → route detail
+      // /clusters/<id>/mesh/mtls[?namespace=]     → mTLS posture
+      //
+      // Composite ids on routing detail follow the
+      // `mesh:namespace:kindCode:name` shape; the route param carries
+      // one layer of percent encoding. The detail screen parses via
+      // [MeshRouteId.tryParse] and emits a validation error screen on
+      // malformed input rather than 500-ing.
+      //
+      // Status-gating is screen-level (each surface checks
+      // `meshStatusProvider` and falls back to
+      // `FeatureUnavailableState.mesh()`) rather than at the router so
+      // the drawer entries stay visible and operators get the
+      // install-guidance UX consistently.
+      GoRoute(
+        path: '/clusters/:clusterId/mesh',
+        builder: (context, state) => const MeshDashboardScreen(),
+        routes: [
+          GoRoute(
+            path: 'routing',
+            builder: (context, state) => MeshRoutingListScreen(
+              initialMesh: state.uri.queryParameters['mesh'],
+            ),
+            routes: [
+              GoRoute(
+                path: ':id',
+                builder: (context, state) => MeshRouteDetailScreen(
+                  id: state.pathParameters['id']!,
+                ),
+              ),
+            ],
+          ),
+          GoRoute(
+            path: 'mtls',
+            builder: (context, state) => MeshMtlsPostureScreen(
+              initialNamespace: state.uri.queryParameters['namespace'],
             ),
           ),
         ],

--- a/mobile/lib/routing/domain_sections.dart
+++ b/mobile/lib/routing/domain_sections.dart
@@ -190,6 +190,42 @@ const List<DomainSection> domainSections = [
       ),
     ],
   ),
+  // Service mesh surfaces (PR-4f). Three entries:
+  //   * Mesh dashboard — Istio + Linkerd side-by-side status cards.
+  //   * Routing — list of every TrafficRoute across both meshes.
+  //   * mTLS posture — per-namespace workload encryption state.
+  // Golden signals tab is rendered inline on Service detail screens
+  // rather than as a drawer entry. All three surfaces gate on
+  // `meshStatusProvider` and fall back to
+  // `FeatureUnavailableState.mesh()` when neither mesh is installed.
+  DomainSection(
+    label: 'Service Mesh',
+    pathSegment: 'mesh',
+    icon: Icons.hub_outlined,
+    kinds: [
+      DomainKind(
+        kind: 'mesh',
+        label: 'Dashboard',
+        icon: Icons.dashboard_outlined,
+        namespaced: false,
+        customListPath: '/clusters/{clusterId}/mesh',
+      ),
+      DomainKind(
+        kind: 'routing',
+        label: 'Routing',
+        icon: Icons.alt_route_outlined,
+        namespaced: false,
+        customListPath: '/clusters/{clusterId}/mesh/routing',
+      ),
+      DomainKind(
+        kind: 'mtls',
+        label: 'mTLS posture',
+        icon: Icons.lock_outline,
+        namespaced: false,
+        customListPath: '/clusters/{clusterId}/mesh/mtls',
+      ),
+    ],
+  ),
 ];
 
 /// Substitutes `{clusterId}` (and any future placeholder) in a

--- a/mobile/test/api/mesh_repository_test.dart
+++ b/mobile/test/api/mesh_repository_test.dart
@@ -1,0 +1,619 @@
+// MeshRepository tests: endpoint paths, X-Cluster-ID forwarding,
+// envelope unwrapping, partial-failure error map parsing, composite-ID
+// encoding round-trip, golden-signals missingQueries handling, 5xx-
+// fallback on status, and 4xx surfacing as ApiError.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kubecenter/api/api_error.dart';
+import 'package:kubecenter/api/dio_client.dart';
+import 'package:kubecenter/api/mesh_repository.dart';
+import 'package:kubecenter/auth/secure_storage.dart';
+
+import '../support/mock_dio_adapter.dart';
+
+ResponseBody _json(Object body, {int status = 200}) {
+  return ResponseBody.fromBytes(
+    Uint8List.fromList(utf8.encode(jsonEncode(body))),
+    status,
+    headers: {
+      Headers.contentTypeHeader: ['application/json'],
+    },
+  );
+}
+
+({ProviderContainer container, MockDioAdapter mock}) _make() {
+  final mock = MockDioAdapter();
+  final container = ProviderContainer(
+    overrides: [
+      backendUrlProvider.overrideWithValue('http://test'),
+      secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+    ],
+  );
+  container.read(refreshDioProvider).httpClientAdapter = mock;
+  container.read(dioProvider).httpClientAdapter = mock;
+  return (container: container, mock: mock);
+}
+
+void main() {
+  group('MeshRepository.status', () {
+    test('parses Istio-only detected with namespace + version', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/mesh/status',
+        body: {
+          'data': {
+            'status': {
+              'detected': 'istio',
+              'istio': {
+                'installed': true,
+                'namespace': 'istio-system',
+                'version': '1.22.0',
+                'mode': 'sidecar',
+              },
+              'linkerd': {'installed': false},
+              'lastChecked': '2026-05-12T10:00:00Z',
+            },
+          },
+        },
+      );
+
+      final s = await container.read(meshRepositoryProvider).status();
+      expect(s.isInstalled, isTrue);
+      expect(s.hasIstio, isTrue);
+      expect(s.hasLinkerd, isFalse);
+      expect(s.istio.installed, isTrue);
+      expect(s.istio.namespace, 'istio-system');
+      expect(s.istio.version, '1.22.0');
+      expect(s.istio.mode, 'sidecar');
+      expect(s.linkerd.installed, isFalse);
+      expect(s.lastChecked, '2026-05-12T10:00:00Z');
+    });
+
+    test('parses both meshes detected', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/mesh/status',
+        body: {
+          'data': {
+            'status': {
+              'detected': 'both',
+              'istio': {'installed': true, 'namespace': 'istio-system'},
+              'linkerd': {'installed': true, 'namespace': 'linkerd'},
+            },
+          },
+        },
+      );
+
+      final s = await container.read(meshRepositoryProvider).status();
+      expect(s.detected, 'both');
+      expect(s.hasBoth, isTrue);
+      expect(s.hasIstio, isTrue);
+      expect(s.hasLinkerd, isTrue);
+    });
+
+    test('non-admin shape (no namespace field) parses cleanly', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/mesh/status',
+        body: {
+          'data': {
+            'status': {
+              'detected': 'istio',
+              'istio': {'installed': true},
+              'linkerd': {'installed': false},
+            },
+          },
+        },
+      );
+
+      final s = await container.read(meshRepositoryProvider).status();
+      expect(s.istio.installed, isTrue);
+      expect(s.istio.namespace, isNull);
+      expect(s.istio.version, isNull);
+    });
+
+    test('503 from status returns MeshStatus.empty', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.on(
+        'GET',
+        '/api/v1/mesh/status',
+        (_) => _json({
+          'error': {'code': 503, 'message': 'mesh discovery offline'},
+        }, status: 503),
+      );
+
+      final s = await container.read(meshRepositoryProvider).status();
+      expect(s.isInstalled, isFalse);
+      expect(s.detected, '');
+    });
+
+    test('401 surfaces as ApiError', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.on(
+        'GET',
+        '/api/v1/mesh/status',
+        (_) => _json({
+          'error': {'code': 401, 'message': 'unauthorized'},
+        }, status: 401),
+      );
+
+      await expectLater(
+        container.read(meshRepositoryProvider).status(),
+        throwsA(isA<ApiError>()),
+      );
+    });
+
+    test('forwards X-Cluster-ID when overridden', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/mesh/status',
+        body: {
+          'data': {
+            'status': {'detected': ''},
+          },
+        },
+      );
+
+      await container
+          .read(meshRepositoryProvider)
+          .status(clusterIdOverride: 'staging-east');
+
+      expect(mock.requests, hasLength(1));
+      expect(mock.requests.single.headers['X-Cluster-ID'], 'staging-east');
+    });
+  });
+
+  group('MeshRepository.listRouting', () {
+    test('parses routes + partial-failure errors map', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/mesh/routing',
+        body: {
+          'data': {
+            'status': {
+              'detected': 'both',
+              'istio': {'installed': true},
+              'linkerd': {'installed': true},
+            },
+            'routes': [
+              {
+                'id': 'istio:app:vs:web',
+                'mesh': 'istio',
+                'kind': 'VirtualService',
+                'name': 'web',
+                'namespace': 'app',
+                'hosts': ['web.example.com'],
+                'gateways': ['mesh-gateway'],
+                'destinations': [
+                  {'host': 'web.app.svc.cluster.local', 'port': 80, 'weight': 100},
+                ],
+                'matchers': [
+                  {'method': 'GET', 'pathPrefix': '/api'},
+                ],
+              },
+              {
+                'id': 'linkerd:app:sp:web',
+                'mesh': 'linkerd',
+                'kind': 'ServiceProfile',
+                'name': 'web',
+                'namespace': 'app',
+                'hosts': <String>[],
+              },
+            ],
+            'errors': {
+              'istio/AuthorizationPolicy': 'forbidden',
+              'prometheus-cross-check': 'timeout',
+            },
+          },
+        },
+      );
+
+      final res = await container.read(meshRepositoryProvider).listRouting();
+      expect(res.routes, hasLength(2));
+      expect(res.routes.first.id, 'istio:app:vs:web');
+      expect(res.routes.first.destinations, hasLength(1));
+      expect(res.routes.first.destinations.first.weight, 100);
+      expect(res.routes.first.matchers.first.method, 'GET');
+      expect(res.routes.first.matchers.first.pathPrefix, '/api');
+      expect(res.errors, {
+        'istio/AuthorizationPolicy': 'forbidden',
+        'prometheus-cross-check': 'timeout',
+      });
+    });
+
+    test('threads namespace query param', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/mesh/routing',
+        body: {
+          'data': {
+            'status': {'detected': 'istio'},
+            'routes': <Map<String, Object?>>[],
+          },
+        },
+      );
+
+      await container
+          .read(meshRepositoryProvider)
+          .listRouting(namespace: 'app');
+
+      expect(mock.requests.single.queryParameters['namespace'], 'app');
+    });
+
+    test('empty namespace skips the query param', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/mesh/routing',
+        body: {
+          'data': {
+            'status': {'detected': 'istio'},
+            'routes': <Map<String, Object?>>[],
+          },
+        },
+      );
+
+      await container.read(meshRepositoryProvider).listRouting(namespace: '');
+      expect(mock.requests.single.queryParameters.containsKey('namespace'),
+          isFalse);
+    });
+
+    test('omits errors map when backend returns empty', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/mesh/routing',
+        body: {
+          'data': {
+            'status': {'detected': 'istio'},
+            'routes': <Map<String, Object?>>[],
+          },
+        },
+      );
+
+      final res = await container.read(meshRepositoryProvider).listRouting();
+      expect(res.errors, isEmpty);
+    });
+  });
+
+  group('MeshRepository.getRoute', () {
+    test('URL-encodes composite id on the wire (single encode)', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      // The backend's parseMeshCompositeID decodes one URL layer before
+      // splitting on ':' — so Uri.encodeComponent("istio:app:vs:web")
+      // = "istio%3Aapp%3Avs%3Aweb" is what hits the wire path.
+      mock.onJson(
+        'GET',
+        '/api/v1/mesh/routing/istio%3Aapp%3Avs%3Aweb',
+        body: {
+          'data': {
+            'id': 'istio:app:vs:web',
+            'mesh': 'istio',
+            'kind': 'VirtualService',
+            'name': 'web',
+            'namespace': 'app',
+            'hosts': ['web.example.com'],
+            'raw': {
+              'apiVersion': 'networking.istio.io/v1',
+              'kind': 'VirtualService',
+              'metadata': {'name': 'web'},
+            },
+          },
+        },
+      );
+
+      final route = await container
+          .read(meshRepositoryProvider)
+          .getRoute(id: 'istio:app:vs:web');
+      expect(route.name, 'web');
+      expect(route.mesh, 'istio');
+      expect(route.kind, 'VirtualService');
+      expect(route.raw, isNotNull);
+      expect(route.raw!['apiVersion'], 'networking.istio.io/v1');
+    });
+
+    test('404 from missing route surfaces as ApiError', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.on(
+        'GET',
+        '/api/v1/mesh/routing/istio%3Aapp%3Avs%3Aghost',
+        (_) => _json({
+          'error': {'code': 404, 'message': 'mesh resource not found'},
+        }, status: 404),
+      );
+
+      await expectLater(
+        container
+            .read(meshRepositoryProvider)
+            .getRoute(id: 'istio:app:vs:ghost'),
+        throwsA(isA<ApiError>().having(
+          (e) => e.statusCode,
+          'statusCode',
+          404,
+        )),
+      );
+    });
+  });
+
+  group('MeshRepository.listPolicies', () {
+    test('parses policies + errors', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/mesh/policies',
+        body: {
+          'data': {
+            'status': {'detected': 'istio'},
+            'policies': [
+              {
+                'id': 'istio:app:pa:default',
+                'mesh': 'istio',
+                'kind': 'PeerAuthentication',
+                'name': 'default',
+                'namespace': 'app',
+                'mtlsMode': 'STRICT',
+                'ruleCount': 1,
+              },
+            ],
+          },
+        },
+      );
+
+      final res = await container.read(meshRepositoryProvider).listPolicies();
+      expect(res.policies, hasLength(1));
+      expect(res.policies.single.mtlsMode, 'STRICT');
+      expect(res.errors, isEmpty);
+    });
+  });
+
+  group('MeshRepository.mtlsPosture', () {
+    test('threads required namespace query param + parses workloads',
+        () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/mesh/mtls',
+        body: {
+          'data': {
+            'status': {'detected': 'istio'},
+            'workloads': [
+              {
+                'namespace': 'app',
+                'workload': 'web',
+                'workloadKind': 'Deployment',
+                'mesh': 'istio',
+                'state': 'active',
+                'source': 'policy',
+                'istioMode': 'STRICT',
+                'sourceDetail': 'namespace',
+                'workloadKindConfident': true,
+              },
+              {
+                'namespace': 'app',
+                'workload': 'legacy-555c6d',
+                'workloadKind': 'Deployment',
+                'mesh': 'istio',
+                'state': 'inactive',
+                'source': 'default',
+                'workloadKindConfident': false,
+              },
+            ],
+            'errors': {'truncated': 'capped at 500 workloads'},
+          },
+        },
+      );
+
+      final res = await container
+          .read(meshRepositoryProvider)
+          .mtlsPosture(namespace: 'app');
+      expect(mock.requests.single.queryParameters['namespace'], 'app');
+      expect(res.workloads, hasLength(2));
+      expect(res.workloads.first.state, 'active');
+      expect(res.workloads.first.istioMode, 'STRICT');
+      expect(res.workloads.first.workloadKindConfident, isTrue);
+      expect(res.workloads.last.workloadKindConfident, isFalse);
+      expect(res.errors, {'truncated': 'capped at 500 workloads'});
+    });
+
+    test('400 from missing namespace surfaces as ApiError', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.on(
+        'GET',
+        '/api/v1/mesh/mtls',
+        (_) => _json({
+          'error': {'code': 400, 'message': 'namespace required'},
+        }, status: 400),
+      );
+
+      await expectLater(
+        container.read(meshRepositoryProvider).mtlsPosture(namespace: ''),
+        throwsA(isA<ApiError>().having(
+          (e) => e.statusCode,
+          'statusCode',
+          400,
+        )),
+      );
+    });
+  });
+
+  group('MeshRepository.goldenSignals', () {
+    test('parses tile scalars + missingQueries banner data', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/mesh/golden-signals',
+        body: {
+          'data': {
+            'status': {'detected': 'istio'},
+            'signals': {
+              'mesh': 'istio',
+              'namespace': 'app',
+              'service': 'web',
+              'available': true,
+              'missingQueries': ['p99'],
+              'rps': 42.5,
+              'errorRate': 0.013,
+              'p50Ms': 12.0,
+              'p95Ms': 75.0,
+              'p99Ms': 0.0,
+            },
+          },
+        },
+      );
+
+      final res = await container.read(meshRepositoryProvider).goldenSignals(
+            namespace: 'app',
+            service: 'web',
+          );
+      expect(res.signals.available, isTrue);
+      expect(res.signals.missingQueries, ['p99']);
+      expect(res.signals.rps, closeTo(42.5, 0.001));
+      expect(res.signals.p95Ms, 75.0);
+      expect(res.signals.isMetricMissing('p99'), isTrue);
+      expect(res.signals.isMetricMissing('p95'), isFalse);
+    });
+
+    test('threads mesh disambiguator when both installed', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/mesh/golden-signals',
+        body: {
+          'data': {
+            'status': {'detected': 'both'},
+            'signals': {
+              'mesh': 'linkerd',
+              'namespace': 'app',
+              'service': 'web',
+              'available': true,
+            },
+          },
+        },
+      );
+
+      await container.read(meshRepositoryProvider).goldenSignals(
+            namespace: 'app',
+            service: 'web',
+            mesh: 'linkerd',
+          );
+      final req = mock.requests.single;
+      expect(req.queryParameters['mesh'], 'linkerd');
+      expect(req.queryParameters['namespace'], 'app');
+      expect(req.queryParameters['service'], 'web');
+    });
+
+    test('available=false carries reason and zero scalars', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/mesh/golden-signals',
+        body: {
+          'data': {
+            'status': {'detected': 'istio'},
+            'signals': {
+              'mesh': 'istio',
+              'namespace': 'app',
+              'service': 'web',
+              'available': false,
+              'reason': 'Prometheus offline',
+            },
+          },
+        },
+      );
+
+      final res = await container.read(meshRepositoryProvider).goldenSignals(
+            namespace: 'app',
+            service: 'web',
+          );
+      expect(res.signals.available, isFalse);
+      expect(res.signals.reason, 'Prometheus offline');
+      expect(res.signals.rps, 0.0);
+      expect(res.signals.p99Ms, 0.0);
+    });
+  });
+
+  group('Provider family keys', () {
+    test('MeshRoutingKey equality', () {
+      const a = MeshRoutingKey(clusterId: 'c1', namespace: 'app');
+      const b = MeshRoutingKey(clusterId: 'c1', namespace: 'app');
+      const c = MeshRoutingKey(clusterId: 'c1', namespace: 'other');
+      const d = MeshRoutingKey(clusterId: 'c1');
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(c)));
+      expect(a, isNot(equals(d)));
+    });
+
+    test('MeshRouteDetailKey distinguishes by id', () {
+      const a = MeshRouteDetailKey(clusterId: 'c1', id: 'istio:a:vs:n');
+      const b = MeshRouteDetailKey(clusterId: 'c1', id: 'istio:b:vs:n');
+      expect(a, isNot(equals(b)));
+    });
+
+    test('MeshMtlsKey + MeshGoldenSignalsKey distinguish all fields', () {
+      const a = MeshMtlsKey(clusterId: 'c1', namespace: 'app');
+      const b = MeshMtlsKey(clusterId: 'c1', namespace: 'other');
+      expect(a, isNot(equals(b)));
+
+      const ga = MeshGoldenSignalsKey(
+        clusterId: 'c1',
+        namespace: 'app',
+        service: 'web',
+      );
+      const gb = MeshGoldenSignalsKey(
+        clusterId: 'c1',
+        namespace: 'app',
+        service: 'web',
+        mesh: 'istio',
+      );
+      expect(ga, isNot(equals(gb)));
+    });
+  });
+}

--- a/mobile/test/api/mesh_repository_test.dart
+++ b/mobile/test/api/mesh_repository_test.dart
@@ -401,6 +401,88 @@ void main() {
       expect(res.policies.single.mtlsMode, 'STRICT');
       expect(res.errors, isEmpty);
     });
+
+    test('threads namespace query param when provided', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/mesh/policies',
+        body: {
+          'data': {
+            'status': {'detected': 'istio'},
+            'policies': <Map<String, Object?>>[],
+          },
+        },
+      );
+
+      await container
+          .read(meshRepositoryProvider)
+          .listPolicies(namespace: 'restricted');
+      expect(
+          mock.requests.single.queryParameters['namespace'], 'restricted');
+    });
+
+    test('empty namespace omits query param (cluster-wide pass-through)',
+        () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/mesh/policies',
+        body: {
+          'data': {
+            'status': {'detected': 'istio'},
+            'policies': <Map<String, Object?>>[],
+          },
+        },
+      );
+
+      await container.read(meshRepositoryProvider).listPolicies(namespace: '');
+      expect(
+          mock.requests.single.queryParameters.containsKey('namespace'),
+          isFalse);
+    });
+  });
+
+  group('MeshRepository._fetchEnvelope error paths', () {
+    test('listPolicies 503 rethrows as ApiError', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.on(
+        'GET',
+        '/api/v1/mesh/policies',
+        (_) => _json({
+          'error': {'code': 503, 'message': 'upstream unavailable'},
+        }, status: 503),
+      );
+
+      await expectLater(
+        container.read(meshRepositoryProvider).listPolicies(),
+        throwsA(isA<ApiError>().having((e) => e.statusCode, 'statusCode', 503)),
+      );
+    });
+
+    test('mtlsPosture 500 rethrows as ApiError', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.on(
+        'GET',
+        '/api/v1/mesh/mtls',
+        (_) => _json({
+          'error': {'code': 500, 'message': 'internal error'},
+        }, status: 500),
+      );
+
+      await expectLater(
+        container.read(meshRepositoryProvider).mtlsPosture(namespace: 'app'),
+        throwsA(isA<ApiError>().having((e) => e.statusCode, 'statusCode', 500)),
+      );
+    });
   });
 
   group('MeshRepository.mtlsPosture', () {
@@ -452,6 +534,30 @@ void main() {
       expect(res.workloads.first.workloadKindConfident, isTrue);
       expect(res.workloads.last.workloadKindConfident, isFalse);
       expect(res.errors, {'truncated': 'capped at 500 workloads'});
+    });
+
+    test('403 from RBAC surfaces as ApiError with correct statusCode', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.on(
+        'GET',
+        '/api/v1/mesh/mtls',
+        (_) => _json({
+          'error': {
+            'code': 403,
+            'message': 'forbidden: cannot list pods in namespace restricted',
+          },
+        }, status: 403),
+      );
+
+      await expectLater(
+        container.read(meshRepositoryProvider).mtlsPosture(namespace: 'restricted'),
+        throwsA(isA<ApiError>()
+            .having((e) => e.statusCode, 'statusCode', 403)
+            .having((e) => e.message, 'message',
+                contains('forbidden'))),
+      );
     });
 
     test('400 from missing namespace surfaces as ApiError', () async {
@@ -512,8 +618,14 @@ void main() {
       expect(res.signals.missingQueries, ['p99']);
       expect(res.signals.rps, closeTo(42.5, 0.001));
       expect(res.signals.p95Ms, 75.0);
-      expect(res.signals.isMetricMissing('p99'), isTrue);
-      expect(res.signals.isMetricMissing('p95'), isFalse);
+      // Metric in missingQueries returns true regardless of scalar value.
+      expect(res.signals.isMetricMissing('p99'), isTrue,
+          reason: 'p99 is in missingQueries — should report missing');
+      // Metric NOT in missingQueries returns false even when scalar is zero.
+      expect(res.signals.isMetricMissing('p95'), isFalse,
+          reason: 'p95 is not in missingQueries — zero scalar is still valid');
+      expect(res.signals.isMetricMissing('rps'), isFalse,
+          reason: 'rps is not in missingQueries — non-zero scalar is valid');
     });
 
     test('threads mesh disambiguator when both installed', () async {
@@ -579,16 +691,55 @@ void main() {
     });
   });
 
+  group('MeshRepository cluster-switch-mid-fetch', () {
+    test('request carries X-Cluster-ID of the cluster that initiated the fetch',
+        () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/mesh/status',
+        body: {
+          'data': {
+            'status': {
+              'detected': 'istio',
+              'istio': {'installed': true},
+              'linkerd': {'installed': false},
+            },
+          },
+        },
+      );
+
+      // Fire the request pinned to clusterA.
+      await container
+          .read(meshRepositoryProvider)
+          .status(clusterIdOverride: 'clusterA');
+
+      // The request on the wire must carry clusterA's header even if the
+      // active cluster was changed to clusterB after the call was made.
+      expect(mock.requests, hasLength(1));
+      expect(mock.requests.single.headers['X-Cluster-ID'], 'clusterA');
+    });
+  });
+
   group('Provider family keys', () {
     test('MeshRoutingKey equality', () {
-      const a = MeshRoutingKey(clusterId: 'c1', namespace: 'app');
-      const b = MeshRoutingKey(clusterId: 'c1', namespace: 'app');
-      const c = MeshRoutingKey(clusterId: 'c1', namespace: 'other');
-      const d = MeshRoutingKey(clusterId: 'c1');
+      final a = MeshRoutingKey(clusterId: 'c1', namespace: 'app');
+      final b = MeshRoutingKey(clusterId: 'c1', namespace: 'app');
+      final c = MeshRoutingKey(clusterId: 'c1', namespace: 'other');
+      final d = MeshRoutingKey(clusterId: 'c1');
       expect(a, equals(b));
       expect(a.hashCode, equals(b.hashCode));
       expect(a, isNot(equals(c)));
       expect(a, isNot(equals(d)));
+    });
+
+    test('MeshRoutingKey normalises empty namespace to null', () {
+      final empty = MeshRoutingKey(clusterId: 'c1', namespace: '');
+      final nullNs = MeshRoutingKey(clusterId: 'c1');
+      expect(empty, equals(nullNs));
+      expect(empty.namespace, isNull);
     });
 
     test('MeshRouteDetailKey distinguishes by id', () {

--- a/mobile/test/features/mesh/golden_signals_tab_test.dart
+++ b/mobile/test/features/mesh/golden_signals_tab_test.dart
@@ -1,0 +1,170 @@
+// Widget tests for the golden signals tab.
+//
+// Coverage:
+//   * `available: false` renders the unavailable banner.
+//   * Happy path renders tile values (RPS / error rate / p50/p95/p99).
+//   * `missingQueries` non-empty renders the banner + dashes for the
+//     affected tiles.
+//   * Both-meshes-installed without selection renders the mesh prompt.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kubecenter/api/dio_client.dart';
+import 'package:kubecenter/api/mesh_repository.dart';
+import 'package:kubecenter/auth/secure_storage.dart';
+import 'package:kubecenter/features/mesh/golden_signals_tab.dart';
+import 'package:kubecenter/theme/kube_theme_builder.dart';
+
+import '../../support/mock_dio_adapter.dart';
+
+Future<void> _pump(
+  WidgetTester tester,
+  MockDioAdapter mock, {
+  required MeshStatus status,
+}) async {
+  await tester.pumpWidget(ProviderScope(
+    overrides: [
+      backendUrlProvider.overrideWithValue('http://test'),
+      secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+    ],
+    child: _DioInstaller(
+      mock: mock,
+      child: MaterialApp(
+        theme: buildKubeTheme('nexus'),
+        home: Scaffold(
+          body: GoldenSignalsTab(
+            namespace: 'app',
+            service: 'web',
+            status: status,
+          ),
+        ),
+      ),
+    ),
+  ));
+  await tester.pump();
+  await tester.pumpAndSettle(const Duration(milliseconds: 200));
+}
+
+class _DioInstaller extends ConsumerWidget {
+  const _DioInstaller({required this.mock, required this.child});
+
+  final MockDioAdapter mock;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.read(dioProvider).httpClientAdapter = mock;
+    return child;
+  }
+}
+
+const _istioStatus = MeshStatus(
+  detected: 'istio',
+  istio: MeshInfo(installed: true),
+  linkerd: MeshInfo(installed: false),
+);
+
+const _bothStatus = MeshStatus(
+  detected: 'both',
+  istio: MeshInfo(installed: true),
+  linkerd: MeshInfo(installed: true),
+);
+
+void main() {
+  testWidgets('available=false renders Metrics unavailable banner',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/mesh/golden-signals', body: {
+        'data': {
+          'status': {'detected': 'istio'},
+          'signals': {
+            'mesh': 'istio',
+            'namespace': 'app',
+            'service': 'web',
+            'available': false,
+            'reason': 'Prometheus offline',
+          },
+        },
+      });
+
+    await _pump(tester, mock, status: _istioStatus);
+
+    expect(find.text('Metrics unavailable'), findsOneWidget);
+    expect(find.text('Prometheus offline'), findsOneWidget);
+  });
+
+  testWidgets('happy path renders five tiles + values', (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/mesh/golden-signals', body: {
+        'data': {
+          'status': {'detected': 'istio'},
+          'signals': {
+            'mesh': 'istio',
+            'namespace': 'app',
+            'service': 'web',
+            'available': true,
+            'rps': 42.5,
+            'errorRate': 0.013,
+            'p50Ms': 12.0,
+            'p95Ms': 75.0,
+            'p99Ms': 220.0,
+          },
+        },
+      });
+
+    await _pump(tester, mock, status: _istioStatus);
+
+    expect(find.text('Requests / s'), findsOneWidget);
+    expect(find.text('Error rate'), findsOneWidget);
+    expect(find.text('p50 latency'), findsOneWidget);
+    expect(find.text('p95 latency'), findsOneWidget);
+    expect(find.text('p99 latency'), findsOneWidget);
+    expect(find.text('42.50'), findsOneWidget);
+    expect(find.text('12.0 ms'), findsOneWidget);
+    expect(find.text('220.0 ms'), findsOneWidget);
+  });
+
+  testWidgets('missingQueries renders banner + em-dash for failed tiles',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/mesh/golden-signals', body: {
+        'data': {
+          'status': {'detected': 'istio'},
+          'signals': {
+            'mesh': 'istio',
+            'namespace': 'app',
+            'service': 'web',
+            'available': true,
+            'missingQueries': ['p99', 'rps'],
+            'rps': 0.0,
+            'errorRate': 0.01,
+            'p50Ms': 8.0,
+            'p95Ms': 20.0,
+            'p99Ms': 0.0,
+          },
+        },
+      });
+
+    await _pump(tester, mock, status: _istioStatus);
+
+    expect(find.textContaining('2 metric(s) unavailable'), findsOneWidget);
+    // Two em-dashes — the rps and p99 tiles.
+    expect(find.text('—'), findsAtLeastNWidgets(2));
+    // p50 still renders.
+    expect(find.text('8.0 ms'), findsOneWidget);
+  });
+
+  testWidgets('both meshes installed shows mesh prompt until picked',
+      (tester) async {
+    // No HTTP mocking needed — the body should not fetch until a mesh
+    // is selected. The default 404 from MockDioAdapter would error if
+    // the request fired, so this also catches "did we fetch too early?".
+    final mock = MockDioAdapter();
+
+    await _pump(tester, mock, status: _bothStatus);
+
+    expect(find.textContaining('Both meshes are installed'), findsOneWidget);
+    expect(find.text('Requests / s'), findsNothing);
+  });
+}

--- a/mobile/test/features/mesh/golden_signals_tab_test.dart
+++ b/mobile/test/features/mesh/golden_signals_tab_test.dart
@@ -155,6 +155,29 @@ void main() {
     expect(find.text('8.0 ms'), findsOneWidget);
   });
 
+  testWidgets('available=false with no reason uses hardcoded fallback string',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/mesh/golden-signals', body: {
+        'data': {
+          'status': {'detected': 'istio'},
+          'signals': {
+            'mesh': 'istio',
+            'namespace': 'app',
+            'service': 'web',
+            'available': false,
+            // 'reason' field deliberately omitted
+          },
+        },
+      });
+
+    await _pump(tester, mock, status: _istioStatus);
+
+    expect(find.text('Metrics unavailable'), findsOneWidget);
+    // No reason field → falls back to the hardcoded 2s timeout copy.
+    expect(find.text('Prometheus did not respond within 2s.'), findsOneWidget);
+  });
+
   testWidgets('both meshes installed shows mesh prompt until picked',
       (tester) async {
     // No HTTP mocking needed — the body should not fetch until a mesh
@@ -163,6 +186,11 @@ void main() {
     final mock = MockDioAdapter();
 
     await _pump(tester, mock, status: _bothStatus);
+
+    // Lock the no-eager-fetch invariant: no request should have been made
+    // before the operator selects a mesh.
+    expect(mock.requests, isEmpty,
+        reason: 'golden-signals must not fetch before mesh is selected');
 
     expect(find.textContaining('Both meshes are installed'), findsOneWidget);
     expect(find.text('Requests / s'), findsNothing);

--- a/mobile/test/features/mesh/mesh_dashboard_screen_test.dart
+++ b/mobile/test/features/mesh/mesh_dashboard_screen_test.dart
@@ -1,0 +1,125 @@
+// Widget tests for the mesh dashboard.
+//
+// Coverage:
+//   * detected=='' → FeatureUnavailableState.mesh()
+//   * Istio-only → Istio card "Installed" + Linkerd card "Not installed"
+//   * Routing + mTLS CTAs render when at least one mesh is installed
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:kubecenter/api/dio_client.dart';
+import 'package:kubecenter/auth/secure_storage.dart';
+import 'package:kubecenter/features/mesh/mesh_dashboard_screen.dart';
+import 'package:kubecenter/theme/kube_theme_builder.dart';
+
+import '../../support/mock_dio_adapter.dart';
+
+Future<void> _pump(WidgetTester tester, MockDioAdapter mock) async {
+  final router = GoRouter(
+    initialLocation: '/',
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (context, state) => const MeshDashboardScreen(),
+      ),
+    ],
+  );
+  await tester.pumpWidget(ProviderScope(
+    overrides: [
+      backendUrlProvider.overrideWithValue('http://test'),
+      secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+    ],
+    child: _DioInstaller(
+      mock: mock,
+      child: MaterialApp.router(
+        theme: buildKubeTheme('nexus'),
+        routerConfig: router,
+      ),
+    ),
+  ));
+  await tester.pump();
+  await tester.pumpAndSettle(const Duration(milliseconds: 200));
+}
+
+class _DioInstaller extends ConsumerWidget {
+  const _DioInstaller({required this.mock, required this.child});
+
+  final MockDioAdapter mock;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.read(dioProvider).httpClientAdapter = mock;
+    return child;
+  }
+}
+
+Map<String, Object?> _notDetected() => {
+      'data': {
+        'status': {
+          'detected': '',
+          'istio': {'installed': false},
+          'linkerd': {'installed': false},
+        },
+      },
+    };
+
+Map<String, Object?> _istioOnly() => {
+      'data': {
+        'status': {
+          'detected': 'istio',
+          'istio': {
+            'installed': true,
+            'namespace': 'istio-system',
+            'version': '1.22.0',
+            'mode': 'sidecar',
+          },
+          'linkerd': {'installed': false},
+          'lastChecked': '2026-05-12T10:00:00Z',
+        },
+      },
+    };
+
+void main() {
+  testWidgets('detected=="" renders FeatureUnavailableState.mesh()',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/mesh/status', body: _notDetected());
+
+    await _pump(tester, mock);
+
+    expect(find.textContaining('service mesh'), findsOneWidget);
+    expect(find.text('Routing rules'), findsNothing);
+  });
+
+  testWidgets('Istio-only shows Installed/Not installed cards',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/mesh/status', body: _istioOnly());
+
+    await _pump(tester, mock);
+
+    expect(find.text('Istio'), findsOneWidget);
+    expect(find.text('Linkerd'), findsOneWidget);
+    expect(find.text('Installed'), findsOneWidget);
+    expect(find.text('Not installed'), findsOneWidget);
+    // Engine details surface for admin (we mock the admin shape with
+    // namespace + version + mode set).
+    expect(find.text('istio-system'), findsOneWidget);
+    expect(find.text('1.22.0'), findsOneWidget);
+    expect(find.text('sidecar'), findsOneWidget);
+  });
+
+  testWidgets('actions row offers routing + mTLS CTAs when installed',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/mesh/status', body: _istioOnly());
+
+    await _pump(tester, mock);
+
+    expect(find.text('Routing rules'), findsOneWidget);
+    expect(find.text('mTLS posture'), findsOneWidget);
+  });
+}

--- a/mobile/test/features/mesh/mtls_posture_screen_test.dart
+++ b/mobile/test/features/mesh/mtls_posture_screen_test.dart
@@ -1,0 +1,260 @@
+// Widget tests for the mTLS posture screen.
+//
+// Coverage:
+//   * not-detected → FeatureUnavailableState.mesh()
+//   * no namespace selected → renders _NamespacePrompt "Choose a namespace"
+//   * happy path with 3 workloads (one mixed-state, one inactive, one with
+//     workloadKindConfident: false) → 3 rows render, asterisk + tooltip
+//     visible on the unconfident row
+//   * partial errors map → MeshErrorsBanner renders above the workload list
+//   * namespace-list fails (5xx for resourceListProvider) → the manual-entry
+//     TextField renders so the user can type a namespace manually
+
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:kubecenter/api/dio_client.dart';
+import 'package:kubecenter/auth/secure_storage.dart';
+import 'package:kubecenter/features/mesh/mtls_posture_screen.dart';
+import 'package:kubecenter/theme/kube_theme_builder.dart';
+
+import '../../support/mock_dio_adapter.dart';
+
+Future<void> _pump(WidgetTester tester, MockDioAdapter mock) async {
+  final router = GoRouter(
+    initialLocation: '/',
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (context, state) => const MeshMtlsPostureScreen(),
+      ),
+    ],
+  );
+  await tester.pumpWidget(ProviderScope(
+    overrides: [
+      backendUrlProvider.overrideWithValue('http://test'),
+      secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+    ],
+    child: _DioInstaller(
+      mock: mock,
+      child: MaterialApp.router(
+        theme: buildKubeTheme('nexus'),
+        routerConfig: router,
+      ),
+    ),
+  ));
+  await tester.pump();
+  await tester.pumpAndSettle(const Duration(milliseconds: 200));
+}
+
+class _DioInstaller extends ConsumerWidget {
+  const _DioInstaller({required this.mock, required this.child});
+
+  final MockDioAdapter mock;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.read(dioProvider).httpClientAdapter = mock;
+    return child;
+  }
+}
+
+Map<String, Object?> _statusNotDetected() => {
+      'data': {
+        'status': {
+          'detected': '',
+          'istio': {'installed': false},
+          'linkerd': {'installed': false},
+        },
+      },
+    };
+
+Map<String, Object?> _statusIstioOnly() => {
+      'data': {
+        'status': {
+          'detected': 'istio',
+          'istio': {'installed': true},
+          'linkerd': {'installed': false},
+        },
+      },
+    };
+
+Map<String, Object?> _emptyNamespaceList() => {
+      'data': <Map<String, Object?>>[],
+      'metadata': {'total': 0},
+    };
+
+Map<String, Object?> _namespaceListWithApp() => {
+      'data': [
+        {
+          'metadata': {'name': 'app'},
+        },
+      ],
+      'metadata': {'total': 1},
+    };
+
+Map<String, Object?> _postureThreeWorkloads() => {
+      'data': {
+        'status': {
+          'detected': 'istio',
+          'istio': {'installed': true},
+          'linkerd': {'installed': false},
+        },
+        'workloads': [
+          {
+            'namespace': 'app',
+            'workload': 'web',
+            'workloadKind': 'Deployment',
+            'mesh': 'istio',
+            'state': 'mixed',
+            'source': 'policy',
+            'workloadKindConfident': true,
+          },
+          {
+            'namespace': 'app',
+            'workload': 'legacy-api',
+            'workloadKind': 'Deployment',
+            'mesh': 'istio',
+            'state': 'inactive',
+            'source': 'default',
+            'workloadKindConfident': true,
+          },
+          {
+            'namespace': 'app',
+            'workload': 'orphan-abc',
+            'workloadKind': 'Deployment',
+            'mesh': 'istio',
+            'state': 'active',
+            'source': 'metric',
+            // workloadKindConfident omitted → defaults to false (finding #8)
+          },
+        ],
+        'errors': <String, Object?>{},
+      },
+    };
+
+Map<String, Object?> _postureWithErrors() => {
+      'data': {
+        'status': {
+          'detected': 'istio',
+          'istio': {'installed': true},
+          'linkerd': {'installed': false},
+        },
+        'workloads': [
+          {
+            'namespace': 'app',
+            'workload': 'web',
+            'workloadKind': 'Deployment',
+            'mesh': 'istio',
+            'state': 'active',
+            'source': 'policy',
+            'workloadKindConfident': true,
+          },
+        ],
+        'errors': {
+          'pods': 'insufficient RBAC to list pods',
+          'truncated': 'capped at 500 workloads',
+        },
+      },
+    };
+
+void main() {
+  testWidgets('not-detected renders FeatureUnavailableState.mesh()',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/mesh/status', body: _statusNotDetected())
+      ..onJson('GET', '/api/v1/resources/namespaces',
+          body: _emptyNamespaceList());
+
+    await _pump(tester, mock);
+
+    expect(find.textContaining('service mesh'), findsOneWidget);
+    expect(find.text('Choose a namespace'), findsNothing);
+  });
+
+  testWidgets('no namespace selected renders namespace prompt', (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/mesh/status', body: _statusIstioOnly())
+      ..onJson('GET', '/api/v1/resources/namespaces',
+          body: _namespaceListWithApp());
+
+    await _pump(tester, mock);
+
+    expect(find.text('Choose a namespace'), findsOneWidget);
+    // mTLS fetch should NOT have fired yet.
+    final mtlsRequests =
+        mock.requests.where((r) => r.path.contains('/api/v1/mesh/mtls'));
+    expect(mtlsRequests, isEmpty);
+  });
+
+  testWidgets('happy path with 3 workloads renders rows + asterisk on unconfident',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/mesh/status', body: _statusIstioOnly())
+      ..onJson('GET', '/api/v1/resources/namespaces',
+          body: _namespaceListWithApp())
+      ..onJson('GET', '/api/v1/mesh/mtls', body: _postureThreeWorkloads());
+
+    await _pump(tester, mock);
+
+    // Select the namespace from the dropdown.
+    await tester.tap(find.byType(DropdownButton<String?>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('app').last);
+    await tester.pumpAndSettle(const Duration(milliseconds: 300));
+
+    // Three workload names are visible.
+    expect(find.text('web'), findsOneWidget);
+    expect(find.text('legacy-api'), findsOneWidget);
+    expect(find.text('orphan-abc'), findsOneWidget);
+
+    // Asterisk visible on the unconfident row (orphan-abc).
+    expect(find.text('*'), findsOneWidget);
+  });
+
+  testWidgets('partial errors map renders MeshErrorsBanner', (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/mesh/status', body: _statusIstioOnly())
+      ..onJson('GET', '/api/v1/resources/namespaces',
+          body: _namespaceListWithApp())
+      ..onJson('GET', '/api/v1/mesh/mtls', body: _postureWithErrors());
+
+    await _pump(tester, mock);
+
+    await tester.tap(find.byType(DropdownButton<String?>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('app').last);
+    await tester.pumpAndSettle(const Duration(milliseconds: 300));
+
+    // Error banner (pods key + message) and warn banner (truncated) both render.
+    expect(find.textContaining('pods'), findsAtLeastNWidgets(1));
+    expect(find.textContaining('truncated'), findsOneWidget);
+  });
+
+  testWidgets(
+      'namespace-list 5xx renders manual-entry TextField + Retry button',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/mesh/status', body: _statusIstioOnly())
+      ..on(
+          'GET',
+          '/api/v1/resources/namespaces',
+          (_) => ResponseBody.fromString(
+                '{"error":{"code":503,"message":"upstream unavailable"}}',
+                503,
+                headers: {
+                  'content-type': ['application/json'],
+                },
+              ));
+
+    await _pump(tester, mock);
+
+    // After the error the manual-entry TextField replaces the dropdown.
+    expect(find.byType(TextField), findsOneWidget);
+    // Retry button present.
+    expect(find.byIcon(Icons.refresh), findsOneWidget);
+  });
+}

--- a/mobile/test/features/mesh/route_detail_screen_test.dart
+++ b/mobile/test/features/mesh/route_detail_screen_test.dart
@@ -57,6 +57,25 @@ void main() {
     expect(find.textContaining('Invalid route ID'), findsOneWidget);
   });
 
+  testWidgets('raw=null hides the RAW SPEC panel', (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/mesh/routing/istio%3Aapp%3Avs%3Anull-raw',
+          body: {
+            'data': {
+              'id': 'istio:app:vs:null-raw',
+              'mesh': 'istio',
+              'kind': 'VirtualService',
+              'name': 'null-raw',
+              'namespace': 'app',
+            },
+          });
+
+    await _pump(tester, mock, 'istio:app:vs:null-raw');
+
+    // The _RawPanel is only rendered when route.raw != null.
+    expect(find.text('RAW SPEC'), findsNothing);
+  });
+
   testWidgets('happy path renders metadata + matchers', (tester) async {
     final mock = MockDioAdapter()
       ..onJson('GET', '/api/v1/mesh/routing/istio%3Aapp%3Avs%3Aweb', body: {

--- a/mobile/test/features/mesh/route_detail_screen_test.dart
+++ b/mobile/test/features/mesh/route_detail_screen_test.dart
@@ -1,0 +1,95 @@
+// Widget tests for the route detail screen.
+//
+// Coverage:
+//   * Malformed composite id renders an inline validation error.
+//   * Happy path renders header + metadata + matchers + destinations.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kubecenter/api/dio_client.dart';
+import 'package:kubecenter/auth/secure_storage.dart';
+import 'package:kubecenter/features/mesh/route_detail_screen.dart';
+import 'package:kubecenter/theme/kube_theme_builder.dart';
+
+import '../../support/mock_dio_adapter.dart';
+
+Future<void> _pump(
+  WidgetTester tester,
+  MockDioAdapter mock,
+  String id,
+) async {
+  await tester.pumpWidget(ProviderScope(
+    overrides: [
+      backendUrlProvider.overrideWithValue('http://test'),
+      secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+    ],
+    child: _DioInstaller(
+      mock: mock,
+      child: MaterialApp(
+        theme: buildKubeTheme('nexus'),
+        home: MeshRouteDetailScreen(id: id),
+      ),
+    ),
+  ));
+  await tester.pump();
+  await tester.pumpAndSettle(const Duration(milliseconds: 200));
+}
+
+class _DioInstaller extends ConsumerWidget {
+  const _DioInstaller({required this.mock, required this.child});
+
+  final MockDioAdapter mock;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.read(dioProvider).httpClientAdapter = mock;
+    return child;
+  }
+}
+
+void main() {
+  testWidgets('malformed composite id renders validation error',
+      (tester) async {
+    final mock = MockDioAdapter();
+    await _pump(tester, mock, 'bogus-not-colons');
+    expect(find.textContaining('Invalid route ID'), findsOneWidget);
+  });
+
+  testWidgets('happy path renders metadata + matchers', (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/mesh/routing/istio%3Aapp%3Avs%3Aweb', body: {
+        'data': {
+          'id': 'istio:app:vs:web',
+          'mesh': 'istio',
+          'kind': 'VirtualService',
+          'name': 'web',
+          'namespace': 'app',
+          'hosts': ['web.example.com'],
+          'destinations': [
+            {'host': 'web.app.svc.cluster.local', 'port': 80, 'weight': 100},
+          ],
+          'matchers': [
+            {'method': 'GET', 'pathPrefix': '/api', 'name': 'api-prefix'},
+          ],
+          'raw': {
+            'apiVersion': 'networking.istio.io/v1',
+            'kind': 'VirtualService',
+            'metadata': {'name': 'web', 'namespace': 'app'},
+          },
+        },
+      });
+
+    await _pump(tester, mock, 'istio:app:vs:web');
+
+    expect(find.text('VirtualService'), findsAtLeastNWidgets(1));
+    expect(find.textContaining('web.example.com'), findsAtLeastNWidgets(1));
+    expect(find.text('GET'), findsOneWidget);
+    expect(find.textContaining('/api'), findsAtLeastNWidgets(1));
+    // Matcher name suffix.
+    expect(find.text('api-prefix'), findsOneWidget);
+    // Destination row has the FQDN.
+    expect(find.textContaining('web.app.svc.cluster.local'), findsOneWidget);
+  });
+}

--- a/mobile/test/features/mesh/routing_list_screen_test.dart
+++ b/mobile/test/features/mesh/routing_list_screen_test.dart
@@ -168,7 +168,19 @@ void main() {
     await tester.tap(istioChip);
     await tester.pumpAndSettle();
 
+    // After selecting Istio chip: only the Istio route "web" remains.
     expect(find.text('web'), findsOneWidget);
     expect(find.text('api'), findsNothing);
+
+    // Strengthen: confirm the Istio chip is now selected (checked).
+    final istioChipWidget =
+        tester.widget<ChoiceChip>(find.widgetWithText(ChoiceChip, 'Istio'));
+    expect(istioChipWidget.selected, isTrue,
+        reason: 'Istio ChoiceChip should be selected after tap');
+
+    // Linkerd chip is NOT selected.
+    final linkerdChipWidget =
+        tester.widget<ChoiceChip>(find.widgetWithText(ChoiceChip, 'Linkerd'));
+    expect(linkerdChipWidget.selected, isFalse);
   });
 }

--- a/mobile/test/features/mesh/routing_list_screen_test.dart
+++ b/mobile/test/features/mesh/routing_list_screen_test.dart
@@ -1,0 +1,174 @@
+// Widget tests for the routing list.
+//
+// Coverage:
+//   * Empty routes set renders the "no routing rules" guidance.
+//   * Mixed Istio + Linkerd rows render.
+//   * Mesh filter chip narrows the list.
+//   * Partial-failure errors map renders a banner above the list.
+//   * Not-detected status falls back to FeatureUnavailableState.mesh().
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:kubecenter/api/dio_client.dart';
+import 'package:kubecenter/auth/secure_storage.dart';
+import 'package:kubecenter/features/mesh/routing_list_screen.dart';
+import 'package:kubecenter/theme/kube_theme_builder.dart';
+
+import '../../support/mock_dio_adapter.dart';
+
+Future<void> _pump(WidgetTester tester, MockDioAdapter mock) async {
+  final router = GoRouter(
+    initialLocation: '/',
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (context, state) => const MeshRoutingListScreen(),
+      ),
+    ],
+  );
+  await tester.pumpWidget(ProviderScope(
+    overrides: [
+      backendUrlProvider.overrideWithValue('http://test'),
+      secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+    ],
+    child: _DioInstaller(
+      mock: mock,
+      child: MaterialApp.router(
+        theme: buildKubeTheme('nexus'),
+        routerConfig: router,
+      ),
+    ),
+  ));
+  await tester.pump();
+  await tester.pumpAndSettle(const Duration(milliseconds: 200));
+}
+
+class _DioInstaller extends ConsumerWidget {
+  const _DioInstaller({required this.mock, required this.child});
+
+  final MockDioAdapter mock;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.read(dioProvider).httpClientAdapter = mock;
+    return child;
+  }
+}
+
+Map<String, Object?> _statusBoth() => {
+      'data': {
+        'status': {
+          'detected': 'both',
+          'istio': {'installed': true},
+          'linkerd': {'installed': true},
+        },
+      },
+    };
+
+Map<String, Object?> _statusNotDetected() => {
+      'data': {
+        'status': {
+          'detected': '',
+          'istio': {'installed': false},
+          'linkerd': {'installed': false},
+        },
+      },
+    };
+
+Map<String, Object?> _emptyRouting() => {
+      'data': {
+        'status': {
+          'detected': 'both',
+          'istio': {'installed': true},
+          'linkerd': {'installed': true},
+        },
+        'routes': <Map<String, Object?>>[],
+      },
+    };
+
+Map<String, Object?> _twoRoutesWithErrors() => {
+      'data': {
+        'status': {
+          'detected': 'both',
+          'istio': {'installed': true},
+          'linkerd': {'installed': true},
+        },
+        'routes': [
+          {
+            'id': 'istio:app:vs:web',
+            'mesh': 'istio',
+            'kind': 'VirtualService',
+            'name': 'web',
+            'namespace': 'app',
+            'hosts': ['web.example.com'],
+            'destinations': [
+              {'host': 'web.app.svc.cluster.local', 'weight': 100}
+            ],
+          },
+          {
+            'id': 'linkerd:app:sp:api',
+            'mesh': 'linkerd',
+            'kind': 'ServiceProfile',
+            'name': 'api',
+            'namespace': 'app',
+          },
+        ],
+        'errors': {
+          'istio/AuthorizationPolicy': 'forbidden',
+        },
+      },
+    };
+
+void main() {
+  testWidgets('not-detected falls back to FeatureUnavailableState.mesh()',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/mesh/status', body: _statusNotDetected())
+      ..onJson('GET', '/api/v1/mesh/routing', body: _emptyRouting());
+
+    await _pump(tester, mock);
+
+    expect(find.textContaining('service mesh'), findsOneWidget);
+  });
+
+  testWidgets('empty routes shows guidance copy', (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/mesh/status', body: _statusBoth())
+      ..onJson('GET', '/api/v1/mesh/routing', body: _emptyRouting());
+
+    await _pump(tester, mock);
+
+    expect(find.textContaining('No routing rules'), findsOneWidget);
+  });
+
+  testWidgets('renders rows + partial-failure banner', (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/mesh/status', body: _statusBoth())
+      ..onJson('GET', '/api/v1/mesh/routing', body: _twoRoutesWithErrors());
+
+    await _pump(tester, mock);
+
+    expect(find.text('web'), findsOneWidget);
+    expect(find.text('api'), findsOneWidget);
+    expect(find.textContaining('istio/AuthorizationPolicy'), findsOneWidget);
+  });
+
+  testWidgets('mesh filter chip narrows visible rows', (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/mesh/status', body: _statusBoth())
+      ..onJson('GET', '/api/v1/mesh/routing', body: _twoRoutesWithErrors());
+
+    await _pump(tester, mock);
+
+    final istioChip = find.widgetWithText(ChoiceChip, 'Istio');
+    expect(istioChip, findsOneWidget);
+    await tester.tap(istioChip);
+    await tester.pumpAndSettle();
+
+    expect(find.text('web'), findsOneWidget);
+    expect(find.text('api'), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary

- Lands U6 from `plans/mobile-app-m4-pr-sequence.md` — five read-side service-mesh surfaces (dashboard, routing list, route detail, mTLS posture, golden signals on Service detail) sharing one `MeshRepository`.
- No backend changes — every endpoint already shipped in web phases 7–14.
- Mesh-detection status gates every surface via `FeatureUnavailableState.mesh()`. Partial-failure errors map renders as severity-tiered banners (yellow for `truncated` / `prometheus-cross-check`, red for everything else) mirroring the web classification.
- Cluster-pin discipline carries: every provider family keys on `clusterId`, every Dio call accepts `clusterIdOverride` and threads it as an explicit `X-Cluster-ID` header.

## Deviations from plan wording

- **Golden signals is a tile grid, not a 4-up LineChart.** The backend exposes point-in-time scalars (`rps`, `errorRate`, `p50Ms`, `p95Ms`, `p99Ms`) — there is no time series to chart. The plan's "4-up LineChart" wording predates the backend audit; the wire format is authoritative.
- **Mesh disambiguator on Service detail** — when both Istio and Linkerd are installed the tab shows a `SegmentedButton` to pick mesh rather than auto-failing on ambiguity. Single-mesh clusters auto-select.

## Surfaces

| Route | Screen | Backend endpoint |
|-------|--------|------------------|
| `/clusters/:id/mesh` | `MeshDashboardScreen` | `GET /v1/mesh/status` |
| `/clusters/:id/mesh/routing` | `MeshRoutingListScreen` | `GET /v1/mesh/routing[?namespace=]` |
| `/clusters/:id/mesh/routing/:id` | `MeshRouteDetailScreen` | `GET /v1/mesh/routing/{id}` |
| `/clusters/:id/mesh/mtls` | `MeshMtlsPostureScreen` | `GET /v1/mesh/mtls?namespace=…` |
| Service detail tab | `GoldenSignalsTab` | `GET /v1/mesh/golden-signals?namespace=…&service=…[&mesh=…]` |

## Tests

- 22 new `mesh_repository_test.dart` cases: status (Istio-only / both / non-admin / 503 fallback / 401 surface / X-Cluster-ID forwarding), routing (errors map / namespace threading / empty), getRoute (single URL-encode round-trip / 404), policies, mtlsPosture (namespace required / 400 surface), goldenSignals (missingQueries / mesh disambiguator / unavailable+reason), family-key equality across all four providers.
- 13 widget tests across four files: dashboard (3), routing list (4), route detail (2), golden signals tab (4).
- Full mobile suite: **637 / 637 passing**.

## Verification

- [x] `cd mobile && flutter analyze` — no issues
- [x] `cd mobile && flutter test` — 637 / 637 passing
- [x] `make check-themes` — themes in sync

## Test plan

- [ ] Smoke against homelab (Istio installed):
  - Open drawer → Service Mesh → Dashboard. Both engine cards render.
  - Tap Routing → walk filter chips (Both / Istio / Linkerd) + namespace text filter.
  - Tap a row → metadata + matchers + destinations + RAW SPEC expand.
  - Tap mTLS posture → pick `app` namespace → workload state pills render with three-source attribution.
  - Open a known Service → Golden signals tab → tile grid renders; partial `missingQueries` banner if Prometheus partial.
- [ ] Switch active cluster mid-fetch on routing list — verify pinned-cluster header on the in-flight request and no stale state writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)