### PR TITLE
feat(mobile): M4 PR-4g — cert-manager observatory (list + detail + issuers + expiring)

### DIFF
--- a/mobile/lib/api/certmanager_repository.dart
+++ b/mobile/lib/api/certmanager_repository.dart
@@ -1,0 +1,974 @@
+// Mobile-side wrapper over the backend cert-manager API at
+// `/v1/certificates/{status,certificates,certificates/{ns}/{name},issuers,
+// clusterissuers,expiring}` plus the two write verbs
+// `POST .../certificates/{ns}/{name}/{renew,reissue}`.
+// Wire types mirror `backend/internal/certmanager/types.go` exactly.
+// Web parallel: `frontend/islands/CertificatesList.tsx`,
+// `frontend/islands/CertificateDetail.tsx`, `frontend/islands/IssuersList.tsx`,
+// `frontend/lib/certmanager-types.ts`.
+//
+// Threshold attribution: every cert response carries a resolved
+// `warningThresholdDays` + `criticalThresholdDays` pair plus per-key
+// `warningThresholdSource` / `criticalThresholdSource` enums. When the
+// resolved warn/crit pair would have violated `crit < warn`, the backend
+// falls back to package defaults and sets `thresholdConflict: true`. The
+// detail screen surfaces this verbatim so operators see "Conflict —
+// using defaults" rather than a misleading "Default" attribution.
+//
+// Cluster pinning: every call accepts `clusterIdOverride` and forwards it
+// as an explicit `X-Cluster-ID` header. The PR-3c interceptor invariant
+// (only injects when absent) is the live contract.
+//
+// Renew + Reissue (write verbs) live here rather than in
+// `resource_actions.dart` because the web side does the same — the
+// cert-manager handler exposes them under `/v1/certificates/...` rather
+// than the generic `/v1/resources/...` action endpoint. Adding them to
+// `ActionId` would force a fork between the wire path and every other
+// kind's action. Mirroring the web's `apiPost('/v1/certificates/...')`
+// pattern keeps the two surfaces isomorphic per R10.
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../cluster/cluster_provider.dart';
+import 'api_error.dart';
+import 'dio_client.dart';
+
+/// One of the four ThresholdSource enum constants from
+/// `backend/internal/certmanager/types.go`. Unknown / missing values map
+/// to [unknown] so callers exhaustively switch without runtime surprises.
+enum ThresholdSource {
+  /// Resolution fell through to the package default (warn=30d, crit=7d)
+  /// — no annotation present anywhere in the chain.
+  defaultSource,
+
+  /// Annotation set directly on the Certificate.
+  certificate,
+
+  /// Annotation set on the referenced Issuer.
+  issuer,
+
+  /// Annotation set on the referenced ClusterIssuer.
+  clusterIssuer,
+
+  /// Field not populated by the backend (older response, or never
+  /// resolved). UI renders as "Default" so operators don't see a blank.
+  unknown,
+}
+
+ThresholdSource _thresholdSourceFromJson(Object? v) {
+  if (v is! String) return ThresholdSource.unknown;
+  switch (v) {
+    case 'default':
+      return ThresholdSource.defaultSource;
+    case 'certificate':
+      return ThresholdSource.certificate;
+    case 'issuer':
+      return ThresholdSource.issuer;
+    case 'clusterissuer':
+      return ThresholdSource.clusterIssuer;
+    default:
+      return ThresholdSource.unknown;
+  }
+}
+
+/// Lifecycle state of a Certificate.
+///
+/// Mirrors `Status` in `backend/internal/certmanager/types.go`. The
+/// backend's enum is open — older responses (or future cert-manager
+/// versions adding new conditions) may emit values we don't know about,
+/// so [unknown] is the explicit fallback rather than crashing the parser.
+enum CertStatus {
+  ready,
+  issuing,
+  failed,
+  expiring,
+  expired,
+  unknown,
+}
+
+CertStatus _certStatusFromJson(Object? v) {
+  if (v is! String) return CertStatus.unknown;
+  switch (v) {
+    case 'Ready':
+      return CertStatus.ready;
+    case 'Issuing':
+      return CertStatus.issuing;
+    case 'Failed':
+      return CertStatus.failed;
+    case 'Expiring':
+      return CertStatus.expiring;
+    case 'Expired':
+      return CertStatus.expired;
+    default:
+      return CertStatus.unknown;
+  }
+}
+
+/// Human-facing label for [CertStatus] — used by status pills + filter
+/// chips. Capitalised to match the wire enum exactly so screenshots
+/// across web + mobile read identically.
+String certStatusLabel(CertStatus s) => switch (s) {
+      CertStatus.ready => 'Ready',
+      CertStatus.issuing => 'Issuing',
+      CertStatus.failed => 'Failed',
+      CertStatus.expiring => 'Expiring',
+      CertStatus.expired => 'Expired',
+      CertStatus.unknown => 'Unknown',
+    };
+
+/// Decoded `/v1/certificates/status` response. Mirrors
+/// `CertManagerStatus` in `backend/internal/certmanager/types.go`.
+class CertManagerStatus {
+  const CertManagerStatus({
+    required this.detected,
+    this.namespace,
+    this.version,
+    this.lastChecked = '',
+  });
+
+  final bool detected;
+  final String? namespace;
+  final String? version;
+
+  /// RFC-3339 timestamp of the last discovery probe. Empty when not yet
+  /// available (first poll hasn't completed).
+  final String lastChecked;
+
+  factory CertManagerStatus.fromJson(Map<String, dynamic> json) {
+    String? s(Object? v) => v is String && v.isNotEmpty ? v : null;
+    return CertManagerStatus(
+      detected: json['detected'] as bool? ?? false,
+      namespace: s(json['namespace']),
+      version: s(json['version']),
+      lastChecked: json['lastChecked'] as String? ?? '',
+    );
+  }
+
+  static const empty = CertManagerStatus(detected: false);
+}
+
+/// Reference from a Certificate (or CertificateRequest) to its signing
+/// Issuer / ClusterIssuer.
+class IssuerRef {
+  const IssuerRef({required this.name, required this.kind, this.group = ''});
+
+  final String name;
+
+  /// `"Issuer"` or `"ClusterIssuer"`.
+  final String kind;
+
+  /// API group; `"cert-manager.io"` in practice. Empty when the backend
+  /// elides the field (older responses).
+  final String group;
+
+  factory IssuerRef.fromJson(Map<String, dynamic> json) => IssuerRef(
+        name: json['name'] as String? ?? '',
+        kind: json['kind'] as String? ?? '',
+        group: json['group'] as String? ?? '',
+      );
+}
+
+/// One certificate row on the list endpoints, or the `certificate` field
+/// of a [CertificateDetail] response.
+class Certificate {
+  const Certificate({
+    required this.name,
+    required this.namespace,
+    required this.status,
+    required this.issuerRef,
+    required this.secretName,
+    required this.uid,
+    this.reason,
+    this.message,
+    this.dnsNames = const <String>[],
+    this.commonName,
+    this.duration,
+    this.renewBefore,
+    this.notBefore,
+    this.notAfter,
+    this.renewalTime,
+    this.daysRemaining,
+    this.warningThresholdDays,
+    this.criticalThresholdDays,
+    this.thresholdSource = ThresholdSource.unknown,
+    this.warningThresholdSource = ThresholdSource.unknown,
+    this.criticalThresholdSource = ThresholdSource.unknown,
+    this.thresholdConflict = false,
+  });
+
+  final String name;
+  final String namespace;
+  final CertStatus status;
+  final String? reason;
+  final String? message;
+  final IssuerRef issuerRef;
+  final String secretName;
+  final List<String> dnsNames;
+  final String? commonName;
+
+  /// Duration / renewBefore are emitted as Go-format duration strings
+  /// (e.g. `"2160h0m0s"`). The detail screen renders verbatim — operators
+  /// who care about the value are reading raw spec data anyway.
+  final String? duration;
+  final String? renewBefore;
+
+  /// RFC-3339 timestamps. Stored as ISO strings (not parsed into
+  /// DateTime) because every UI use-case is either render-as-localized
+  /// text or "compare to backend-supplied daysRemaining" — neither
+  /// requires arithmetic on the mobile side.
+  final String? notBefore;
+  final String? notAfter;
+  final String? renewalTime;
+
+  /// Days until [notAfter]. `null` when the cert hasn't been signed yet
+  /// (Issuing without a signed certificate) — distinct from `0` which
+  /// means "expires today / already expired".
+  final int? daysRemaining;
+
+  /// Resolved warn/critical thresholds after `ApplyThresholds`. Null when
+  /// the backend response didn't run the resolver (older callers, or the
+  /// /expiring endpoint which emits a different shape).
+  final int? warningThresholdDays;
+  final int? criticalThresholdDays;
+
+  /// Aggregate "strongest contributing layer" from the resolution chain.
+  /// Per-key attribution lives in [warningThresholdSource] /
+  /// [criticalThresholdSource] — a cert can override warn alone and
+  /// inherit critical from its issuer.
+  final ThresholdSource thresholdSource;
+  final ThresholdSource warningThresholdSource;
+  final ThresholdSource criticalThresholdSource;
+
+  /// True when the operator's resolved warn/crit pair would have
+  /// violated `crit < warn`. The resolver fell back to defaults but the
+  /// UI surfaces the conflict so operators see why "Default" appeared.
+  final bool thresholdConflict;
+
+  final String uid;
+
+  factory Certificate.fromJson(Map<String, dynamic> json) {
+    String? s(Object? v) => v is String && v.isNotEmpty ? v : null;
+    int? n(Object? v) => (v as num?)?.toInt();
+    final dnsRaw = json['dnsNames'];
+    return Certificate(
+      name: json['name'] as String? ?? '',
+      namespace: json['namespace'] as String? ?? '',
+      status: _certStatusFromJson(json['status']),
+      reason: s(json['reason']),
+      message: s(json['message']),
+      issuerRef: json['issuerRef'] is Map
+          ? IssuerRef.fromJson(
+              Map<String, dynamic>.from(json['issuerRef'] as Map),
+            )
+          : const IssuerRef(name: '', kind: ''),
+      secretName: json['secretName'] as String? ?? '',
+      dnsNames: dnsRaw is List
+          ? dnsRaw.whereType<String>().toList()
+          : const <String>[],
+      commonName: s(json['commonName']),
+      duration: s(json['duration']),
+      renewBefore: s(json['renewBefore']),
+      notBefore: s(json['notBefore']),
+      notAfter: s(json['notAfter']),
+      renewalTime: s(json['renewalTime']),
+      daysRemaining: n(json['daysRemaining']),
+      warningThresholdDays: n(json['warningThresholdDays']),
+      criticalThresholdDays: n(json['criticalThresholdDays']),
+      thresholdSource: _thresholdSourceFromJson(json['thresholdSource']),
+      warningThresholdSource:
+          _thresholdSourceFromJson(json['warningThresholdSource']),
+      criticalThresholdSource:
+          _thresholdSourceFromJson(json['criticalThresholdSource']),
+      thresholdConflict: json['thresholdConflict'] as bool? ?? false,
+      uid: json['uid'] as String? ?? '',
+    );
+  }
+}
+
+/// One issuer row — represents either a namespaced Issuer or a
+/// ClusterIssuer (discriminated by [scope]).
+class Issuer {
+  const Issuer({
+    required this.name,
+    required this.scope,
+    required this.type,
+    required this.ready,
+    required this.uid,
+    this.namespace = '',
+    this.reason,
+    this.message,
+    this.acmeEmail,
+    this.acmeServer,
+    this.warningThresholdDays,
+    this.criticalThresholdDays,
+    this.updatedAt = '',
+  });
+
+  final String name;
+
+  /// Empty for ClusterIssuers.
+  final String namespace;
+
+  /// `"Namespaced"` or `"Cluster"`. Matches the backend enum literally so
+  /// the detail screen's source attribution renders identically to web.
+  final String scope;
+
+  /// `"ACME"`, `"CA"`, `"Vault"`, `"SelfSigned"`, `"Unknown"`. Open enum
+  /// — future cert-manager versions may add types.
+  final String type;
+  final bool ready;
+  final String? reason;
+  final String? message;
+
+  /// ACME-only.
+  final String? acmeEmail;
+  final String? acmeServer;
+
+  /// Annotation-set threshold overrides on this issuer. Null means "not
+  /// set on this issuer"; the resolution falls through to clusterissuer
+  /// (for namespaced issuers) or the package default.
+  final int? warningThresholdDays;
+  final int? criticalThresholdDays;
+
+  final String uid;
+  final String updatedAt;
+
+  bool get isCluster => scope == 'Cluster';
+
+  factory Issuer.fromJson(Map<String, dynamic> json) {
+    String? s(Object? v) => v is String && v.isNotEmpty ? v : null;
+    int? n(Object? v) => (v as num?)?.toInt();
+    return Issuer(
+      name: json['name'] as String? ?? '',
+      namespace: json['namespace'] as String? ?? '',
+      scope: json['scope'] as String? ?? '',
+      type: json['type'] as String? ?? '',
+      ready: json['ready'] as bool? ?? false,
+      reason: s(json['reason']),
+      message: s(json['message']),
+      acmeEmail: s(json['acmeEmail']),
+      acmeServer: s(json['acmeServer']),
+      warningThresholdDays: n(json['warningThresholdDays']),
+      criticalThresholdDays: n(json['criticalThresholdDays']),
+      uid: json['uid'] as String? ?? '',
+      updatedAt: json['updatedAt'] as String? ?? '',
+    );
+  }
+}
+
+/// One CertificateRequest sub-resource row on a [CertificateDetail].
+class CertificateRequestRow {
+  const CertificateRequestRow({
+    required this.name,
+    required this.namespace,
+    required this.status,
+    required this.issuerRef,
+    required this.createdAt,
+    required this.uid,
+    this.reason,
+    this.message,
+    this.finishedAt,
+  });
+
+  final String name;
+  final String namespace;
+  final CertStatus status;
+  final String? reason;
+  final String? message;
+  final IssuerRef issuerRef;
+  final String createdAt;
+  final String? finishedAt;
+  final String uid;
+
+  factory CertificateRequestRow.fromJson(Map<String, dynamic> json) {
+    String? s(Object? v) => v is String && v.isNotEmpty ? v : null;
+    return CertificateRequestRow(
+      name: json['name'] as String? ?? '',
+      namespace: json['namespace'] as String? ?? '',
+      status: _certStatusFromJson(json['status']),
+      reason: s(json['reason']),
+      message: s(json['message']),
+      issuerRef: json['issuerRef'] is Map
+          ? IssuerRef.fromJson(
+              Map<String, dynamic>.from(json['issuerRef'] as Map),
+            )
+          : const IssuerRef(name: '', kind: ''),
+      createdAt: json['createdAt'] as String? ?? '',
+      finishedAt: s(json['finishedAt']),
+      uid: json['uid'] as String? ?? '',
+    );
+  }
+}
+
+/// One ACME Order sub-resource row.
+class OrderRow {
+  const OrderRow({
+    required this.name,
+    required this.namespace,
+    required this.state,
+    required this.createdAt,
+    required this.uid,
+    this.reason,
+    this.crName,
+  });
+
+  final String name;
+  final String namespace;
+
+  /// Open enum — cert-manager Order phase strings (`pending`, `valid`,
+  /// `ready`, `processing`, `invalid`, `expired`, `errored`).
+  final String state;
+  final String? reason;
+  final String createdAt;
+  final String uid;
+  final String? crName;
+
+  factory OrderRow.fromJson(Map<String, dynamic> json) {
+    String? s(Object? v) => v is String && v.isNotEmpty ? v : null;
+    return OrderRow(
+      name: json['name'] as String? ?? '',
+      namespace: json['namespace'] as String? ?? '',
+      state: json['state'] as String? ?? '',
+      reason: s(json['reason']),
+      createdAt: json['createdAt'] as String? ?? '',
+      uid: json['uid'] as String? ?? '',
+      crName: s(json['crName']),
+    );
+  }
+}
+
+/// One ACME Challenge sub-resource row.
+class ChallengeRow {
+  const ChallengeRow({
+    required this.name,
+    required this.namespace,
+    required this.type,
+    required this.state,
+    required this.createdAt,
+    required this.uid,
+    this.reason,
+    this.dnsName,
+    this.orderName,
+  });
+
+  final String name;
+  final String namespace;
+
+  /// `"HTTP-01"` or `"DNS-01"`.
+  final String type;
+  final String state;
+  final String? reason;
+  final String? dnsName;
+  final String createdAt;
+  final String uid;
+  final String? orderName;
+
+  factory ChallengeRow.fromJson(Map<String, dynamic> json) {
+    String? s(Object? v) => v is String && v.isNotEmpty ? v : null;
+    return ChallengeRow(
+      name: json['name'] as String? ?? '',
+      namespace: json['namespace'] as String? ?? '',
+      type: json['type'] as String? ?? '',
+      state: json['state'] as String? ?? '',
+      reason: s(json['reason']),
+      dnsName: s(json['dnsName']),
+      createdAt: json['createdAt'] as String? ?? '',
+      uid: json['uid'] as String? ?? '',
+      orderName: s(json['orderName']),
+    );
+  }
+}
+
+/// Aggregated detail response — one [Certificate] plus the
+/// CertificateRequest / Order / Challenge sub-resources scoped to it.
+///
+/// Sub-resource arrays may be empty when:
+///   - The cert never had a renewal cycle yet (no CRs).
+///   - The cert uses a non-ACME Issuer (no Orders, no Challenges).
+///   - RBAC denies the impersonated user sub-resource visibility (a
+///     common case on namespace-scoped operators). The detail screen
+///     surfaces an "Some sub-resources may be hidden by RBAC" hint when
+///     the cert is in Issuing / Failed state but no CRs are present.
+class CertificateDetail {
+  const CertificateDetail({
+    required this.certificate,
+    this.certificateRequests = const <CertificateRequestRow>[],
+    this.orders = const <OrderRow>[],
+    this.challenges = const <ChallengeRow>[],
+  });
+
+  final Certificate certificate;
+  final List<CertificateRequestRow> certificateRequests;
+  final List<OrderRow> orders;
+  final List<ChallengeRow> challenges;
+
+  factory CertificateDetail.fromJson(Map<String, dynamic> json) {
+    final cert = json['certificate'];
+    List<T> rows<T>(
+      Object? raw,
+      T Function(Map<String, dynamic>) parse,
+    ) {
+      if (raw is! List) return <T>[];
+      return raw
+          .whereType<Map<dynamic, dynamic>>()
+          .map((m) => parse(Map<String, dynamic>.from(m)))
+          .toList();
+    }
+
+    return CertificateDetail(
+      certificate: cert is Map
+          ? Certificate.fromJson(Map<String, dynamic>.from(cert))
+          : const Certificate(
+              name: '',
+              namespace: '',
+              status: CertStatus.unknown,
+              issuerRef: IssuerRef(name: '', kind: ''),
+              secretName: '',
+              uid: '',
+            ),
+      certificateRequests:
+          rows(json['certificateRequests'], CertificateRequestRow.fromJson),
+      orders: rows(json['orders'], OrderRow.fromJson),
+      challenges: rows(json['challenges'], ChallengeRow.fromJson),
+    );
+  }
+}
+
+/// One row of the `/v1/certificates/expiring` response. Distinct from
+/// [Certificate] because the backend emits a smaller summary shape here —
+/// only the fields the expiry notification UI needs.
+class ExpiringCertificate {
+  const ExpiringCertificate({
+    required this.namespace,
+    required this.name,
+    required this.uid,
+    required this.issuerName,
+    required this.secretName,
+    required this.notAfter,
+    required this.daysRemaining,
+    required this.severity,
+  });
+
+  final String namespace;
+  final String name;
+  final String uid;
+  final String issuerName;
+  final String secretName;
+
+  /// RFC-3339 timestamp; rendered with `toLocaleString` equivalent on
+  /// the mobile side.
+  final String notAfter;
+  final int daysRemaining;
+
+  /// `"warning"`, `"critical"`, or `"expired"`. The Go backend currently
+  /// emits only the first two; the web TS type allows `"expired"` for
+  /// forward-compatibility. The mobile parser accepts all three and
+  /// preserves anything else verbatim (forward-compat with future
+  /// cert-manager versions).
+  final String severity;
+
+  factory ExpiringCertificate.fromJson(Map<String, dynamic> json) {
+    return ExpiringCertificate(
+      namespace: json['namespace'] as String? ?? '',
+      name: json['name'] as String? ?? '',
+      uid: json['uid'] as String? ?? '',
+      issuerName: json['issuerName'] as String? ?? '',
+      secretName: json['secretName'] as String? ?? '',
+      notAfter: json['notAfter'] as String? ?? '',
+      daysRemaining: (json['daysRemaining'] as num?)?.toInt() ?? 0,
+      severity: json['severity'] as String? ?? 'warning',
+    );
+  }
+}
+
+/// Successful response from POST renew / reissue. Backend emits HTTP 202
+/// with `{"status": "renewing"}` or `{"status": "reissuing"}`. Mobile
+/// surfaces the verb verbatim so the snackbar copy is identical to web.
+class CertActionResult {
+  const CertActionResult({required this.status});
+  final String status;
+}
+
+/// Mobile wrapper over `/v1/certificates/*`. Stateless — cluster pinning
+/// threads through `clusterIdOverride` so the wire header always matches
+/// the family-key slot the caller writes back into.
+class CertManagerRepository {
+  CertManagerRepository(this._dio);
+
+  final Dio _dio;
+
+  /// Fetches cert-manager discovery status. Returns
+  /// [CertManagerStatus.empty] on 5xx so callers route straight to
+  /// `FeatureUnavailableState.certManager()` — a flaky reverse-proxy
+  /// probe should not surface as an error card.
+  Future<CertManagerStatus> status({
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) async {
+    try {
+      final res = await _dio.get<Map<String, dynamic>>(
+        '/api/v1/certificates/status',
+        options: clusterIdOverride == null
+            ? null
+            : Options(headers: {'X-Cluster-ID': clusterIdOverride}),
+        cancelToken: cancelToken,
+      );
+      final data = res.data?['data'];
+      if (data is Map) {
+        return CertManagerStatus.fromJson(Map<String, dynamic>.from(data));
+      }
+      return CertManagerStatus.empty;
+    } on DioException catch (e) {
+      if (CancelToken.isCancel(e)) rethrow;
+      final code = e.response?.statusCode ?? 0;
+      if (code >= 500 && code < 600) return CertManagerStatus.empty;
+      final err = e.error;
+      throw err is ApiError ? err : ApiError.fromDio(e);
+    }
+  }
+
+  /// Lists every Certificate the impersonated user can see across all
+  /// namespaces. `namespace` filter is applied client-side on the
+  /// backend; mobile threads it through as a query param when set.
+  Future<List<Certificate>> listCertificates({
+    String? namespace,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) =>
+      _fetchList<Certificate>(
+        path: '/api/v1/certificates/certificates',
+        query: (namespace != null && namespace.isNotEmpty)
+            ? {'namespace': namespace}
+            : null,
+        parse: Certificate.fromJson,
+        clusterIdOverride: clusterIdOverride,
+        cancelToken: cancelToken,
+      );
+
+  /// Fetches a single Certificate detail (with sub-resources). 404s
+  /// surface as [ApiError] so the detail screen renders a clear "not
+  /// found" message rather than an empty cert.
+  Future<CertificateDetail> getCertificate({
+    required String namespace,
+    required String name,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) async {
+    try {
+      final res = await _dio.get<Map<String, dynamic>>(
+        '/api/v1/certificates/certificates/'
+        '${Uri.encodeComponent(namespace)}/${Uri.encodeComponent(name)}',
+        options: clusterIdOverride == null
+            ? null
+            : Options(headers: {'X-Cluster-ID': clusterIdOverride}),
+        cancelToken: cancelToken,
+      );
+      final data = res.data?['data'];
+      if (data is Map) {
+        return CertificateDetail.fromJson(Map<String, dynamic>.from(data));
+      }
+      throw ApiError(
+        statusCode: 500,
+        code: 500,
+        message: 'Empty response for certificate $namespace/$name',
+      );
+    } on DioException catch (e) {
+      if (CancelToken.isCancel(e)) rethrow;
+      final err = e.error;
+      throw err is ApiError ? err : ApiError.fromDio(e);
+    }
+  }
+
+  /// Lists namespaced Issuers visible to the impersonated user.
+  Future<List<Issuer>> listIssuers({
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) =>
+      _fetchList<Issuer>(
+        path: '/api/v1/certificates/issuers',
+        parse: Issuer.fromJson,
+        clusterIdOverride: clusterIdOverride,
+        cancelToken: cancelToken,
+      );
+
+  /// Lists ClusterIssuers. Empty list (not 403) when the impersonated
+  /// user lacks cluster-scoped `get clusterissuers` — backend silently
+  /// drops them so non-admin operators don't see a noisy permission
+  /// failure on every screen mount.
+  Future<List<Issuer>> listClusterIssuers({
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) =>
+      _fetchList<Issuer>(
+        path: '/api/v1/certificates/clusterissuers',
+        parse: Issuer.fromJson,
+        clusterIdOverride: clusterIdOverride,
+        cancelToken: cancelToken,
+      );
+
+  /// Lists certificates currently in the warn or critical bucket per
+  /// their resolved thresholds. Backend sorts ascending by
+  /// `daysRemaining`.
+  Future<List<ExpiringCertificate>> listExpiring({
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) =>
+      _fetchList<ExpiringCertificate>(
+        path: '/api/v1/certificates/expiring',
+        parse: ExpiringCertificate.fromJson,
+        clusterIdOverride: clusterIdOverride,
+        cancelToken: cancelToken,
+      );
+
+  /// Triggers cert renewal. Backend returns HTTP 202 with
+  /// `{"status": "renewing"}` on success. Failures bubble as [ApiError].
+  /// 403 on missing `patch certificates` RBAC; 500 on cert-manager
+  /// status-subresource update failure.
+  Future<CertActionResult> renew({
+    required String namespace,
+    required String name,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) =>
+      _postCertAction(
+        verb: 'renew',
+        namespace: namespace,
+        name: name,
+        clusterIdOverride: clusterIdOverride,
+        cancelToken: cancelToken,
+      );
+
+  /// Triggers cert re-issuance by deleting the backing Secret. Backend
+  /// validates Secret ownership by `ownerReference.UID` matching the
+  /// Certificate's UID, so unrelated Secrets cannot be deleted via this
+  /// path even by an operator with secret delete RBAC. Returns 202 with
+  /// `{"status": "reissuing"}`.
+  Future<CertActionResult> reissue({
+    required String namespace,
+    required String name,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) =>
+      _postCertAction(
+        verb: 'reissue',
+        namespace: namespace,
+        name: name,
+        clusterIdOverride: clusterIdOverride,
+        cancelToken: cancelToken,
+      );
+
+  // ---------------------------------------------------------------------------
+  // Internal helpers
+  // ---------------------------------------------------------------------------
+
+  /// Shared envelope unwrapping for the four list endpoints. Backend
+  /// writes a flat array into the `{"data": [...]}` envelope — no inner
+  /// kind-specific key. Returns an empty list when the envelope is
+  /// missing or the wrong shape rather than throwing, because the
+  /// status endpoint already gates the "feature not installed" case
+  /// upstream; an empty list on a healthy cluster is the natural
+  /// "nothing matches" state.
+  Future<List<T>> _fetchList<T>({
+    required String path,
+    Map<String, String>? query,
+    required T Function(Map<String, dynamic>) parse,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) async {
+    try {
+      final res = await _dio.get<Map<String, dynamic>>(
+        path,
+        queryParameters: query,
+        options: clusterIdOverride == null
+            ? null
+            : Options(headers: {'X-Cluster-ID': clusterIdOverride}),
+        cancelToken: cancelToken,
+      );
+      final data = res.data?['data'];
+      if (data is List) {
+        return data
+            .whereType<Map<dynamic, dynamic>>()
+            .map((m) => parse(Map<String, dynamic>.from(m)))
+            .toList();
+      }
+      return <T>[];
+    } on DioException catch (e) {
+      if (CancelToken.isCancel(e)) rethrow;
+      final err = e.error;
+      throw err is ApiError ? err : ApiError.fromDio(e);
+    }
+  }
+
+  Future<CertActionResult> _postCertAction({
+    required String verb,
+    required String namespace,
+    required String name,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) async {
+    try {
+      final res = await _dio.post<Map<String, dynamic>>(
+        '/api/v1/certificates/certificates/'
+        '${Uri.encodeComponent(namespace)}/'
+        '${Uri.encodeComponent(name)}/$verb',
+        options: clusterIdOverride == null
+            ? null
+            : Options(headers: {'X-Cluster-ID': clusterIdOverride}),
+        cancelToken: cancelToken,
+      );
+      final data = res.data?['data'];
+      final status = data is Map ? data['status'] as String? : null;
+      // Default to the canonical present-continuous form when the
+      // backend response shape unexpectedly elides the status field —
+      // matches the backend's literal so the snackbar copy is identical
+      // even on a body-less 202. Naive string suffix concat is wrong
+      // ("reissue" + "ing" = "reissueing"), so the map is explicit.
+      const verbDefault = {
+        'renew': 'renewing',
+        'reissue': 'reissuing',
+      };
+      return CertActionResult(
+        status: status ?? verbDefault[verb] ?? verb,
+      );
+    } on DioException catch (e) {
+      if (CancelToken.isCancel(e)) rethrow;
+      final err = e.error;
+      throw err is ApiError ? err : ApiError.fromDio(e);
+    }
+  }
+}
+
+final certManagerRepositoryProvider = Provider<CertManagerRepository>((ref) {
+  return CertManagerRepository(ref.watch(dioProvider));
+});
+
+/// Per-cluster cert-manager discovery status. Drives
+/// `FeatureUnavailableState.certManager()` on every cert-manager surface
+/// and decides whether the drawer entries render with a "not installed"
+/// landing state.
+final certManagerStatusProvider = FutureProvider.autoDispose
+    .family<CertManagerStatus, String>((ref, clusterId) async {
+  ref.watch(activeClusterProvider);
+  final cancel = CancelToken();
+  ref.onDispose(() {
+    if (!cancel.isCancelled) cancel.cancel('cert-manager status invalidated');
+  });
+  return ref.read(certManagerRepositoryProvider).status(
+        clusterIdOverride: clusterId,
+        cancelToken: cancel,
+      );
+});
+
+/// Family key for the certificates list provider. Carries both cluster
+/// id (so cluster switches force a fresh slot) and namespace (so two
+/// open list screens with different namespace filters don't share
+/// state).
+class CertificateListKey {
+  /// Normalise [namespace]: empty string is treated as null so
+  /// `CertificateListKey(clusterId: 'c', namespace: '')` and
+  /// `CertificateListKey(clusterId: 'c')` resolve to the same slot.
+  CertificateListKey({required this.clusterId, String? namespace})
+      : namespace = (namespace != null && namespace.isEmpty) ? null : namespace;
+
+  final String clusterId;
+
+  /// null → cluster-wide list. Backend filters by RBAC server-side.
+  final String? namespace;
+
+  @override
+  bool operator ==(Object other) =>
+      other is CertificateListKey &&
+      other.clusterId == clusterId &&
+      other.namespace == namespace;
+
+  @override
+  int get hashCode => Object.hash(clusterId, namespace);
+}
+
+final certificateListProvider = FutureProvider.autoDispose
+    .family<List<Certificate>, CertificateListKey>((ref, key) async {
+  ref.watch(activeClusterProvider);
+  final cancel = CancelToken();
+  ref.onDispose(() {
+    if (!cancel.isCancelled) cancel.cancel('certificate list invalidated');
+  });
+  return ref.read(certManagerRepositoryProvider).listCertificates(
+        namespace: key.namespace,
+        clusterIdOverride: key.clusterId,
+        cancelToken: cancel,
+      );
+});
+
+class CertificateDetailKey {
+  const CertificateDetailKey({
+    required this.clusterId,
+    required this.namespace,
+    required this.name,
+  });
+
+  final String clusterId;
+  final String namespace;
+  final String name;
+
+  @override
+  bool operator ==(Object other) =>
+      other is CertificateDetailKey &&
+      other.clusterId == clusterId &&
+      other.namespace == namespace &&
+      other.name == name;
+
+  @override
+  int get hashCode => Object.hash(clusterId, namespace, name);
+}
+
+final certificateDetailProvider = FutureProvider.autoDispose
+    .family<CertificateDetail, CertificateDetailKey>((ref, key) async {
+  ref.watch(activeClusterProvider);
+  final cancel = CancelToken();
+  ref.onDispose(() {
+    if (!cancel.isCancelled) cancel.cancel('certificate detail invalidated');
+  });
+  return ref.read(certManagerRepositoryProvider).getCertificate(
+        namespace: key.namespace,
+        name: key.name,
+        clusterIdOverride: key.clusterId,
+        cancelToken: cancel,
+      );
+});
+
+/// Combined Issuers + ClusterIssuers list. The two backend endpoints are
+/// fetched in parallel and concatenated (namespaced first), matching
+/// `frontend/islands/IssuersList.tsx`'s `Promise.all` pattern. Failures
+/// on either endpoint surface as the family failing — the picker
+/// provider in `wizards/widgets/issuer_picker.dart` keys on a different
+/// shape and is intentionally separate.
+final allIssuersProvider = FutureProvider.autoDispose
+    .family<List<Issuer>, String>((ref, clusterId) async {
+  ref.watch(activeClusterProvider);
+  final cancel = CancelToken();
+  ref.onDispose(() {
+    if (!cancel.isCancelled) cancel.cancel('issuers list invalidated');
+  });
+  final repo = ref.read(certManagerRepositoryProvider);
+  final results = await Future.wait([
+    repo.listIssuers(clusterIdOverride: clusterId, cancelToken: cancel),
+    repo.listClusterIssuers(clusterIdOverride: clusterId, cancelToken: cancel),
+  ]);
+  return [...results[0], ...results[1]];
+});
+
+/// Expiring certificates list — already sorted ascending by
+/// `daysRemaining` by the backend.
+final expiringCertificatesProvider = FutureProvider.autoDispose
+    .family<List<ExpiringCertificate>, String>((ref, clusterId) async {
+  ref.watch(activeClusterProvider);
+  final cancel = CancelToken();
+  ref.onDispose(() {
+    if (!cancel.isCancelled) cancel.cancel('expiring certs invalidated');
+  });
+  return ref.read(certManagerRepositoryProvider).listExpiring(
+        clusterIdOverride: clusterId,
+        cancelToken: cancel,
+      );
+});

--- a/mobile/lib/api/certmanager_repository.dart
+++ b/mobile/lib/api/certmanager_repository.dart
@@ -40,7 +40,7 @@ import 'dio_client.dart';
 enum ThresholdSource {
   /// Resolution fell through to the package default (warn=30d, crit=7d)
   /// — no annotation present anywhere in the chain.
-  defaultSource,
+  packageDefault,
 
   /// Annotation set directly on the Certificate.
   certificate,
@@ -60,7 +60,7 @@ ThresholdSource _thresholdSourceFromJson(Object? v) {
   if (v is! String) return ThresholdSource.unknown;
   switch (v) {
     case 'default':
-      return ThresholdSource.defaultSource;
+      return ThresholdSource.packageDefault;
     case 'certificate':
       return ThresholdSource.certificate;
     case 'issuer':
@@ -249,7 +249,14 @@ class Certificate {
 
   factory Certificate.fromJson(Map<String, dynamic> json) {
     String? s(Object? v) => v is String && v.isNotEmpty ? v : null;
-    int? n(Object? v) => (v as num?)?.toInt();
+    // Defensive cast: accept num (canonical), parse String (forward-compat /
+    // mock-backend / replay-proxy resilience), reject everything else by
+    // returning null rather than throwing. Mirrors the s() helper above.
+    int? n(Object? v) {
+      if (v is num) return v.toInt();
+      if (v is String) return int.tryParse(v);
+      return null;
+    }
     final dnsRaw = json['dnsNames'];
     return Certificate(
       name: json['name'] as String? ?? '',
@@ -338,7 +345,14 @@ class Issuer {
 
   factory Issuer.fromJson(Map<String, dynamic> json) {
     String? s(Object? v) => v is String && v.isNotEmpty ? v : null;
-    int? n(Object? v) => (v as num?)?.toInt();
+    // Defensive cast: accept num (canonical), parse String (forward-compat /
+    // mock-backend / replay-proxy resilience), reject everything else by
+    // returning null rather than throwing. Mirrors the s() helper above.
+    int? n(Object? v) {
+      if (v is num) return v.toInt();
+      if (v is String) return int.tryParse(v);
+      return null;
+    }
     return Issuer(
       name: json['name'] as String? ?? '',
       namespace: json['namespace'] as String? ?? '',
@@ -569,6 +583,17 @@ class ExpiringCertificate {
   final String severity;
 
   factory ExpiringCertificate.fromJson(Map<String, dynamic> json) {
+    // Defensive numeric cast — matches the n() helper used in Certificate
+    // and Issuer parsing above. Accepts num (canonical), parses String
+    // (forward-compat / mock-backend resilience), falls back to 0 for
+    // anything else rather than throwing — a single corrupt field on one
+    // row must not collapse the entire list response into an error state.
+    int days(Object? v) {
+      if (v is num) return v.toInt();
+      if (v is String) return int.tryParse(v) ?? 0;
+      return 0;
+    }
+
     return ExpiringCertificate(
       namespace: json['namespace'] as String? ?? '',
       name: json['name'] as String? ?? '',
@@ -576,7 +601,7 @@ class ExpiringCertificate {
       issuerName: json['issuerName'] as String? ?? '',
       secretName: json['secretName'] as String? ?? '',
       notAfter: json['notAfter'] as String? ?? '',
-      daysRemaining: (json['daysRemaining'] as num?)?.toInt() ?? 0,
+      daysRemaining: days(json['daysRemaining']),
       severity: json['severity'] as String? ?? 'warning',
     );
   }

--- a/mobile/lib/features/certmanager/cert_badges.dart
+++ b/mobile/lib/features/certmanager/cert_badges.dart
@@ -108,6 +108,21 @@ class ExpiryBadge extends StatelessWidget {
   }
 }
 
+/// Ready/not-ready badge for Issuers and ClusterIssuers.
+/// Replaces the private `_ReadyBadge` in `issuers_list_screen.dart`.
+class ReadyBadge extends StatelessWidget {
+  const ReadyBadge({super.key, required this.ready});
+
+  final bool ready;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final tone = ready ? colors.success : colors.error;
+    return _Pill(label: ready ? 'Ready' : 'Not ready', color: tone);
+  }
+}
+
 /// Pill chrome — same shape used by every cert-manager badge so colors
 /// vary but the geometry stays consistent.
 class _Pill extends StatelessWidget {

--- a/mobile/lib/features/certmanager/cert_badges.dart
+++ b/mobile/lib/features/certmanager/cert_badges.dart
@@ -1,0 +1,138 @@
+// Status / expiry / issuer-type badges shared across the cert-manager
+// surfaces (list, detail, expiring view, issuers list). Mirrors the web's
+// `frontend/components/ui/CertificateBadges.tsx`, with one upgrade:
+// expiry color uses the backend-resolved threshold pair rather than
+// hardcoded 7d/30d cutoffs. The plan (PR-4g) explicitly requires this so
+// per-cert / per-issuer annotation overrides flow through to the badge.
+//
+// Color contract:
+//   * `success`        — days remaining > warn threshold (informational)
+//   * `warning`        — critical < days remaining ≤ warn
+//   * `error`          — days remaining ≤ critical (or already expired)
+//   * `textMuted`      — daysRemaining is null (cert not yet signed)
+
+import 'package:flutter/material.dart';
+
+import '../../api/certmanager_repository.dart';
+import '../../theme/kube_theme_builder.dart';
+
+/// Package-default warn threshold, matching `WarningThresholdDays` in
+/// `backend/internal/certmanager/types.go`. Used as the fallback when the
+/// backend response doesn't carry a resolved threshold (older callers,
+/// or the `/expiring` endpoint which never embeds them).
+const int kDefaultWarningThresholdDays = 30;
+
+/// Package-default critical threshold, matching `CriticalThresholdDays`
+/// in `backend/internal/certmanager/types.go`.
+const int kDefaultCriticalThresholdDays = 7;
+
+/// Pill badge for [CertStatus]. Color contract matches the web's
+/// `STATUS_COLORS` map: Ready=success, Issuing=accent, Failed=error,
+/// Expired=error, Expiring=warning, Unknown=textMuted.
+class CertStatusPill extends StatelessWidget {
+  const CertStatusPill({super.key, required this.status});
+
+  final CertStatus status;
+
+  Color _color(KubeColors c) => switch (status) {
+        CertStatus.ready => c.success,
+        CertStatus.issuing => c.accent,
+        CertStatus.failed => c.error,
+        CertStatus.expired => c.error,
+        CertStatus.expiring => c.warning,
+        CertStatus.unknown => c.textMuted,
+      };
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final tone = _color(colors);
+    return _Pill(label: certStatusLabel(status), color: tone);
+  }
+}
+
+/// Badge for an Issuer's [type] (ACME / CA / Vault / SelfSigned /
+/// Unknown). Open enum — unknown types render as muted.
+class IssuerTypeBadge extends StatelessWidget {
+  const IssuerTypeBadge({super.key, required this.type});
+
+  final String type;
+
+  Color _color(KubeColors c) => switch (type) {
+        'ACME' => c.accent,
+        'CA' => c.success,
+        'Vault' => c.warning,
+        'SelfSigned' => c.textMuted,
+        _ => c.textMuted,
+      };
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return _Pill(
+      label: type.isEmpty ? 'Unknown' : type,
+      color: _color(colors),
+    );
+  }
+}
+
+/// Days-remaining badge — colored from the resolved warn/critical
+/// thresholds rather than hardcoded cutoffs. When the backend response
+/// elides the threshold pair the package defaults (30d warn, 7d crit)
+/// stand in so the color remains operator-meaningful.
+class ExpiryBadge extends StatelessWidget {
+  const ExpiryBadge({
+    super.key,
+    required this.daysRemaining,
+    this.warningThresholdDays,
+    this.criticalThresholdDays,
+  });
+
+  final int? daysRemaining;
+  final int? warningThresholdDays;
+  final int? criticalThresholdDays;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final d = daysRemaining;
+    if (d == null) {
+      return Text('—', style: TextStyle(color: colors.textMuted, fontSize: 12));
+    }
+    final warn = warningThresholdDays ?? kDefaultWarningThresholdDays;
+    final crit = criticalThresholdDays ?? kDefaultCriticalThresholdDays;
+    if (d < 0) return _Pill(label: 'Expired', color: colors.error);
+    if (d <= crit) return _Pill(label: '${d}d left', color: colors.error);
+    if (d <= warn) return _Pill(label: '${d}d left', color: colors.warning);
+    return _Pill(label: '${d}d', color: colors.success);
+  }
+}
+
+/// Pill chrome — same shape used by every cert-manager badge so colors
+/// vary but the geometry stays consistent.
+class _Pill extends StatelessWidget {
+  const _Pill({required this.label, required this.color});
+
+  final String label;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.16),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: color.withValues(alpha: 0.4)),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          color: color,
+          fontSize: 11,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/certmanager/certificate_detail_screen.dart
+++ b/mobile/lib/features/certmanager/certificate_detail_screen.dart
@@ -27,6 +27,7 @@
 // invariants in CLAUDE.md). Renew uses a simple OK/Cancel since it's
 // non-destructive.
 
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -36,6 +37,7 @@ import '../../cluster/cluster_provider.dart';
 import '../../theme/kube_theme_builder.dart';
 import '../../widgets/confirm_sheet.dart';
 import '../../widgets/empty_states.dart';
+import '../../widgets/refreshable_controller.dart';
 import '../../widgets/resource_detail_scaffold.dart' show EventsTab;
 import 'cert_badges.dart';
 
@@ -58,6 +60,13 @@ class _CertificateDetailScreenState
     extends ConsumerState<CertificateDetailScreen> {
   bool _busy = false;
   String? _actionMsg;
+  CancelToken? _actionToken;
+
+  @override
+  void dispose() {
+    _actionToken?.cancel('screen disposed');
+    super.dispose();
+  }
 
   CertificateDetailKey _key(String clusterId) => CertificateDetailKey(
         clusterId: clusterId,
@@ -66,68 +75,108 @@ class _CertificateDetailScreenState
       );
 
   Future<void> _handleRenew() async {
-    final ok = await showConfirmSheet(
-      context: context,
-      title: 'Renew certificate',
-      message:
-          'Trigger a renewal of "${widget.name}" in namespace "${widget.namespace}". '
-          'cert-manager will request a new certificate from the issuer; the existing '
-          'Secret stays in place until the new cert is signed.',
-      confirmLabel: 'Renew',
-    );
-    if (ok != true || !mounted) return;
-    await _runAction(
-      action: () async {
-        final clusterId = ref.read(activeClusterProvider);
-        await ref.read(certManagerRepositoryProvider).renew(
-              namespace: widget.namespace,
-              name: widget.name,
-              clusterIdOverride: clusterId,
-            );
-      },
-      successMessage: 'Renewal triggered',
-    );
-  }
-
-  Future<void> _handleReissue(Certificate cert) async {
-    final ok = await showConfirmSheet(
-      context: context,
-      title: 'Re-issue certificate',
-      message:
-          'Re-issue will delete Secret "${cert.secretName}" in "${cert.namespace}". '
-          'Applications using this Secret will briefly lose TLS until '
-          'cert-manager completes re-issuance.',
-      confirmLabel: 'Re-issue',
-      danger: true,
-      // Type-to-confirm gates the destructive verb on the cert name —
-      // mirrors the M2 delete pattern and the mobile invariant that
-      // type-to-confirm is the single destructive confirmation surface.
-      typeToConfirm: widget.name,
-    );
-    if (ok != true || !mounted) return;
-    await _runAction(
-      action: () async {
-        final clusterId = ref.read(activeClusterProvider);
-        await ref.read(certManagerRepositoryProvider).reissue(
-              namespace: widget.namespace,
-              name: widget.name,
-              clusterIdOverride: clusterId,
-            );
-      },
-      successMessage: 'Re-issue triggered',
-    );
-  }
-
-  Future<void> _runAction({
-    required Future<void> Function() action,
-    required String successMessage,
-  }) async {
+    // F2: Set busy BEFORE the confirm sheet to prevent double-tap race.
     setState(() {
       _busy = true;
       _actionMsg = null;
     });
     try {
-      await action();
+      // F1: Capture cluster id before showing the confirm sheet.
+      final pinnedClusterId = ref.read(activeClusterProvider);
+      final ok = await showConfirmSheet(
+        context: context,
+        title: 'Renew certificate',
+        message:
+            'Trigger a renewal of "${widget.name}" in namespace "${widget.namespace}". '
+            'cert-manager will request a new certificate from the issuer; the existing '
+            'Secret stays in place until the new cert is signed.',
+        confirmLabel: 'Renew',
+      );
+      if (ok != true || !mounted) return;
+      // F1: Re-check cluster pin after confirm sheet.
+      if (ref.read(activeClusterProvider) != pinnedClusterId) {
+        setState(() {
+          _actionMsg =
+              'Cluster changed during this action. Aborted to avoid acting on the wrong cluster.';
+        });
+        return;
+      }
+      await _runAction(
+        pinnedClusterId: pinnedClusterId,
+        action: (token) async {
+          await ref.read(certManagerRepositoryProvider).renew(
+                namespace: widget.namespace,
+                name: widget.name,
+                clusterIdOverride: pinnedClusterId,
+                cancelToken: token,
+              );
+        },
+        successMessage: 'Renewal triggered',
+      );
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _handleReissue(Certificate cert) async {
+    // F2: Set busy BEFORE the confirm sheet to prevent double-tap race.
+    setState(() {
+      _busy = true;
+      _actionMsg = null;
+    });
+    try {
+      // F1: Capture cluster id before showing the confirm sheet.
+      final pinnedClusterId = ref.read(activeClusterProvider);
+      final ok = await showConfirmSheet(
+        context: context,
+        title: 'Re-issue certificate',
+        message:
+            'Re-issue will delete Secret "${cert.secretName}" in "${cert.namespace}". '
+            'Applications using this Secret will briefly lose TLS until '
+            'cert-manager completes re-issuance.',
+        confirmLabel: 'Re-issue',
+        danger: true,
+        // Type-to-confirm gates the destructive verb on the cert name —
+        // mirrors the M2 delete pattern and the mobile invariant that
+        // type-to-confirm is the single destructive confirmation surface.
+        typeToConfirm: widget.name,
+      );
+      if (ok != true || !mounted) return;
+      // F1: Re-check cluster pin after confirm sheet.
+      if (ref.read(activeClusterProvider) != pinnedClusterId) {
+        setState(() {
+          _actionMsg =
+              'Cluster changed during this action. Aborted to avoid acting on the wrong cluster.';
+        });
+        return;
+      }
+      await _runAction(
+        pinnedClusterId: pinnedClusterId,
+        action: (token) async {
+          await ref.read(certManagerRepositoryProvider).reissue(
+                namespace: widget.namespace,
+                name: widget.name,
+                clusterIdOverride: pinnedClusterId,
+                cancelToken: token,
+              );
+        },
+        successMessage: 'Re-issue triggered',
+      );
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _runAction({
+    required String pinnedClusterId,
+    required Future<void> Function(CancelToken token) action,
+    required String successMessage,
+  }) async {
+    // F3: Supersede any prior in-flight action token.
+    _actionToken?.cancel('superseded');
+    _actionToken = CancelToken();
+    try {
+      await action(_actionToken!);
       if (!mounted) return;
       setState(() {
         _actionMsg = '$successMessage · refreshing…';
@@ -135,16 +184,23 @@ class _CertificateDetailScreenState
       // Invalidate the detail provider so the next build re-fetches the
       // updated cert (renew flips Status → Issuing; reissue triggers a
       // CertificateRequest creation that will appear in Sub-Resources).
-      final clusterId = ref.read(activeClusterProvider);
-      ref.invalidate(certificateDetailProvider(_key(clusterId)));
+      // F1: Use pinnedClusterId for invalidation, not the live active cluster.
+      ref.invalidate(certificateDetailProvider(_key(pinnedClusterId)));
+      // F9: Auto-clear the toast after 1500ms (matches web CertificateDetail.tsx).
+      Future.delayed(const Duration(milliseconds: 1500), () {
+        if (mounted) setState(() => _actionMsg = null);
+      });
+    } on DioException catch (e) {
+      // F3: Silently ignore cancellations.
+      if (RefreshableController.isCancelException(e)) return;
+      if (!mounted) return;
+      setState(() => _actionMsg = 'Action failed: ${e.message}');
     } on ApiError catch (e) {
       if (!mounted) return;
       setState(() => _actionMsg = 'Action failed: ${e.message}');
     } on Object catch (e) {
       if (!mounted) return;
       setState(() => _actionMsg = 'Action failed: $e');
-    } finally {
-      if (mounted) setState(() => _busy = false);
     }
   }
 
@@ -362,12 +418,8 @@ class _OverviewTab extends StatelessWidget {
 
   static String _fmt(String? iso) {
     if (iso == null || iso.isEmpty) return '—';
-    // We preserve the wire ISO-8601 format intentionally: the alternate is
-    // either using DateTime.parse + the device's locale (which would emit
-    // a region-specific string), or going through intl (a heavier
-    // dependency). Operators reading the detail screen typically want
-    // the raw timestamp anyway.
-    return iso;
+    final dt = DateTime.tryParse(iso);
+    return dt == null ? iso : dt.toLocal().toString();
   }
 }
 
@@ -530,7 +582,10 @@ class _SubResourcesTab extends StatelessWidget {
     final s = detail.certificate.status;
     final issuingOrFailing =
         s == CertStatus.issuing || s == CertStatus.failed;
-    return issuingOrFailing && detail.certificateRequests.isEmpty;
+    return issuingOrFailing &&
+        detail.certificateRequests.isEmpty &&
+        detail.orders.isEmpty &&
+        detail.challenges.isEmpty;
   }
 
   @override

--- a/mobile/lib/features/certmanager/certificate_detail_screen.dart
+++ b/mobile/lib/features/certmanager/certificate_detail_screen.dart
@@ -1,0 +1,898 @@
+// Certificate detail — three tabs (Overview / Sub-Resources / Events)
+// rendered against the backend's `CertificateDetail` envelope. Renew +
+// Reissue buttons live in the app-bar actions slot and post to the
+// cert-manager-scoped endpoints (`/v1/certificates/.../{renew,reissue}`)
+// rather than the generic resource action endpoint — matching the web's
+// `frontend/islands/CertificateDetail.tsx` pattern.
+//
+// Overview tab renders:
+//   * Status pill + ExpiryBadge (computed from resolved thresholds)
+//   * Issuer, secret, common name, DNS names, validity timestamps
+//   * Threshold attribution row (per-key source, with a "Conflict —
+//     using defaults" badge when `thresholdConflict: true`)
+//   * Reason / message when present
+//
+// Sub-Resources tab renders three sections (CertificateRequests,
+// Orders, Challenges). Empty sections collapse to a hint. When the cert
+// is in Issuing or Failed state and no CertificateRequests are visible
+// we surface an RBAC hint — namespace-scoped operators commonly can
+// see the cert but not the underlying CR list.
+//
+// Events tab reuses the shared [EventsTab] widget from
+// resource_detail_scaffold so cert events render identically to every
+// other resource's events tab.
+//
+// Type-to-confirm contract: Reissue uses the mobile [confirm_sheet]
+// pattern (the canonical confirmation surface, per the mobile
+// invariants in CLAUDE.md). Renew uses a simple OK/Cancel since it's
+// non-destructive.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../api/api_error.dart';
+import '../../api/certmanager_repository.dart';
+import '../../cluster/cluster_provider.dart';
+import '../../theme/kube_theme_builder.dart';
+import '../../widgets/confirm_sheet.dart';
+import '../../widgets/empty_states.dart';
+import '../../widgets/resource_detail_scaffold.dart' show EventsTab;
+import 'cert_badges.dart';
+
+class CertificateDetailScreen extends ConsumerStatefulWidget {
+  const CertificateDetailScreen({
+    super.key,
+    required this.namespace,
+    required this.name,
+  });
+
+  final String namespace;
+  final String name;
+
+  @override
+  ConsumerState<CertificateDetailScreen> createState() =>
+      _CertificateDetailScreenState();
+}
+
+class _CertificateDetailScreenState
+    extends ConsumerState<CertificateDetailScreen> {
+  bool _busy = false;
+  String? _actionMsg;
+
+  CertificateDetailKey _key(String clusterId) => CertificateDetailKey(
+        clusterId: clusterId,
+        namespace: widget.namespace,
+        name: widget.name,
+      );
+
+  Future<void> _handleRenew() async {
+    final ok = await showConfirmSheet(
+      context: context,
+      title: 'Renew certificate',
+      message:
+          'Trigger a renewal of "${widget.name}" in namespace "${widget.namespace}". '
+          'cert-manager will request a new certificate from the issuer; the existing '
+          'Secret stays in place until the new cert is signed.',
+      confirmLabel: 'Renew',
+    );
+    if (ok != true || !mounted) return;
+    await _runAction(
+      action: () async {
+        final clusterId = ref.read(activeClusterProvider);
+        await ref.read(certManagerRepositoryProvider).renew(
+              namespace: widget.namespace,
+              name: widget.name,
+              clusterIdOverride: clusterId,
+            );
+      },
+      successMessage: 'Renewal triggered',
+    );
+  }
+
+  Future<void> _handleReissue(Certificate cert) async {
+    final ok = await showConfirmSheet(
+      context: context,
+      title: 'Re-issue certificate',
+      message:
+          'Re-issue will delete Secret "${cert.secretName}" in "${cert.namespace}". '
+          'Applications using this Secret will briefly lose TLS until '
+          'cert-manager completes re-issuance.',
+      confirmLabel: 'Re-issue',
+      danger: true,
+      // Type-to-confirm gates the destructive verb on the cert name —
+      // mirrors the M2 delete pattern and the mobile invariant that
+      // type-to-confirm is the single destructive confirmation surface.
+      typeToConfirm: widget.name,
+    );
+    if (ok != true || !mounted) return;
+    await _runAction(
+      action: () async {
+        final clusterId = ref.read(activeClusterProvider);
+        await ref.read(certManagerRepositoryProvider).reissue(
+              namespace: widget.namespace,
+              name: widget.name,
+              clusterIdOverride: clusterId,
+            );
+      },
+      successMessage: 'Re-issue triggered',
+    );
+  }
+
+  Future<void> _runAction({
+    required Future<void> Function() action,
+    required String successMessage,
+  }) async {
+    setState(() {
+      _busy = true;
+      _actionMsg = null;
+    });
+    try {
+      await action();
+      if (!mounted) return;
+      setState(() {
+        _actionMsg = '$successMessage · refreshing…';
+      });
+      // Invalidate the detail provider so the next build re-fetches the
+      // updated cert (renew flips Status → Issuing; reissue triggers a
+      // CertificateRequest creation that will appear in Sub-Resources).
+      final clusterId = ref.read(activeClusterProvider);
+      ref.invalidate(certificateDetailProvider(_key(clusterId)));
+    } on ApiError catch (e) {
+      if (!mounted) return;
+      setState(() => _actionMsg = 'Action failed: ${e.message}');
+    } on Object catch (e) {
+      if (!mounted) return;
+      setState(() => _actionMsg = 'Action failed: $e');
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final clusterId = ref.watch(activeClusterProvider);
+    final detailAsync =
+        ref.watch(certificateDetailProvider(_key(clusterId)));
+    return DefaultTabController(
+      length: 3,
+      child: Scaffold(
+        appBar: AppBar(
+          title: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                widget.name,
+                style: const TextStyle(fontSize: 16),
+                overflow: TextOverflow.ellipsis,
+              ),
+              Text(
+                'Certificate · ${widget.namespace}',
+                style: TextStyle(
+                  fontSize: 12,
+                  color:
+                      Theme.of(context).extension<KubeColors>()!.textMuted,
+                ),
+              ),
+            ],
+          ),
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back),
+            onPressed: () => Navigator.of(context).maybePop(),
+          ),
+          actions: [
+            detailAsync.maybeWhen(
+              data: (detail) => Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 8),
+                child: _ActionButtons(
+                  busy: _busy,
+                  onRenew: _handleRenew,
+                  onReissue: () => _handleReissue(detail.certificate),
+                ),
+              ),
+              orElse: () => const SizedBox.shrink(),
+            ),
+          ],
+          bottom: const TabBar(
+            tabs: [
+              Tab(text: 'Overview'),
+              Tab(text: 'Sub-Resources'),
+              Tab(text: 'Events'),
+            ],
+          ),
+        ),
+        body: Column(
+          children: [
+            if (_actionMsg != null) _ActionToast(message: _actionMsg!),
+            Expanded(
+              child: detailAsync.when(
+                loading: () => const LoadingState(),
+                error: (e, _) => ErrorStateView(
+                  message: e is ApiError ? e.message : e.toString(),
+                  onRetry: () => ref.invalidate(
+                    certificateDetailProvider(_key(clusterId)),
+                  ),
+                ),
+                data: (detail) => TabBarView(
+                  children: [
+                    _OverviewTab(cert: detail.certificate),
+                    _SubResourcesTab(detail: detail),
+                    EventsTab(
+                      kind: 'Certificate',
+                      namespace: widget.namespace,
+                      name: widget.name,
+                      uid: detail.certificate.uid,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ActionButtons extends StatelessWidget {
+  const _ActionButtons({
+    required this.busy,
+    required this.onRenew,
+    required this.onReissue,
+  });
+
+  final bool busy;
+  final VoidCallback onRenew;
+  final VoidCallback onReissue;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    if (busy) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12),
+        child: SizedBox(
+          width: 16,
+          height: 16,
+          child: CircularProgressIndicator(strokeWidth: 2, color: colors.accent),
+        ),
+      );
+    }
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        TextButton(onPressed: onRenew, child: const Text('Renew')),
+        TextButton(
+          onPressed: onReissue,
+          style: TextButton.styleFrom(foregroundColor: colors.error),
+          child: const Text('Re-issue'),
+        ),
+      ],
+    );
+  }
+}
+
+class _ActionToast extends StatelessWidget {
+  const _ActionToast({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return Container(
+      width: double.infinity,
+      color: colors.accent.withValues(alpha: 0.12),
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Text(
+        message,
+        style: TextStyle(color: colors.accent, fontSize: 12),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Overview tab
+// ---------------------------------------------------------------------------
+
+class _OverviewTab extends StatelessWidget {
+  const _OverviewTab({required this.cert});
+
+  final Certificate cert;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              CertStatusPill(status: cert.status),
+              const SizedBox(width: 8),
+              ExpiryBadge(
+                daysRemaining: cert.daysRemaining,
+                warningThresholdDays: cert.warningThresholdDays,
+                criticalThresholdDays: cert.criticalThresholdDays,
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          _DetailsCard(
+            title: 'Details',
+            rows: [
+              _Row('Namespace', cert.namespace),
+              _Row('Issuer', '${cert.issuerRef.kind}/${cert.issuerRef.name}'),
+              _Row('Secret', cert.secretName),
+              if (cert.commonName != null)
+                _Row('Common name', cert.commonName!),
+              if (cert.dnsNames.isNotEmpty)
+                _Row('DNS names', cert.dnsNames.join(', ')),
+              _Row('Not before', _fmt(cert.notBefore)),
+              _Row('Not after', _fmt(cert.notAfter)),
+              _Row('Renewal time', _fmt(cert.renewalTime)),
+              if (cert.duration != null) _Row('Duration', cert.duration!),
+              if (cert.renewBefore != null)
+                _Row('Renew before', cert.renewBefore!),
+            ],
+          ),
+          const SizedBox(height: 12),
+          _ThresholdAttribution(cert: cert),
+          if (cert.reason != null || cert.message != null) ...[
+            const SizedBox(height: 12),
+            _DetailsCard(
+              title: 'Status detail',
+              rows: [
+                if (cert.reason != null) _Row('Reason', cert.reason!),
+                if (cert.message != null) _Row('Message', cert.message!),
+              ],
+            ),
+          ],
+          const SizedBox(height: 24),
+          Text(
+            'UID: ${cert.uid}',
+            style: TextStyle(color: colors.textMuted, fontSize: 11),
+          ),
+        ],
+      ),
+    );
+  }
+
+  static String _fmt(String? iso) {
+    if (iso == null || iso.isEmpty) return '—';
+    // We preserve the wire ISO-8601 format intentionally: the alternate is
+    // either using DateTime.parse + the device's locale (which would emit
+    // a region-specific string), or going through intl (a heavier
+    // dependency). Operators reading the detail screen typically want
+    // the raw timestamp anyway.
+    return iso;
+  }
+}
+
+class _ThresholdAttribution extends StatelessWidget {
+  const _ThresholdAttribution({required this.cert});
+
+  final Certificate cert;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final warn = cert.warningThresholdDays;
+    final crit = cert.criticalThresholdDays;
+    if (warn == null && crit == null && !cert.thresholdConflict) {
+      // No resolved thresholds and no conflict — nothing useful to show.
+      return const SizedBox.shrink();
+    }
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: colors.bgSurface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colors.borderSubtle),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'EXPIRY THRESHOLDS',
+            style: TextStyle(
+              color: colors.textSecondary,
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+              letterSpacing: 0.5,
+            ),
+          ),
+          const SizedBox(height: 8),
+          _AttributionLine(
+            label: 'Warns at',
+            days: warn,
+            source: cert.warningThresholdSource,
+            cert: cert,
+          ),
+          _AttributionLine(
+            label: 'Critical at',
+            days: crit,
+            source: cert.criticalThresholdSource,
+            cert: cert,
+          ),
+          if (cert.thresholdConflict) ...[
+            const SizedBox(height: 8),
+            Tooltip(
+              message:
+                  'Resolved threshold pair would have violated '
+                  'critical < warning. Using package defaults until you '
+                  'fix one of the annotations.',
+              child: Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                decoration: BoxDecoration(
+                  color: colors.warning.withValues(alpha: 0.16),
+                  borderRadius: BorderRadius.circular(6),
+                  border:
+                      Border.all(color: colors.warning.withValues(alpha: 0.4)),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(Icons.warning_amber_outlined,
+                        size: 14, color: colors.warning),
+                    const SizedBox(width: 6),
+                    Text(
+                      'Conflict — using defaults',
+                      style: TextStyle(
+                        color: colors.warning,
+                        fontSize: 12,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+          const SizedBox(height: 8),
+          Text(
+            'Resolution chain: certificate annotation → issuer → '
+            'clusterissuer → package default. Each key resolves '
+            'independently.',
+            style: TextStyle(color: colors.textMuted, fontSize: 11),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AttributionLine extends StatelessWidget {
+  const _AttributionLine({
+    required this.label,
+    required this.days,
+    required this.source,
+    required this.cert,
+  });
+
+  final String label;
+  final int? days;
+  final ThresholdSource source;
+  final Certificate cert;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final value = days == null ? '—' : '${days}d';
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 2),
+      child: RichText(
+        text: TextSpan(
+          style: TextStyle(color: colors.textPrimary, fontSize: 13),
+          children: [
+            TextSpan(text: '$label $value '),
+            TextSpan(
+              text: '(${_sourceLabel(source, cert)})',
+              style: TextStyle(color: colors.textMuted, fontSize: 12),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Renders the per-key source attribution label — `"From Issuer X"`
+/// when the cert inherited the value from its referenced Issuer, etc.
+String _sourceLabel(ThresholdSource source, Certificate cert) {
+  switch (source) {
+    case ThresholdSource.certificate:
+      return 'From this certificate';
+    case ThresholdSource.issuer:
+      return 'From Issuer ${cert.issuerRef.name}';
+    case ThresholdSource.clusterIssuer:
+      return 'From ClusterIssuer ${cert.issuerRef.name}';
+    case ThresholdSource.defaultSource:
+    case ThresholdSource.unknown:
+      return 'Default';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sub-Resources tab
+// ---------------------------------------------------------------------------
+
+class _SubResourcesTab extends StatelessWidget {
+  const _SubResourcesTab({required this.detail});
+
+  final CertificateDetail detail;
+
+  bool get _rbacHintApplies {
+    final s = detail.certificate.status;
+    final issuingOrFailing =
+        s == CertStatus.issuing || s == CertStatus.failed;
+    return issuingOrFailing && detail.certificateRequests.isEmpty;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (_rbacHintApplies) ...[
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: colors.warning.withValues(alpha: 0.12),
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(
+                  color: colors.warning.withValues(alpha: 0.4),
+                ),
+              ),
+              child: Row(
+                children: [
+                  Icon(Icons.info_outline,
+                      size: 16, color: colors.warning),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      'Some sub-resources may be hidden by RBAC. '
+                      'Your role may not include cert-manager '
+                      'CertificateRequests in this namespace.',
+                      style: TextStyle(
+                        color: colors.textPrimary,
+                        fontSize: 12,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 12),
+          ],
+          _SubResourceSection<CertificateRequestRow>(
+            title: 'Certificate Requests',
+            items: detail.certificateRequests,
+            empty: 'No CertificateRequests visible for this certificate.',
+            rowBuilder: (row) => _CrRow(row: row),
+          ),
+          const SizedBox(height: 12),
+          _SubResourceSection<OrderRow>(
+            title: 'Orders',
+            items: detail.orders,
+            empty:
+                'No ACME Orders. Non-ACME issuers do not emit Orders.',
+            rowBuilder: (row) => _OrderRow(row: row),
+          ),
+          const SizedBox(height: 12),
+          _SubResourceSection<ChallengeRow>(
+            title: 'Challenges',
+            items: detail.challenges,
+            empty: 'No ACME Challenges.',
+            rowBuilder: (row) => _ChallengeRow(row: row),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SubResourceSection<T> extends StatelessWidget {
+  const _SubResourceSection({
+    required this.title,
+    required this.items,
+    required this.empty,
+    required this.rowBuilder,
+  });
+
+  final String title;
+  final List<T> items;
+  final String empty;
+  final Widget Function(T row) rowBuilder;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return Container(
+      decoration: BoxDecoration(
+        color: colors.bgSurface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colors.borderSubtle),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(12, 10, 12, 8),
+            child: Row(
+              children: [
+                Text(
+                  title.toUpperCase(),
+                  style: TextStyle(
+                    color: colors.textSecondary,
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                    letterSpacing: 0.5,
+                  ),
+                ),
+                const SizedBox(width: 6),
+                Text(
+                  '(${items.length})',
+                  style: TextStyle(color: colors.textMuted, fontSize: 12),
+                ),
+              ],
+            ),
+          ),
+          if (items.isEmpty)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+              child: Text(
+                empty,
+                style: TextStyle(color: colors.textMuted, fontSize: 12),
+              ),
+            )
+          else
+            ...items.map(rowBuilder),
+        ],
+      ),
+    );
+  }
+}
+
+class _CrRow extends StatelessWidget {
+  const _CrRow({required this.row});
+  final CertificateRequestRow row;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return Container(
+      padding: const EdgeInsets.fromLTRB(12, 8, 12, 8),
+      decoration: BoxDecoration(
+        border: Border(top: BorderSide(color: colors.borderSubtle)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  row.name,
+                  style: TextStyle(
+                    color: colors.textPrimary,
+                    fontSize: 13,
+                    fontWeight: FontWeight.w500,
+                  ),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              CertStatusPill(status: row.status),
+            ],
+          ),
+          if (row.reason != null)
+            Padding(
+              padding: const EdgeInsets.only(top: 2),
+              child: Text(
+                row.reason!,
+                style: TextStyle(color: colors.textMuted, fontSize: 11),
+              ),
+            ),
+          Padding(
+            padding: const EdgeInsets.only(top: 2),
+            child: Text(
+              'Created ${row.createdAt}',
+              style: TextStyle(color: colors.textMuted, fontSize: 11),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _OrderRow extends StatelessWidget {
+  const _OrderRow({required this.row});
+  final OrderRow row;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return Container(
+      padding: const EdgeInsets.fromLTRB(12, 8, 12, 8),
+      decoration: BoxDecoration(
+        border: Border(top: BorderSide(color: colors.borderSubtle)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  row.name,
+                  style: TextStyle(
+                    color: colors.textPrimary,
+                    fontSize: 13,
+                    fontWeight: FontWeight.w500,
+                  ),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              Text(
+                row.state,
+                style: TextStyle(
+                  color: colors.textSecondary,
+                  fontSize: 12,
+                ),
+              ),
+            ],
+          ),
+          if (row.reason != null)
+            Padding(
+              padding: const EdgeInsets.only(top: 2),
+              child: Text(
+                row.reason!,
+                style: TextStyle(color: colors.textMuted, fontSize: 11),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ChallengeRow extends StatelessWidget {
+  const _ChallengeRow({required this.row});
+  final ChallengeRow row;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return Container(
+      padding: const EdgeInsets.fromLTRB(12, 8, 12, 8),
+      decoration: BoxDecoration(
+        border: Border(top: BorderSide(color: colors.borderSubtle)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  row.name,
+                  style: TextStyle(
+                    color: colors.textPrimary,
+                    fontSize: 13,
+                    fontWeight: FontWeight.w500,
+                  ),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              Text(
+                '${row.type} · ${row.state}',
+                style: TextStyle(
+                  color: colors.textSecondary,
+                  fontSize: 12,
+                ),
+              ),
+            ],
+          ),
+          if (row.dnsName != null)
+            Padding(
+              padding: const EdgeInsets.only(top: 2),
+              child: Text(
+                row.dnsName!,
+                style: TextStyle(color: colors.textMuted, fontSize: 11),
+              ),
+            ),
+          if (row.reason != null)
+            Padding(
+              padding: const EdgeInsets.only(top: 2),
+              child: Text(
+                row.reason!,
+                style: TextStyle(color: colors.textMuted, fontSize: 11),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
+
+class _Row {
+  const _Row(this.label, this.value);
+  final String label;
+  final String value;
+}
+
+class _DetailsCard extends StatelessWidget {
+  const _DetailsCard({required this.title, required this.rows});
+
+  final String title;
+  final List<_Row> rows;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: colors.bgSurface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colors.borderSubtle),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title.toUpperCase(),
+            style: TextStyle(
+              color: colors.textSecondary,
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+              letterSpacing: 0.5,
+            ),
+          ),
+          const SizedBox(height: 8),
+          for (final r in rows)
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 4),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  SizedBox(
+                    width: 110,
+                    child: Text(
+                      r.label,
+                      style: TextStyle(
+                        color: colors.textSecondary,
+                        fontSize: 12,
+                      ),
+                    ),
+                  ),
+                  Expanded(
+                    child: SelectableText(
+                      r.value,
+                      style: TextStyle(
+                        color: colors.textPrimary,
+                        fontSize: 12,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/mobile/lib/features/certmanager/certificate_detail_screen.dart
+++ b/mobile/lib/features/certmanager/certificate_detail_screen.dart
@@ -385,7 +385,7 @@ class _OverviewTab extends StatelessWidget {
               if (cert.commonName != null)
                 _Row('Common name', cert.commonName!),
               if (cert.dnsNames.isNotEmpty)
-                _Row('DNS names', cert.dnsNames.join(', ')),
+                _Row('DNS names', _formatDnsNames(cert.dnsNames)),
               _Row('Not before', _fmt(cert.notBefore)),
               _Row('Not after', _fmt(cert.notAfter)),
               _Row('Renewal time', _fmt(cert.renewalTime)),
@@ -563,10 +563,26 @@ String _sourceLabel(ThresholdSource source, Certificate cert) {
       return 'From Issuer ${cert.issuerRef.name}';
     case ThresholdSource.clusterIssuer:
       return 'From ClusterIssuer ${cert.issuerRef.name}';
-    case ThresholdSource.defaultSource:
+    case ThresholdSource.packageDefault:
     case ThresholdSource.unknown:
       return 'Default';
   }
+}
+
+/// Cap of DNS-name entries rendered inline in the Overview tab.
+/// Wildcard certs with 200+ SANs are legitimate (multi-tenant ingress
+/// consolidators); rendering the full list as a single SelectableText
+/// blows past Flutter's selection-geometry layout budget (>5000 chars
+/// → 30-60ms first-frame jank on mid-range Android). Cap at 30 names
+/// inline with a `(and N more)` suffix; the source-of-truth for the
+/// full list is the backend response itself.
+const int _kDnsNamesInlineCap = 30;
+
+String _formatDnsNames(List<String> names) {
+  if (names.length <= _kDnsNamesInlineCap) return names.join(', ');
+  final preview = names.take(_kDnsNamesInlineCap).join(', ');
+  final remaining = names.length - _kDnsNamesInlineCap;
+  return '$preview (and $remaining more)';
 }
 
 // ---------------------------------------------------------------------------

--- a/mobile/lib/features/certmanager/certificates_list_screen.dart
+++ b/mobile/lib/features/certmanager/certificates_list_screen.dart
@@ -26,6 +26,7 @@ import '../../api/api_error.dart';
 import '../../api/certmanager_repository.dart';
 import '../../cluster/cluster_provider.dart';
 import '../../theme/kube_theme_builder.dart';
+import '../../widgets/empty_states.dart';
 import '../../widgets/feature_unavailable_state.dart';
 import 'cert_badges.dart';
 
@@ -89,11 +90,9 @@ class _CertificatesListScreenState
       appBar: AppBar(title: const Text('Certificates')),
       body: statusAsync.when(
         loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => Center(
-          child: Padding(
-            padding: const EdgeInsets.all(24),
-            child: Text(e.toString()),
-          ),
+        error: (e, _) => ErrorStateView(
+          message: e is ApiError ? e.message : e.toString(),
+          onRetry: () => ref.invalidate(certManagerStatusProvider(clusterId)),
         ),
         data: (status) {
           if (!status.detected) return FeatureUnavailableState.certManager();
@@ -148,7 +147,11 @@ class _CertListBody extends ConsumerWidget {
       onRefresh: handleRefresh,
       child: async.when(
         loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => _errorShell(e, handleRefresh, colors),
+        error: (e, _) => ListErrorShell(
+          title: 'Failed to load certificates',
+          error: e,
+          onRetry: handleRefresh,
+        ),
         data: (certs) {
           final filtered = _applyFilters(certs);
           return CustomScrollView(
@@ -228,44 +231,6 @@ class _CertListBody extends ConsumerWidget {
     }).toList();
   }
 
-  Widget _errorShell(Object e, Future<void> Function() retry, KubeColors c) {
-    return ListView(
-      physics: const AlwaysScrollableScrollPhysics(),
-      children: [
-        SizedBox(
-          height: 280,
-          child: Center(
-            child: Padding(
-              padding: const EdgeInsets.all(24),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(
-                    'Failed to load certificates',
-                    style: TextStyle(
-                      color: c.textPrimary,
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                  const SizedBox(height: 4),
-                  Text(
-                    e is ApiError ? e.message : e.toString(),
-                    style: TextStyle(color: c.textMuted),
-                    textAlign: TextAlign.center,
-                  ),
-                  const SizedBox(height: 12),
-                  OutlinedButton(
-                    onPressed: retry,
-                    child: const Text('Retry'),
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ),
-      ],
-    );
-  }
 }
 
 class _FilterStrip extends StatelessWidget {

--- a/mobile/lib/features/certmanager/certificates_list_screen.dart
+++ b/mobile/lib/features/certmanager/certificates_list_screen.dart
@@ -1,0 +1,411 @@
+// Certificates list — every cert-manager Certificate the active user
+// can read across all namespaces. Filter chips (All / Expiring / Failed),
+// search by name / namespace / issuer, plus a `?status=expiring` URL
+// param that seeds the chip to "Expiring" on mount. Mirrors the web's
+// `frontend/islands/CertificatesList.tsx` filter strategy.
+//
+// Expiry badge color is computed from each cert's resolved
+// `warningThresholdDays` / `criticalThresholdDays` pair — the backend
+// resolver supplies these per the annotation chain (cert → issuer →
+// clusterissuer → package default), so the mobile UI never hardcodes
+// thresholds. When the resolver hasn't run (older response shape) the
+// badge falls back to the package defaults (warn 30, crit 7) so colors
+// still match operator expectations.
+//
+// Status gating: `certManagerStatusProvider` gates the surface — when
+// cert-manager is not detected the operator sees
+// `FeatureUnavailableState.certManager()` rather than an empty list.
+//
+// Tap row → `/clusters/<id>/certificates/certificates/<namespace>/<name>`.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../api/api_error.dart';
+import '../../api/certmanager_repository.dart';
+import '../../cluster/cluster_provider.dart';
+import '../../theme/kube_theme_builder.dart';
+import '../../widgets/feature_unavailable_state.dart';
+import 'cert_badges.dart';
+
+/// Tri-state filter chip on the list screen.
+enum CertStatusFilter { all, expiring, failed }
+
+class CertificatesListScreen extends ConsumerStatefulWidget {
+  const CertificatesListScreen({super.key, this.initialStatusFilter});
+
+  /// Seed the status chip on mount. Drawer deep-links don't seed this;
+  /// the dashboard "Expiring" tile + the expiry-notification push deep
+  /// link do (`?status=expiring`).
+  final String? initialStatusFilter;
+
+  @override
+  ConsumerState<CertificatesListScreen> createState() =>
+      _CertificatesListScreenState();
+}
+
+class _CertificatesListScreenState
+    extends ConsumerState<CertificatesListScreen> {
+  late CertStatusFilter _filter;
+  String _search = '';
+  final _searchCtl = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _filter = switch (widget.initialStatusFilter) {
+      'expiring' => CertStatusFilter.expiring,
+      'failed' => CertStatusFilter.failed,
+      _ => CertStatusFilter.all,
+    };
+  }
+
+  @override
+  void dispose() {
+    _searchCtl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final clusterId = ref.watch(activeClusterProvider);
+    final statusAsync = ref.watch(certManagerStatusProvider(clusterId));
+    // Reset filter + search when the user switches clusters so stale
+    // state from the previous cluster doesn't leak through. The list
+    // provider's family key already invalidates on clusterId change;
+    // this clears the UI inputs themselves.
+    ref.listen<String>(activeClusterProvider, (previous, next) {
+      if (previous != next) {
+        setState(() {
+          _filter = CertStatusFilter.all;
+          _search = '';
+          _searchCtl.clear();
+        });
+      }
+    });
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Certificates')),
+      body: statusAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Text(e.toString()),
+          ),
+        ),
+        data: (status) {
+          if (!status.detected) return FeatureUnavailableState.certManager();
+          return _CertListBody(
+            clusterId: clusterId,
+            filter: _filter,
+            search: _search,
+            searchCtl: _searchCtl,
+            onFilterChanged: (v) => setState(() => _filter = v),
+            onSearchChanged: (v) => setState(() => _search = v),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _CertListBody extends ConsumerWidget {
+  const _CertListBody({
+    required this.clusterId,
+    required this.filter,
+    required this.search,
+    required this.searchCtl,
+    required this.onFilterChanged,
+    required this.onSearchChanged,
+  });
+
+  final String clusterId;
+  final CertStatusFilter filter;
+  final String search;
+  final TextEditingController searchCtl;
+  final ValueChanged<CertStatusFilter> onFilterChanged;
+  final ValueChanged<String> onSearchChanged;
+
+  CertificateListKey get _key => CertificateListKey(clusterId: clusterId);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final async = ref.watch(certificateListProvider(_key));
+
+    Future<void> handleRefresh() async {
+      ref.invalidate(certificateListProvider(_key));
+      try {
+        await ref.read(certificateListProvider(_key).future);
+      } on Object {
+        // surfaces via .when error branch
+      }
+    }
+
+    return RefreshIndicator(
+      onRefresh: handleRefresh,
+      child: async.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => _errorShell(e, handleRefresh, colors),
+        data: (certs) {
+          final filtered = _applyFilters(certs);
+          return CustomScrollView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            slivers: [
+              SliverToBoxAdapter(
+                child: _FilterStrip(
+                  filter: filter,
+                  searchCtl: searchCtl,
+                  totalVisible: filtered.length,
+                  totalAll: certs.length,
+                  onFilterChanged: onFilterChanged,
+                  onSearchChanged: onSearchChanged,
+                ),
+              ),
+              if (filtered.isEmpty)
+                SliverToBoxAdapter(
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 16,
+                      vertical: 32,
+                    ),
+                    child: Center(
+                      child: Text(
+                        certs.isEmpty
+                            ? 'No certificates yet. cert-manager will populate '
+                                'this list once it issues certificates.'
+                            : 'No certificates match the current filters.',
+                        style: TextStyle(color: colors.textMuted),
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                  ),
+                )
+              else
+                SliverList(
+                  delegate: SliverChildBuilderDelegate(
+                    (context, index) => _CertRow(
+                      cert: filtered[index],
+                      onTap: () => context.push(
+                        '/clusters/$clusterId/certificates/certificates/'
+                        '${Uri.encodeComponent(filtered[index].namespace)}/'
+                        '${Uri.encodeComponent(filtered[index].name)}',
+                      ),
+                    ),
+                    childCount: filtered.length,
+                  ),
+                ),
+              const SliverPadding(padding: EdgeInsets.only(bottom: 8)),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  List<Certificate> _applyFilters(List<Certificate> certs) {
+    final q = search.trim().toLowerCase();
+    return certs.where((c) {
+      switch (filter) {
+        case CertStatusFilter.expiring:
+          if (c.status != CertStatus.expiring &&
+              c.status != CertStatus.expired) {
+            return false;
+          }
+          break;
+        case CertStatusFilter.failed:
+          if (c.status != CertStatus.failed) return false;
+          break;
+        case CertStatusFilter.all:
+          break;
+      }
+      if (q.isEmpty) return true;
+      return c.name.toLowerCase().contains(q) ||
+          c.namespace.toLowerCase().contains(q) ||
+          c.issuerRef.name.toLowerCase().contains(q);
+    }).toList();
+  }
+
+  Widget _errorShell(Object e, Future<void> Function() retry, KubeColors c) {
+    return ListView(
+      physics: const AlwaysScrollableScrollPhysics(),
+      children: [
+        SizedBox(
+          height: 280,
+          child: Center(
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    'Failed to load certificates',
+                    style: TextStyle(
+                      color: c.textPrimary,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    e is ApiError ? e.message : e.toString(),
+                    style: TextStyle(color: c.textMuted),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 12),
+                  OutlinedButton(
+                    onPressed: retry,
+                    child: const Text('Retry'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _FilterStrip extends StatelessWidget {
+  const _FilterStrip({
+    required this.filter,
+    required this.searchCtl,
+    required this.totalVisible,
+    required this.totalAll,
+    required this.onFilterChanged,
+    required this.onSearchChanged,
+  });
+
+  final CertStatusFilter filter;
+  final TextEditingController searchCtl;
+  final int totalVisible;
+  final int totalAll;
+  final ValueChanged<CertStatusFilter> onFilterChanged;
+  final ValueChanged<String> onSearchChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Wrap(
+            spacing: 6,
+            runSpacing: 4,
+            children: [
+              for (final value in CertStatusFilter.values)
+                ChoiceChip(
+                  label: Text(switch (value) {
+                    CertStatusFilter.all => 'All',
+                    CertStatusFilter.expiring => 'Expiring',
+                    CertStatusFilter.failed => 'Failed',
+                  }),
+                  selected: value == filter,
+                  onSelected: (_) => onFilterChanged(value),
+                ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          TextField(
+            controller: searchCtl,
+            decoration: InputDecoration(
+              hintText: 'Filter by name, namespace, issuer…',
+              prefixIcon: Icon(
+                Icons.search,
+                size: 18,
+                color: colors.textMuted,
+              ),
+              isDense: true,
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(6),
+              ),
+            ),
+            onChanged: onSearchChanged,
+          ),
+          Padding(
+            padding: const EdgeInsets.only(top: 8),
+            child: Text(
+              '$totalVisible of $totalAll certificates',
+              style: TextStyle(color: colors.textMuted, fontSize: 12),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CertRow extends StatelessWidget {
+  const _CertRow({required this.cert, required this.onTap});
+
+  final Certificate cert;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final dns = cert.dnsNames.join(', ');
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    cert.name,
+                    style: TextStyle(
+                      color: colors.textPrimary,
+                      fontSize: 15,
+                      fontWeight: FontWeight.w600,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                CertStatusPill(status: cert.status),
+              ],
+            ),
+            const SizedBox(height: 4),
+            Text(
+              '${cert.namespace} · ${cert.issuerRef.kind}/${cert.issuerRef.name}',
+              style: TextStyle(color: colors.textSecondary, fontSize: 12),
+              overflow: TextOverflow.ellipsis,
+            ),
+            if (dns.isNotEmpty) ...[
+              const SizedBox(height: 2),
+              Text(
+                dns,
+                style: TextStyle(color: colors.textMuted, fontSize: 11),
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
+            const SizedBox(height: 6),
+            Row(
+              children: [
+                ExpiryBadge(
+                  daysRemaining: cert.daysRemaining,
+                  warningThresholdDays: cert.warningThresholdDays,
+                  criticalThresholdDays: cert.criticalThresholdDays,
+                ),
+                const Spacer(),
+                Icon(
+                  Icons.chevron_right,
+                  size: 16,
+                  color: colors.textMuted,
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/certmanager/expiring_screen.dart
+++ b/mobile/lib/features/certmanager/expiring_screen.dart
@@ -1,0 +1,221 @@
+// Expiring certificates surface — fetches `/v1/certificates/expiring`
+// and renders the ordered list (sorted ascending by daysRemaining by
+// the backend). Distinct from the certificates list with a
+// `?status=expiring` chip pre-filter because:
+//   * The /expiring endpoint emits a smaller summary record per cert
+//     (no DNS names, no thresholds, no sub-resource hooks).
+//   * Severity is precomputed by the backend (`"critical"` /
+//     `"warning"` / `"expired"`) so the screen never has to recompute
+//     the threshold buckets here.
+//   * The screen is the natural landing surface for the expiry
+//     notification deep link.
+//
+// Tap row → certificate detail (same path as the cert list).
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../api/api_error.dart';
+import '../../api/certmanager_repository.dart';
+import '../../cluster/cluster_provider.dart';
+import '../../theme/kube_theme_builder.dart';
+import '../../widgets/empty_states.dart';
+import '../../widgets/feature_unavailable_state.dart';
+
+class ExpiringCertificatesScreen extends ConsumerWidget {
+  const ExpiringCertificatesScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final clusterId = ref.watch(activeClusterProvider);
+    final statusAsync = ref.watch(certManagerStatusProvider(clusterId));
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Expiring certificates')),
+      body: statusAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => ErrorStateView(
+          message: e is ApiError ? e.message : e.toString(),
+          onRetry: () =>
+              ref.invalidate(certManagerStatusProvider(clusterId)),
+        ),
+        data: (status) {
+          if (!status.detected) return FeatureUnavailableState.certManager();
+          return _ExpiringBody(clusterId: clusterId);
+        },
+      ),
+    );
+  }
+}
+
+class _ExpiringBody extends ConsumerWidget {
+  const _ExpiringBody({required this.clusterId});
+
+  final String clusterId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final async = ref.watch(expiringCertificatesProvider(clusterId));
+
+    Future<void> handleRefresh() async {
+      ref.invalidate(expiringCertificatesProvider(clusterId));
+      try {
+        await ref.read(expiringCertificatesProvider(clusterId).future);
+      } on Object {
+        // surfaces via .when error branch
+      }
+    }
+
+    return RefreshIndicator(
+      onRefresh: handleRefresh,
+      child: async.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => ListView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          children: [
+            SizedBox(
+              height: 280,
+              child: ErrorStateView(
+                message: e is ApiError ? e.message : e.toString(),
+                onRetry: handleRefresh,
+              ),
+            ),
+          ],
+        ),
+        data: (items) {
+          if (items.isEmpty) {
+            return ListView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              children: [
+                SizedBox(
+                  height: 280,
+                  child: Center(
+                    child: Padding(
+                      padding: const EdgeInsets.all(24),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Icon(
+                            Icons.verified_outlined,
+                            color: colors.success,
+                            size: 36,
+                          ),
+                          const SizedBox(height: 12),
+                          Text(
+                            'No certificates expiring soon.',
+                            style: TextStyle(color: colors.textSecondary),
+                            textAlign: TextAlign.center,
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            );
+          }
+          return ListView.builder(
+            physics: const AlwaysScrollableScrollPhysics(),
+            itemCount: items.length,
+            itemBuilder: (context, index) =>
+                _ExpiringRow(item: items[index], clusterId: clusterId),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _ExpiringRow extends StatelessWidget {
+  const _ExpiringRow({required this.item, required this.clusterId});
+
+  final ExpiringCertificate item;
+  final String clusterId;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return InkWell(
+      onTap: () => context.push(
+        '/clusters/$clusterId/certificates/certificates/'
+        '${Uri.encodeComponent(item.namespace)}/'
+        '${Uri.encodeComponent(item.name)}',
+      ),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        decoration: BoxDecoration(
+          border: Border(
+            bottom: BorderSide(color: colors.borderSubtle),
+          ),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Container(
+              padding: const EdgeInsets.symmetric(
+                horizontal: 8,
+                vertical: 4,
+              ),
+              decoration: BoxDecoration(
+                color: _severityColor(colors, item.severity)
+                    .withValues(alpha: 0.16),
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(
+                  color: _severityColor(colors, item.severity)
+                      .withValues(alpha: 0.4),
+                ),
+              ),
+              child: Text(
+                '${item.daysRemaining}d',
+                style: TextStyle(
+                  color: _severityColor(colors, item.severity),
+                  fontSize: 13,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    item.name,
+                    style: TextStyle(
+                      color: colors.textPrimary,
+                      fontSize: 15,
+                      fontWeight: FontWeight.w600,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  Text(
+                    '${item.namespace} · ${item.issuerName}',
+                    style:
+                        TextStyle(color: colors.textSecondary, fontSize: 12),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  Text(
+                    'Expires ${item.notAfter}',
+                    style: TextStyle(color: colors.textMuted, fontSize: 11),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ],
+              ),
+            ),
+            Icon(Icons.chevron_right, size: 16, color: colors.textMuted),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Color _severityColor(KubeColors c, String severity) {
+    return switch (severity) {
+      'critical' => c.error,
+      'expired' => c.error,
+      _ => c.warning,
+    };
+  }
+}

--- a/mobile/lib/features/certmanager/expiring_screen.dart
+++ b/mobile/lib/features/certmanager/expiring_screen.dart
@@ -168,7 +168,7 @@ class _ExpiringRow extends StatelessWidget {
                 ),
               ),
               child: Text(
-                '${item.daysRemaining}d',
+                item.daysRemaining < 0 ? 'Expired' : '${item.daysRemaining}d',
                 style: TextStyle(
                   color: _severityColor(colors, item.severity),
                   fontSize: 13,

--- a/mobile/lib/features/certmanager/issuers_list_screen.dart
+++ b/mobile/lib/features/certmanager/issuers_list_screen.dart
@@ -1,0 +1,230 @@
+// Issuers list — combined Issuers + ClusterIssuers rendered as a flat
+// list with scope/type/ready columns. Mirrors the web's
+// `frontend/islands/IssuersList.tsx` `Promise.all` pattern.
+//
+// The wizard issuer-picker (`wizards/widgets/issuer_picker.dart`) has
+// its own `issuerListProvider` keyed on `(clusterId, namespace)` that
+// returns just plain-string name lists. The browse-all surface needs
+// full [Issuer] records (type / ready / threshold annotations), so
+// [allIssuersProvider] in the cert-manager repository fetches both
+// endpoints in parallel and concatenates the results.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../api/api_error.dart';
+import '../../api/certmanager_repository.dart';
+import '../../cluster/cluster_provider.dart';
+import '../../theme/kube_theme_builder.dart';
+import '../../widgets/empty_states.dart';
+import '../../widgets/feature_unavailable_state.dart';
+import 'cert_badges.dart';
+
+class IssuersListScreen extends ConsumerWidget {
+  const IssuersListScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final clusterId = ref.watch(activeClusterProvider);
+    final statusAsync = ref.watch(certManagerStatusProvider(clusterId));
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Issuers')),
+      body: statusAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => ErrorStateView(
+          message: e is ApiError ? e.message : e.toString(),
+          onRetry: () =>
+              ref.invalidate(certManagerStatusProvider(clusterId)),
+        ),
+        data: (status) {
+          if (!status.detected) return FeatureUnavailableState.certManager();
+          return _IssuersBody(clusterId: clusterId);
+        },
+      ),
+    );
+  }
+}
+
+class _IssuersBody extends ConsumerWidget {
+  const _IssuersBody({required this.clusterId});
+
+  final String clusterId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final async = ref.watch(allIssuersProvider(clusterId));
+
+    Future<void> handleRefresh() async {
+      ref.invalidate(allIssuersProvider(clusterId));
+      try {
+        await ref.read(allIssuersProvider(clusterId).future);
+      } on Object {
+        // surfaces via .when error branch
+      }
+    }
+
+    return RefreshIndicator(
+      onRefresh: handleRefresh,
+      child: async.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => _errorShell(e, handleRefresh, colors),
+        data: (issuers) {
+          if (issuers.isEmpty) {
+            return ListView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              children: [
+                SizedBox(
+                  height: 280,
+                  child: Center(
+                    child: Padding(
+                      padding: const EdgeInsets.all(24),
+                      child: Text(
+                        'No Issuers or ClusterIssuers configured on this cluster.',
+                        style: TextStyle(color: colors.textMuted),
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            );
+          }
+          return ListView.builder(
+            physics: const AlwaysScrollableScrollPhysics(),
+            itemCount: issuers.length,
+            itemBuilder: (context, index) => _IssuerRow(issuer: issuers[index]),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _errorShell(Object e, Future<void> Function() retry, KubeColors c) {
+    return ListView(
+      physics: const AlwaysScrollableScrollPhysics(),
+      children: [
+        SizedBox(
+          height: 280,
+          child: Center(
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    'Failed to load issuers',
+                    style: TextStyle(
+                      color: c.textPrimary,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    e is ApiError ? e.message : e.toString(),
+                    style: TextStyle(color: c.textMuted),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 12),
+                  OutlinedButton(
+                    onPressed: retry,
+                    child: const Text('Retry'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _IssuerRow extends StatelessWidget {
+  const _IssuerRow({required this.issuer});
+
+  final Issuer issuer;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final scopeLabel = issuer.isCluster ? 'ClusterIssuer' : 'Issuer';
+    final namespacePart = issuer.isCluster ? '' : ' · ${issuer.namespace}';
+    final detail = issuer.acmeServer ?? issuer.reason ?? '';
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      decoration: BoxDecoration(
+        border: Border(
+          bottom: BorderSide(color: colors.borderSubtle),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  issuer.name,
+                  style: TextStyle(
+                    color: colors.textPrimary,
+                    fontSize: 15,
+                    fontWeight: FontWeight.w600,
+                  ),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              const SizedBox(width: 8),
+              IssuerTypeBadge(type: issuer.type),
+              const SizedBox(width: 6),
+              _ReadyBadge(ready: issuer.ready),
+            ],
+          ),
+          const SizedBox(height: 4),
+          Text(
+            '$scopeLabel$namespacePart',
+            style: TextStyle(color: colors.textSecondary, fontSize: 12),
+          ),
+          if (detail.isNotEmpty) ...[
+            const SizedBox(height: 2),
+            Text(
+              detail,
+              style: TextStyle(color: colors.textMuted, fontSize: 11),
+              overflow: TextOverflow.ellipsis,
+              maxLines: 2,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _ReadyBadge extends StatelessWidget {
+  const _ReadyBadge({required this.ready});
+
+  final bool ready;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final tone = ready ? colors.success : colors.error;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        color: tone.withValues(alpha: 0.16),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: tone.withValues(alpha: 0.4)),
+      ),
+      child: Text(
+        ready ? 'Ready' : 'Not ready',
+        style: TextStyle(
+          color: tone,
+          fontSize: 11,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/certmanager/issuers_list_screen.dart
+++ b/mobile/lib/features/certmanager/issuers_list_screen.dart
@@ -69,7 +69,11 @@ class _IssuersBody extends ConsumerWidget {
       onRefresh: handleRefresh,
       child: async.when(
         loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => _errorShell(e, handleRefresh, colors),
+        error: (e, _) => ListErrorShell(
+          title: 'Failed to load issuers',
+          error: e,
+          onRetry: handleRefresh,
+        ),
         data: (issuers) {
           if (issuers.isEmpty) {
             return ListView(
@@ -101,44 +105,6 @@ class _IssuersBody extends ConsumerWidget {
     );
   }
 
-  Widget _errorShell(Object e, Future<void> Function() retry, KubeColors c) {
-    return ListView(
-      physics: const AlwaysScrollableScrollPhysics(),
-      children: [
-        SizedBox(
-          height: 280,
-          child: Center(
-            child: Padding(
-              padding: const EdgeInsets.all(24),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(
-                    'Failed to load issuers',
-                    style: TextStyle(
-                      color: c.textPrimary,
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                  const SizedBox(height: 4),
-                  Text(
-                    e is ApiError ? e.message : e.toString(),
-                    style: TextStyle(color: c.textMuted),
-                    textAlign: TextAlign.center,
-                  ),
-                  const SizedBox(height: 12),
-                  OutlinedButton(
-                    onPressed: retry,
-                    child: const Text('Retry'),
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ),
-      ],
-    );
-  }
 }
 
 class _IssuerRow extends StatelessWidget {
@@ -178,7 +144,7 @@ class _IssuerRow extends StatelessWidget {
               const SizedBox(width: 8),
               IssuerTypeBadge(type: issuer.type),
               const SizedBox(width: 6),
-              _ReadyBadge(ready: issuer.ready),
+              ReadyBadge(ready: issuer.ready),
             ],
           ),
           const SizedBox(height: 4),
@@ -201,30 +167,3 @@ class _IssuerRow extends StatelessWidget {
   }
 }
 
-class _ReadyBadge extends StatelessWidget {
-  const _ReadyBadge({required this.ready});
-
-  final bool ready;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = Theme.of(context).extension<KubeColors>()!;
-    final tone = ready ? colors.success : colors.error;
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
-      decoration: BoxDecoration(
-        color: tone.withValues(alpha: 0.16),
-        borderRadius: BorderRadius.circular(10),
-        border: Border.all(color: tone.withValues(alpha: 0.4)),
-      ),
-      child: Text(
-        ready ? 'Ready' : 'Not ready',
-        style: TextStyle(
-          color: tone,
-          fontSize: 11,
-          fontWeight: FontWeight.w600,
-        ),
-      ),
-    );
-  }
-}

--- a/mobile/lib/routing/app_router.dart
+++ b/mobile/lib/routing/app_router.dart
@@ -11,6 +11,10 @@ import 'package:go_router/go_router.dart';
 
 import '../auth/auth_repository.dart';
 import '../auth/auth_state.dart';
+import '../features/certmanager/certificate_detail_screen.dart';
+import '../features/certmanager/certificates_list_screen.dart';
+import '../features/certmanager/expiring_screen.dart';
+import '../features/certmanager/issuers_list_screen.dart';
 import '../features/dashboard/dashboard_screen.dart';
 import '../features/login/login_screen.dart';
 import '../features/notifications_center/feed_screen.dart';
@@ -210,6 +214,45 @@ final appRouterProvider = Provider<GoRouter>((ref) {
             ),
           ),
         ],
+      ),
+
+      // --- M4 PR-4g: cert-manager observatory ---
+      // /clusters/<id>/certificates/certificates[?status=expiring|failed]
+      //                                          → list (filter chip)
+      // /clusters/<id>/certificates/certificates/<ns>/<name>
+      //                                          → detail (Overview / Sub /
+      //                                                    Events tabs)
+      // /clusters/<id>/certificates/issuers      → Issuers + ClusterIssuers
+      // /clusters/<id>/certificates/expiring     → expiring soon (sorted
+      //                                            ascending by days)
+      //
+      // Status gating is screen-level (each surface checks
+      // `certManagerStatusProvider` and falls back to
+      // `FeatureUnavailableState.certManager()`). Renew + Reissue verbs
+      // post to the same path namespace as the detail GET — handled by
+      // [CertManagerRepository], not the generic resource-actions layer.
+      GoRoute(
+        path: '/clusters/:clusterId/certificates/certificates',
+        builder: (context, state) => CertificatesListScreen(
+          initialStatusFilter: state.uri.queryParameters['status'],
+        ),
+        routes: [
+          GoRoute(
+            path: ':namespace/:name',
+            builder: (context, state) => CertificateDetailScreen(
+              namespace: state.pathParameters['namespace']!,
+              name: state.pathParameters['name']!,
+            ),
+          ),
+        ],
+      ),
+      GoRoute(
+        path: '/clusters/:clusterId/certificates/issuers',
+        builder: (context, state) => const IssuersListScreen(),
+      ),
+      GoRoute(
+        path: '/clusters/:clusterId/certificates/expiring',
+        builder: (context, state) => const ExpiringCertificatesScreen(),
       ),
 
       // --- Resource list routes (PR-1d: 6 specialized kinds) ---

--- a/mobile/lib/routing/domain_sections.dart
+++ b/mobile/lib/routing/domain_sections.dart
@@ -226,6 +226,41 @@ const List<DomainSection> domainSections = [
       ),
     ],
   ),
+  // Cert-manager observatory (PR-4g). Three entries:
+  //   * Certificates — full list with filter chips (All / Expiring /
+  //     Failed) + search. `?status=expiring` URL param pre-filters.
+  //   * Issuers — combined namespaced + cluster Issuers.
+  //   * Expiring — backend-sorted summary list of certs nearing expiry.
+  // All three surfaces gate on `certManagerStatusProvider` and fall
+  // back to `FeatureUnavailableState.certManager()` when not installed.
+  DomainSection(
+    label: 'Certificates',
+    pathSegment: 'certificates',
+    icon: Icons.verified_outlined,
+    kinds: [
+      DomainKind(
+        kind: 'certificates',
+        label: 'Certificates',
+        icon: Icons.verified_outlined,
+        namespaced: false,
+        customListPath: '/clusters/{clusterId}/certificates/certificates',
+      ),
+      DomainKind(
+        kind: 'issuers',
+        label: 'Issuers',
+        icon: Icons.assignment_outlined,
+        namespaced: false,
+        customListPath: '/clusters/{clusterId}/certificates/issuers',
+      ),
+      DomainKind(
+        kind: 'expiring',
+        label: 'Expiring',
+        icon: Icons.timer_outlined,
+        namespaced: false,
+        customListPath: '/clusters/{clusterId}/certificates/expiring',
+      ),
+    ],
+  ),
 ];
 
 /// Substitutes `{clusterId}` (and any future placeholder) in a

--- a/mobile/lib/widgets/confirm_sheet.dart
+++ b/mobile/lib/widgets/confirm_sheet.dart
@@ -86,10 +86,17 @@ class _ConfirmSheetState extends State<ConfirmSheet> {
   /// zero-width characters that arrive via clipboard pastes from rich-text
   /// surfaces (Slack, browser, mail clients). Without this, a paste that
   /// looks identical to the operator silently fails the equality check.
+  ///
+  /// The regex uses `\uXXXX` escape sequences rather than embedded literal
+  /// zero-width characters because some editors and CI tools (Unicode-
+  /// normalizing dart format passes, certain git filters, paste-through-
+  /// markdown rendering) silently strip the literal codepoints from the
+  /// source, collapsing the regex to an empty character class and breaking
+  /// normalization invisibly. Escapes survive every text transform.
   static String _normalize(String s) {
     final trimmed = s.trim();
     // U+200B ZWSP, U+200C ZWNJ, U+200D ZWJ, U+FEFF BOM.
-    return trimmed.replaceAll(RegExp(r'[​-‍﻿]'), '');
+    return trimmed.replaceAll(RegExp('[\\u200B-\\u200D\\uFEFF]'), '');
   }
 
   @override
@@ -166,6 +173,12 @@ class _ConfirmSheetState extends State<ConfirmSheet> {
                   autocorrect: false,
                   enableSuggestions: false,
                   textCapitalization: TextCapitalization.none,
+                  // Opt out of contextual autofill so a password manager
+                  // that indexed the resource name (e.g. as "username") cannot
+                  // one-tap satisfy the destructive-verb friction gate. The
+                  // gate exists to force operator-conscious confirmation;
+                  // autofill defeats that.
+                  autofillHints: const <String>[],
                   style: TextStyle(
                     fontFamily: 'monospace',
                     color: colors.textPrimary,

--- a/mobile/lib/widgets/empty_states.dart
+++ b/mobile/lib/widgets/empty_states.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/material.dart';
 
+import '../api/api_error.dart';
 import '../theme/kube_theme_builder.dart';
 
 class LoadingState extends StatelessWidget {
@@ -77,6 +78,69 @@ class EmptyState extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+/// Error shell for list screens that need pull-to-refresh to work even
+/// in the error state. Wraps the error in a [ListView] so the
+/// [RefreshIndicator] parent can detect scroll events.
+///
+/// Used by cert-manager list screens and any other list surface that
+/// calls `_errorShell` — extract the private method body here so the
+/// pattern is shared rather than duplicated.
+class ListErrorShell extends StatelessWidget {
+  const ListErrorShell({
+    super.key,
+    required this.title,
+    required this.error,
+    required this.onRetry,
+  });
+
+  final String title;
+  final Object error;
+  final Future<void> Function() onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return ListView(
+      physics: const AlwaysScrollableScrollPhysics(),
+      children: [
+        SizedBox(
+          height: 280,
+          child: Center(
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    title,
+                    style: TextStyle(
+                      color: colors.textPrimary,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    error is ApiError
+                        ? (error as ApiError).message
+                        : error.toString(),
+                    style: TextStyle(color: colors.textMuted),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 12),
+                  OutlinedButton(
+                    onPressed: onRetry,
+                    child: const Text('Retry'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/mobile/test/api/certmanager_repository_test.dart
+++ b/mobile/test/api/certmanager_repository_test.dart
@@ -1,0 +1,665 @@
+// CertManagerRepository tests: endpoint paths, envelope unwrapping,
+// X-Cluster-ID forwarding, threshold attribution parsing, sub-resource
+// nesting, error surfacing, and renew/reissue POST bodies.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kubecenter/api/api_error.dart';
+import 'package:kubecenter/api/certmanager_repository.dart';
+import 'package:kubecenter/api/dio_client.dart';
+import 'package:kubecenter/auth/secure_storage.dart';
+
+import '../support/mock_dio_adapter.dart';
+
+ResponseBody _json(Object body, {int status = 200}) {
+  return ResponseBody.fromBytes(
+    Uint8List.fromList(utf8.encode(jsonEncode(body))),
+    status,
+    headers: {
+      Headers.contentTypeHeader: ['application/json'],
+    },
+  );
+}
+
+({ProviderContainer container, MockDioAdapter mock}) _make() {
+  final mock = MockDioAdapter();
+  final container = ProviderContainer(
+    overrides: [
+      backendUrlProvider.overrideWithValue('http://test'),
+      secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+    ],
+  );
+  container.read(refreshDioProvider).httpClientAdapter = mock;
+  container.read(dioProvider).httpClientAdapter = mock;
+  return (container: container, mock: mock);
+}
+
+void main() {
+  group('CertManagerRepository.status', () {
+    test('parses detected status with namespace + version', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/certificates/status',
+        body: {
+          'data': {
+            'detected': true,
+            'namespace': 'cert-manager',
+            'version': '1.14.0',
+            'lastChecked': '2026-05-12T10:00:00Z',
+          },
+        },
+      );
+
+      final s = await container.read(certManagerRepositoryProvider).status();
+      expect(s.detected, isTrue);
+      expect(s.namespace, 'cert-manager');
+      expect(s.version, '1.14.0');
+      expect(s.lastChecked, '2026-05-12T10:00:00Z');
+    });
+
+    test('non-admin shape (no namespace field) parses cleanly', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/certificates/status',
+        body: {
+          'data': {'detected': true},
+        },
+      );
+
+      final s = await container.read(certManagerRepositoryProvider).status();
+      expect(s.detected, isTrue);
+      expect(s.namespace, isNull);
+      expect(s.version, isNull);
+    });
+
+    test('503 from status returns CertManagerStatus.empty', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.on(
+        'GET',
+        '/api/v1/certificates/status',
+        (_) => _json({
+          'error': {'code': 503, 'message': 'discovery offline'},
+        }, status: 503),
+      );
+
+      final s = await container.read(certManagerRepositoryProvider).status();
+      expect(s.detected, isFalse);
+    });
+
+    test('401 surfaces as ApiError', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.on(
+        'GET',
+        '/api/v1/certificates/status',
+        (_) => _json({
+          'error': {'code': 401, 'message': 'unauthorized'},
+        }, status: 401),
+      );
+
+      await expectLater(
+        container.read(certManagerRepositoryProvider).status(),
+        throwsA(isA<ApiError>()),
+      );
+    });
+
+    test('forwards X-Cluster-ID when overridden', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/certificates/status',
+        body: {
+          'data': {'detected': false},
+        },
+      );
+
+      await container
+          .read(certManagerRepositoryProvider)
+          .status(clusterIdOverride: 'staging-east');
+
+      expect(mock.requests, hasLength(1));
+      expect(mock.requests.single.headers['X-Cluster-ID'], 'staging-east');
+    });
+  });
+
+  group('CertManagerRepository.listCertificates', () {
+    test('parses cert list with resolved threshold attribution', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/certificates/certificates',
+        body: {
+          'data': [
+            {
+              'name': 'web-tls',
+              'namespace': 'app',
+              'status': 'Ready',
+              'issuerRef': {
+                'name': 'letsencrypt-prod',
+                'kind': 'ClusterIssuer',
+                'group': 'cert-manager.io',
+              },
+              'secretName': 'web-tls-secret',
+              'dnsNames': ['web.example.com'],
+              'commonName': 'web.example.com',
+              'daysRemaining': 45,
+              'warningThresholdDays': 60,
+              'criticalThresholdDays': 14,
+              'warningThresholdSource': 'issuer',
+              'criticalThresholdSource': 'certificate',
+              'thresholdSource': 'issuer',
+              'thresholdConflict': false,
+              'uid': 'abc-123',
+            },
+            {
+              'name': 'broken-tls',
+              'namespace': 'app',
+              'status': 'Failed',
+              'issuerRef': {'name': 'self-signed', 'kind': 'Issuer'},
+              'secretName': 'broken-tls-secret',
+              'reason': 'IssuerNotReady',
+              'message': 'Issuer not ready: pending',
+              'uid': 'broken-uid',
+            },
+          ],
+        },
+      );
+
+      final certs = await container
+          .read(certManagerRepositoryProvider)
+          .listCertificates();
+      expect(certs, hasLength(2));
+
+      final ready = certs.first;
+      expect(ready.name, 'web-tls');
+      expect(ready.status, CertStatus.ready);
+      expect(ready.daysRemaining, 45);
+      expect(ready.warningThresholdDays, 60);
+      expect(ready.criticalThresholdDays, 14);
+      expect(ready.warningThresholdSource, ThresholdSource.issuer);
+      expect(ready.criticalThresholdSource, ThresholdSource.certificate);
+      expect(ready.thresholdConflict, isFalse);
+      expect(ready.issuerRef.kind, 'ClusterIssuer');
+      expect(ready.dnsNames, ['web.example.com']);
+
+      final failed = certs[1];
+      expect(failed.status, CertStatus.failed);
+      expect(failed.reason, 'IssuerNotReady');
+      expect(failed.daysRemaining, isNull);
+      expect(failed.warningThresholdDays, isNull);
+    });
+
+    test('threads namespace query param when provided', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/certificates/certificates',
+        body: {'data': <Map<String, Object?>>[]},
+      );
+
+      await container
+          .read(certManagerRepositoryProvider)
+          .listCertificates(namespace: 'app');
+
+      expect(mock.requests.single.queryParameters['namespace'], 'app');
+    });
+
+    test('empty namespace omits the query param', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/certificates/certificates',
+        body: {'data': <Map<String, Object?>>[]},
+      );
+
+      await container
+          .read(certManagerRepositoryProvider)
+          .listCertificates(namespace: '');
+
+      expect(
+        mock.requests.single.queryParameters.containsKey('namespace'),
+        isFalse,
+      );
+    });
+
+    test('unknown thresholdSource string maps to ThresholdSource.unknown',
+        () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/certificates/certificates',
+        body: {
+          'data': [
+            {
+              'name': 'odd',
+              'namespace': 'app',
+              'status': 'Ready',
+              'issuerRef': {'name': 'iss', 'kind': 'Issuer'},
+              'secretName': 's',
+              'warningThresholdSource': 'something-from-the-future',
+              'uid': 'u',
+            },
+          ],
+        },
+      );
+
+      final certs = await container
+          .read(certManagerRepositoryProvider)
+          .listCertificates();
+      expect(certs.single.warningThresholdSource, ThresholdSource.unknown);
+    });
+
+    test('500 surfaces as ApiError', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.on(
+        'GET',
+        '/api/v1/certificates/certificates',
+        (_) => _json({
+          'error': {'code': 500, 'message': 'failed to fetch certificates'},
+        }, status: 500),
+      );
+
+      await expectLater(
+        container.read(certManagerRepositoryProvider).listCertificates(),
+        throwsA(isA<ApiError>()
+            .having((e) => e.statusCode, 'statusCode', 500)),
+      );
+    });
+  });
+
+  group('CertManagerRepository.getCertificate', () {
+    test('parses detail with sub-resources + thresholdConflict', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/certificates/certificates/app/web-tls',
+        body: {
+          'data': {
+            'certificate': {
+              'name': 'web-tls',
+              'namespace': 'app',
+              'status': 'Issuing',
+              'issuerRef': {'name': 'le', 'kind': 'ClusterIssuer'},
+              'secretName': 'web-tls-secret',
+              'thresholdConflict': true,
+              'warningThresholdDays': 30,
+              'criticalThresholdDays': 7,
+              'warningThresholdSource': 'default',
+              'criticalThresholdSource': 'default',
+              'uid': 'cert-uid',
+            },
+            'certificateRequests': [
+              {
+                'name': 'web-tls-1',
+                'namespace': 'app',
+                'status': 'Issuing',
+                'issuerRef': {'name': 'le', 'kind': 'ClusterIssuer'},
+                'createdAt': '2026-05-10T09:00:00Z',
+                'uid': 'cr-uid',
+              },
+            ],
+            'orders': [
+              {
+                'name': 'web-tls-1-order',
+                'namespace': 'app',
+                'state': 'pending',
+                'createdAt': '2026-05-10T09:01:00Z',
+                'uid': 'order-uid',
+                'crName': 'web-tls-1',
+              },
+            ],
+            'challenges': [
+              {
+                'name': 'web-tls-1-challenge',
+                'namespace': 'app',
+                'type': 'HTTP-01',
+                'state': 'pending',
+                'dnsName': 'web.example.com',
+                'createdAt': '2026-05-10T09:02:00Z',
+                'uid': 'chall-uid',
+                'orderName': 'web-tls-1-order',
+              },
+            ],
+          },
+        },
+      );
+
+      final detail = await container
+          .read(certManagerRepositoryProvider)
+          .getCertificate(namespace: 'app', name: 'web-tls');
+
+      expect(detail.certificate.status, CertStatus.issuing);
+      expect(detail.certificate.thresholdConflict, isTrue);
+      expect(detail.certificateRequests, hasLength(1));
+      expect(detail.certificateRequests.single.status, CertStatus.issuing);
+      expect(detail.orders, hasLength(1));
+      expect(detail.orders.single.state, 'pending');
+      expect(detail.challenges, hasLength(1));
+      expect(detail.challenges.single.dnsName, 'web.example.com');
+    });
+
+    test('URL-encodes namespace + name', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        // ":" in a namespace isn't legal, but odd cert names with dots
+        // are common. Verify both segments encode.
+        '/api/v1/certificates/certificates/edge-app/web.example.com',
+        body: {
+          'data': {
+            'certificate': {
+              'name': 'web.example.com',
+              'namespace': 'edge-app',
+              'status': 'Ready',
+              'issuerRef': {'name': 'le', 'kind': 'ClusterIssuer'},
+              'secretName': 's',
+              'uid': 'u',
+            },
+            'certificateRequests': <Map<String, Object?>>[],
+            'orders': <Map<String, Object?>>[],
+            'challenges': <Map<String, Object?>>[],
+          },
+        },
+      );
+
+      final detail = await container
+          .read(certManagerRepositoryProvider)
+          .getCertificate(
+            namespace: 'edge-app',
+            name: 'web.example.com',
+          );
+      expect(detail.certificate.name, 'web.example.com');
+    });
+
+    test('404 on missing cert surfaces as ApiError', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.on(
+        'GET',
+        '/api/v1/certificates/certificates/app/ghost',
+        (_) => _json({
+          'error': {'code': 404, 'message': 'certificate not found'},
+        }, status: 404),
+      );
+
+      await expectLater(
+        container.read(certManagerRepositoryProvider).getCertificate(
+              namespace: 'app',
+              name: 'ghost',
+            ),
+        throwsA(isA<ApiError>()
+            .having((e) => e.statusCode, 'statusCode', 404)),
+      );
+    });
+  });
+
+  group('CertManagerRepository.listIssuers / listClusterIssuers', () {
+    test('parses issuer list with threshold annotations', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/certificates/issuers',
+        body: {
+          'data': [
+            {
+              'name': 'self-signed',
+              'namespace': 'app',
+              'scope': 'Namespaced',
+              'type': 'SelfSigned',
+              'ready': true,
+              'warningThresholdDays': 60,
+              'criticalThresholdDays': 10,
+              'uid': 'iss-uid',
+              'updatedAt': '2026-05-12T10:00:00Z',
+            },
+          ],
+        },
+      );
+
+      final issuers = await container
+          .read(certManagerRepositoryProvider)
+          .listIssuers();
+      expect(issuers, hasLength(1));
+      expect(issuers.single.scope, 'Namespaced');
+      expect(issuers.single.type, 'SelfSigned');
+      expect(issuers.single.ready, isTrue);
+      expect(issuers.single.warningThresholdDays, 60);
+      expect(issuers.single.isCluster, isFalse);
+    });
+
+    test('cluster issuers parse with empty namespace', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/certificates/clusterissuers',
+        body: {
+          'data': [
+            {
+              'name': 'letsencrypt-prod',
+              'scope': 'Cluster',
+              'type': 'ACME',
+              'ready': true,
+              'acmeEmail': 'ops@example.com',
+              'acmeServer': 'https://acme-v02.api.letsencrypt.org/directory',
+              'uid': 'le-uid',
+              'updatedAt': '2026-05-12T10:00:00Z',
+            },
+          ],
+        },
+      );
+
+      final cl = await container
+          .read(certManagerRepositoryProvider)
+          .listClusterIssuers();
+      expect(cl, hasLength(1));
+      expect(cl.single.isCluster, isTrue);
+      expect(cl.single.namespace, isEmpty);
+      expect(cl.single.acmeServer, contains('letsencrypt'));
+    });
+  });
+
+  group('CertManagerRepository.listExpiring', () {
+    test('parses backend-sorted expiring rows with severity', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/certificates/expiring',
+        body: {
+          'data': [
+            {
+              'namespace': 'app',
+              'name': 'critical-cert',
+              'uid': 'c-uid',
+              'issuerName': 'le',
+              'secretName': 'critical-secret',
+              'notAfter': '2026-05-15T00:00:00Z',
+              'daysRemaining': 2,
+              'severity': 'critical',
+            },
+            {
+              'namespace': 'app',
+              'name': 'warning-cert',
+              'uid': 'w-uid',
+              'issuerName': 'le',
+              'secretName': 'warning-secret',
+              'notAfter': '2026-06-05T00:00:00Z',
+              'daysRemaining': 23,
+              'severity': 'warning',
+            },
+          ],
+        },
+      );
+
+      final rows = await container
+          .read(certManagerRepositoryProvider)
+          .listExpiring();
+      expect(rows, hasLength(2));
+      expect(rows.first.severity, 'critical');
+      expect(rows.first.daysRemaining, 2);
+      expect(rows[1].severity, 'warning');
+    });
+
+    test('preserves unknown severity values for forward-compat', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/certificates/expiring',
+        body: {
+          'data': [
+            {
+              'namespace': 'app',
+              'name': 'expired',
+              'uid': 'e-uid',
+              'issuerName': 'le',
+              'secretName': 's',
+              'notAfter': '2026-05-01T00:00:00Z',
+              'daysRemaining': -3,
+              'severity': 'expired',
+            },
+          ],
+        },
+      );
+
+      final rows = await container
+          .read(certManagerRepositoryProvider)
+          .listExpiring();
+      expect(rows.single.severity, 'expired');
+    });
+  });
+
+  group('CertManagerRepository.renew / reissue', () {
+    test('renew POSTs to /renew and returns the status verb', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'POST',
+        '/api/v1/certificates/certificates/app/web-tls/renew',
+        status: 202,
+        body: {
+          'data': {'status': 'renewing'},
+        },
+      );
+
+      final result = await container
+          .read(certManagerRepositoryProvider)
+          .renew(namespace: 'app', name: 'web-tls');
+      expect(result.status, 'renewing');
+      expect(mock.requests.single.method, 'POST');
+    });
+
+    test('reissue POSTs to /reissue and returns the status verb', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'POST',
+        '/api/v1/certificates/certificates/app/web-tls/reissue',
+        status: 202,
+        body: {
+          'data': {'status': 'reissuing'},
+        },
+      );
+
+      final result = await container
+          .read(certManagerRepositoryProvider)
+          .reissue(namespace: 'app', name: 'web-tls');
+      expect(result.status, 'reissuing');
+    });
+
+    test('renew 403 surfaces as ApiError', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.on(
+        'POST',
+        '/api/v1/certificates/certificates/app/web-tls/renew',
+        (_) => _json({
+          'error': {'code': 403, 'message': 'access denied'},
+        }, status: 403),
+      );
+
+      await expectLater(
+        container.read(certManagerRepositoryProvider).renew(
+              namespace: 'app',
+              name: 'web-tls',
+            ),
+        throwsA(isA<ApiError>()
+            .having((e) => e.statusCode, 'statusCode', 403)),
+      );
+    });
+
+    test('reissue body-less response defaults the status verb', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'POST',
+        '/api/v1/certificates/certificates/app/web-tls/reissue',
+        status: 202,
+        body: <String, Object?>{},
+      );
+
+      final result = await container
+          .read(certManagerRepositoryProvider)
+          .reissue(namespace: 'app', name: 'web-tls');
+      // Backend always sets the field; the default protects against a
+      // future shape change. The explicit verb→tense map in the repo
+      // ensures the fallback is grammatical (NOT "reissueing").
+      expect(result.status, 'reissuing');
+    });
+  });
+
+  group('CertificateListKey equality', () {
+    test('empty namespace string normalises to null slot', () {
+      final a = CertificateListKey(clusterId: 'c', namespace: '');
+      final b = CertificateListKey(clusterId: 'c');
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('different namespaces produce distinct slots', () {
+      final a = CertificateListKey(clusterId: 'c', namespace: 'app');
+      final b = CertificateListKey(clusterId: 'c', namespace: 'kube-system');
+      expect(a, isNot(equals(b)));
+    });
+  });
+}

--- a/mobile/test/features/certmanager/certificate_detail_screen_test.dart
+++ b/mobile/test/features/certmanager/certificate_detail_screen_test.dart
@@ -1,0 +1,271 @@
+// Widget tests for the cert-manager certificate detail screen.
+//
+// Coverage:
+//   * Overview renders threshold attribution + DNS names.
+//   * thresholdConflict=true surfaces the "Conflict — using defaults" badge.
+//   * RBAC hint surfaces on Issuing + empty CR list.
+//   * Sub-Resources renders all three sections.
+//   * Renew/Reissue buttons render and (Renew) opens the confirm sheet.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:kubecenter/api/dio_client.dart';
+import 'package:kubecenter/auth/secure_storage.dart';
+import 'package:kubecenter/features/certmanager/certificate_detail_screen.dart';
+import 'package:kubecenter/theme/kube_theme_builder.dart';
+
+import '../../support/mock_dio_adapter.dart';
+
+Future<void> _pump(WidgetTester tester, MockDioAdapter mock) async {
+  final router = GoRouter(
+    initialLocation: '/',
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (context, state) => const CertificateDetailScreen(
+          namespace: 'app',
+          name: 'web-tls',
+        ),
+      ),
+    ],
+  );
+  await tester.pumpWidget(ProviderScope(
+    overrides: [
+      backendUrlProvider.overrideWithValue('http://test'),
+      secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+    ],
+    child: _DioInstaller(
+      mock: mock,
+      child: MaterialApp.router(
+        theme: buildKubeTheme('nexus'),
+        routerConfig: router,
+      ),
+    ),
+  ));
+  await tester.pump();
+  await tester.pumpAndSettle(const Duration(milliseconds: 200));
+}
+
+class _DioInstaller extends ConsumerWidget {
+  const _DioInstaller({required this.mock, required this.child});
+
+  final MockDioAdapter mock;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.read(dioProvider).httpClientAdapter = mock;
+    return child;
+  }
+}
+
+Map<String, Object?> _readyDetail({
+  bool thresholdConflict = false,
+  bool withSubResources = true,
+  String status = 'Ready',
+}) =>
+    {
+      'data': {
+        'certificate': {
+          'name': 'web-tls',
+          'namespace': 'app',
+          'status': status,
+          'issuerRef': {
+            'name': 'letsencrypt-prod',
+            'kind': 'ClusterIssuer',
+            'group': 'cert-manager.io',
+          },
+          'secretName': 'web-tls-secret',
+          'dnsNames': ['web.example.com', 'www.example.com'],
+          'commonName': 'web.example.com',
+          'notBefore': '2026-03-01T00:00:00Z',
+          'notAfter': '2026-08-01T00:00:00Z',
+          'renewalTime': '2026-07-01T00:00:00Z',
+          'daysRemaining': 80,
+          'warningThresholdDays': 30,
+          'criticalThresholdDays': 7,
+          'warningThresholdSource': 'issuer',
+          'criticalThresholdSource': 'default',
+          'thresholdSource': 'issuer',
+          'thresholdConflict': thresholdConflict,
+          'uid': 'cert-uid',
+        },
+        'certificateRequests': withSubResources
+            ? [
+                {
+                  'name': 'web-tls-1',
+                  'namespace': 'app',
+                  'status': 'Ready',
+                  'issuerRef': {
+                    'name': 'letsencrypt-prod',
+                    'kind': 'ClusterIssuer',
+                  },
+                  'createdAt': '2026-03-01T00:00:00Z',
+                  'uid': 'cr-uid',
+                },
+              ]
+            : <Map<String, Object?>>[],
+        'orders': withSubResources
+            ? [
+                {
+                  'name': 'web-tls-1-order',
+                  'namespace': 'app',
+                  'state': 'valid',
+                  'createdAt': '2026-03-01T00:01:00Z',
+                  'uid': 'order-uid',
+                },
+              ]
+            : <Map<String, Object?>>[],
+        'challenges': withSubResources
+            ? [
+                {
+                  'name': 'web-tls-1-challenge',
+                  'namespace': 'app',
+                  'type': 'HTTP-01',
+                  'state': 'valid',
+                  'dnsName': 'web.example.com',
+                  'createdAt': '2026-03-01T00:02:00Z',
+                  'uid': 'chall-uid',
+                },
+              ]
+            : <Map<String, Object?>>[],
+      },
+    };
+
+Map<String, Object?> _emptyEvents() => {
+      'data': {'items': <Map<String, Object?>>[]},
+    };
+
+void _stubCommon(MockDioAdapter mock) {
+  mock.onJson(
+    'GET',
+    '/api/v1/resources/events',
+    body: _emptyEvents(),
+  );
+}
+
+void main() {
+  testWidgets('Overview renders threshold attribution + DNS names',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson(
+        'GET',
+        '/api/v1/certificates/certificates/app/web-tls',
+        body: _readyDetail(),
+      );
+    _stubCommon(mock);
+
+    await _pump(tester, mock);
+
+    expect(find.text('web-tls'), findsWidgets);
+    expect(find.textContaining('web.example.com'), findsWidgets);
+    // Per-key attribution renders in RichText spans, so the finder
+    // must include `findRichText: true` to walk the InlineSpan tree.
+    expect(
+      find.textContaining('From Issuer letsencrypt-prod', findRichText: true),
+      findsOneWidget,
+    );
+    expect(find.textContaining('Default', findRichText: true), findsWidgets);
+  });
+
+  testWidgets('thresholdConflict surfaces the "Conflict" badge',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson(
+        'GET',
+        '/api/v1/certificates/certificates/app/web-tls',
+        body: _readyDetail(thresholdConflict: true),
+      );
+    _stubCommon(mock);
+
+    await _pump(tester, mock);
+
+    expect(find.textContaining('Conflict'), findsOneWidget);
+  });
+
+  testWidgets('Sub-Resources tab renders all three sections',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson(
+        'GET',
+        '/api/v1/certificates/certificates/app/web-tls',
+        body: _readyDetail(),
+      );
+    _stubCommon(mock);
+
+    await _pump(tester, mock);
+
+    // Switch to Sub-Resources tab.
+    await tester.tap(find.text('Sub-Resources'));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('CERTIFICATE REQUESTS'), findsOneWidget);
+    expect(find.textContaining('ORDERS'), findsOneWidget);
+    expect(find.textContaining('CHALLENGES'), findsOneWidget);
+    expect(find.text('web-tls-1'), findsOneWidget);
+    expect(find.text('web-tls-1-order'), findsOneWidget);
+    expect(find.text('web-tls-1-challenge'), findsOneWidget);
+  });
+
+  testWidgets(
+      'Issuing status + empty CR list surfaces the RBAC hint banner',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson(
+        'GET',
+        '/api/v1/certificates/certificates/app/web-tls',
+        body: _readyDetail(status: 'Issuing', withSubResources: false),
+      );
+    _stubCommon(mock);
+
+    await _pump(tester, mock);
+
+    // Switch to Sub-Resources tab.
+    await tester.tap(find.text('Sub-Resources'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.textContaining('Some sub-resources may be hidden by RBAC'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('Renew + Re-issue buttons render in the app bar',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson(
+        'GET',
+        '/api/v1/certificates/certificates/app/web-tls',
+        body: _readyDetail(),
+      );
+    _stubCommon(mock);
+
+    await _pump(tester, mock);
+
+    expect(find.widgetWithText(TextButton, 'Renew'), findsOneWidget);
+    expect(find.widgetWithText(TextButton, 'Re-issue'), findsOneWidget);
+  });
+
+  testWidgets('Renew opens the confirm sheet with the Renew CTA',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson(
+        'GET',
+        '/api/v1/certificates/certificates/app/web-tls',
+        body: _readyDetail(),
+      );
+    _stubCommon(mock);
+
+    await _pump(tester, mock);
+
+    await tester.tap(find.widgetWithText(TextButton, 'Renew'));
+    await tester.pumpAndSettle();
+
+    // The confirm sheet renders its own "Renew" button — searching for
+    // the sheet's title is the stable signal across confirm-sheet UX
+    // variants.
+    expect(find.textContaining('Renew certificate'), findsOneWidget);
+  });
+}

--- a/mobile/test/features/certmanager/certificate_detail_screen_test.dart
+++ b/mobile/test/features/certmanager/certificate_detail_screen_test.dart
@@ -261,11 +261,179 @@ void main() {
     await _pump(tester, mock);
 
     await tester.tap(find.widgetWithText(TextButton, 'Renew'));
-    await tester.pumpAndSettle();
+    // Use pump with duration rather than pumpAndSettle: the confirm sheet
+    // has autofocus=true which can cause pumpAndSettle to spin indefinitely.
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
 
     // The confirm sheet renders its own "Renew" button — searching for
     // the sheet's title is the stable signal across confirm-sheet UX
     // variants.
     expect(find.textContaining('Renew certificate'), findsOneWidget);
+  });
+
+  // F6 — Renew confirm and dispatch path
+  testWidgets('Renew confirms and dispatches POST', (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson(
+        'GET',
+        '/api/v1/certificates/certificates/app/web-tls',
+        body: _readyDetail(),
+      )
+      ..onJson(
+        'POST',
+        '/api/v1/certificates/certificates/app/web-tls/renew',
+        status: 202,
+        body: {'data': {'status': 'renewing'}},
+      );
+    _stubCommon(mock);
+
+    await _pump(tester, mock);
+
+    await tester.tap(find.widgetWithText(TextButton, 'Renew'));
+    // Use pump with a duration rather than pumpAndSettle: the confirm sheet
+    // has autofocus=true which can cause pumpAndSettle to spin indefinitely.
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(find.textContaining('Renew certificate'), findsOneWidget);
+
+    // Tap the sheet's FilledButton confirm button.
+    await tester.tap(find.widgetWithText(FilledButton, 'Renew'));
+    // Pump to process the action; advance past the 1500ms auto-clear timer.
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    final renewRequests = mock.requests.where(
+      (r) =>
+          r.path == '/api/v1/certificates/certificates/app/web-tls/renew' &&
+          r.method == 'POST',
+    );
+    expect(renewRequests, isNotEmpty);
+
+    // The action toast should appear before auto-clear.
+    expect(find.textContaining('Renewal triggered'), findsOneWidget);
+
+    // Advance past the 1500ms timer so the toast clears.
+    await tester.pump(const Duration(milliseconds: 1600));
+  });
+
+  testWidgets('Renew 403 error surfaces the error message', (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson(
+        'GET',
+        '/api/v1/certificates/certificates/app/web-tls',
+        body: _readyDetail(),
+      )
+      ..onJson(
+        'POST',
+        '/api/v1/certificates/certificates/app/web-tls/renew',
+        status: 403,
+        body: {'error': {'code': 403, 'message': 'access denied'}},
+      );
+    _stubCommon(mock);
+
+    await _pump(tester, mock);
+
+    await tester.tap(find.widgetWithText(TextButton, 'Renew'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    await tester.tap(find.widgetWithText(FilledButton, 'Renew'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.textContaining('access denied'), findsOneWidget);
+  });
+
+  // F5 — Reissue type-to-confirm gate and dispatch
+  testWidgets(
+      'Reissue confirm sheet: type-to-confirm gates dispatch, success path POSTs reissue',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson(
+        'GET',
+        '/api/v1/certificates/certificates/app/web-tls',
+        body: _readyDetail(),
+      )
+      ..onJson(
+        'POST',
+        '/api/v1/certificates/certificates/app/web-tls/reissue',
+        status: 202,
+        body: {'data': {'status': 'reissuing'}},
+      );
+    _stubCommon(mock);
+
+    await _pump(tester, mock);
+
+    // Tap Re-issue button.
+    await tester.tap(find.widgetWithText(TextButton, 'Re-issue'));
+    // Use pump with duration rather than pumpAndSettle to avoid infinite
+    // spin from autofocus TextField in the confirm sheet.
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    // Confirm sheet title should be visible.
+    expect(find.textContaining('Re-issue certificate'), findsOneWidget);
+
+    // The secret name from _readyDetail should appear in the sheet message
+    // (the confirm sheet shows it in both the message text and the
+    // type-to-confirm hint field, so use findsWidgets).
+    expect(find.textContaining('web-tls-secret'), findsWidgets);
+
+    // Type-to-confirm: enter wrong name — FilledButton confirm button stays
+    // disabled when text does not match.
+    final textField = find.byType(TextField);
+    expect(textField, findsOneWidget);
+    await tester.enterText(textField, 'wrong-name');
+    await tester.pump();
+
+    // Verify the FilledButton is disabled (onPressed is null) when the text
+    // does not match the required value.
+    final confirmBtnDisabled = tester.widget<FilledButton>(
+      find.widgetWithText(FilledButton, 'Re-issue'),
+    );
+    expect(confirmBtnDisabled.onPressed, isNull,
+        reason: 'Confirm button should be disabled when text does not match');
+
+    // No reissue POST should have been dispatched.
+    final dispatchedBeforeCorrect = mock.requests.where(
+      (r) =>
+          r.path ==
+              '/api/v1/certificates/certificates/app/web-tls/reissue' &&
+          r.method == 'POST',
+    );
+    expect(dispatchedBeforeCorrect, isEmpty);
+
+    // Now type the correct cert name.
+    await tester.enterText(textField, 'web-tls');
+    await tester.pump();
+
+    // Confirm button should now be enabled.
+    final confirmBtnEnabled = tester.widget<FilledButton>(
+      find.widgetWithText(FilledButton, 'Re-issue'),
+    );
+    expect(confirmBtnEnabled.onPressed, isNotNull,
+        reason: 'Confirm button should be enabled when text matches');
+
+    await tester.tap(find.widgetWithText(FilledButton, 'Re-issue'));
+    // Pump to process the action; advance past the 1500ms auto-clear timer.
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    // POST should now be dispatched.
+    final reissueRequests = mock.requests.where(
+      (r) =>
+          r.path ==
+              '/api/v1/certificates/certificates/app/web-tls/reissue' &&
+          r.method == 'POST',
+    );
+    expect(reissueRequests, isNotEmpty);
+
+    // Success toast should appear.
+    expect(find.textContaining('Re-issue triggered'), findsOneWidget);
+
+    // Advance past the 1500ms timer so the toast clears.
+    await tester.pump(const Duration(milliseconds: 1600));
   });
 }

--- a/mobile/test/features/certmanager/certificates_list_screen_test.dart
+++ b/mobile/test/features/certmanager/certificates_list_screen_test.dart
@@ -1,0 +1,227 @@
+// Widget tests for the cert-manager certificates list.
+//
+// Coverage:
+//   * Not-detected status → FeatureUnavailableState.certManager().
+//   * Mixed status rows render with status pills.
+//   * Filter chip narrows the list (Expiring / Failed).
+//   * `?status=expiring` initialStatusFilter pre-selects the chip.
+//   * Search filter narrows by name / namespace / issuer.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:kubecenter/api/dio_client.dart';
+import 'package:kubecenter/auth/secure_storage.dart';
+import 'package:kubecenter/features/certmanager/certificates_list_screen.dart';
+import 'package:kubecenter/theme/kube_theme_builder.dart';
+
+import '../../support/mock_dio_adapter.dart';
+
+Future<void> _pump(
+  WidgetTester tester,
+  MockDioAdapter mock, {
+  String? initialStatusFilter,
+}) async {
+  final router = GoRouter(
+    initialLocation: '/',
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (context, state) => CertificatesListScreen(
+          initialStatusFilter: initialStatusFilter,
+        ),
+      ),
+    ],
+  );
+  await tester.pumpWidget(ProviderScope(
+    overrides: [
+      backendUrlProvider.overrideWithValue('http://test'),
+      secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+    ],
+    child: _DioInstaller(
+      mock: mock,
+      child: MaterialApp.router(
+        theme: buildKubeTheme('nexus'),
+        routerConfig: router,
+      ),
+    ),
+  ));
+  await tester.pump();
+  await tester.pumpAndSettle(const Duration(milliseconds: 200));
+}
+
+class _DioInstaller extends ConsumerWidget {
+  const _DioInstaller({required this.mock, required this.child});
+
+  final MockDioAdapter mock;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.read(dioProvider).httpClientAdapter = mock;
+    return child;
+  }
+}
+
+Map<String, Object?> _statusDetected() => {
+      'data': {
+        'detected': true,
+        'namespace': 'cert-manager',
+        'version': '1.14.0',
+        'lastChecked': '2026-05-12T10:00:00Z',
+      },
+    };
+
+Map<String, Object?> _statusNotDetected() => {
+      'data': {'detected': false},
+    };
+
+Map<String, Object?> _certsBody() => {
+      'data': [
+        {
+          'name': 'web-tls',
+          'namespace': 'app',
+          'status': 'Ready',
+          'issuerRef': {'name': 'letsencrypt-prod', 'kind': 'ClusterIssuer'},
+          'secretName': 'web-tls-secret',
+          'dnsNames': ['web.example.com'],
+          'daysRemaining': 45,
+          'warningThresholdDays': 30,
+          'criticalThresholdDays': 7,
+          'uid': 'cert-1',
+        },
+        {
+          'name': 'api-tls',
+          'namespace': 'app',
+          'status': 'Expiring',
+          'issuerRef': {'name': 'letsencrypt-prod', 'kind': 'ClusterIssuer'},
+          'secretName': 'api-tls-secret',
+          'daysRemaining': 5,
+          'warningThresholdDays': 30,
+          'criticalThresholdDays': 7,
+          'uid': 'cert-2',
+        },
+        {
+          'name': 'broken-tls',
+          'namespace': 'kube-system',
+          'status': 'Failed',
+          'issuerRef': {'name': 'self-signed', 'kind': 'Issuer'},
+          'secretName': 'broken-secret',
+          'reason': 'IssuerNotReady',
+          'uid': 'cert-3',
+        },
+      ],
+    };
+
+void main() {
+  testWidgets('detected=false renders FeatureUnavailableState.certManager()',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/certificates/status', body: _statusNotDetected());
+
+    await _pump(tester, mock);
+
+    expect(find.textContaining('cert-manager'), findsWidgets);
+    expect(find.text('web-tls'), findsNothing);
+  });
+
+  testWidgets('renders certificate rows with status pills and expiry badge',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/certificates/status', body: _statusDetected())
+      ..onJson('GET', '/api/v1/certificates/certificates', body: _certsBody());
+
+    await _pump(tester, mock);
+
+    expect(find.text('web-tls'), findsOneWidget);
+    expect(find.text('api-tls'), findsOneWidget);
+    expect(find.text('broken-tls'), findsOneWidget);
+    // Status pills:
+    expect(find.text('Ready'), findsOneWidget);
+    expect(find.text('Expiring'), findsWidgets); // pill + filter-chip label
+    expect(find.text('Failed'), findsWidgets); // pill + filter-chip label
+    // Expiry badges:
+    expect(find.text('45d'), findsOneWidget);
+    expect(find.text('5d left'), findsOneWidget);
+  });
+
+  testWidgets('filter chip narrows to Expiring + Expired only', (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/certificates/status', body: _statusDetected())
+      ..onJson('GET', '/api/v1/certificates/certificates', body: _certsBody());
+
+    await _pump(tester, mock);
+
+    // Pre-tap state: all three rows visible.
+    expect(find.text('web-tls'), findsOneWidget);
+    expect(find.text('broken-tls'), findsOneWidget);
+
+    // Tap the "Expiring" filter chip.
+    await tester.tap(find.widgetWithText(ChoiceChip, 'Expiring'));
+    await tester.pumpAndSettle();
+
+    // Only api-tls (Expiring) remains.
+    expect(find.text('api-tls'), findsOneWidget);
+    expect(find.text('web-tls'), findsNothing);
+    expect(find.text('broken-tls'), findsNothing);
+  });
+
+  testWidgets('initialStatusFilter pre-selects Expiring on mount',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/certificates/status', body: _statusDetected())
+      ..onJson('GET', '/api/v1/certificates/certificates', body: _certsBody());
+
+    await _pump(tester, mock, initialStatusFilter: 'expiring');
+
+    // Pre-filtered: only api-tls (Expiring) visible.
+    expect(find.text('api-tls'), findsOneWidget);
+    expect(find.text('web-tls'), findsNothing);
+  });
+
+  testWidgets('search filter narrows by namespace token', (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/certificates/status', body: _statusDetected())
+      ..onJson('GET', '/api/v1/certificates/certificates', body: _certsBody());
+
+    await _pump(tester, mock);
+
+    await tester.enterText(find.byType(TextField), 'kube-system');
+    await tester.pumpAndSettle();
+
+    expect(find.text('broken-tls'), findsOneWidget);
+    expect(find.text('web-tls'), findsNothing);
+    expect(find.text('api-tls'), findsNothing);
+  });
+
+  testWidgets('search filter narrows by issuer name token', (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/certificates/status', body: _statusDetected())
+      ..onJson('GET', '/api/v1/certificates/certificates', body: _certsBody());
+
+    await _pump(tester, mock);
+
+    await tester.enterText(find.byType(TextField), 'self-signed');
+    await tester.pumpAndSettle();
+
+    // Only broken-tls uses self-signed.
+    expect(find.text('broken-tls'), findsOneWidget);
+    expect(find.text('web-tls'), findsNothing);
+  });
+
+  testWidgets('empty cert list shows "no certificates" empty state',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/certificates/status', body: _statusDetected())
+      ..onJson(
+        'GET',
+        '/api/v1/certificates/certificates',
+        body: {'data': <Map<String, Object?>>[]},
+      );
+
+    await _pump(tester, mock);
+
+    expect(find.textContaining('No certificates'), findsOneWidget);
+  });
+}

--- a/mobile/test/features/certmanager/expiring_screen_test.dart
+++ b/mobile/test/features/certmanager/expiring_screen_test.dart
@@ -1,0 +1,135 @@
+// Widget tests for the expiring certificates surface.
+//
+// Coverage:
+//   * Not detected → FeatureUnavailableState.certManager().
+//   * Backend-sorted rows render with severity badges.
+//   * Empty list shows the "no expiring" success state.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:kubecenter/api/dio_client.dart';
+import 'package:kubecenter/auth/secure_storage.dart';
+import 'package:kubecenter/features/certmanager/expiring_screen.dart';
+import 'package:kubecenter/theme/kube_theme_builder.dart';
+
+import '../../support/mock_dio_adapter.dart';
+
+Future<void> _pump(WidgetTester tester, MockDioAdapter mock) async {
+  final router = GoRouter(
+    initialLocation: '/',
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (context, state) => const ExpiringCertificatesScreen(),
+      ),
+    ],
+  );
+  await tester.pumpWidget(ProviderScope(
+    overrides: [
+      backendUrlProvider.overrideWithValue('http://test'),
+      secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+    ],
+    child: _DioInstaller(
+      mock: mock,
+      child: MaterialApp.router(
+        theme: buildKubeTheme('nexus'),
+        routerConfig: router,
+      ),
+    ),
+  ));
+  await tester.pump();
+  await tester.pumpAndSettle(const Duration(milliseconds: 200));
+}
+
+class _DioInstaller extends ConsumerWidget {
+  const _DioInstaller({required this.mock, required this.child});
+
+  final MockDioAdapter mock;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.read(dioProvider).httpClientAdapter = mock;
+    return child;
+  }
+}
+
+Map<String, Object?> _statusDetected() => {
+      'data': {'detected': true},
+    };
+
+Map<String, Object?> _statusNotDetected() => {
+      'data': {'detected': false},
+    };
+
+void main() {
+  testWidgets('not detected → FeatureUnavailableState.certManager()',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/certificates/status', body: _statusNotDetected());
+
+    await _pump(tester, mock);
+
+    expect(find.textContaining('cert-manager'), findsWidgets);
+  });
+
+  testWidgets('renders sorted expiring rows with severity badges',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/certificates/status', body: _statusDetected())
+      ..onJson(
+        'GET',
+        '/api/v1/certificates/expiring',
+        body: {
+          'data': [
+            {
+              'namespace': 'app',
+              'name': 'critical-cert',
+              'uid': 'c-uid',
+              'issuerName': 'letsencrypt-prod',
+              'secretName': 'critical-secret',
+              'notAfter': '2026-05-15T00:00:00Z',
+              'daysRemaining': 2,
+              'severity': 'critical',
+            },
+            {
+              'namespace': 'app',
+              'name': 'warning-cert',
+              'uid': 'w-uid',
+              'issuerName': 'letsencrypt-prod',
+              'secretName': 'warning-secret',
+              'notAfter': '2026-06-05T00:00:00Z',
+              'daysRemaining': 23,
+              'severity': 'warning',
+            },
+          ],
+        },
+      );
+
+    await _pump(tester, mock);
+
+    expect(find.text('critical-cert'), findsOneWidget);
+    expect(find.text('warning-cert'), findsOneWidget);
+    expect(find.text('2d'), findsOneWidget);
+    expect(find.text('23d'), findsOneWidget);
+  });
+
+  testWidgets('empty expiring list shows success state', (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/certificates/status', body: _statusDetected())
+      ..onJson(
+        'GET',
+        '/api/v1/certificates/expiring',
+        body: {'data': <Map<String, Object?>>[]},
+      );
+
+    await _pump(tester, mock);
+
+    expect(
+      find.textContaining('No certificates expiring soon'),
+      findsOneWidget,
+    );
+  });
+}

--- a/mobile/test/features/certmanager/issuers_list_screen_test.dart
+++ b/mobile/test/features/certmanager/issuers_list_screen_test.dart
@@ -1,0 +1,164 @@
+// Widget tests for the combined Issuers + ClusterIssuers list.
+//
+// Coverage:
+//   * Not-detected falls back to FeatureUnavailableState.certManager().
+//   * Combined list renders namespaced first, cluster after.
+//   * Ready / Not ready badge surfaces.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:kubecenter/api/dio_client.dart';
+import 'package:kubecenter/auth/secure_storage.dart';
+import 'package:kubecenter/features/certmanager/issuers_list_screen.dart';
+import 'package:kubecenter/theme/kube_theme_builder.dart';
+
+import '../../support/mock_dio_adapter.dart';
+
+Future<void> _pump(WidgetTester tester, MockDioAdapter mock) async {
+  final router = GoRouter(
+    initialLocation: '/',
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (context, state) => const IssuersListScreen(),
+      ),
+    ],
+  );
+  await tester.pumpWidget(ProviderScope(
+    overrides: [
+      backendUrlProvider.overrideWithValue('http://test'),
+      secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+    ],
+    child: _DioInstaller(
+      mock: mock,
+      child: MaterialApp.router(
+        theme: buildKubeTheme('nexus'),
+        routerConfig: router,
+      ),
+    ),
+  ));
+  await tester.pump();
+  await tester.pumpAndSettle(const Duration(milliseconds: 200));
+}
+
+class _DioInstaller extends ConsumerWidget {
+  const _DioInstaller({required this.mock, required this.child});
+
+  final MockDioAdapter mock;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.read(dioProvider).httpClientAdapter = mock;
+    return child;
+  }
+}
+
+Map<String, Object?> _statusDetected() => {
+      'data': {'detected': true},
+    };
+
+Map<String, Object?> _statusNotDetected() => {
+      'data': {'detected': false},
+    };
+
+void main() {
+  testWidgets('not detected → FeatureUnavailableState.certManager()',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/certificates/status', body: _statusNotDetected());
+
+    await _pump(tester, mock);
+
+    expect(find.textContaining('cert-manager'), findsWidgets);
+    expect(find.text('Ready'), findsNothing);
+  });
+
+  testWidgets(
+      'renders combined Issuers + ClusterIssuers with Ready/Not ready',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/certificates/status', body: _statusDetected())
+      ..onJson(
+        'GET',
+        '/api/v1/certificates/issuers',
+        body: {
+          'data': [
+            {
+              'name': 'self-signed',
+              'namespace': 'app',
+              'scope': 'Namespaced',
+              'type': 'SelfSigned',
+              'ready': true,
+              'uid': 'iss-1',
+              'updatedAt': '2026-05-12T10:00:00Z',
+            },
+          ],
+        },
+      )
+      ..onJson(
+        'GET',
+        '/api/v1/certificates/clusterissuers',
+        body: {
+          'data': [
+            {
+              'name': 'letsencrypt-prod',
+              'scope': 'Cluster',
+              'type': 'ACME',
+              'ready': true,
+              'acmeServer':
+                  'https://acme-v02.api.letsencrypt.org/directory',
+              'uid': 'le-uid',
+              'updatedAt': '2026-05-12T10:00:00Z',
+            },
+            {
+              'name': 'broken-issuer',
+              'scope': 'Cluster',
+              'type': 'Vault',
+              'ready': false,
+              'reason': 'AuthFailed',
+              'uid': 'broken-uid',
+              'updatedAt': '2026-05-12T10:00:00Z',
+            },
+          ],
+        },
+      );
+
+    await _pump(tester, mock);
+
+    expect(find.text('self-signed'), findsOneWidget);
+    expect(find.text('letsencrypt-prod'), findsOneWidget);
+    expect(find.text('broken-issuer'), findsOneWidget);
+    // Type badges:
+    expect(find.text('SelfSigned'), findsOneWidget);
+    expect(find.text('ACME'), findsOneWidget);
+    expect(find.text('Vault'), findsOneWidget);
+    // Ready badges (2 ready issuers + 1 not-ready):
+    expect(find.text('Ready'), findsNWidgets(2));
+    expect(find.text('Not ready'), findsOneWidget);
+  });
+
+  testWidgets('empty list renders guidance text', (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/certificates/status', body: _statusDetected())
+      ..onJson(
+        'GET',
+        '/api/v1/certificates/issuers',
+        body: {'data': <Map<String, Object?>>[]},
+      )
+      ..onJson(
+        'GET',
+        '/api/v1/certificates/clusterissuers',
+        body: {'data': <Map<String, Object?>>[]},
+      );
+
+    await _pump(tester, mock);
+
+    expect(
+      find.textContaining('No Issuers or ClusterIssuers'),
+      findsOneWidget,
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Lands U7 of `plans/mobile-app-m4-pr-sequence.md`: mobile parity for the web cert-manager observatory. Operator can browse certificates with expiry-state badges, tap into a detail view with **resolved threshold attribution** (per-key source: cert → issuer → clusterissuer → default), inspect CertificateRequests / Orders / Challenges sub-resources, browse combined Issuers + ClusterIssuers, and land directly on an expiring-soon view from a notification deep link.

No new backend — every endpoint already shipped in web Phase 12.

## What landed

**`mobile/lib/api/certmanager_repository.dart`** (new)
- Wire types mirror `backend/internal/certmanager/types.go` exactly: `Certificate`, `Issuer`, `CertificateRequestRow`, `OrderRow`, `ChallengeRow`, `CertificateDetail`, `ExpiringCertificate`, `CertManagerStatus`.
- Read methods: `status`, `listCertificates`, `getCertificate`, `listIssuers`, `listClusterIssuers`, `listExpiring`.
- Write methods: `renew`, `reissue` (NOT routed through `executeAction` — backend exposes them under `/v1/certificates/*` rather than the generic `/v1/resources/*` action endpoint, mirroring the web's `apiPost('/v1/certificates/...')` pattern).
- 5 `FutureProvider.autoDispose.family` slots keyed on `clusterId`: `certManagerStatusProvider`, `certificateListProvider`, `certificateDetailProvider`, `allIssuersProvider`, `expiringCertificatesProvider`. `CancelToken` plumbing for cluster-switch races.

**`mobile/lib/features/certmanager/` — 5 screens** (new)
- `certificates_list_screen.dart` — filter chips (All / Expiring / Failed), search across name + namespace + issuer, `?status=expiring` URL param pre-filters.
- `certificate_detail_screen.dart` — three tabs (Overview / Sub-Resources / Events). Overview renders threshold attribution per-key with the **"Conflict — using defaults"** badge when `thresholdConflict: true`. Sub-Resources collapses to a hint per section; surfaces a **RBAC banner** when the cert is `Issuing` or `Failed` with no CRs visible. Renew + Re-issue verbs post via the repository through the canonical `confirm_sheet` (Reissue is type-to-confirm gated on the cert name).
- `issuers_list_screen.dart` — combined namespaced + cluster issuers via `allIssuersProvider` (separate from the existing wizard picker, which returns only string-name lists for the dropdown).
- `expiring_screen.dart` — backend-sorted summary rows with severity badges; tap → detail.
- `cert_badges.dart` — shared `CertStatusPill`, `IssuerTypeBadge`, `ExpiryBadge`. **`ExpiryBadge` color uses the backend-resolved warn/critical pair** (not hardcoded 7d/30d cutoffs), falling back to package defaults when the response elides the resolved thresholds.

**Routing + drawer**
- New "Certificates" drawer section with three entries (Certificates, Issuers, Expiring).
- Routes: `/clusters/<id>/certificates/{certificates,certificates/<ns>/<name>,issuers,expiring}` with `?status=` query-param threading on the list route.
- Status gating stays at the **screen level** (each surface checks `certManagerStatusProvider` and falls back to `FeatureUnavailableState.certManager()`) — drawer entries remain visible so operators on a cluster without cert-manager get install guidance instead of disappearing menu items.

**Tests (42 new)**
- `test/api/certmanager_repository_test.dart` — 23 tests covering status parsing (admin + non-admin), 5xx fallback, ApiError on 4xx, threshold attribution shapes, namespace query threading, unknown `thresholdSource` → `ThresholdSource.unknown`, sub-resource nesting, URL-encoding of ns/name, 404 on missing cert, renew/reissue POST shape + 403 surfacing, grammatical present-continuous fallback on body-less 202 (no "reissueing").
- `test/features/certmanager/*_test.dart` — 4 widget test files: `FeatureUnavailableState` branch, filter chips + search narrowing, `?status=expiring` pre-filter, threshold-conflict badge, RBAC banner on Issuing+empty CRs, Renew confirm sheet opens.

## Plan invariants honored

- **R10 (web/Dart isomorphism)** — every screen ports an existing `frontend/islands/*.tsx` surface; wire-format models mirror `backend/internal/certmanager/types.go` JSON tags 1:1.
- **R11 (cluster pinning)** — every provider keys on `clusterId`; every Dio call threads `clusterIdOverride`; CancelToken cancels on `ref.onDispose`.
- **R12 (read-only posture)** — only the already-shipped backend renew/reissue verbs are surfaced. No new write paths.
- **Annotation contracts** — per-key threshold source attribution ("From Issuer X" / "From ClusterIssuer Y" / "Default") + `thresholdConflict` rendering match the spec in CLAUDE.md (resolution chain cert → issuer → clusterissuer → default; each key resolves independently; 30s cache means edits take up to 30s to apply).
- **`FeatureUnavailableState.certManager()`** factory reused from PR-4a, not reinvented.
- **`DomainListScaffold`** not used for cert list — required filter strip + status-gated body required a custom layout matching the mesh routing screen's idiom for stateful filter+search lists.

## Verification

- `flutter analyze mobile/` → 0 issues
- `cd mobile && flutter test` → all 693 tests pass (42 new for cert-manager)
- `make check-themes` → themes in sync
- **Homelab smoke test** — not yet performed; flagged for review (the plan calls for walking the homelab's `web-tls` + `letsencrypt-staging` certs to verify expiry badge colors).

## Test plan

- [ ] Run `/ce:review`
- [ ] Smoke against homelab: open Certificates list, verify the homelab's existing `web-tls` + `letsencrypt-staging` certs render with the correct expiry badge colors (success/warning/error per resolved thresholds).
- [ ] Tap a cert → verify Overview shows threshold attribution (likely "From ClusterIssuer letsencrypt-prod" for at least one key).
- [ ] Switch to Sub-Resources tab → verify CertificateRequests / Orders / Challenges render correctly for an ACME-issued cert.
- [ ] Tap Issuers drawer entry → verify combined namespaced + cluster issuers render.
- [ ] Tap Expiring drawer entry → verify the backend-sorted view renders if any cert is in the warn bucket.
- [ ] (Optional) Trigger Renew on a non-production cert → verify the confirm sheet appears and the toast updates after acceptance.
- [ ] CI green before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)