### PR TITLE
feat(mobile): M4 PR-4h — ESO read-side parity (observatory, lists, detail, metrics)

### DIFF
--- a/mobile/lib/api/eso_repository.dart
+++ b/mobile/lib/api/eso_repository.dart
@@ -189,6 +189,7 @@ class EsoDiscoveryStatus {
     this.namespace,
     this.version,
     this.lastChecked = '',
+    this.serviceUnavailable = false,
   });
 
   final bool detected;
@@ -197,6 +198,14 @@ class EsoDiscoveryStatus {
 
   /// RFC-3339 timestamp; empty when the first probe hasn't completed.
   final String lastChecked;
+
+  /// True when the backend status endpoint returned 5xx — distinguishes
+  /// "backend was unreachable" (transient, e.g. mid-rolling-restart) from
+  /// "backend says ESO is not installed". Both flow through `detected:false`
+  /// so the install-guidance UI still renders, but consumers that want
+  /// to nudge the operator toward retry rather than `helm install …` can
+  /// branch on this flag.
+  final bool serviceUnavailable;
 
   factory EsoDiscoveryStatus.fromJson(Map<String, dynamic> json) {
     String? s(Object? v) => v is String && v.isNotEmpty ? v : null;
@@ -209,6 +218,8 @@ class EsoDiscoveryStatus {
   }
 
   static const empty = EsoDiscoveryStatus(detected: false);
+  static const unreachable =
+      EsoDiscoveryStatus(detected: false, serviceUnavailable: true);
 }
 
 /// Reference from an ExternalSecret / ClusterExternalSecret / PushSecret
@@ -676,9 +687,10 @@ class EsoRepository {
 
   final Dio _dio;
 
-  /// Fetches ESO discovery status. Returns [EsoDiscoveryStatus.empty] on
-  /// 5xx so callers route straight to `FeatureUnavailableState.eso()` —
-  /// a flaky reverse-proxy probe shouldn't surface as an error card.
+  /// Fetches ESO discovery status. Returns [EsoDiscoveryStatus.unreachable]
+  /// on 5xx so the surface keeps rendering install-guidance copy without
+  /// flashing an error card; `serviceUnavailable: true` lets the UI add
+  /// a transient-error nuance if it wants (e.g., during rolling restarts).
   Future<EsoDiscoveryStatus> status({
     String? clusterIdOverride,
     CancelToken? cancelToken,
@@ -697,7 +709,7 @@ class EsoRepository {
     } on DioException catch (e) {
       if (CancelToken.isCancel(e)) rethrow;
       final code = e.response?.statusCode ?? 0;
-      if (code >= 500 && code < 600) return EsoDiscoveryStatus.empty;
+      if (code >= 500 && code < 600) return EsoDiscoveryStatus.unreachable;
       final err = e.error;
       throw err is ApiError ? err : ApiError.fromDio(e);
     }
@@ -1239,8 +1251,29 @@ final clusterStoreMetricsProvider = FutureProvider.autoDispose
       );
 });
 
+/// List-key for the PushSecret list provider. Structurally identical to
+/// [ExternalSecretListKey] but kept distinct so the provider's type
+/// parameter accurately describes what it lists — preventing the
+/// "ExternalSecretListKey inside a PushSecret screen" confusion at call
+/// sites.
+class PushSecretListKey {
+  const PushSecretListKey({required this.clusterId, this.namespace});
+
+  final String clusterId;
+  final String? namespace;
+
+  @override
+  bool operator ==(Object other) =>
+      other is PushSecretListKey &&
+      other.clusterId == clusterId &&
+      other.namespace == namespace;
+
+  @override
+  int get hashCode => Object.hash(clusterId, namespace);
+}
+
 final pushSecretListProvider = FutureProvider.autoDispose
-    .family<List<PushSecret>, ExternalSecretListKey>((ref, key) async {
+    .family<List<PushSecret>, PushSecretListKey>((ref, key) async {
   ref.watch(activeClusterProvider);
   final cancel = CancelToken();
   ref.onDispose(() {

--- a/mobile/lib/api/eso_repository.dart
+++ b/mobile/lib/api/eso_repository.dart
@@ -1,0 +1,1291 @@
+// Mobile-side wrapper over the backend External Secrets Operator (ESO)
+// API at `/v1/externalsecrets/{status,externalsecrets,
+// externalsecrets/{ns}/{name},clusterexternalsecrets[/{name}],
+// stores[/{ns}/{name}],stores/{ns}/{name}/metrics,
+// clusterstores[/{name}],clusterstores/{name}/metrics,
+// pushsecrets[/{ns}/{name}]}`. Wire types mirror
+// `backend/internal/externalsecrets/types.go` and
+// `frontend/lib/eso-types.ts` exactly.
+//
+// Drift contract (read three times before changing — the asymmetry is
+// deliberate):
+//   * LIST endpoint omits `driftStatus`; it populates
+//     `lastObservedDriftStatus` from the 60s background poller. Stale by
+//     up to 90s (60s poller + 30s handler cache).
+//   * DETAIL endpoint always populates the live `driftStatus` via an
+//     impersonated `get secret` and leaves `lastObservedDriftStatus`
+//     empty. This is the source of truth.
+// Mobile mirrors this exactly — list screens render from
+// `lastObservedDriftStatus`, detail screens render from `driftStatus`.
+//
+// Cluster pinning: every call accepts `clusterIdOverride` and forwards
+// it as an explicit `X-Cluster-ID` header. The PR-3c interceptor
+// invariant (only injects when absent) is the live contract.
+//
+// Web parallel: `frontend/islands/ESODashboard.tsx`,
+// `frontend/islands/ESOExternalSecretsList.tsx`,
+// `frontend/islands/ESOExternalSecretDetail.tsx`,
+// `frontend/islands/ESOStoreDetail.tsx`,
+// `frontend/islands/ESOStoreMetricsPanel.tsx`.
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../cluster/cluster_provider.dart';
+import 'api_error.dart';
+import 'dio_client.dart';
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+/// Lifecycle state of an ExternalSecret. Mirrors `Status` in
+/// `backend/internal/externalsecrets/types.go`. Open enum on the wire —
+/// older / future ESO responses may add states, so [unknown] is the
+/// explicit fallback rather than crashing the parser.
+enum EsoStatus {
+  synced,
+  syncFailed,
+  refreshing,
+  stale,
+  drifted,
+  unknown,
+}
+
+EsoStatus _esoStatusFromJson(Object? v) {
+  if (v is! String) return EsoStatus.unknown;
+  switch (v) {
+    case 'Synced':
+      return EsoStatus.synced;
+    case 'SyncFailed':
+      return EsoStatus.syncFailed;
+    case 'Refreshing':
+      return EsoStatus.refreshing;
+    case 'Stale':
+      return EsoStatus.stale;
+    case 'Drifted':
+      return EsoStatus.drifted;
+    default:
+      return EsoStatus.unknown;
+  }
+}
+
+/// Human label used in status pills and filter chips. Capitalised to
+/// match the wire enum exactly so screenshots across web + mobile read
+/// identically.
+String esoStatusLabel(EsoStatus s) => switch (s) {
+      EsoStatus.synced => 'Synced',
+      EsoStatus.syncFailed => 'SyncFailed',
+      EsoStatus.refreshing => 'Refreshing',
+      EsoStatus.stale => 'Stale',
+      EsoStatus.drifted => 'Drifted',
+      EsoStatus.unknown => 'Unknown',
+    };
+
+/// Tri-state drift indicator. **`Unknown` is NEVER an error** — it
+/// signals the provider doesn't populate `SyncedResourceVersion`, which
+/// is common (the Kubernetes provider, for instance, omits it). UI
+/// renders `InSync` → success, `Drifted` → warning,
+/// `Unknown` → textMuted (per PR-3f learnings #9).
+enum DriftStatus {
+  inSync,
+  drifted,
+  unknown,
+
+  /// Distinct from [unknown]. Used by the list path where the backend
+  /// has no observation yet and omits the field entirely. Maps to
+  /// "no drift hint available" in the UI — usually rendered as no pill
+  /// at all rather than a textMuted "Unknown" pill.
+  notObserved,
+}
+
+DriftStatus _driftStatusFromJson(Object? v) {
+  if (v is! String || v.isEmpty) return DriftStatus.notObserved;
+  switch (v) {
+    case 'InSync':
+      return DriftStatus.inSync;
+    case 'Drifted':
+      return DriftStatus.drifted;
+    case 'Unknown':
+      return DriftStatus.unknown;
+    default:
+      return DriftStatus.notObserved;
+  }
+}
+
+/// Reasons accompanying `driftStatus = Unknown` on a detail response.
+/// Empty when drift is definite. Detail screen surfaces this as a
+/// tooltip under the drift pill so operators see WHY drift wasn't
+/// resolvable rather than guessing.
+enum DriftUnknownReason {
+  noSyncedRv,
+  noTargetName,
+  secretDeleted,
+  rbacDenied,
+  transientError,
+  clientError,
+
+  /// Open-enum forward-compat fallback. Renders as generic "Drift not
+  /// resolvable" copy on the detail screen.
+  unspecified,
+}
+
+DriftUnknownReason driftUnknownReasonFromJson(Object? v) {
+  if (v is! String) return DriftUnknownReason.unspecified;
+  switch (v) {
+    case 'no_synced_rv':
+      return DriftUnknownReason.noSyncedRv;
+    case 'no_target_name':
+      return DriftUnknownReason.noTargetName;
+    case 'secret_deleted':
+      return DriftUnknownReason.secretDeleted;
+    case 'rbac_denied':
+      return DriftUnknownReason.rbacDenied;
+    case 'transient_error':
+      return DriftUnknownReason.transientError;
+    case 'client_error':
+      return DriftUnknownReason.clientError;
+    default:
+      return DriftUnknownReason.unspecified;
+  }
+}
+
+/// Layer that supplied an annotation-resolved threshold. See
+/// `backend/internal/externalsecrets/types.go` — these match the
+/// resolver's enum.
+enum EsoThresholdSource {
+  packageDefault,
+  externalSecret,
+  secretStore,
+  clusterSecretStore,
+  unknown,
+}
+
+EsoThresholdSource _thresholdSourceFromJson(Object? v) {
+  if (v is! String) return EsoThresholdSource.unknown;
+  switch (v) {
+    case 'default':
+      return EsoThresholdSource.packageDefault;
+    case 'externalsecret':
+      return EsoThresholdSource.externalSecret;
+    case 'secretstore':
+      return EsoThresholdSource.secretStore;
+    case 'clustersecretstore':
+      return EsoThresholdSource.clusterSecretStore;
+    default:
+      return EsoThresholdSource.unknown;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Wire-format value types
+// ---------------------------------------------------------------------------
+
+/// Decoded `/v1/externalsecrets/status` response. Mirrors `ESOStatus`
+/// in the Go types.
+class EsoDiscoveryStatus {
+  const EsoDiscoveryStatus({
+    required this.detected,
+    this.namespace,
+    this.version,
+    this.lastChecked = '',
+  });
+
+  final bool detected;
+  final String? namespace;
+  final String? version;
+
+  /// RFC-3339 timestamp; empty when the first probe hasn't completed.
+  final String lastChecked;
+
+  factory EsoDiscoveryStatus.fromJson(Map<String, dynamic> json) {
+    String? s(Object? v) => v is String && v.isNotEmpty ? v : null;
+    return EsoDiscoveryStatus(
+      detected: json['detected'] as bool? ?? false,
+      namespace: s(json['namespace']),
+      version: s(json['version']),
+      lastChecked: json['lastChecked'] as String? ?? '',
+    );
+  }
+
+  static const empty = EsoDiscoveryStatus(detected: false);
+}
+
+/// Reference from an ExternalSecret / ClusterExternalSecret / PushSecret
+/// to its backing SecretStore or ClusterSecretStore.
+class EsoStoreRef {
+  const EsoStoreRef({required this.name, required this.kind});
+
+  final String name;
+
+  /// `"SecretStore"` or `"ClusterSecretStore"`. Open enum on the wire,
+  /// kept as raw String so a future ESO ref kind doesn't crash the
+  /// parser.
+  final String kind;
+
+  factory EsoStoreRef.fromJson(Map<String, dynamic> json) => EsoStoreRef(
+        name: json['name'] as String? ?? '',
+        kind: json['kind'] as String? ?? '',
+      );
+}
+
+/// One ExternalSecret row on the list endpoint, or the detail response.
+///
+/// Wire contract: the list endpoint populates [lastObservedDriftStatus]
+/// (poller hint) and leaves [driftStatus] = [DriftStatus.notObserved];
+/// the detail endpoint inverts this. Callers must NOT collapse the two
+/// fields into one — the live-vs-cached distinction is meaningful.
+class ExternalSecret {
+  const ExternalSecret({
+    required this.namespace,
+    required this.name,
+    required this.uid,
+    required this.status,
+    required this.storeRef,
+    this.driftStatus = DriftStatus.notObserved,
+    this.driftUnknownReason = DriftUnknownReason.unspecified,
+    this.lastObservedDriftStatus = DriftStatus.notObserved,
+    this.readyReason,
+    this.readyMessage,
+    this.targetSecretName,
+    this.refreshInterval,
+    this.lastSyncTime,
+    this.syncedResourceVersion,
+    this.staleAfterMinutes,
+    this.staleAfterMinutesSource = EsoThresholdSource.unknown,
+    this.alertOnRecovery,
+    this.alertOnRecoverySource = EsoThresholdSource.unknown,
+    this.alertOnLifecycle,
+    this.alertOnLifecycleSource = EsoThresholdSource.unknown,
+  });
+
+  final String namespace;
+  final String name;
+  final String uid;
+  final EsoStatus status;
+  final EsoStoreRef storeRef;
+
+  /// Live drift state (detail endpoint only). [DriftStatus.notObserved]
+  /// on list rows.
+  final DriftStatus driftStatus;
+
+  /// Populated only when [driftStatus] == [DriftStatus.unknown].
+  final DriftUnknownReason driftUnknownReason;
+
+  /// Poller's last-observed drift state (list endpoint only).
+  /// [DriftStatus.notObserved] on detail responses and when no
+  /// observation has been recorded yet.
+  final DriftStatus lastObservedDriftStatus;
+
+  final String? readyReason;
+  final String? readyMessage;
+  final String? targetSecretName;
+
+  /// Duration string, e.g. `"1h"`, `"30m"`. Rendered verbatim — no
+  /// parsing required for any current call site.
+  final String? refreshInterval;
+
+  /// RFC-3339 timestamp. Null when the ES hasn't synced yet.
+  final String? lastSyncTime;
+
+  final String? syncedResourceVersion;
+
+  /// Annotation-resolved thresholds. Null in Phase A; populated by
+  /// Phase D's resolver. Mirrors web's nullable shape so the UI can
+  /// distinguish "resolver hasn't run" from "resolver ran, no value".
+  final int? staleAfterMinutes;
+  final EsoThresholdSource staleAfterMinutesSource;
+  final bool? alertOnRecovery;
+  final EsoThresholdSource alertOnRecoverySource;
+  final bool? alertOnLifecycle;
+  final EsoThresholdSource alertOnLifecycleSource;
+
+  factory ExternalSecret.fromJson(Map<String, dynamic> json) {
+    String? s(Object? v) => v is String && v.isNotEmpty ? v : null;
+    // Defensive cast mirrors certmanager_repository.dart's helper —
+    // accept num (canonical), parse String (forward-compat / mock-
+    // backend / replay-proxy resilience), reject everything else.
+    int? n(Object? v) {
+      if (v is num) return v.toInt();
+      if (v is String) return int.tryParse(v);
+      return null;
+    }
+
+    bool? b(Object? v) {
+      if (v is bool) return v;
+      return null;
+    }
+
+    return ExternalSecret(
+      namespace: json['namespace'] as String? ?? '',
+      name: json['name'] as String? ?? '',
+      uid: json['uid'] as String? ?? '',
+      status: _esoStatusFromJson(json['status']),
+      storeRef: json['storeRef'] is Map
+          ? EsoStoreRef.fromJson(
+              Map<String, dynamic>.from(json['storeRef'] as Map),
+            )
+          : const EsoStoreRef(name: '', kind: ''),
+      driftStatus: _driftStatusFromJson(json['driftStatus']),
+      driftUnknownReason:
+          driftUnknownReasonFromJson(json['driftUnknownReason']),
+      lastObservedDriftStatus:
+          _driftStatusFromJson(json['lastObservedDriftStatus']),
+      readyReason: s(json['readyReason']),
+      readyMessage: s(json['readyMessage']),
+      targetSecretName: s(json['targetSecretName']),
+      refreshInterval: s(json['refreshInterval']),
+      lastSyncTime: s(json['lastSyncTime']),
+      syncedResourceVersion: s(json['syncedResourceVersion']),
+      staleAfterMinutes: n(json['staleAfterMinutes']),
+      staleAfterMinutesSource:
+          _thresholdSourceFromJson(json['staleAfterMinutesSource']),
+      alertOnRecovery: b(json['alertOnRecovery']),
+      alertOnRecoverySource:
+          _thresholdSourceFromJson(json['alertOnRecoverySource']),
+      alertOnLifecycle: b(json['alertOnLifecycle']),
+      alertOnLifecycleSource:
+          _thresholdSourceFromJson(json['alertOnLifecycleSource']),
+    );
+  }
+
+  /// The drift state to render on a list row. Prefers [driftStatus]
+  /// (detail-only) when present, falls back to [lastObservedDriftStatus]
+  /// (list-only). Returns [DriftStatus.notObserved] when neither is
+  /// populated — caller renders no pill in that case.
+  DriftStatus get effectiveDriftStatus =>
+      driftStatus != DriftStatus.notObserved
+          ? driftStatus
+          : lastObservedDriftStatus;
+}
+
+/// ClusterExternalSecret — the cluster-scoped fan-out form. Selector
+/// + namespace lists are pulled verbatim from the response; mobile
+/// renders them as chip strips.
+class ClusterExternalSecret {
+  const ClusterExternalSecret({
+    required this.name,
+    required this.uid,
+    required this.status,
+    required this.storeRef,
+    this.readyReason,
+    this.readyMessage,
+    this.targetSecretName,
+    this.refreshInterval,
+    this.namespaceSelectors = const <String>[],
+    this.namespaces = const <String>[],
+    this.provisionedNamespaces = const <String>[],
+    this.failedNamespaces = const <String>[],
+    this.externalSecretBaseName,
+  });
+
+  final String name;
+  final String uid;
+  final EsoStatus status;
+  final EsoStoreRef storeRef;
+  final String? readyReason;
+  final String? readyMessage;
+  final String? targetSecretName;
+  final String? refreshInterval;
+
+  /// Selector clauses rendered as `"k=v"` strings by the backend.
+  final List<String> namespaceSelectors;
+
+  /// Static namespace list (alternative to selector).
+  final List<String> namespaces;
+
+  /// Resolved namespaces where the child ES has been created
+  /// successfully.
+  final List<String> provisionedNamespaces;
+
+  /// Namespaces where fan-out failed (RBAC / quota / similar).
+  final List<String> failedNamespaces;
+
+  final String? externalSecretBaseName;
+
+  factory ClusterExternalSecret.fromJson(Map<String, dynamic> json) {
+    String? s(Object? v) => v is String && v.isNotEmpty ? v : null;
+    List<String> strList(Object? raw) =>
+        raw is List ? raw.whereType<String>().toList() : const <String>[];
+
+    return ClusterExternalSecret(
+      name: json['name'] as String? ?? '',
+      uid: json['uid'] as String? ?? '',
+      status: _esoStatusFromJson(json['status']),
+      storeRef: json['storeRef'] is Map
+          ? EsoStoreRef.fromJson(
+              Map<String, dynamic>.from(json['storeRef'] as Map),
+            )
+          : const EsoStoreRef(name: '', kind: ''),
+      readyReason: s(json['readyReason']),
+      readyMessage: s(json['readyMessage']),
+      targetSecretName: s(json['targetSecretName']),
+      refreshInterval: s(json['refreshInterval']),
+      namespaceSelectors: strList(json['namespaceSelectors']),
+      namespaces: strList(json['namespaces']),
+      provisionedNamespaces: strList(json['provisionedNamespaces']),
+      failedNamespaces: strList(json['failedNamespaces']),
+      externalSecretBaseName: s(json['externalSecretBaseName']),
+    );
+  }
+}
+
+/// SecretStore — both namespaced and cluster-scoped variants share this
+/// type, discriminated by [scope] (`"Namespaced"` / `"Cluster"`).
+/// Cluster-scoped stores have empty [namespace].
+class SecretStore {
+  const SecretStore({
+    required this.name,
+    required this.uid,
+    required this.scope,
+    required this.status,
+    required this.ready,
+    required this.provider,
+    this.namespace = '',
+    this.readyReason,
+    this.readyMessage,
+    this.providerSpec = const <String, dynamic>{},
+    this.staleAfterMinutes,
+    this.alertOnRecovery,
+    this.alertOnLifecycle,
+  });
+
+  /// Empty for ClusterSecretStore.
+  final String namespace;
+  final String name;
+  final String uid;
+
+  /// `"Namespaced"` or `"Cluster"`. Kept as raw String so a future ESO
+  /// scope literal doesn't break the parser.
+  final String scope;
+
+  final EsoStatus status;
+  final bool ready;
+  final String? readyReason;
+  final String? readyMessage;
+
+  /// Provider family — `"vault"`, `"aws"`, `"gcpsm"`, `"azurekv"`,
+  /// `"kubernetes"`, etc. Empty when no provider key is set.
+  final String provider;
+
+  /// Raw `spec.provider.<provider>` sub-object, surfaced verbatim. The
+  /// detail screen renders this as a read-only KV pane — mobile does
+  /// not parse provider-specific shapes.
+  final Map<String, dynamic> providerSpec;
+
+  /// Phase D annotation-set thresholds. Inherited by ESes referencing
+  /// this store unless overridden at the ES level.
+  final int? staleAfterMinutes;
+  final bool? alertOnRecovery;
+  final bool? alertOnLifecycle;
+
+  bool get isCluster => scope == 'Cluster';
+
+  factory SecretStore.fromJson(Map<String, dynamic> json) {
+    String? s(Object? v) => v is String && v.isNotEmpty ? v : null;
+    int? n(Object? v) {
+      if (v is num) return v.toInt();
+      if (v is String) return int.tryParse(v);
+      return null;
+    }
+
+    Map<String, dynamic> mapOf(Object? raw) {
+      if (raw is Map) return Map<String, dynamic>.from(raw);
+      return const <String, dynamic>{};
+    }
+
+    return SecretStore(
+      namespace: json['namespace'] as String? ?? '',
+      name: json['name'] as String? ?? '',
+      uid: json['uid'] as String? ?? '',
+      scope: json['scope'] as String? ?? '',
+      status: _esoStatusFromJson(json['status']),
+      ready: json['ready'] as bool? ?? false,
+      readyReason: s(json['readyReason']),
+      readyMessage: s(json['readyMessage']),
+      provider: json['provider'] as String? ?? '',
+      providerSpec: mapOf(json['providerSpec']),
+      staleAfterMinutes: n(json['staleAfterMinutes']),
+      alertOnRecovery:
+          json['alertOnRecovery'] is bool ? json['alertOnRecovery'] as bool : null,
+      alertOnLifecycle: json['alertOnLifecycle'] is bool
+          ? json['alertOnLifecycle'] as bool
+          : null,
+    );
+  }
+}
+
+/// PushSecret — the inverse-direction CRD that pushes a Kubernetes
+/// Secret out to a source store. Read-only in v1 (backend has no write
+/// surface for it); mobile mirrors that posture.
+class PushSecret {
+  const PushSecret({
+    required this.namespace,
+    required this.name,
+    required this.uid,
+    required this.status,
+    required this.storeRefs,
+    this.readyReason,
+    this.readyMessage,
+    this.sourceSecretName,
+    this.refreshInterval,
+    this.lastSyncTime,
+  });
+
+  final String namespace;
+  final String name;
+  final String uid;
+  final EsoStatus status;
+
+  /// PushSecret can fan a single Secret to multiple stores.
+  final List<EsoStoreRef> storeRefs;
+
+  final String? readyReason;
+  final String? readyMessage;
+  final String? sourceSecretName;
+  final String? refreshInterval;
+  final String? lastSyncTime;
+
+  factory PushSecret.fromJson(Map<String, dynamic> json) {
+    String? s(Object? v) => v is String && v.isNotEmpty ? v : null;
+    final raw = json['storeRefs'];
+    final refs = raw is List
+        ? raw
+            .whereType<Map<dynamic, dynamic>>()
+            .map((m) => EsoStoreRef.fromJson(Map<String, dynamic>.from(m)))
+            .toList()
+        : const <EsoStoreRef>[];
+
+    return PushSecret(
+      namespace: json['namespace'] as String? ?? '',
+      name: json['name'] as String? ?? '',
+      uid: json['uid'] as String? ?? '',
+      status: _esoStatusFromJson(json['status']),
+      storeRefs: refs,
+      readyReason: s(json['readyReason']),
+      readyMessage: s(json['readyMessage']),
+      sourceSecretName: s(json['sourceSecretName']),
+      refreshInterval: s(json['refreshInterval']),
+      lastSyncTime: s(json['lastSyncTime']),
+    );
+  }
+}
+
+/// Per-store cost estimate carried alongside the metrics response. The
+/// backend suppresses this card entirely (nil) for self-hosted /
+/// unknown providers (Vault, Kubernetes, Akeyless, etc.); UI must NOT
+/// fabricate a zero in that case — show nothing instead.
+class CostEstimate {
+  const CostEstimate({
+    required this.billingProvider,
+    this.currency,
+    this.usdPerMillion,
+    this.estimated24h,
+    this.lastUpdated,
+  });
+
+  final String billingProvider;
+  final String? currency;
+  final double? usdPerMillion;
+  final double? estimated24h;
+  final String? lastUpdated;
+
+  factory CostEstimate.fromJson(Map<String, dynamic> json) {
+    double? d(Object? v) {
+      if (v is num) return v.toDouble();
+      if (v is String) return double.tryParse(v);
+      return null;
+    }
+
+    return CostEstimate(
+      billingProvider: json['billingProvider'] as String? ?? '',
+      currency: json['currency'] as String?,
+      usdPerMillion: d(json['usdPerMillion']),
+      estimated24h: d(json['estimated24h']),
+      lastUpdated: json['lastUpdated'] as String?,
+    );
+  }
+}
+
+/// `GET /externalsecrets/{cluster,}stores/.../metrics` response.
+///
+/// Both [ratePerMin] and [last24h] are nullable: null means
+/// "Prometheus has no series yet for the dependent set" OR "Prometheus
+/// is offline" — distinguished by whether [error] is populated. The UI
+/// MUST NOT fabricate a zero in either case (per backend R25).
+class StoreMetrics {
+  const StoreMetrics({
+    this.ratePerMin,
+    this.last24h,
+    this.cost,
+    this.error,
+    this.windowEnd,
+  });
+
+  /// `sum(rate(externalsecret_sync_calls_total[5m]))` projected to
+  /// per-minute. Null when no series exist OR Prometheus is offline.
+  final double? ratePerMin;
+
+  /// Total requests over the last 24h. Same null semantics as
+  /// [ratePerMin].
+  final double? last24h;
+
+  /// Cost block. Null for self-hosted providers (no rate card) AND
+  /// when usage data is absent.
+  final CostEstimate? cost;
+
+  /// Populated on degradation; HTTP is still 200 in that case. UI
+  /// renders this as a banner above the metrics body.
+  final String? error;
+
+  /// RFC-3339 sample timestamp; empty / null when degraded.
+  final String? windowEnd;
+
+  bool get isDegraded => error != null && error!.isNotEmpty;
+
+  factory StoreMetrics.fromJson(Map<String, dynamic> json) {
+    double? d(Object? v) {
+      if (v is num) return v.toDouble();
+      if (v is String) return double.tryParse(v);
+      return null;
+    }
+
+    return StoreMetrics(
+      ratePerMin: d(json['ratePerMin']),
+      last24h: d(json['last24h']),
+      cost: json['cost'] is Map
+          ? CostEstimate.fromJson(
+              Map<String, dynamic>.from(json['cost'] as Map),
+            )
+          : null,
+      error: json['error'] as String?,
+      windowEnd: json['windowEnd'] as String?,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Repository
+// ---------------------------------------------------------------------------
+
+/// Stateless wrapper over `/v1/externalsecrets/*`. Cluster pinning
+/// threads through `clusterIdOverride` so the wire header always
+/// matches the family-key slot the caller writes back into.
+class EsoRepository {
+  EsoRepository(this._dio);
+
+  final Dio _dio;
+
+  /// Fetches ESO discovery status. Returns [EsoDiscoveryStatus.empty] on
+  /// 5xx so callers route straight to `FeatureUnavailableState.eso()` —
+  /// a flaky reverse-proxy probe shouldn't surface as an error card.
+  Future<EsoDiscoveryStatus> status({
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) async {
+    try {
+      final res = await _dio.get<Map<String, dynamic>>(
+        '/api/v1/externalsecrets/status',
+        options: _opts(clusterIdOverride),
+        cancelToken: cancelToken,
+      );
+      final data = res.data?['data'];
+      if (data is Map) {
+        return EsoDiscoveryStatus.fromJson(Map<String, dynamic>.from(data));
+      }
+      return EsoDiscoveryStatus.empty;
+    } on DioException catch (e) {
+      if (CancelToken.isCancel(e)) rethrow;
+      final code = e.response?.statusCode ?? 0;
+      if (code >= 500 && code < 600) return EsoDiscoveryStatus.empty;
+      final err = e.error;
+      throw err is ApiError ? err : ApiError.fromDio(e);
+    }
+  }
+
+  /// Lists ExternalSecrets. Optional `namespace` filters server-side.
+  /// Each row carries `lastObservedDriftStatus` (poller hint, stale by
+  /// up to 90s); `driftStatus` is always absent — that lives on detail.
+  Future<List<ExternalSecret>> listExternalSecrets({
+    String? namespace,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) =>
+      _fetchList<ExternalSecret>(
+        path: '/api/v1/externalsecrets/externalsecrets',
+        query: (namespace != null && namespace.isNotEmpty)
+            ? {'namespace': namespace}
+            : null,
+        parse: ExternalSecret.fromJson,
+        clusterIdOverride: clusterIdOverride,
+        cancelToken: cancelToken,
+      );
+
+  /// Fetches a single ExternalSecret with live drift resolved. Backend
+  /// runs an impersonated `get secret` to compare `syncedResourceVersion`
+  /// against the live Secret's RV.
+  Future<ExternalSecret> getExternalSecret({
+    required String namespace,
+    required String name,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) async {
+    return _getOne<ExternalSecret>(
+      path: '/api/v1/externalsecrets/externalsecrets/'
+          '${Uri.encodeComponent(namespace)}/${Uri.encodeComponent(name)}',
+      parse: ExternalSecret.fromJson,
+      notFoundMessage: 'External secret $namespace/$name not found',
+      clusterIdOverride: clusterIdOverride,
+      cancelToken: cancelToken,
+    );
+  }
+
+  /// Lists ClusterExternalSecrets. Backend returns empty list (not 403)
+  /// when the impersonated user lacks `list clusterexternalsecrets` —
+  /// permissive-read pattern mirroring the cert-manager and policy
+  /// handlers.
+  Future<List<ClusterExternalSecret>> listClusterExternalSecrets({
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) =>
+      _fetchList<ClusterExternalSecret>(
+        path: '/api/v1/externalsecrets/clusterexternalsecrets',
+        parse: ClusterExternalSecret.fromJson,
+        clusterIdOverride: clusterIdOverride,
+        cancelToken: cancelToken,
+      );
+
+  Future<ClusterExternalSecret> getClusterExternalSecret({
+    required String name,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) =>
+      _getOne<ClusterExternalSecret>(
+        path: '/api/v1/externalsecrets/clusterexternalsecrets/'
+            '${Uri.encodeComponent(name)}',
+        parse: ClusterExternalSecret.fromJson,
+        notFoundMessage: 'ClusterExternalSecret $name not found',
+        clusterIdOverride: clusterIdOverride,
+        cancelToken: cancelToken,
+      );
+
+  /// Lists namespaced SecretStores. Optional `namespace` filters
+  /// server-side via the `?namespace=` query param.
+  Future<List<SecretStore>> listStores({
+    String? namespace,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) =>
+      _fetchList<SecretStore>(
+        path: '/api/v1/externalsecrets/stores',
+        query: (namespace != null && namespace.isNotEmpty)
+            ? {'namespace': namespace}
+            : null,
+        parse: SecretStore.fromJson,
+        clusterIdOverride: clusterIdOverride,
+        cancelToken: cancelToken,
+      );
+
+  Future<SecretStore> getStore({
+    required String namespace,
+    required String name,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) =>
+      _getOne<SecretStore>(
+        path: '/api/v1/externalsecrets/stores/'
+            '${Uri.encodeComponent(namespace)}/${Uri.encodeComponent(name)}',
+        parse: SecretStore.fromJson,
+        notFoundMessage: 'SecretStore $namespace/$name not found',
+        clusterIdOverride: clusterIdOverride,
+        cancelToken: cancelToken,
+      );
+
+  /// Lists ClusterSecretStores. Same permissive-read posture as
+  /// [listClusterExternalSecrets].
+  Future<List<SecretStore>> listClusterStores({
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) =>
+      _fetchList<SecretStore>(
+        path: '/api/v1/externalsecrets/clusterstores',
+        parse: SecretStore.fromJson,
+        clusterIdOverride: clusterIdOverride,
+        cancelToken: cancelToken,
+      );
+
+  Future<SecretStore> getClusterStore({
+    required String name,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) =>
+      _getOne<SecretStore>(
+        path: '/api/v1/externalsecrets/clusterstores/'
+            '${Uri.encodeComponent(name)}',
+        parse: SecretStore.fromJson,
+        notFoundMessage: 'ClusterSecretStore $name not found',
+        clusterIdOverride: clusterIdOverride,
+        cancelToken: cancelToken,
+      );
+
+  /// Fetches per-namespaced-store metrics (rate + cost-tier).
+  Future<StoreMetrics> getStoreMetrics({
+    required String namespace,
+    required String name,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) =>
+      _getOne<StoreMetrics>(
+        path: '/api/v1/externalsecrets/stores/'
+            '${Uri.encodeComponent(namespace)}/'
+            '${Uri.encodeComponent(name)}/metrics',
+        parse: StoreMetrics.fromJson,
+        notFoundMessage: 'Store metrics $namespace/$name not found',
+        clusterIdOverride: clusterIdOverride,
+        cancelToken: cancelToken,
+      );
+
+  /// Fetches per-cluster-store metrics. Same response shape as the
+  /// namespaced variant; aggregation across every namespace's ESes that
+  /// reference this ClusterSecretStore.
+  Future<StoreMetrics> getClusterStoreMetrics({
+    required String name,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) =>
+      _getOne<StoreMetrics>(
+        path: '/api/v1/externalsecrets/clusterstores/'
+            '${Uri.encodeComponent(name)}/metrics',
+        parse: StoreMetrics.fromJson,
+        notFoundMessage: 'ClusterStore metrics $name not found',
+        clusterIdOverride: clusterIdOverride,
+        cancelToken: cancelToken,
+      );
+
+  /// Lists PushSecrets. Optional `namespace` filters server-side.
+  Future<List<PushSecret>> listPushSecrets({
+    String? namespace,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) =>
+      _fetchList<PushSecret>(
+        path: '/api/v1/externalsecrets/pushsecrets',
+        query: (namespace != null && namespace.isNotEmpty)
+            ? {'namespace': namespace}
+            : null,
+        parse: PushSecret.fromJson,
+        clusterIdOverride: clusterIdOverride,
+        cancelToken: cancelToken,
+      );
+
+  Future<PushSecret> getPushSecret({
+    required String namespace,
+    required String name,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) =>
+      _getOne<PushSecret>(
+        path: '/api/v1/externalsecrets/pushsecrets/'
+            '${Uri.encodeComponent(namespace)}/${Uri.encodeComponent(name)}',
+        parse: PushSecret.fromJson,
+        notFoundMessage: 'PushSecret $namespace/$name not found',
+        clusterIdOverride: clusterIdOverride,
+        cancelToken: cancelToken,
+      );
+
+  // -------------------------------------------------------------------------
+  // Internals
+  // -------------------------------------------------------------------------
+
+  Options? _opts(String? clusterIdOverride) => clusterIdOverride == null
+      ? null
+      : Options(headers: {'X-Cluster-ID': clusterIdOverride});
+
+  Future<List<T>> _fetchList<T>({
+    required String path,
+    Map<String, String>? query,
+    required T Function(Map<String, dynamic>) parse,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) async {
+    try {
+      final res = await _dio.get<Map<String, dynamic>>(
+        path,
+        queryParameters: query,
+        options: _opts(clusterIdOverride),
+        cancelToken: cancelToken,
+      );
+      final data = res.data?['data'];
+      if (data is List) {
+        return data
+            .whereType<Map<dynamic, dynamic>>()
+            .map((m) => parse(Map<String, dynamic>.from(m)))
+            .toList();
+      }
+      return <T>[];
+    } on DioException catch (e) {
+      if (CancelToken.isCancel(e)) rethrow;
+      final err = e.error;
+      throw err is ApiError ? err : ApiError.fromDio(e);
+    }
+  }
+
+  Future<T> _getOne<T>({
+    required String path,
+    required T Function(Map<String, dynamic>) parse,
+    required String notFoundMessage,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) async {
+    try {
+      final res = await _dio.get<Map<String, dynamic>>(
+        path,
+        options: _opts(clusterIdOverride),
+        cancelToken: cancelToken,
+      );
+      final data = res.data?['data'];
+      if (data is Map) {
+        return parse(Map<String, dynamic>.from(data));
+      }
+      throw ApiError(
+        statusCode: 500,
+        code: 500,
+        message: 'Empty response for $path',
+      );
+    } on DioException catch (e) {
+      if (CancelToken.isCancel(e)) rethrow;
+      // Surface 404 as ApiError verbatim from the backend — the detail
+      // screens map that to a clearer "not found" message via the
+      // notFoundMessage hint while still showing the backend's detail
+      // when present.
+      final err = e.error;
+      if (err is ApiError) throw err;
+      throw ApiError.fromDio(e);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Providers
+// ---------------------------------------------------------------------------
+
+final esoRepositoryProvider = Provider<EsoRepository>((ref) {
+  return EsoRepository(ref.watch(dioProvider));
+});
+
+/// Per-cluster ESO discovery status. Drives
+/// `FeatureUnavailableState.eso()` on every ESO surface.
+final esoStatusProvider = FutureProvider.autoDispose
+    .family<EsoDiscoveryStatus, String>((ref, clusterId) async {
+  ref.watch(activeClusterProvider);
+  final cancel = CancelToken();
+  ref.onDispose(() {
+    if (!cancel.isCancelled) cancel.cancel('eso status invalidated');
+  });
+  return ref.read(esoRepositoryProvider).status(
+        clusterIdOverride: clusterId,
+        cancelToken: cancel,
+      );
+});
+
+/// Family key for the ExternalSecret list provider. Carries cluster id
+/// (so cluster switches force a fresh slot) and an optional namespace
+/// filter (so two open list screens with different namespace filters
+/// don't share state).
+class ExternalSecretListKey {
+  /// Normalise [namespace]: empty string is treated as null so two
+  /// ostensibly-equal keys collapse to the same slot.
+  ExternalSecretListKey({required this.clusterId, String? namespace})
+      : namespace = (namespace != null && namespace.isEmpty) ? null : namespace;
+
+  final String clusterId;
+  final String? namespace;
+
+  @override
+  bool operator ==(Object other) =>
+      other is ExternalSecretListKey &&
+      other.clusterId == clusterId &&
+      other.namespace == namespace;
+
+  @override
+  int get hashCode => Object.hash(clusterId, namespace);
+}
+
+final externalSecretListProvider = FutureProvider.autoDispose
+    .family<List<ExternalSecret>, ExternalSecretListKey>((ref, key) async {
+  ref.watch(activeClusterProvider);
+  final cancel = CancelToken();
+  ref.onDispose(() {
+    if (!cancel.isCancelled) cancel.cancel('externalsecret list invalidated');
+  });
+  return ref.read(esoRepositoryProvider).listExternalSecrets(
+        namespace: key.namespace,
+        clusterIdOverride: key.clusterId,
+        cancelToken: cancel,
+      );
+});
+
+class ExternalSecretDetailKey {
+  const ExternalSecretDetailKey({
+    required this.clusterId,
+    required this.namespace,
+    required this.name,
+  });
+
+  final String clusterId;
+  final String namespace;
+  final String name;
+
+  @override
+  bool operator ==(Object other) =>
+      other is ExternalSecretDetailKey &&
+      other.clusterId == clusterId &&
+      other.namespace == namespace &&
+      other.name == name;
+
+  @override
+  int get hashCode => Object.hash(clusterId, namespace, name);
+}
+
+final externalSecretDetailProvider = FutureProvider.autoDispose
+    .family<ExternalSecret, ExternalSecretDetailKey>((ref, key) async {
+  ref.watch(activeClusterProvider);
+  final cancel = CancelToken();
+  ref.onDispose(() {
+    if (!cancel.isCancelled) cancel.cancel('externalsecret detail invalidated');
+  });
+  return ref.read(esoRepositoryProvider).getExternalSecret(
+        namespace: key.namespace,
+        name: key.name,
+        clusterIdOverride: key.clusterId,
+        cancelToken: cancel,
+      );
+});
+
+final clusterExternalSecretListProvider = FutureProvider.autoDispose
+    .family<List<ClusterExternalSecret>, String>((ref, clusterId) async {
+  ref.watch(activeClusterProvider);
+  final cancel = CancelToken();
+  ref.onDispose(() {
+    if (!cancel.isCancelled) cancel.cancel('CES list invalidated');
+  });
+  return ref.read(esoRepositoryProvider).listClusterExternalSecrets(
+        clusterIdOverride: clusterId,
+        cancelToken: cancel,
+      );
+});
+
+class ClusterExternalSecretDetailKey {
+  const ClusterExternalSecretDetailKey({
+    required this.clusterId,
+    required this.name,
+  });
+
+  final String clusterId;
+  final String name;
+
+  @override
+  bool operator ==(Object other) =>
+      other is ClusterExternalSecretDetailKey &&
+      other.clusterId == clusterId &&
+      other.name == name;
+
+  @override
+  int get hashCode => Object.hash(clusterId, name);
+}
+
+final clusterExternalSecretDetailProvider = FutureProvider.autoDispose.family<
+    ClusterExternalSecret, ClusterExternalSecretDetailKey>((ref, key) async {
+  ref.watch(activeClusterProvider);
+  final cancel = CancelToken();
+  ref.onDispose(() {
+    if (!cancel.isCancelled) cancel.cancel('CES detail invalidated');
+  });
+  return ref.read(esoRepositoryProvider).getClusterExternalSecret(
+        name: key.name,
+        clusterIdOverride: key.clusterId,
+        cancelToken: cancel,
+      );
+});
+
+/// Standalone provider for namespaced stores keyed by clusterId — this
+/// is distinct from `wizards/widgets/store_picker.dart`'s
+/// `storeListProvider` (which pairs namespaced + cluster lists into a
+/// `_StoreLists` struct for the picker dropdown). PR-4h's read-side
+/// screens need separate stream slots per scope, so they don't share
+/// the picker's combined family.
+final storesListProvider = FutureProvider.autoDispose
+    .family<List<SecretStore>, String>((ref, clusterId) async {
+  ref.watch(activeClusterProvider);
+  final cancel = CancelToken();
+  ref.onDispose(() {
+    if (!cancel.isCancelled) cancel.cancel('stores list invalidated');
+  });
+  return ref.read(esoRepositoryProvider).listStores(
+        clusterIdOverride: clusterId,
+        cancelToken: cancel,
+      );
+});
+
+class StoreDetailKey {
+  const StoreDetailKey({
+    required this.clusterId,
+    required this.namespace,
+    required this.name,
+  });
+
+  final String clusterId;
+  final String namespace;
+  final String name;
+
+  @override
+  bool operator ==(Object other) =>
+      other is StoreDetailKey &&
+      other.clusterId == clusterId &&
+      other.namespace == namespace &&
+      other.name == name;
+
+  @override
+  int get hashCode => Object.hash(clusterId, namespace, name);
+}
+
+final storeDetailProvider = FutureProvider.autoDispose
+    .family<SecretStore, StoreDetailKey>((ref, key) async {
+  ref.watch(activeClusterProvider);
+  final cancel = CancelToken();
+  ref.onDispose(() {
+    if (!cancel.isCancelled) cancel.cancel('store detail invalidated');
+  });
+  return ref.read(esoRepositoryProvider).getStore(
+        namespace: key.namespace,
+        name: key.name,
+        clusterIdOverride: key.clusterId,
+        cancelToken: cancel,
+      );
+});
+
+final clusterStoresListProvider = FutureProvider.autoDispose
+    .family<List<SecretStore>, String>((ref, clusterId) async {
+  ref.watch(activeClusterProvider);
+  final cancel = CancelToken();
+  ref.onDispose(() {
+    if (!cancel.isCancelled) cancel.cancel('cluster stores list invalidated');
+  });
+  return ref.read(esoRepositoryProvider).listClusterStores(
+        clusterIdOverride: clusterId,
+        cancelToken: cancel,
+      );
+});
+
+class ClusterStoreDetailKey {
+  const ClusterStoreDetailKey({required this.clusterId, required this.name});
+
+  final String clusterId;
+  final String name;
+
+  @override
+  bool operator ==(Object other) =>
+      other is ClusterStoreDetailKey &&
+      other.clusterId == clusterId &&
+      other.name == name;
+
+  @override
+  int get hashCode => Object.hash(clusterId, name);
+}
+
+final clusterStoreDetailProvider = FutureProvider.autoDispose
+    .family<SecretStore, ClusterStoreDetailKey>((ref, key) async {
+  ref.watch(activeClusterProvider);
+  final cancel = CancelToken();
+  ref.onDispose(() {
+    if (!cancel.isCancelled) cancel.cancel('cluster store detail invalidated');
+  });
+  return ref.read(esoRepositoryProvider).getClusterStore(
+        name: key.name,
+        clusterIdOverride: key.clusterId,
+        cancelToken: cancel,
+      );
+});
+
+/// Metrics family — same key shape as the store detail key so the
+/// detail screen can fetch detail + metrics in parallel without a
+/// shared key class.
+final storeMetricsProvider = FutureProvider.autoDispose
+    .family<StoreMetrics, StoreDetailKey>((ref, key) async {
+  ref.watch(activeClusterProvider);
+  final cancel = CancelToken();
+  ref.onDispose(() {
+    if (!cancel.isCancelled) cancel.cancel('store metrics invalidated');
+  });
+  return ref.read(esoRepositoryProvider).getStoreMetrics(
+        namespace: key.namespace,
+        name: key.name,
+        clusterIdOverride: key.clusterId,
+        cancelToken: cancel,
+      );
+});
+
+final clusterStoreMetricsProvider = FutureProvider.autoDispose
+    .family<StoreMetrics, ClusterStoreDetailKey>((ref, key) async {
+  ref.watch(activeClusterProvider);
+  final cancel = CancelToken();
+  ref.onDispose(() {
+    if (!cancel.isCancelled) cancel.cancel('cluster store metrics invalidated');
+  });
+  return ref.read(esoRepositoryProvider).getClusterStoreMetrics(
+        name: key.name,
+        clusterIdOverride: key.clusterId,
+        cancelToken: cancel,
+      );
+});
+
+final pushSecretListProvider = FutureProvider.autoDispose
+    .family<List<PushSecret>, ExternalSecretListKey>((ref, key) async {
+  ref.watch(activeClusterProvider);
+  final cancel = CancelToken();
+  ref.onDispose(() {
+    if (!cancel.isCancelled) cancel.cancel('pushsecret list invalidated');
+  });
+  return ref.read(esoRepositoryProvider).listPushSecrets(
+        namespace: key.namespace,
+        clusterIdOverride: key.clusterId,
+        cancelToken: cancel,
+      );
+});
+
+class PushSecretDetailKey {
+  const PushSecretDetailKey({
+    required this.clusterId,
+    required this.namespace,
+    required this.name,
+  });
+
+  final String clusterId;
+  final String namespace;
+  final String name;
+
+  @override
+  bool operator ==(Object other) =>
+      other is PushSecretDetailKey &&
+      other.clusterId == clusterId &&
+      other.namespace == namespace &&
+      other.name == name;
+
+  @override
+  int get hashCode => Object.hash(clusterId, namespace, name);
+}
+
+final pushSecretDetailProvider = FutureProvider.autoDispose
+    .family<PushSecret, PushSecretDetailKey>((ref, key) async {
+  ref.watch(activeClusterProvider);
+  final cancel = CancelToken();
+  ref.onDispose(() {
+    if (!cancel.isCancelled) cancel.cancel('pushsecret detail invalidated');
+  });
+  return ref.read(esoRepositoryProvider).getPushSecret(
+        namespace: key.namespace,
+        name: key.name,
+        clusterIdOverride: key.clusterId,
+        cancelToken: cancel,
+      );
+});

--- a/mobile/lib/features/eso/cluster_external_secret_detail_screen.dart
+++ b/mobile/lib/features/eso/cluster_external_secret_detail_screen.dart
@@ -6,11 +6,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../api/api_error.dart';
 import '../../api/eso_repository.dart';
 import '../../cluster/cluster_provider.dart';
 import '../../theme/kube_theme_builder.dart';
-import '../../widgets/empty_states.dart';
 import 'eso_widgets.dart';
 
 class ClusterExternalSecretDetailScreen extends ConsumerWidget {
@@ -41,8 +39,8 @@ class ClusterExternalSecretDetailScreen extends ConsumerWidget {
       ),
       body: async.when(
         loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => ErrorStateView(
-          message: e is ApiError ? e.message : e.toString(),
+        error: (e, _) => esoDetailErrorState(
+          error: e,
           onRetry: () =>
               ref.invalidate(clusterExternalSecretDetailProvider(key)),
         ),
@@ -68,7 +66,7 @@ class _Body extends StatelessWidget {
         _AttributesCard(ces: ces, colors: colors),
         if (ces.readyMessage != null && ces.readyMessage!.isNotEmpty) ...[
           const SizedBox(height: 12),
-          _ReadyMessageCard(
+          EsoReadyMessageCard(
             reason: ces.readyReason,
             message: ces.readyMessage!,
             colors: colors,
@@ -158,45 +156,6 @@ class _AttributesCard extends StatelessWidget {
             EsoKvRow(label: 'Refresh interval', value: ces.refreshInterval!),
           if (ces.externalSecretBaseName != null)
             EsoKvRow(label: 'Child base name', value: ces.externalSecretBaseName!),
-        ],
-      ),
-    );
-  }
-}
-
-class _ReadyMessageCard extends StatelessWidget {
-  const _ReadyMessageCard({
-    required this.reason,
-    required this.message,
-    required this.colors,
-  });
-
-  final String? reason;
-  final String message;
-  final KubeColors colors;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.all(14),
-      decoration: BoxDecoration(
-        color: colors.bgSurface,
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: colors.borderSubtle),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            reason ?? 'Status detail',
-            style: TextStyle(
-              color: colors.textPrimary,
-              fontSize: 14,
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-          const SizedBox(height: 6),
-          Text(message, style: TextStyle(color: colors.textSecondary)),
         ],
       ),
     );

--- a/mobile/lib/features/eso/cluster_external_secret_detail_screen.dart
+++ b/mobile/lib/features/eso/cluster_external_secret_detail_screen.dart
@@ -1,0 +1,261 @@
+// ClusterExternalSecret detail — cluster-scoped fan-out. Renders the
+// store reference, the resolved namespace strategy (selector vs static
+// list), provisioned + failed namespace chips, and the generated child
+// ES base name.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../api/api_error.dart';
+import '../../api/eso_repository.dart';
+import '../../cluster/cluster_provider.dart';
+import '../../theme/kube_theme_builder.dart';
+import '../../widgets/empty_states.dart';
+import 'eso_widgets.dart';
+
+class ClusterExternalSecretDetailScreen extends ConsumerWidget {
+  const ClusterExternalSecretDetailScreen({super.key, required this.name});
+
+  final String name;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final clusterId = ref.watch(activeClusterProvider);
+    final key = ClusterExternalSecretDetailKey(
+      clusterId: clusterId,
+      name: name,
+    );
+    final async = ref.watch(clusterExternalSecretDetailProvider(key));
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(name),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            tooltip: 'Refresh',
+            onPressed: () =>
+                ref.invalidate(clusterExternalSecretDetailProvider(key)),
+          ),
+        ],
+      ),
+      body: async.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => ErrorStateView(
+          message: e is ApiError ? e.message : e.toString(),
+          onRetry: () =>
+              ref.invalidate(clusterExternalSecretDetailProvider(key)),
+        ),
+        data: (ces) => _Body(ces: ces),
+      ),
+    );
+  }
+}
+
+class _Body extends StatelessWidget {
+  const _Body({required this.ces});
+
+  final ClusterExternalSecret ces;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return ListView(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      children: [
+        _HeaderCard(ces: ces, colors: colors),
+        const SizedBox(height: 12),
+        _AttributesCard(ces: ces, colors: colors),
+        if (ces.readyMessage != null && ces.readyMessage!.isNotEmpty) ...[
+          const SizedBox(height: 12),
+          _ReadyMessageCard(
+            reason: ces.readyReason,
+            message: ces.readyMessage!,
+            colors: colors,
+          ),
+        ],
+        const SizedBox(height: 12),
+        _NamespacesCard(ces: ces, colors: colors),
+      ],
+    );
+  }
+}
+
+class _HeaderCard extends StatelessWidget {
+  const _HeaderCard({required this.ces, required this.colors});
+
+  final ClusterExternalSecret ces;
+  final KubeColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: colors.bgSurface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colors.borderSubtle),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              EsoStatusPill(status: ces.status),
+              const SizedBox(width: 8),
+              Text(
+                'Cluster scope',
+                style: TextStyle(color: colors.textMuted, fontSize: 11),
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          Text(
+            ces.name,
+            style: TextStyle(
+              color: colors.textPrimary,
+              fontSize: 18,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AttributesCard extends StatelessWidget {
+  const _AttributesCard({required this.ces, required this.colors});
+
+  final ClusterExternalSecret ces;
+  final KubeColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: colors.bgSurface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colors.borderSubtle),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Configuration',
+            style: TextStyle(
+              color: colors.textPrimary,
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 8),
+          EsoKvRow(label: 'Store', value: '${ces.storeRef.kind} / ${ces.storeRef.name}'),
+          if (ces.targetSecretName != null)
+            EsoKvRow(label: 'Target secret', value: ces.targetSecretName!),
+          if (ces.refreshInterval != null)
+            EsoKvRow(label: 'Refresh interval', value: ces.refreshInterval!),
+          if (ces.externalSecretBaseName != null)
+            EsoKvRow(label: 'Child base name', value: ces.externalSecretBaseName!),
+        ],
+      ),
+    );
+  }
+}
+
+class _ReadyMessageCard extends StatelessWidget {
+  const _ReadyMessageCard({
+    required this.reason,
+    required this.message,
+    required this.colors,
+  });
+
+  final String? reason;
+  final String message;
+  final KubeColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: colors.bgSurface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colors.borderSubtle),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            reason ?? 'Status detail',
+            style: TextStyle(
+              color: colors.textPrimary,
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(message, style: TextStyle(color: colors.textSecondary)),
+        ],
+      ),
+    );
+  }
+}
+
+class _NamespacesCard extends StatelessWidget {
+  const _NamespacesCard({required this.ces, required this.colors});
+
+  final ClusterExternalSecret ces;
+  final KubeColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: colors.bgSurface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colors.borderSubtle),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Namespaces',
+            style: TextStyle(
+              color: colors.textPrimary,
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 4),
+          ChipStrip(label: 'Selectors', items: ces.namespaceSelectors),
+          ChipStrip(label: 'Static list', items: ces.namespaces),
+          ChipStrip(
+            label: 'Provisioned',
+            items: ces.provisionedNamespaces,
+            foreground: colors.success,
+          ),
+          ChipStrip(
+            label: 'Failed',
+            items: ces.failedNamespaces,
+            foreground: colors.error,
+          ),
+          if (ces.namespaceSelectors.isEmpty &&
+              ces.namespaces.isEmpty &&
+              ces.provisionedNamespaces.isEmpty &&
+              ces.failedNamespaces.isEmpty)
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8),
+              child: Text(
+                'No namespaces resolved yet — controller may not have run, '
+                'or the selector matches nothing.',
+                style: TextStyle(color: colors.textMuted, fontSize: 12),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/eso/cluster_external_secrets_list_screen.dart
+++ b/mobile/lib/features/eso/cluster_external_secrets_list_screen.dart
@@ -1,0 +1,170 @@
+// ClusterExternalSecrets list — cluster-scoped fan-out form. Backend
+// returns an empty list when the impersonated user lacks
+// `list clusterexternalsecrets`, so non-admin operators see a clean
+// "no entries" state rather than a 403 toast.
+//
+// Drift is intentionally absent here — the backend doesn't track
+// drift on cluster-scoped variants (it's a property of each fanned-out
+// child ES, not the parent CES).
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../api/api_error.dart';
+import '../../api/eso_repository.dart';
+import '../../cluster/cluster_provider.dart';
+import '../../theme/kube_theme_builder.dart';
+import '../../widgets/empty_states.dart';
+import '../../widgets/feature_unavailable_state.dart';
+import 'eso_widgets.dart';
+
+class ClusterExternalSecretsListScreen extends ConsumerWidget {
+  const ClusterExternalSecretsListScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final clusterId = ref.watch(activeClusterProvider);
+    final statusAsync = ref.watch(esoStatusProvider(clusterId));
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('ClusterExternalSecrets')),
+      body: statusAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => ErrorStateView(
+          message: e is ApiError ? e.message : e.toString(),
+          onRetry: () => ref.invalidate(esoStatusProvider(clusterId)),
+        ),
+        data: (status) {
+          if (!status.detected) return FeatureUnavailableState.eso();
+          return _ListBody(clusterId: clusterId);
+        },
+      ),
+    );
+  }
+}
+
+class _ListBody extends ConsumerWidget {
+  const _ListBody({required this.clusterId});
+
+  final String clusterId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final async = ref.watch(clusterExternalSecretListProvider(clusterId));
+
+    Future<void> handleRefresh() async {
+      ref.invalidate(clusterExternalSecretListProvider(clusterId));
+      try {
+        await ref.read(clusterExternalSecretListProvider(clusterId).future);
+      } on Object {/* surfaces via .when */}
+    }
+
+    return RefreshIndicator(
+      onRefresh: handleRefresh,
+      child: async.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => ListErrorShell(
+          title: 'Failed to load ClusterExternalSecrets',
+          error: e,
+          onRetry: handleRefresh,
+        ),
+        data: (items) {
+          if (items.isEmpty) {
+            return ListView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              children: [
+                SizedBox(
+                  height: 280,
+                  child: Center(
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 32),
+                      child: Text(
+                        'No ClusterExternalSecrets visible. They are cluster-'
+                        'scoped — your account may need broader permissions, '
+                        'or none exist on this cluster.',
+                        style: TextStyle(color: colors.textMuted),
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            );
+          }
+          return ListView.builder(
+            physics: const AlwaysScrollableScrollPhysics(),
+            itemCount: items.length,
+            itemBuilder: (context, i) => _CesRow(
+              ces: items[i],
+              onTap: () => context.push(
+                '/clusters/$clusterId/eso/cluster-externalsecrets/'
+                '${Uri.encodeComponent(items[i].name)}',
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _CesRow extends StatelessWidget {
+  const _CesRow({required this.ces, required this.onTap});
+
+  final ClusterExternalSecret ces;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final nsCount = ces.namespaces.length + ces.provisionedNamespaces.length;
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    ces.name,
+                    style: TextStyle(
+                      color: colors.textPrimary,
+                      fontSize: 15,
+                      fontWeight: FontWeight.w600,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                EsoStatusPill(status: ces.status, dense: true),
+              ],
+            ),
+            const SizedBox(height: 4),
+            Text(
+              '${ces.storeRef.kind}/${ces.storeRef.name}',
+              style: TextStyle(color: colors.textSecondary, fontSize: 12),
+              overflow: TextOverflow.ellipsis,
+            ),
+            if (nsCount > 0) ...[
+              const SizedBox(height: 2),
+              Text(
+                '$nsCount namespace${nsCount == 1 ? '' : 's'}'
+                "${ces.failedNamespaces.isEmpty ? '' : '  ·  ${ces.failedNamespaces.length} failed'}",
+                style: TextStyle(
+                  color: ces.failedNamespaces.isEmpty
+                      ? colors.textMuted
+                      : colors.warning,
+                  fontSize: 11,
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/eso/cluster_external_secrets_list_screen.dart
+++ b/mobile/lib/features/eso/cluster_external_secrets_list_screen.dart
@@ -11,64 +11,62 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../api/api_error.dart';
 import '../../api/eso_repository.dart';
-import '../../cluster/cluster_provider.dart';
 import '../../theme/kube_theme_builder.dart';
 import '../../widgets/empty_states.dart';
-import '../../widgets/feature_unavailable_state.dart';
+import '../../widgets/refresh_guard.dart';
 import 'eso_widgets.dart';
 
-class ClusterExternalSecretsListScreen extends ConsumerWidget {
+class ClusterExternalSecretsListScreen extends StatelessWidget {
   const ClusterExternalSecretsListScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final clusterId = ref.watch(activeClusterProvider);
-    final statusAsync = ref.watch(esoStatusProvider(clusterId));
-
+  Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('ClusterExternalSecrets')),
-      body: statusAsync.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => ErrorStateView(
-          message: e is ApiError ? e.message : e.toString(),
-          onRetry: () => ref.invalidate(esoStatusProvider(clusterId)),
-        ),
-        data: (status) {
-          if (!status.detected) return FeatureUnavailableState.eso();
-          return _ListBody(clusterId: clusterId);
-        },
+      body: EsoStatusGate(
+        builder: (clusterId) => _ListBody(clusterId: clusterId),
       ),
     );
   }
 }
 
-class _ListBody extends ConsumerWidget {
+class _ListBody extends ConsumerStatefulWidget {
   const _ListBody({required this.clusterId});
 
   final String clusterId;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final colors = Theme.of(context).extension<KubeColors>()!;
-    final async = ref.watch(clusterExternalSecretListProvider(clusterId));
+  ConsumerState<_ListBody> createState() => _ListBodyState();
+}
 
-    Future<void> handleRefresh() async {
-      ref.invalidate(clusterExternalSecretListProvider(clusterId));
-      try {
-        await ref.read(clusterExternalSecretListProvider(clusterId).future);
-      } on Object {/* surfaces via .when */}
-    }
+class _ListBodyState extends ConsumerState<_ListBody>
+    with RefreshGuardMixin {
+  Future<void> _handleRefresh() => guardedRefresh(() async {
+        ref.invalidate(
+          clusterExternalSecretListProvider(widget.clusterId),
+        );
+        try {
+          await ref.read(
+            clusterExternalSecretListProvider(widget.clusterId).future,
+          );
+        } on Object {/* surfaces via .when */}
+      });
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final async =
+        ref.watch(clusterExternalSecretListProvider(widget.clusterId));
 
     return RefreshIndicator(
-      onRefresh: handleRefresh,
+      onRefresh: _handleRefresh,
       child: async.when(
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (e, _) => ListErrorShell(
           title: 'Failed to load ClusterExternalSecrets',
           error: e,
-          onRetry: handleRefresh,
+          onRetry: _handleRefresh,
         ),
         data: (items) {
           if (items.isEmpty) {
@@ -99,7 +97,7 @@ class _ListBody extends ConsumerWidget {
             itemBuilder: (context, i) => _CesRow(
               ces: items[i],
               onTap: () => context.push(
-                '/clusters/$clusterId/eso/cluster-externalsecrets/'
+                '/clusters/${widget.clusterId}/eso/cluster-externalsecrets/'
                 '${Uri.encodeComponent(items[i].name)}',
               ),
             ),
@@ -119,7 +117,11 @@ class _CesRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = Theme.of(context).extension<KubeColors>()!;
-    final nsCount = ces.namespaces.length + ces.provisionedNamespaces.length;
+    // Dedupe: a namespace can appear in both the configured `namespaces`
+    // list and `provisionedNamespaces` once the controller has reconciled.
+    // Set-union prevents the "12 namespaces" badge from inflating to 24.
+    final nsCount =
+        {...ces.namespaces, ...ces.provisionedNamespaces}.length;
     return InkWell(
       onTap: onTap,
       child: Padding(

--- a/mobile/lib/features/eso/cluster_stores_list_screen.dart
+++ b/mobile/lib/features/eso/cluster_stores_list_screen.dart
@@ -1,0 +1,163 @@
+// ClusterSecretStores list — cluster-scoped variant of the SecretStore
+// list. Same row shape as the namespaced screen, minus the namespace
+// label.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../api/api_error.dart';
+import '../../api/eso_repository.dart';
+import '../../cluster/cluster_provider.dart';
+import '../../theme/kube_theme_builder.dart';
+import '../../widgets/empty_states.dart';
+import '../../widgets/feature_unavailable_state.dart';
+import 'eso_widgets.dart';
+
+class ClusterStoresListScreen extends ConsumerWidget {
+  const ClusterStoresListScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final clusterId = ref.watch(activeClusterProvider);
+    final statusAsync = ref.watch(esoStatusProvider(clusterId));
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('ClusterSecretStores')),
+      body: statusAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => ErrorStateView(
+          message: e is ApiError ? e.message : e.toString(),
+          onRetry: () => ref.invalidate(esoStatusProvider(clusterId)),
+        ),
+        data: (status) {
+          if (!status.detected) return FeatureUnavailableState.eso();
+          return _ListBody(clusterId: clusterId);
+        },
+      ),
+    );
+  }
+}
+
+class _ListBody extends ConsumerWidget {
+  const _ListBody({required this.clusterId});
+
+  final String clusterId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final async = ref.watch(clusterStoresListProvider(clusterId));
+
+    Future<void> handleRefresh() async {
+      ref.invalidate(clusterStoresListProvider(clusterId));
+      try {
+        await ref.read(clusterStoresListProvider(clusterId).future);
+      } on Object {/* surfaces via .when */}
+    }
+
+    return RefreshIndicator(
+      onRefresh: handleRefresh,
+      child: async.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => ListErrorShell(
+          title: 'Failed to load ClusterSecretStores',
+          error: e,
+          onRetry: handleRefresh,
+        ),
+        data: (items) {
+          if (items.isEmpty) {
+            return ListView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              children: [
+                SizedBox(
+                  height: 280,
+                  child: Center(
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 32),
+                      child: Text(
+                        'No ClusterSecretStores visible. They are cluster-'
+                        'scoped — your account may need broader permissions, '
+                        'or none exist on this cluster.',
+                        style: TextStyle(color: colors.textMuted),
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            );
+          }
+          return ListView.builder(
+            physics: const AlwaysScrollableScrollPhysics(),
+            itemCount: items.length,
+            itemBuilder: (context, i) => _StoreRow(
+              store: items[i],
+              onTap: () => context.push(
+                '/clusters/$clusterId/eso/cluster-stores/'
+                '${Uri.encodeComponent(items[i].name)}',
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _StoreRow extends StatelessWidget {
+  const _StoreRow({required this.store, required this.onTap});
+
+  final SecretStore store;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  Icons.public_outlined,
+                  size: 16,
+                  color: colors.accent,
+                ),
+                const SizedBox(width: 6),
+                Expanded(
+                  child: Text(
+                    store.name,
+                    style: TextStyle(
+                      color: colors.textPrimary,
+                      fontSize: 15,
+                      fontWeight: FontWeight.w600,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                EsoStatusPill(status: store.status, dense: true),
+              ],
+            ),
+            const SizedBox(height: 4),
+            ProviderChip(provider: store.provider),
+            if (store.readyMessage != null && store.readyMessage!.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 4),
+                child: Text(
+                  store.readyMessage!,
+                  style: TextStyle(color: colors.textMuted, fontSize: 11),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/eso/cluster_stores_list_screen.dart
+++ b/mobile/lib/features/eso/cluster_stores_list_screen.dart
@@ -6,64 +6,59 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../api/api_error.dart';
 import '../../api/eso_repository.dart';
-import '../../cluster/cluster_provider.dart';
 import '../../theme/kube_theme_builder.dart';
 import '../../widgets/empty_states.dart';
-import '../../widgets/feature_unavailable_state.dart';
+import '../../widgets/refresh_guard.dart';
 import 'eso_widgets.dart';
 
-class ClusterStoresListScreen extends ConsumerWidget {
+class ClusterStoresListScreen extends StatelessWidget {
   const ClusterStoresListScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final clusterId = ref.watch(activeClusterProvider);
-    final statusAsync = ref.watch(esoStatusProvider(clusterId));
-
+  Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('ClusterSecretStores')),
-      body: statusAsync.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => ErrorStateView(
-          message: e is ApiError ? e.message : e.toString(),
-          onRetry: () => ref.invalidate(esoStatusProvider(clusterId)),
-        ),
-        data: (status) {
-          if (!status.detected) return FeatureUnavailableState.eso();
-          return _ListBody(clusterId: clusterId);
-        },
+      body: EsoStatusGate(
+        builder: (clusterId) => _ListBody(clusterId: clusterId),
       ),
     );
   }
 }
 
-class _ListBody extends ConsumerWidget {
+class _ListBody extends ConsumerStatefulWidget {
   const _ListBody({required this.clusterId});
 
   final String clusterId;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final colors = Theme.of(context).extension<KubeColors>()!;
-    final async = ref.watch(clusterStoresListProvider(clusterId));
+  ConsumerState<_ListBody> createState() => _ListBodyState();
+}
 
-    Future<void> handleRefresh() async {
-      ref.invalidate(clusterStoresListProvider(clusterId));
-      try {
-        await ref.read(clusterStoresListProvider(clusterId).future);
-      } on Object {/* surfaces via .when */}
-    }
+class _ListBodyState extends ConsumerState<_ListBody>
+    with RefreshGuardMixin {
+  Future<void> _handleRefresh() => guardedRefresh(() async {
+        ref.invalidate(clusterStoresListProvider(widget.clusterId));
+        try {
+          await ref.read(
+            clusterStoresListProvider(widget.clusterId).future,
+          );
+        } on Object {/* surfaces via .when */}
+      });
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final async = ref.watch(clusterStoresListProvider(widget.clusterId));
 
     return RefreshIndicator(
-      onRefresh: handleRefresh,
+      onRefresh: _handleRefresh,
       child: async.when(
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (e, _) => ListErrorShell(
           title: 'Failed to load ClusterSecretStores',
           error: e,
-          onRetry: handleRefresh,
+          onRetry: _handleRefresh,
         ),
         data: (items) {
           if (items.isEmpty) {
@@ -94,7 +89,7 @@ class _ListBody extends ConsumerWidget {
             itemBuilder: (context, i) => _StoreRow(
               store: items[i],
               onTap: () => context.push(
-                '/clusters/$clusterId/eso/cluster-stores/'
+                '/clusters/${widget.clusterId}/eso/cluster-stores/'
                 '${Uri.encodeComponent(items[i].name)}',
               ),
             ),

--- a/mobile/lib/features/eso/dashboard_screen.dart
+++ b/mobile/lib/features/eso/dashboard_screen.dart
@@ -13,76 +13,80 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../api/api_error.dart';
 import '../../api/eso_repository.dart';
-import '../../cluster/cluster_provider.dart';
 import '../../theme/kube_theme_builder.dart';
 import '../../widgets/empty_states.dart';
-import '../../widgets/feature_unavailable_state.dart';
 import '../../widgets/kube_gauge_ring.dart';
 import '../../widgets/kube_line_chart.dart' show KubeChartSeverity;
+import '../../widgets/refresh_guard.dart';
 import 'eso_widgets.dart';
 
-class EsoDashboardScreen extends ConsumerWidget {
+class EsoDashboardScreen extends StatelessWidget {
   const EsoDashboardScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final clusterId = ref.watch(activeClusterProvider);
-    final statusAsync = ref.watch(esoStatusProvider(clusterId));
-
+  Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('External Secrets')),
-      body: statusAsync.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => ErrorStateView(
-          message: e is ApiError ? e.message : e.toString(),
-          onRetry: () => ref.invalidate(esoStatusProvider(clusterId)),
-        ),
-        data: (status) {
-          if (!status.detected) return FeatureUnavailableState.eso();
-          return _DashboardBody(clusterId: clusterId);
-        },
+      body: EsoStatusGate(
+        builder: (clusterId) => _DashboardBody(clusterId: clusterId),
       ),
     );
   }
 }
 
-class _DashboardBody extends ConsumerWidget {
+class _DashboardBody extends ConsumerStatefulWidget {
   const _DashboardBody({required this.clusterId});
 
   final String clusterId;
 
+  @override
+  ConsumerState<_DashboardBody> createState() => _DashboardBodyState();
+}
+
+class _DashboardBodyState extends ConsumerState<_DashboardBody>
+    with RefreshGuardMixin {
   ExternalSecretListKey get _listKey =>
-      ExternalSecretListKey(clusterId: clusterId);
+      ExternalSecretListKey(clusterId: widget.clusterId);
+
+  // Refresh entry point shared by the RefreshIndicator pull-down and the
+  // ListErrorShell retry. The guard collapses a second concurrent call
+  // into the in-flight future so rapid pulls don't race two
+  // invalidate+fetch cycles against the same provider slot.
+  Future<void> _handleRefresh() => guardedRefresh(() async {
+        ref.invalidate(externalSecretListProvider(_listKey));
+        ref.invalidate(storesListProvider(widget.clusterId));
+        ref.invalidate(clusterStoresListProvider(widget.clusterId));
+        try {
+          // Wait for all three so the RefreshIndicator stays visible
+          // until the slowest of them resolves; the ES list is the only
+          // one we surface errors for via .when.
+          await Future.wait([
+            ref.read(externalSecretListProvider(_listKey).future),
+            ref.read(storesListProvider(widget.clusterId).future),
+            ref.read(clusterStoresListProvider(widget.clusterId).future),
+          ]);
+        } on Object {
+          // Surfaces via .when error branch.
+        }
+      });
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     final colors = Theme.of(context).extension<KubeColors>()!;
     final esAsync = ref.watch(externalSecretListProvider(_listKey));
 
-    Future<void> handleRefresh() async {
-      ref.invalidate(externalSecretListProvider(_listKey));
-      ref.invalidate(storesListProvider(clusterId));
-      ref.invalidate(clusterStoresListProvider(clusterId));
-      try {
-        await ref.read(externalSecretListProvider(_listKey).future);
-      } on Object {
-        // Surfaces via .when error branch.
-      }
-    }
-
     return RefreshIndicator(
-      onRefresh: handleRefresh,
+      onRefresh: _handleRefresh,
       child: esAsync.when(
         loading: () => const _ScrollableShell(child: LoadingState()),
         error: (e, _) => ListErrorShell(
           title: 'Failed to load ExternalSecrets',
           error: e,
-          onRetry: handleRefresh,
+          onRetry: _handleRefresh,
         ),
         data: (items) => _DashboardContent(
-          clusterId: clusterId,
+          clusterId: widget.clusterId,
           items: items,
           colors: colors,
         ),
@@ -127,9 +131,17 @@ class _DashboardContent extends StatelessWidget {
     // distinct and shouldn't double-count here. (The web dashboard
     // tracks drift Unknown in the gauge subtitle rather than a card.)
     final unknown = counts[EsoStatus.unknown] ?? 0;
+    final refreshing = counts[EsoStatus.refreshing] ?? 0;
 
-    final pct = total > 0 ? synced / total : 0.0;
-    final severity = total == 0
+    // Refreshing is a transient state (30-60s during controller restart
+    // / reconcile). Excluding it from the gauge denominator avoids a
+    // fleet-wide red dashboard during routine reconciles — the operator
+    // sees the actual error rate among items that have a settled state.
+    // The hero label still reflects total fleet size; only the
+    // percentage and severity colour use the settled subset.
+    final settled = total - refreshing;
+    final pct = settled > 0 ? synced / settled : 1.0;
+    final severity = total == 0 || settled == 0
         ? KubeChartSeverity.info
         : (pct >= 0.95
             ? KubeChartSeverity.success
@@ -375,7 +387,7 @@ class _FailureTable extends StatelessWidget {
             if (i > 0) Divider(color: colors.borderSubtle, height: 1),
             _FailureRow(
               clusterId: clusterId,
-              cert: broken[i],
+              es: broken[i],
               colors: colors,
             ),
           ],
@@ -396,12 +408,12 @@ class _FailureTable extends StatelessWidget {
 class _FailureRow extends StatelessWidget {
   const _FailureRow({
     required this.clusterId,
-    required this.cert,
+    required this.es,
     required this.colors,
   });
 
   final String clusterId;
-  final ExternalSecret cert;
+  final ExternalSecret es;
   final KubeColors colors;
 
   @override
@@ -409,8 +421,8 @@ class _FailureRow extends StatelessWidget {
     return InkWell(
       onTap: () => context.push(
         '/clusters/$clusterId/eso/externalsecrets/'
-        '${Uri.encodeComponent(cert.namespace)}/'
-        '${Uri.encodeComponent(cert.name)}',
+        '${Uri.encodeComponent(es.namespace)}/'
+        '${Uri.encodeComponent(es.name)}',
       ),
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
@@ -421,7 +433,7 @@ class _FailureRow extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Text(
-                    cert.name,
+                    es.name,
                     style: TextStyle(
                       color: colors.textPrimary,
                       fontSize: 13,
@@ -430,19 +442,19 @@ class _FailureRow extends StatelessWidget {
                     overflow: TextOverflow.ellipsis,
                   ),
                   Text(
-                    cert.namespace,
+                    es.namespace,
                     style: TextStyle(
                       color: colors.textSecondary,
                       fontSize: 11,
                     ),
                     overflow: TextOverflow.ellipsis,
                   ),
-                  if (cert.readyMessage != null &&
-                      cert.readyMessage!.isNotEmpty)
+                  if (es.readyMessage != null &&
+                      es.readyMessage!.isNotEmpty)
                     Padding(
                       padding: const EdgeInsets.only(top: 2),
                       child: Text(
-                        cert.readyMessage!,
+                        es.readyMessage!,
                         style: TextStyle(color: colors.textMuted, fontSize: 11),
                         overflow: TextOverflow.ellipsis,
                         maxLines: 2,
@@ -452,7 +464,7 @@ class _FailureRow extends StatelessWidget {
               ),
             ),
             const SizedBox(width: 8),
-            EsoStatusPill(status: cert.status, dense: true),
+            EsoStatusPill(status: es.status, dense: true),
             const SizedBox(width: 6),
             Icon(Icons.chevron_right, size: 16, color: colors.textMuted),
           ],

--- a/mobile/lib/features/eso/dashboard_screen.dart
+++ b/mobile/lib/features/eso/dashboard_screen.dart
@@ -1,0 +1,477 @@
+// External Secrets Operator dashboard — synced/total hero gauge,
+// SyncFailed / Stale / Drifted / Unknown secondary cards, top-N
+// failure table. Mirrors `frontend/islands/ESODashboard.tsx`.
+//
+// Status gating: `esoStatusProvider` gates the surface — when ESO is
+// not detected the operator sees `FeatureUnavailableState.eso()` rather
+// than an empty dashboard. Tertiary store-breakdown row is deliberately
+// minimal at phone size (the desktop dashboard pairs provider + cost
+// tier; mobile pushes operators to the per-store metrics panel for
+// detailed numbers).
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../api/api_error.dart';
+import '../../api/eso_repository.dart';
+import '../../cluster/cluster_provider.dart';
+import '../../theme/kube_theme_builder.dart';
+import '../../widgets/empty_states.dart';
+import '../../widgets/feature_unavailable_state.dart';
+import '../../widgets/kube_gauge_ring.dart';
+import '../../widgets/kube_line_chart.dart' show KubeChartSeverity;
+import 'eso_widgets.dart';
+
+class EsoDashboardScreen extends ConsumerWidget {
+  const EsoDashboardScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final clusterId = ref.watch(activeClusterProvider);
+    final statusAsync = ref.watch(esoStatusProvider(clusterId));
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('External Secrets')),
+      body: statusAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => ErrorStateView(
+          message: e is ApiError ? e.message : e.toString(),
+          onRetry: () => ref.invalidate(esoStatusProvider(clusterId)),
+        ),
+        data: (status) {
+          if (!status.detected) return FeatureUnavailableState.eso();
+          return _DashboardBody(clusterId: clusterId);
+        },
+      ),
+    );
+  }
+}
+
+class _DashboardBody extends ConsumerWidget {
+  const _DashboardBody({required this.clusterId});
+
+  final String clusterId;
+
+  ExternalSecretListKey get _listKey =>
+      ExternalSecretListKey(clusterId: clusterId);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final esAsync = ref.watch(externalSecretListProvider(_listKey));
+
+    Future<void> handleRefresh() async {
+      ref.invalidate(externalSecretListProvider(_listKey));
+      ref.invalidate(storesListProvider(clusterId));
+      ref.invalidate(clusterStoresListProvider(clusterId));
+      try {
+        await ref.read(externalSecretListProvider(_listKey).future);
+      } on Object {
+        // Surfaces via .when error branch.
+      }
+    }
+
+    return RefreshIndicator(
+      onRefresh: handleRefresh,
+      child: esAsync.when(
+        loading: () => const _ScrollableShell(child: LoadingState()),
+        error: (e, _) => ListErrorShell(
+          title: 'Failed to load ExternalSecrets',
+          error: e,
+          onRetry: handleRefresh,
+        ),
+        data: (items) => _DashboardContent(
+          clusterId: clusterId,
+          items: items,
+          colors: colors,
+        ),
+      ),
+    );
+  }
+}
+
+class _DashboardContent extends StatelessWidget {
+  const _DashboardContent({
+    required this.clusterId,
+    required this.items,
+    required this.colors,
+  });
+
+  final String clusterId;
+  final List<ExternalSecret> items;
+  final KubeColors colors;
+
+  static const int _failureTableLimit = 50;
+
+  /// Severity ordering for the failure table — mirrors web's
+  /// FAILURE_SEVERITY in `ESODashboard.tsx`.
+  static int _severityRank(EsoStatus s) => switch (s) {
+        EsoStatus.syncFailed => 0,
+        EsoStatus.stale => 1,
+        EsoStatus.drifted => 2,
+        EsoStatus.unknown => 3,
+        EsoStatus.refreshing => 4,
+        EsoStatus.synced => 5,
+      };
+
+  @override
+  Widget build(BuildContext context) {
+    final total = items.length;
+    final counts = _countByStatus(items);
+    final synced = counts[EsoStatus.synced] ?? 0;
+    final syncFailed = counts[EsoStatus.syncFailed] ?? 0;
+    final stale = counts[EsoStatus.stale] ?? 0;
+    final drifted = counts[EsoStatus.drifted] ?? 0;
+    // Unknown counts ONLY the lifecycle Status — drift Unknown is
+    // distinct and shouldn't double-count here. (The web dashboard
+    // tracks drift Unknown in the gauge subtitle rather than a card.)
+    final unknown = counts[EsoStatus.unknown] ?? 0;
+
+    final pct = total > 0 ? synced / total : 0.0;
+    final severity = total == 0
+        ? KubeChartSeverity.info
+        : (pct >= 0.95
+            ? KubeChartSeverity.success
+            : (pct >= 0.8
+                ? KubeChartSeverity.warning
+                : KubeChartSeverity.error));
+
+    final broken = items
+        .where((e) =>
+            e.status != EsoStatus.synced && e.status != EsoStatus.refreshing)
+        .toList()
+      ..sort((a, b) {
+        final cmp = _severityRank(a.status).compareTo(_severityRank(b.status));
+        if (cmp != 0) return cmp;
+        final nsCmp = a.namespace.compareTo(b.namespace);
+        if (nsCmp != 0) return nsCmp;
+        return a.name.compareTo(b.name);
+      });
+
+    return ListView(
+      physics: const AlwaysScrollableScrollPhysics(),
+      padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
+      children: [
+        Center(
+          child: KubeGaugeRing(
+            percentage: pct,
+            centerLabel: '$synced / $total',
+            subtitle: 'ExternalSecrets synced',
+            severity: severity,
+            size: 160,
+          ),
+        ),
+        const SizedBox(height: 16),
+        GridView.count(
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          crossAxisCount: 2,
+          mainAxisSpacing: 8,
+          crossAxisSpacing: 8,
+          childAspectRatio: 2.4,
+          children: [
+            _SummaryCard(
+              label: 'SyncFailed',
+              count: syncFailed,
+              color: colors.error,
+              colors: colors,
+            ),
+            _SummaryCard(
+              label: 'Stale',
+              count: stale,
+              color: colors.warning,
+              colors: colors,
+            ),
+            _SummaryCard(
+              label: 'Drifted',
+              count: drifted,
+              color: colors.warning,
+              colors: colors,
+            ),
+            _SummaryCard(
+              label: 'Unknown',
+              // textMuted, NEVER red. PR-3f learnings #9 in operative
+              // form — dashboard summary mirrors the drift pill rule.
+              count: unknown,
+              color: colors.textMuted,
+              colors: colors,
+            ),
+          ],
+        ),
+        const SizedBox(height: 16),
+        _BrowseLinks(clusterId: clusterId, colors: colors),
+        const SizedBox(height: 16),
+        if (broken.isEmpty)
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 24),
+            child: Center(
+              child: Text(
+                total == 0
+                    ? 'No ExternalSecrets in this cluster yet.'
+                    : 'Every ExternalSecret is syncing cleanly.',
+                style: TextStyle(color: colors.textMuted),
+                textAlign: TextAlign.center,
+              ),
+            ),
+          )
+        else
+          _FailureTable(
+            clusterId: clusterId,
+            broken: broken.take(_failureTableLimit).toList(),
+            colors: colors,
+            truncated: broken.length > _failureTableLimit,
+          ),
+      ],
+    );
+  }
+
+  static Map<EsoStatus, int> _countByStatus(List<ExternalSecret> items) {
+    final out = <EsoStatus, int>{};
+    for (final es in items) {
+      out[es.status] = (out[es.status] ?? 0) + 1;
+    }
+    return out;
+  }
+}
+
+class _SummaryCard extends StatelessWidget {
+  const _SummaryCard({
+    required this.label,
+    required this.count,
+    required this.color,
+    required this.colors,
+  });
+
+  final String label;
+  final int count;
+  final Color color;
+  final KubeColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: colors.bgSurface,
+        borderRadius: BorderRadius.circular(6),
+        border: Border.all(color: colors.borderSubtle),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            label,
+            style: TextStyle(
+              color: colors.textMuted,
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            '$count',
+            style: TextStyle(
+              color: color,
+              fontSize: 22,
+              fontWeight: FontWeight.bold,
+              fontFeatures: const [FontFeature.tabularFigures()],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _BrowseLinks extends StatelessWidget {
+  const _BrowseLinks({required this.clusterId, required this.colors});
+
+  final String clusterId;
+  final KubeColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    Widget tile(String label, IconData icon, String path) => Expanded(
+          child: InkWell(
+            onTap: () => context.push(path),
+            child: Container(
+              padding: const EdgeInsets.symmetric(vertical: 12),
+              decoration: BoxDecoration(
+                color: colors.bgSurface,
+                borderRadius: BorderRadius.circular(6),
+                border: Border.all(color: colors.borderSubtle),
+              ),
+              child: Column(
+                children: [
+                  Icon(icon, color: colors.accent, size: 22),
+                  const SizedBox(height: 6),
+                  Text(
+                    label,
+                    style: TextStyle(
+                      color: colors.textPrimary,
+                      fontSize: 12,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+
+    return Row(
+      children: [
+        tile('ExternalSecrets', Icons.lock_open_outlined,
+            '/clusters/$clusterId/eso/externalsecrets'),
+        const SizedBox(width: 8),
+        tile('Stores', Icons.account_tree_outlined,
+            '/clusters/$clusterId/eso/stores'),
+        const SizedBox(width: 8),
+        tile('Cluster stores', Icons.public_outlined,
+            '/clusters/$clusterId/eso/cluster-stores'),
+      ],
+    );
+  }
+}
+
+class _FailureTable extends StatelessWidget {
+  const _FailureTable({
+    required this.clusterId,
+    required this.broken,
+    required this.colors,
+    required this.truncated,
+  });
+
+  final String clusterId;
+  final List<ExternalSecret> broken;
+  final KubeColors colors;
+  final bool truncated;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: colors.bgSurface,
+        borderRadius: BorderRadius.circular(6),
+        border: Border.all(color: colors.borderSubtle),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(12, 12, 12, 4),
+            child: Text(
+              'Needs attention',
+              style: TextStyle(
+                color: colors.textPrimary,
+                fontSize: 14,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+          for (var i = 0; i < broken.length; i++) ...[
+            if (i > 0) Divider(color: colors.borderSubtle, height: 1),
+            _FailureRow(
+              clusterId: clusterId,
+              cert: broken[i],
+              colors: colors,
+            ),
+          ],
+          if (truncated)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(12, 8, 12, 12),
+              child: Text(
+                'Showing the first 50 — open the full list to see more.',
+                style: TextStyle(color: colors.textMuted, fontSize: 11),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FailureRow extends StatelessWidget {
+  const _FailureRow({
+    required this.clusterId,
+    required this.cert,
+    required this.colors,
+  });
+
+  final String clusterId;
+  final ExternalSecret cert;
+  final KubeColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: () => context.push(
+        '/clusters/$clusterId/eso/externalsecrets/'
+        '${Uri.encodeComponent(cert.namespace)}/'
+        '${Uri.encodeComponent(cert.name)}',
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    cert.name,
+                    style: TextStyle(
+                      color: colors.textPrimary,
+                      fontSize: 13,
+                      fontWeight: FontWeight.w600,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  Text(
+                    cert.namespace,
+                    style: TextStyle(
+                      color: colors.textSecondary,
+                      fontSize: 11,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  if (cert.readyMessage != null &&
+                      cert.readyMessage!.isNotEmpty)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 2),
+                      child: Text(
+                        cert.readyMessage!,
+                        style: TextStyle(color: colors.textMuted, fontSize: 11),
+                        overflow: TextOverflow.ellipsis,
+                        maxLines: 2,
+                      ),
+                    ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 8),
+            EsoStatusPill(status: cert.status, dense: true),
+            const SizedBox(width: 6),
+            Icon(Icons.chevron_right, size: 16, color: colors.textMuted),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ScrollableShell extends StatelessWidget {
+  const _ScrollableShell({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      physics: const AlwaysScrollableScrollPhysics(),
+      children: [SizedBox(height: 280, child: child)],
+    );
+  }
+}

--- a/mobile/lib/features/eso/eso_widgets.dart
+++ b/mobile/lib/features/eso/eso_widgets.dart
@@ -1,0 +1,393 @@
+// Shared pill + small-widget helpers consumed by every ESO surface
+// (dashboard, lists, details, metrics panel). Keeping the pill mapping
+// in one file is what enforces R10 (web/dart isomorphism) for drift
+// tri-state colour and EsoStatus colour — a future regression where
+// `Unknown` rendered as `error` instead of `textMuted` (PR-3f learnings
+// #9) would have to land here first.
+
+import 'package:flutter/material.dart';
+
+import '../../api/eso_repository.dart';
+import '../../theme/kube_theme_builder.dart';
+
+/// Drift indicator pill. Tri-state colour mapping is the only place
+/// drift colour lives — every drift surface across PR-4h reads from
+/// here. Per R7: **`Unknown` is never red.** It means the provider
+/// doesn't populate `SyncedResourceVersion`; rendering it red would
+/// confuse operators on every ESO store backed by the Kubernetes
+/// provider (or any other provider that omits resource versions).
+class DriftPill extends StatelessWidget {
+  const DriftPill({
+    super.key,
+    required this.status,
+    this.reason = DriftUnknownReason.unspecified,
+    this.dense = false,
+  });
+
+  final DriftStatus status;
+
+  /// Only consulted when [status] is [DriftStatus.unknown]. Drives the
+  /// hover tooltip — "Provider doesn't expose resource version", "RBAC
+  /// denied", etc. — so operators know WHY drift wasn't resolvable.
+  final DriftUnknownReason reason;
+
+  /// Dense mode shrinks padding + font for embedding inside list rows
+  /// next to the resource name.
+  final bool dense;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final theme = _driftPillTheme(status, colors);
+    if (theme == null) {
+      // notObserved → render no pill at all. The list endpoint omits
+      // `lastObservedDriftStatus` when the poller has never observed
+      // this ES; rendering an "Unknown" pill in that case would
+      // contradict the wire-shape contract documented on the backend
+      // type (LastObservedDriftStatus omitempty).
+      return const SizedBox.shrink();
+    }
+    final pill = Container(
+      padding: EdgeInsets.symmetric(
+        horizontal: dense ? 6 : 8,
+        vertical: dense ? 2 : 3,
+      ),
+      decoration: BoxDecoration(
+        color: theme.background,
+        borderRadius: BorderRadius.circular(dense ? 3 : 4),
+        border: Border.all(color: theme.foreground),
+      ),
+      child: Text(
+        theme.label,
+        style: TextStyle(
+          color: theme.foreground,
+          fontSize: dense ? 10 : 11,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+    if (status == DriftStatus.unknown) {
+      return Tooltip(message: _driftUnknownTooltip(reason), child: pill);
+    }
+    return pill;
+  }
+}
+
+class _PillTheme {
+  const _PillTheme({
+    required this.label,
+    required this.foreground,
+    required this.background,
+  });
+  final String label;
+  final Color foreground;
+  final Color background;
+}
+
+/// Returns the pill theme for a drift state, or null when the caller
+/// should render nothing ([DriftStatus.notObserved]).
+_PillTheme? _driftPillTheme(DriftStatus s, KubeColors colors) {
+  switch (s) {
+    case DriftStatus.inSync:
+      return _PillTheme(
+        label: 'In sync',
+        foreground: colors.success,
+        background: colors.successDim,
+      );
+    case DriftStatus.drifted:
+      return _PillTheme(
+        label: 'Drifted',
+        foreground: colors.warning,
+        background: colors.warningDim,
+      );
+    case DriftStatus.unknown:
+      return _PillTheme(
+        label: 'Unknown',
+        foreground: colors.textMuted,
+        // Subtle background — textMuted is the "informational, not
+        // actionable" token. Mixing it with bgElevated keeps the pill
+        // recognizable without elevating its visual weight to match
+        // SyncFailed or Drifted (which ARE actionable).
+        background: colors.bgElevated,
+      );
+    case DriftStatus.notObserved:
+      return null;
+  }
+}
+
+String _driftUnknownTooltip(DriftUnknownReason r) => switch (r) {
+      DriftUnknownReason.noSyncedRv =>
+        'Provider does not populate syncedResourceVersion — drift '
+            'cannot be determined.',
+      DriftUnknownReason.noTargetName =>
+        'ExternalSecret has no target Secret name set yet.',
+      DriftUnknownReason.secretDeleted =>
+        'Synced Secret was deleted — the controller will recreate it on '
+            'the next sync.',
+      DriftUnknownReason.rbacDenied =>
+        'Your account lacks "get secret" permission on this namespace, '
+            'so drift cannot be checked.',
+      DriftUnknownReason.transientError =>
+        'Temporary error reaching the Kubernetes API — retry shortly.',
+      DriftUnknownReason.clientError =>
+        'Internal error building the impersonating Kubernetes client.',
+      DriftUnknownReason.unspecified =>
+        'Drift status is not available for this resource.',
+    };
+
+/// Status pill for ExternalSecret / SecretStore / PushSecret lifecycle
+/// state. Maps the open-enum [EsoStatus] onto the canonical
+/// success/warning/error/info palette per status.
+class EsoStatusPill extends StatelessWidget {
+  const EsoStatusPill({
+    super.key,
+    required this.status,
+    this.dense = false,
+  });
+
+  final EsoStatus status;
+  final bool dense;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final theme = _statusPillTheme(status, colors);
+    return Container(
+      padding: EdgeInsets.symmetric(
+        horizontal: dense ? 6 : 8,
+        vertical: dense ? 2 : 3,
+      ),
+      decoration: BoxDecoration(
+        color: theme.background,
+        borderRadius: BorderRadius.circular(dense ? 3 : 4),
+        border: Border.all(color: theme.foreground),
+      ),
+      child: Text(
+        theme.label,
+        style: TextStyle(
+          color: theme.foreground,
+          fontSize: dense ? 10 : 11,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+_PillTheme _statusPillTheme(EsoStatus s, KubeColors colors) {
+  switch (s) {
+    case EsoStatus.synced:
+      return _PillTheme(
+        label: 'Synced',
+        foreground: colors.success,
+        background: colors.successDim,
+      );
+    case EsoStatus.refreshing:
+      return _PillTheme(
+        label: 'Refreshing',
+        foreground: colors.info,
+        background: colors.bgElevated,
+      );
+    case EsoStatus.stale:
+      return _PillTheme(
+        label: 'Stale',
+        foreground: colors.warning,
+        background: colors.warningDim,
+      );
+    case EsoStatus.drifted:
+      return _PillTheme(
+        label: 'Drifted',
+        foreground: colors.warning,
+        background: colors.warningDim,
+      );
+    case EsoStatus.syncFailed:
+      return _PillTheme(
+        label: 'SyncFailed',
+        foreground: colors.error,
+        background: colors.errorDim,
+      );
+    case EsoStatus.unknown:
+      return _PillTheme(
+        label: 'Unknown',
+        foreground: colors.textMuted,
+        background: colors.bgElevated,
+      );
+  }
+}
+
+/// Small chip surfaced next to a SecretStore name to indicate its
+/// provider family. Mirrors `frontend/components/eso/ESOBadges.tsx`'s
+/// `ProviderBadge` — colour-neutral (textSecondary on bgElevated) so
+/// it doesn't compete with the status pill for attention.
+class ProviderChip extends StatelessWidget {
+  const ProviderChip({super.key, required this.provider});
+
+  final String provider;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final label = provider.isEmpty ? 'no provider' : provider;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: colors.bgElevated,
+        borderRadius: BorderRadius.circular(3),
+        border: Border.all(color: colors.borderSubtle),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          color: colors.textSecondary,
+          fontSize: 10,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+/// Disabled "Revert drift" button with a tooltip pointing to desktop.
+/// Per R12: M4 ships read-only; the drift-revert write action is
+/// deferred to M5+. Rendering the button (rather than omitting it)
+/// signals to operators that the capability exists but isn't available
+/// on this surface — same affordance as the web.
+class DisabledRevertDriftButton extends StatelessWidget {
+  const DisabledRevertDriftButton({super.key});
+
+  /// Snackbar copy is exported so tests can assert on the exact wording
+  /// without duplicating the string literal.
+  static const String desktopMessage = 'Use desktop to revert drift';
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: desktopMessage,
+      child: OutlinedButton.icon(
+        // Null onPressed disables the button. Material's disabled style
+        // automatically dims the foreground using onSurface @ 38%, so
+        // operators can see the button exists but it's clearly inert.
+        onPressed: null,
+        icon: const Icon(Icons.undo_outlined, size: 16),
+        label: const Text('Revert drift'),
+      ),
+    );
+  }
+
+  /// Convenience for screens that want to surface the desktop message
+  /// as a snackbar (e.g., on a long-press hint).
+  static void showDesktopHint(BuildContext context) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text(desktopMessage)),
+    );
+  }
+}
+
+/// Renders a "key: value" row using theme tokens. Used by detail
+/// screens for read-only attribute dumps (storeRef, refreshInterval,
+/// lastSyncTime). Pulled out so all ESO detail surfaces share one
+/// labeling pattern.
+class EsoKvRow extends StatelessWidget {
+  const EsoKvRow({
+    super.key,
+    required this.label,
+    required this.value,
+    this.valueColor,
+  });
+
+  final String label;
+  final String value;
+  final Color? valueColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 120,
+            child: Text(
+              label,
+              style: TextStyle(
+                color: colors.textMuted,
+                fontSize: 12,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+          Expanded(
+            child: Text(
+              value,
+              style: TextStyle(
+                color: valueColor ?? colors.textPrimary,
+                fontSize: 13,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Renders a wrap of small chips. Used for selector / namespace lists
+/// on ClusterExternalSecret detail.
+class ChipStrip extends StatelessWidget {
+  const ChipStrip({
+    super.key,
+    required this.label,
+    required this.items,
+    this.foreground,
+  });
+
+  final String label;
+  final List<String> items;
+  final Color? foreground;
+
+  @override
+  Widget build(BuildContext context) {
+    if (items.isEmpty) return const SizedBox.shrink();
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final fg = foreground ?? colors.textSecondary;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: TextStyle(
+              color: colors.textMuted,
+              fontSize: 12,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Wrap(
+            spacing: 6,
+            runSpacing: 4,
+            children: [
+              for (final item in items)
+                Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                  decoration: BoxDecoration(
+                    color: colors.bgElevated,
+                    borderRadius: BorderRadius.circular(3),
+                    border: Border.all(color: colors.borderSubtle),
+                  ),
+                  child: Text(
+                    item,
+                    style: TextStyle(color: fg, fontSize: 11),
+                  ),
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/eso/eso_widgets.dart
+++ b/mobile/lib/features/eso/eso_widgets.dart
@@ -6,9 +6,114 @@
 // #9) would have to land here first.
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../api/api_error.dart';
 import '../../api/eso_repository.dart';
+import '../../cluster/cluster_provider.dart';
 import '../../theme/kube_theme_builder.dart';
+import '../../widgets/empty_states.dart';
+import '../../widgets/feature_unavailable_state.dart';
+
+/// Wraps a per-cluster ESO surface body in the standard discovery-status
+/// gate. The outer ConsumerWidget watches `esoStatusProvider(clusterId)`,
+/// handles loading / error / not-detected uniformly, and only calls
+/// [builder] when ESO is detected. Six ESO list screens and the dashboard
+/// previously copy-pasted this outer shell; adding a seventh surface no
+/// longer requires duplicating it.
+class EsoStatusGate extends ConsumerWidget {
+  const EsoStatusGate({super.key, required this.builder});
+
+  /// Called with the current activeClusterId once status resolves to
+  /// `detected: true`. Implementations typically return the screen's
+  /// per-cluster `_ListBody`-shaped body.
+  final Widget Function(String clusterId) builder;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final clusterId = ref.watch(activeClusterProvider);
+    final statusAsync = ref.watch(esoStatusProvider(clusterId));
+    return statusAsync.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (e, _) => ErrorStateView(
+        message: e is ApiError ? e.message : e.toString(),
+        onRetry: () => ref.invalidate(esoStatusProvider(clusterId)),
+      ),
+      data: (status) {
+        if (!status.detected) return FeatureUnavailableState.eso();
+        return builder(clusterId);
+      },
+    );
+  }
+}
+
+/// Render the appropriate degraded state for an ESO detail endpoint
+/// failure. List screens gate on `esoStatusProvider` before fetching, but
+/// detail screens are reached directly via deep-link / push notification,
+/// so they have no chance to render `FeatureUnavailableState.eso()` until
+/// the detail endpoint itself responds. A 503 here means the backend has
+/// observed that ESO is no longer detected (cluster restart, CRD
+/// removal); collapse it to the same install-guidance UX the lists use,
+/// not a generic retry-this-error view.
+Widget esoDetailErrorState({
+  required Object error,
+  required VoidCallback onRetry,
+}) {
+  if (error is ApiError && error.statusCode == 503) {
+    return FeatureUnavailableState.eso();
+  }
+  return ErrorStateView(
+    message: error is ApiError ? error.message : error.toString(),
+    onRetry: onRetry,
+  );
+}
+
+/// Surface a non-empty readyMessage from any ESO resource (ExternalSecret /
+/// ClusterExternalSecret / SecretStore / ClusterSecretStore). Three
+/// detail screens previously kept private copies of an identical widget;
+/// this is the canonical one.
+class EsoReadyMessageCard extends StatelessWidget {
+  const EsoReadyMessageCard({
+    super.key,
+    required this.reason,
+    required this.message,
+    required this.colors,
+  });
+
+  final String? reason;
+  final String message;
+  final KubeColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: colors.bgSurface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colors.borderSubtle),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            reason ?? 'Status detail',
+            style: TextStyle(
+              color: colors.textPrimary,
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            message,
+            style: TextStyle(color: colors.textSecondary, fontSize: 13),
+          ),
+        ],
+      ),
+    );
+  }
+}
 
 /// Drift indicator pill. Tri-state colour mapping is the only place
 /// drift colour lives — every drift surface across PR-4h reads from
@@ -335,23 +440,33 @@ class EsoKvRow extends StatelessWidget {
 
 /// Renders a wrap of small chips. Used for selector / namespace lists
 /// on ClusterExternalSecret detail.
+///
+/// Caps the visible chip count at [maxVisible] so a `ClusterExternalSecret`
+/// whose namespaceSelector matches hundreds of namespaces does not stall
+/// the detail screen during layout. The remainder is summarised inline
+/// with a "+N more" trailing chip — full visibility is a desktop affordance.
 class ChipStrip extends StatelessWidget {
   const ChipStrip({
     super.key,
     required this.label,
     required this.items,
     this.foreground,
+    this.maxVisible = 50,
   });
 
   final String label;
   final List<String> items;
   final Color? foreground;
+  final int maxVisible;
 
   @override
   Widget build(BuildContext context) {
     if (items.isEmpty) return const SizedBox.shrink();
     final colors = Theme.of(context).extension<KubeColors>()!;
     final fg = foreground ?? colors.textSecondary;
+    final visible =
+        items.length <= maxVisible ? items : items.sublist(0, maxVisible);
+    final overflow = items.length - visible.length;
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 4),
       child: Column(
@@ -370,7 +485,7 @@ class ChipStrip extends StatelessWidget {
             spacing: 6,
             runSpacing: 4,
             children: [
-              for (final item in items)
+              for (final item in visible)
                 Container(
                   padding:
                       const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
@@ -382,6 +497,24 @@ class ChipStrip extends StatelessWidget {
                   child: Text(
                     item,
                     style: TextStyle(color: fg, fontSize: 11),
+                  ),
+                ),
+              if (overflow > 0)
+                Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                  decoration: BoxDecoration(
+                    color: colors.bgElevated,
+                    borderRadius: BorderRadius.circular(3),
+                    border: Border.all(color: colors.borderSubtle),
+                  ),
+                  child: Text(
+                    '+$overflow more',
+                    style: TextStyle(
+                      color: colors.textMuted,
+                      fontSize: 11,
+                      fontStyle: FontStyle.italic,
+                    ),
                   ),
                 ),
             ],

--- a/mobile/lib/features/eso/external_secret_detail_screen.dart
+++ b/mobile/lib/features/eso/external_secret_detail_screen.dart
@@ -9,11 +9,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../api/api_error.dart';
 import '../../api/eso_repository.dart';
 import '../../cluster/cluster_provider.dart';
 import '../../theme/kube_theme_builder.dart';
-import '../../widgets/empty_states.dart';
 import 'eso_widgets.dart';
 
 class ExternalSecretDetailScreen extends ConsumerWidget {
@@ -49,8 +47,8 @@ class ExternalSecretDetailScreen extends ConsumerWidget {
       ),
       body: async.when(
         loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => ErrorStateView(
-          message: e is ApiError ? e.message : e.toString(),
+        error: (e, _) => esoDetailErrorState(
+          error: e,
           onRetry: () => ref.invalidate(externalSecretDetailProvider(key)),
         ),
         data: (es) => _Body(clusterId: clusterId, es: es),
@@ -76,7 +74,7 @@ class _Body extends StatelessWidget {
         _AttributesCard(es: es, clusterId: clusterId, colors: colors),
         if (es.readyMessage != null && es.readyMessage!.isNotEmpty) ...[
           const SizedBox(height: 12),
-          _ReadyMessageCard(
+          EsoReadyMessageCard(
             reason: es.readyReason,
             message: es.readyMessage!,
             colors: colors,
@@ -286,48 +284,6 @@ class _StoreRefLink extends StatelessWidget {
             ),
           ],
         ),
-      ),
-    );
-  }
-}
-
-class _ReadyMessageCard extends StatelessWidget {
-  const _ReadyMessageCard({
-    required this.reason,
-    required this.message,
-    required this.colors,
-  });
-
-  final String? reason;
-  final String message;
-  final KubeColors colors;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.all(14),
-      decoration: BoxDecoration(
-        color: colors.bgSurface,
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: colors.borderSubtle),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            reason ?? 'Status detail',
-            style: TextStyle(
-              color: colors.textPrimary,
-              fontSize: 14,
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-          const SizedBox(height: 6),
-          Text(
-            message,
-            style: TextStyle(color: colors.textSecondary, fontSize: 13),
-          ),
-        ],
       ),
     );
   }

--- a/mobile/lib/features/eso/external_secret_detail_screen.dart
+++ b/mobile/lib/features/eso/external_secret_detail_screen.dart
@@ -1,0 +1,393 @@
+// ExternalSecret detail — fetches the live `driftStatus` (the list
+// endpoint only emits `lastObservedDriftStatus`; this screen is the
+// source of truth for drift). Renders a read-only attribute dump, the
+// store reference (tappable → store detail), and a disabled "Revert
+// drift" button per R12. Drift-Unknown surfaces with the backend's
+// reason tooltip so operators understand WHY drift wasn't resolvable.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../api/api_error.dart';
+import '../../api/eso_repository.dart';
+import '../../cluster/cluster_provider.dart';
+import '../../theme/kube_theme_builder.dart';
+import '../../widgets/empty_states.dart';
+import 'eso_widgets.dart';
+
+class ExternalSecretDetailScreen extends ConsumerWidget {
+  const ExternalSecretDetailScreen({
+    super.key,
+    required this.namespace,
+    required this.name,
+  });
+
+  final String namespace;
+  final String name;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final clusterId = ref.watch(activeClusterProvider);
+    final key = ExternalSecretDetailKey(
+      clusterId: clusterId,
+      namespace: namespace,
+      name: name,
+    );
+    final async = ref.watch(externalSecretDetailProvider(key));
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(name),
+        actions: [
+          IconButton(
+            tooltip: 'Refresh',
+            icon: const Icon(Icons.refresh),
+            onPressed: () => ref.invalidate(externalSecretDetailProvider(key)),
+          ),
+        ],
+      ),
+      body: async.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => ErrorStateView(
+          message: e is ApiError ? e.message : e.toString(),
+          onRetry: () => ref.invalidate(externalSecretDetailProvider(key)),
+        ),
+        data: (es) => _Body(clusterId: clusterId, es: es),
+      ),
+    );
+  }
+}
+
+class _Body extends StatelessWidget {
+  const _Body({required this.clusterId, required this.es});
+
+  final String clusterId;
+  final ExternalSecret es;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return ListView(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      children: [
+        _HeaderCard(es: es, colors: colors),
+        const SizedBox(height: 12),
+        _AttributesCard(es: es, clusterId: clusterId, colors: colors),
+        if (es.readyMessage != null && es.readyMessage!.isNotEmpty) ...[
+          const SizedBox(height: 12),
+          _ReadyMessageCard(
+            reason: es.readyReason,
+            message: es.readyMessage!,
+            colors: colors,
+          ),
+        ],
+        if (es.staleAfterMinutes != null ||
+            es.alertOnRecovery != null ||
+            es.alertOnLifecycle != null) ...[
+          const SizedBox(height: 12),
+          _ThresholdsCard(es: es, colors: colors),
+        ],
+      ],
+    );
+  }
+}
+
+class _HeaderCard extends StatelessWidget {
+  const _HeaderCard({required this.es, required this.colors});
+
+  final ExternalSecret es;
+  final KubeColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    final drift = es.driftStatus;
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: colors.bgSurface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colors.borderSubtle),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              EsoStatusPill(status: es.status),
+              const SizedBox(width: 8),
+              if (drift != DriftStatus.notObserved)
+                DriftPill(status: drift, reason: es.driftUnknownReason),
+              const Spacer(),
+              // Disabled per R12 — write surface defers to desktop. The
+              // tooltip carries the desktop-redirect copy.
+              const DisabledRevertDriftButton(),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Text(
+            es.namespace,
+            style: TextStyle(color: colors.textSecondary, fontSize: 12),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            es.name,
+            style: TextStyle(
+              color: colors.textPrimary,
+              fontSize: 18,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AttributesCard extends StatelessWidget {
+  const _AttributesCard({
+    required this.es,
+    required this.clusterId,
+    required this.colors,
+  });
+
+  final ExternalSecret es;
+  final String clusterId;
+  final KubeColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: colors.bgSurface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colors.borderSubtle),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Configuration',
+            style: TextStyle(
+              color: colors.textPrimary,
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 8),
+          // Tappable store row — links to store detail in the matching
+          // section. Distinguishes namespaced vs cluster store via the
+          // ref kind, mirrors web's deep-link behaviour.
+          _StoreRefLink(
+            storeRef: es.storeRef,
+            esNamespace: es.namespace,
+            clusterId: clusterId,
+            colors: colors,
+          ),
+          if (es.targetSecretName != null)
+            EsoKvRow(
+              label: 'Target secret',
+              value: es.targetSecretName!,
+            ),
+          if (es.refreshInterval != null)
+            EsoKvRow(
+              label: 'Refresh interval',
+              value: es.refreshInterval!,
+            ),
+          if (es.lastSyncTime != null)
+            EsoKvRow(
+              label: 'Last sync',
+              value: es.lastSyncTime!,
+            ),
+          if (es.syncedResourceVersion != null)
+            EsoKvRow(
+              label: 'Synced RV',
+              value: es.syncedResourceVersion!,
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StoreRefLink extends StatelessWidget {
+  const _StoreRefLink({
+    required this.storeRef,
+    required this.esNamespace,
+    required this.clusterId,
+    required this.colors,
+  });
+
+  final EsoStoreRef storeRef;
+  final String esNamespace;
+  final String clusterId;
+  final KubeColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    final ref = storeRef;
+    if (ref.name.isEmpty) {
+      return EsoKvRow(label: 'Store', value: '(none)');
+    }
+    final isCluster = ref.kind == 'ClusterSecretStore';
+    final path = isCluster
+        ? '/clusters/$clusterId/eso/cluster-stores/'
+            '${Uri.encodeComponent(ref.name)}'
+        : '/clusters/$clusterId/eso/stores/'
+            '${Uri.encodeComponent(esNamespace)}/'
+            '${Uri.encodeComponent(ref.name)}';
+    return InkWell(
+      onTap: () => context.push(path),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 4),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SizedBox(
+              width: 120,
+              child: Text(
+                'Store',
+                style: TextStyle(
+                  color: colors.textMuted,
+                  fontSize: 12,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ),
+            Expanded(
+              child: Row(
+                children: [
+                  Icon(
+                    isCluster ? Icons.public_outlined : Icons.account_tree_outlined,
+                    size: 14,
+                    color: colors.accent,
+                  ),
+                  const SizedBox(width: 6),
+                  Flexible(
+                    child: Text(
+                      '${ref.kind} / ${ref.name}',
+                      style: TextStyle(
+                        color: colors.accent,
+                        fontSize: 13,
+                        fontWeight: FontWeight.w600,
+                      ),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                  const SizedBox(width: 4),
+                  Icon(
+                    Icons.open_in_new,
+                    size: 12,
+                    color: colors.accent,
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ReadyMessageCard extends StatelessWidget {
+  const _ReadyMessageCard({
+    required this.reason,
+    required this.message,
+    required this.colors,
+  });
+
+  final String? reason;
+  final String message;
+  final KubeColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: colors.bgSurface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colors.borderSubtle),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            reason ?? 'Status detail',
+            style: TextStyle(
+              color: colors.textPrimary,
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            message,
+            style: TextStyle(color: colors.textSecondary, fontSize: 13),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ThresholdsCard extends StatelessWidget {
+  const _ThresholdsCard({required this.es, required this.colors});
+
+  final ExternalSecret es;
+  final KubeColors colors;
+
+  String _sourceLabel(EsoThresholdSource s) => switch (s) {
+        EsoThresholdSource.packageDefault => 'package default',
+        EsoThresholdSource.externalSecret => 'ExternalSecret',
+        EsoThresholdSource.secretStore => 'SecretStore',
+        EsoThresholdSource.clusterSecretStore => 'ClusterSecretStore',
+        EsoThresholdSource.unknown => '—',
+      };
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: colors.bgSurface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colors.borderSubtle),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Resolved thresholds',
+            style: TextStyle(
+              color: colors.textPrimary,
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 8),
+          if (es.staleAfterMinutes != null)
+            EsoKvRow(
+              label: 'Stale after',
+              value:
+                  '${es.staleAfterMinutes}m  ·  source: ${_sourceLabel(es.staleAfterMinutesSource)}',
+            ),
+          if (es.alertOnRecovery != null)
+            EsoKvRow(
+              label: 'Alert on recovery',
+              value:
+                  '${es.alertOnRecovery}  ·  source: ${_sourceLabel(es.alertOnRecoverySource)}',
+            ),
+          if (es.alertOnLifecycle != null)
+            EsoKvRow(
+              label: 'Alert on lifecycle',
+              value:
+                  '${es.alertOnLifecycle}  ·  source: ${_sourceLabel(es.alertOnLifecycleSource)}',
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/eso/external_secrets_list_screen.dart
+++ b/mobile/lib/features/eso/external_secrets_list_screen.dart
@@ -13,12 +13,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../api/api_error.dart';
 import '../../api/eso_repository.dart';
 import '../../cluster/cluster_provider.dart';
 import '../../theme/kube_theme_builder.dart';
 import '../../widgets/empty_states.dart';
-import '../../widgets/feature_unavailable_state.dart';
+import '../../widgets/refresh_guard.dart';
 import 'eso_widgets.dart';
 
 /// Filter chip values for the ExternalSecrets list. Mirrors the
@@ -75,9 +74,6 @@ class _ExternalSecretsListScreenState
 
   @override
   Widget build(BuildContext context) {
-    final clusterId = ref.watch(activeClusterProvider);
-    final statusAsync = ref.watch(esoStatusProvider(clusterId));
-
     ref.listen<String>(activeClusterProvider, (previous, next) {
       if (previous != next) {
         setState(() {
@@ -90,29 +86,21 @@ class _ExternalSecretsListScreenState
 
     return Scaffold(
       appBar: AppBar(title: const Text('ExternalSecrets')),
-      body: statusAsync.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => ErrorStateView(
-          message: e is ApiError ? e.message : e.toString(),
-          onRetry: () => ref.invalidate(esoStatusProvider(clusterId)),
+      body: EsoStatusGate(
+        builder: (clusterId) => _ListBody(
+          clusterId: clusterId,
+          filter: _filter,
+          search: _search,
+          searchCtl: _searchCtl,
+          onFilterChanged: (v) => setState(() => _filter = v),
+          onSearchChanged: (v) => setState(() => _search = v),
         ),
-        data: (status) {
-          if (!status.detected) return FeatureUnavailableState.eso();
-          return _ListBody(
-            clusterId: clusterId,
-            filter: _filter,
-            search: _search,
-            searchCtl: _searchCtl,
-            onFilterChanged: (v) => setState(() => _filter = v),
-            onSearchChanged: (v) => setState(() => _search = v),
-          );
-        },
       ),
     );
   }
 }
 
-class _ListBody extends ConsumerWidget {
+class _ListBody extends ConsumerStatefulWidget {
   const _ListBody({
     required this.clusterId,
     required this.filter,
@@ -129,31 +117,43 @@ class _ListBody extends ConsumerWidget {
   final ValueChanged<EsListFilter> onFilterChanged;
   final ValueChanged<String> onSearchChanged;
 
+  @override
+  ConsumerState<_ListBody> createState() => _ListBodyState();
+}
+
+class _ListBodyState extends ConsumerState<_ListBody> with RefreshGuardMixin {
+  // Cached lower-cased search haystack ("name namespace storeName") parallel
+  // to [_lastItems]. Rebuilt only when the items list reference changes —
+  // the typical keystroke path reuses the cache, dropping the per-keystroke
+  // cost from O(N) `toLowerCase` calls to a constant array lookup.
+  List<ExternalSecret>? _lastItems;
+  List<String>? _haystacks;
+
   ExternalSecretListKey get _key =>
-      ExternalSecretListKey(clusterId: clusterId);
+      ExternalSecretListKey(clusterId: widget.clusterId);
+
+  Future<void> _handleRefresh() => guardedRefresh(() async {
+        ref.invalidate(externalSecretListProvider(_key));
+        try {
+          await ref.read(externalSecretListProvider(_key).future);
+        } on Object {
+          // surfaces via .when
+        }
+      });
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     final colors = Theme.of(context).extension<KubeColors>()!;
     final async = ref.watch(externalSecretListProvider(_key));
 
-    Future<void> handleRefresh() async {
-      ref.invalidate(externalSecretListProvider(_key));
-      try {
-        await ref.read(externalSecretListProvider(_key).future);
-      } on Object {
-        // surfaces via .when
-      }
-    }
-
     return RefreshIndicator(
-      onRefresh: handleRefresh,
+      onRefresh: _handleRefresh,
       child: async.when(
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (e, _) => ListErrorShell(
           title: 'Failed to load ExternalSecrets',
           error: e,
-          onRetry: handleRefresh,
+          onRetry: _handleRefresh,
         ),
         data: (items) {
           final filtered = _applyFilters(items);
@@ -162,12 +162,12 @@ class _ListBody extends ConsumerWidget {
             slivers: [
               SliverToBoxAdapter(
                 child: _FilterStrip(
-                  filter: filter,
-                  searchCtl: searchCtl,
+                  filter: widget.filter,
+                  searchCtl: widget.searchCtl,
                   totalVisible: filtered.length,
                   totalAll: items.length,
-                  onFilterChanged: onFilterChanged,
-                  onSearchChanged: onSearchChanged,
+                  onFilterChanged: widget.onFilterChanged,
+                  onSearchChanged: widget.onSearchChanged,
                 ),
               ),
               if (filtered.isEmpty)
@@ -196,7 +196,7 @@ class _ListBody extends ConsumerWidget {
                     (context, index) => _EsRow(
                       cert: filtered[index],
                       onTap: () => context.push(
-                        '/clusters/$clusterId/eso/externalsecrets/'
+                        '/clusters/${widget.clusterId}/eso/externalsecrets/'
                         '${Uri.encodeComponent(filtered[index].namespace)}/'
                         '${Uri.encodeComponent(filtered[index].name)}',
                       ),
@@ -213,29 +213,49 @@ class _ListBody extends ConsumerWidget {
   }
 
   List<ExternalSecret> _applyFilters(List<ExternalSecret> items) {
-    final q = search.trim().toLowerCase();
-    return items.where((es) {
-      switch (filter) {
+    final q = widget.search.trim().toLowerCase();
+
+    // Refresh the haystack cache only when the underlying items list
+    // changes identity (refresh, cluster switch). Keystroke rebuilds keep
+    // the cache.
+    if (!identical(_lastItems, items)) {
+      _lastItems = items;
+      _haystacks = List<String>.generate(
+        items.length,
+        (i) {
+          final es = items[i];
+          return '${es.name} ${es.namespace} ${es.storeRef.name}'
+              .toLowerCase();
+        },
+        growable: false,
+      );
+    }
+
+    final haystacks = _haystacks!;
+    final out = <ExternalSecret>[];
+    for (var i = 0; i < items.length; i++) {
+      final es = items[i];
+      switch (widget.filter) {
         case EsListFilter.syncFailed:
-          if (es.status != EsoStatus.syncFailed) return false;
+          if (es.status != EsoStatus.syncFailed) continue;
           break;
         case EsListFilter.stale:
-          if (es.status != EsoStatus.stale) return false;
+          if (es.status != EsoStatus.stale) continue;
           break;
         case EsListFilter.drifted:
-          if (es.status != EsoStatus.drifted) return false;
+          if (es.status != EsoStatus.drifted) continue;
           break;
         case EsListFilter.unknown:
-          if (es.status != EsoStatus.unknown) return false;
+          if (es.status != EsoStatus.unknown) continue;
           break;
         case EsListFilter.all:
           break;
       }
-      if (q.isEmpty) return true;
-      return es.name.toLowerCase().contains(q) ||
-          es.namespace.toLowerCase().contains(q) ||
-          es.storeRef.name.toLowerCase().contains(q);
-    }).toList();
+      if (q.isEmpty || haystacks[i].contains(q)) {
+        out.add(es);
+      }
+    }
+    return out;
   }
 }
 

--- a/mobile/lib/features/eso/external_secrets_list_screen.dart
+++ b/mobile/lib/features/eso/external_secrets_list_screen.dart
@@ -1,0 +1,396 @@
+// ExternalSecrets list — every ESO ExternalSecret the active user can
+// read across all namespaces. Tap row → detail screen (which fetches
+// live `driftStatus`; this screen renders only the poller's
+// `lastObservedDriftStatus`).
+//
+// Filter chips (All / SyncFailed / Stale / Drifted / Unknown) + free-
+// text search. `?status=*` URL param seeds the chip on mount.
+//
+// Status gating: `esoStatusProvider` gates the surface — `FeatureUnavailableState.eso()`
+// when ESO isn't detected.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../api/api_error.dart';
+import '../../api/eso_repository.dart';
+import '../../cluster/cluster_provider.dart';
+import '../../theme/kube_theme_builder.dart';
+import '../../widgets/empty_states.dart';
+import '../../widgets/feature_unavailable_state.dart';
+import 'eso_widgets.dart';
+
+/// Filter chip values for the ExternalSecrets list. Mirrors the
+/// failure-table severity grouping on the dashboard so chip-based
+/// navigation from a dashboard summary stays consistent.
+enum EsListFilter { all, syncFailed, stale, drifted, unknown }
+
+EsListFilter _filterFromInitial(String? initial) {
+  switch (initial) {
+    case 'syncfailed':
+    case 'syncFailed':
+    case 'sync-failed':
+      return EsListFilter.syncFailed;
+    case 'stale':
+      return EsListFilter.stale;
+    case 'drifted':
+      return EsListFilter.drifted;
+    case 'unknown':
+      return EsListFilter.unknown;
+    default:
+      return EsListFilter.all;
+  }
+}
+
+class ExternalSecretsListScreen extends ConsumerStatefulWidget {
+  const ExternalSecretsListScreen({super.key, this.initialStatusFilter});
+
+  /// Seed the status chip on mount. Drawer deep-links leave this null;
+  /// dashboard-card taps (or expiry-style push deep links) pass a value.
+  final String? initialStatusFilter;
+
+  @override
+  ConsumerState<ExternalSecretsListScreen> createState() =>
+      _ExternalSecretsListScreenState();
+}
+
+class _ExternalSecretsListScreenState
+    extends ConsumerState<ExternalSecretsListScreen> {
+  late EsListFilter _filter;
+  String _search = '';
+  final _searchCtl = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _filter = _filterFromInitial(widget.initialStatusFilter);
+  }
+
+  @override
+  void dispose() {
+    _searchCtl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final clusterId = ref.watch(activeClusterProvider);
+    final statusAsync = ref.watch(esoStatusProvider(clusterId));
+
+    ref.listen<String>(activeClusterProvider, (previous, next) {
+      if (previous != next) {
+        setState(() {
+          _filter = EsListFilter.all;
+          _search = '';
+          _searchCtl.clear();
+        });
+      }
+    });
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('ExternalSecrets')),
+      body: statusAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => ErrorStateView(
+          message: e is ApiError ? e.message : e.toString(),
+          onRetry: () => ref.invalidate(esoStatusProvider(clusterId)),
+        ),
+        data: (status) {
+          if (!status.detected) return FeatureUnavailableState.eso();
+          return _ListBody(
+            clusterId: clusterId,
+            filter: _filter,
+            search: _search,
+            searchCtl: _searchCtl,
+            onFilterChanged: (v) => setState(() => _filter = v),
+            onSearchChanged: (v) => setState(() => _search = v),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _ListBody extends ConsumerWidget {
+  const _ListBody({
+    required this.clusterId,
+    required this.filter,
+    required this.search,
+    required this.searchCtl,
+    required this.onFilterChanged,
+    required this.onSearchChanged,
+  });
+
+  final String clusterId;
+  final EsListFilter filter;
+  final String search;
+  final TextEditingController searchCtl;
+  final ValueChanged<EsListFilter> onFilterChanged;
+  final ValueChanged<String> onSearchChanged;
+
+  ExternalSecretListKey get _key =>
+      ExternalSecretListKey(clusterId: clusterId);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final async = ref.watch(externalSecretListProvider(_key));
+
+    Future<void> handleRefresh() async {
+      ref.invalidate(externalSecretListProvider(_key));
+      try {
+        await ref.read(externalSecretListProvider(_key).future);
+      } on Object {
+        // surfaces via .when
+      }
+    }
+
+    return RefreshIndicator(
+      onRefresh: handleRefresh,
+      child: async.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => ListErrorShell(
+          title: 'Failed to load ExternalSecrets',
+          error: e,
+          onRetry: handleRefresh,
+        ),
+        data: (items) {
+          final filtered = _applyFilters(items);
+          return CustomScrollView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            slivers: [
+              SliverToBoxAdapter(
+                child: _FilterStrip(
+                  filter: filter,
+                  searchCtl: searchCtl,
+                  totalVisible: filtered.length,
+                  totalAll: items.length,
+                  onFilterChanged: onFilterChanged,
+                  onSearchChanged: onSearchChanged,
+                ),
+              ),
+              if (filtered.isEmpty)
+                SliverToBoxAdapter(
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 16,
+                      vertical: 32,
+                    ),
+                    child: Center(
+                      child: Text(
+                        items.isEmpty
+                            ? 'No ExternalSecrets in this cluster yet. The '
+                                'ESO controller will populate the list once '
+                                'an ExternalSecret resource is created.'
+                            : 'No ExternalSecrets match the current filters.',
+                        style: TextStyle(color: colors.textMuted),
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                  ),
+                )
+              else
+                SliverList(
+                  delegate: SliverChildBuilderDelegate(
+                    (context, index) => _EsRow(
+                      cert: filtered[index],
+                      onTap: () => context.push(
+                        '/clusters/$clusterId/eso/externalsecrets/'
+                        '${Uri.encodeComponent(filtered[index].namespace)}/'
+                        '${Uri.encodeComponent(filtered[index].name)}',
+                      ),
+                    ),
+                    childCount: filtered.length,
+                  ),
+                ),
+              const SliverPadding(padding: EdgeInsets.only(bottom: 8)),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  List<ExternalSecret> _applyFilters(List<ExternalSecret> items) {
+    final q = search.trim().toLowerCase();
+    return items.where((es) {
+      switch (filter) {
+        case EsListFilter.syncFailed:
+          if (es.status != EsoStatus.syncFailed) return false;
+          break;
+        case EsListFilter.stale:
+          if (es.status != EsoStatus.stale) return false;
+          break;
+        case EsListFilter.drifted:
+          if (es.status != EsoStatus.drifted) return false;
+          break;
+        case EsListFilter.unknown:
+          if (es.status != EsoStatus.unknown) return false;
+          break;
+        case EsListFilter.all:
+          break;
+      }
+      if (q.isEmpty) return true;
+      return es.name.toLowerCase().contains(q) ||
+          es.namespace.toLowerCase().contains(q) ||
+          es.storeRef.name.toLowerCase().contains(q);
+    }).toList();
+  }
+}
+
+class _FilterStrip extends StatelessWidget {
+  const _FilterStrip({
+    required this.filter,
+    required this.searchCtl,
+    required this.totalVisible,
+    required this.totalAll,
+    required this.onFilterChanged,
+    required this.onSearchChanged,
+  });
+
+  final EsListFilter filter;
+  final TextEditingController searchCtl;
+  final int totalVisible;
+  final int totalAll;
+  final ValueChanged<EsListFilter> onFilterChanged;
+  final ValueChanged<String> onSearchChanged;
+
+  String _label(EsListFilter v) => switch (v) {
+        EsListFilter.all => 'All',
+        EsListFilter.syncFailed => 'SyncFailed',
+        EsListFilter.stale => 'Stale',
+        EsListFilter.drifted => 'Drifted',
+        EsListFilter.unknown => 'Unknown',
+      };
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Wrap(
+            spacing: 6,
+            runSpacing: 4,
+            children: [
+              for (final value in EsListFilter.values)
+                ChoiceChip(
+                  label: Text(_label(value)),
+                  selected: value == filter,
+                  onSelected: (_) => onFilterChanged(value),
+                ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          TextField(
+            controller: searchCtl,
+            decoration: InputDecoration(
+              hintText: 'Filter by name, namespace, store…',
+              prefixIcon: Icon(
+                Icons.search,
+                size: 18,
+                color: colors.textMuted,
+              ),
+              isDense: true,
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(6),
+              ),
+            ),
+            onChanged: onSearchChanged,
+          ),
+          Padding(
+            padding: const EdgeInsets.only(top: 8),
+            child: Text(
+              '$totalVisible of $totalAll ExternalSecrets',
+              style: TextStyle(color: colors.textMuted, fontSize: 12),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EsRow extends StatelessWidget {
+  const _EsRow({required this.cert, required this.onTap});
+
+  final ExternalSecret cert;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final drift = cert.effectiveDriftStatus;
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    cert.name,
+                    style: TextStyle(
+                      color: colors.textPrimary,
+                      fontSize: 15,
+                      fontWeight: FontWeight.w600,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                EsoStatusPill(status: cert.status, dense: true),
+              ],
+            ),
+            const SizedBox(height: 4),
+            Text(
+              '${cert.namespace} · ${cert.storeRef.kind}/${cert.storeRef.name}',
+              style: TextStyle(color: colors.textSecondary, fontSize: 12),
+              overflow: TextOverflow.ellipsis,
+            ),
+            if (cert.refreshInterval != null) ...[
+              const SizedBox(height: 2),
+              Text(
+                'refresh every ${cert.refreshInterval}',
+                style: TextStyle(color: colors.textMuted, fontSize: 11),
+              ),
+            ],
+            const SizedBox(height: 6),
+            Row(
+              children: [
+                if (drift != DriftStatus.notObserved) ...[
+                  DriftPill(
+                    status: drift,
+                    reason: cert.driftUnknownReason,
+                    dense: true,
+                  ),
+                  const SizedBox(width: 6),
+                ],
+                if (cert.targetSecretName != null)
+                  Flexible(
+                    child: Text(
+                      '→ ${cert.targetSecretName}',
+                      style: TextStyle(color: colors.textMuted, fontSize: 11),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                const Spacer(),
+                Icon(
+                  Icons.chevron_right,
+                  size: 16,
+                  color: colors.textMuted,
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/eso/push_secret_detail_screen.dart
+++ b/mobile/lib/features/eso/push_secret_detail_screen.dart
@@ -5,11 +5,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../api/api_error.dart';
 import '../../api/eso_repository.dart';
 import '../../cluster/cluster_provider.dart';
 import '../../theme/kube_theme_builder.dart';
-import '../../widgets/empty_states.dart';
 import 'eso_widgets.dart';
 
 class PushSecretDetailScreen extends ConsumerWidget {
@@ -45,8 +43,8 @@ class PushSecretDetailScreen extends ConsumerWidget {
       ),
       body: async.when(
         loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => ErrorStateView(
-          message: e is ApiError ? e.message : e.toString(),
+        error: (e, _) => esoDetailErrorState(
+          error: e,
           onRetry: () => ref.invalidate(pushSecretDetailProvider(key)),
         ),
         data: (ps) => _Body(ps: ps),

--- a/mobile/lib/features/eso/push_secret_detail_screen.dart
+++ b/mobile/lib/features/eso/push_secret_detail_screen.dart
@@ -1,0 +1,204 @@
+// PushSecret detail — read-only. Surfaces the source Secret, the
+// store-refs fan-out, and ready/lastSync timestamps. There is no
+// action button — the v1 backend exposes no write surface.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../api/api_error.dart';
+import '../../api/eso_repository.dart';
+import '../../cluster/cluster_provider.dart';
+import '../../theme/kube_theme_builder.dart';
+import '../../widgets/empty_states.dart';
+import 'eso_widgets.dart';
+
+class PushSecretDetailScreen extends ConsumerWidget {
+  const PushSecretDetailScreen({
+    super.key,
+    required this.namespace,
+    required this.name,
+  });
+
+  final String namespace;
+  final String name;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final clusterId = ref.watch(activeClusterProvider);
+    final key = PushSecretDetailKey(
+      clusterId: clusterId,
+      namespace: namespace,
+      name: name,
+    );
+    final async = ref.watch(pushSecretDetailProvider(key));
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(name),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            tooltip: 'Refresh',
+            onPressed: () => ref.invalidate(pushSecretDetailProvider(key)),
+          ),
+        ],
+      ),
+      body: async.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => ErrorStateView(
+          message: e is ApiError ? e.message : e.toString(),
+          onRetry: () => ref.invalidate(pushSecretDetailProvider(key)),
+        ),
+        data: (ps) => _Body(ps: ps),
+      ),
+    );
+  }
+}
+
+class _Body extends StatelessWidget {
+  const _Body({required this.ps});
+
+  final PushSecret ps;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return ListView(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      children: [
+        Container(
+          padding: const EdgeInsets.all(14),
+          decoration: BoxDecoration(
+            color: colors.bgSurface,
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(color: colors.borderSubtle),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              EsoStatusPill(status: ps.status),
+              const SizedBox(height: 10),
+              Text(
+                ps.namespace,
+                style: TextStyle(color: colors.textSecondary, fontSize: 12),
+              ),
+              Text(
+                ps.name,
+                style: TextStyle(
+                  color: colors.textPrimary,
+                  fontSize: 18,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 12),
+        Container(
+          padding: const EdgeInsets.all(14),
+          decoration: BoxDecoration(
+            color: colors.bgSurface,
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(color: colors.borderSubtle),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Configuration',
+                style: TextStyle(
+                  color: colors.textPrimary,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: 8),
+              if (ps.sourceSecretName != null)
+                EsoKvRow(label: 'Source secret', value: ps.sourceSecretName!),
+              if (ps.refreshInterval != null)
+                EsoKvRow(label: 'Refresh interval', value: ps.refreshInterval!),
+              if (ps.lastSyncTime != null)
+                EsoKvRow(label: 'Last sync', value: ps.lastSyncTime!),
+            ],
+          ),
+        ),
+        if (ps.storeRefs.isNotEmpty) ...[
+          const SizedBox(height: 12),
+          Container(
+            padding: const EdgeInsets.all(14),
+            decoration: BoxDecoration(
+              color: colors.bgSurface,
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(color: colors.borderSubtle),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Pushes to',
+                  style: TextStyle(
+                    color: colors.textPrimary,
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                for (final ref in ps.storeRefs)
+                  Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 4),
+                    child: Row(
+                      children: [
+                        Icon(
+                          ref.kind == 'ClusterSecretStore'
+                              ? Icons.public_outlined
+                              : Icons.account_tree_outlined,
+                          size: 14,
+                          color: colors.accent,
+                        ),
+                        const SizedBox(width: 6),
+                        Expanded(
+                          child: Text(
+                            '${ref.kind} / ${ref.name}',
+                            style: TextStyle(color: colors.textPrimary),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
+        if (ps.readyMessage != null && ps.readyMessage!.isNotEmpty) ...[
+          const SizedBox(height: 12),
+          Container(
+            padding: const EdgeInsets.all(14),
+            decoration: BoxDecoration(
+              color: colors.bgSurface,
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(color: colors.borderSubtle),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  ps.readyReason ?? 'Status detail',
+                  style: TextStyle(
+                    color: colors.textPrimary,
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  ps.readyMessage!,
+                  style: TextStyle(color: colors.textSecondary),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}

--- a/mobile/lib/features/eso/push_secrets_list_screen.dart
+++ b/mobile/lib/features/eso/push_secrets_list_screen.dart
@@ -7,67 +7,60 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../api/api_error.dart';
 import '../../api/eso_repository.dart';
-import '../../cluster/cluster_provider.dart';
 import '../../theme/kube_theme_builder.dart';
 import '../../widgets/empty_states.dart';
-import '../../widgets/feature_unavailable_state.dart';
+import '../../widgets/refresh_guard.dart';
 import 'eso_widgets.dart';
 
-class PushSecretsListScreen extends ConsumerWidget {
+class PushSecretsListScreen extends StatelessWidget {
   const PushSecretsListScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final clusterId = ref.watch(activeClusterProvider);
-    final statusAsync = ref.watch(esoStatusProvider(clusterId));
-
+  Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('PushSecrets')),
-      body: statusAsync.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => ErrorStateView(
-          message: e is ApiError ? e.message : e.toString(),
-          onRetry: () => ref.invalidate(esoStatusProvider(clusterId)),
-        ),
-        data: (status) {
-          if (!status.detected) return FeatureUnavailableState.eso();
-          return _ListBody(clusterId: clusterId);
-        },
+      body: EsoStatusGate(
+        builder: (clusterId) => _ListBody(clusterId: clusterId),
       ),
     );
   }
 }
 
-class _ListBody extends ConsumerWidget {
+class _ListBody extends ConsumerStatefulWidget {
   const _ListBody({required this.clusterId});
 
   final String clusterId;
 
-  ExternalSecretListKey get _key =>
-      ExternalSecretListKey(clusterId: clusterId);
+  @override
+  ConsumerState<_ListBody> createState() => _ListBodyState();
+}
+
+class _ListBodyState extends ConsumerState<_ListBody>
+    with RefreshGuardMixin {
+  PushSecretListKey get _key =>
+      PushSecretListKey(clusterId: widget.clusterId);
+
+  Future<void> _handleRefresh() => guardedRefresh(() async {
+        ref.invalidate(pushSecretListProvider(_key));
+        try {
+          await ref.read(pushSecretListProvider(_key).future);
+        } on Object {/* surfaces via .when */}
+      });
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     final colors = Theme.of(context).extension<KubeColors>()!;
     final async = ref.watch(pushSecretListProvider(_key));
 
-    Future<void> handleRefresh() async {
-      ref.invalidate(pushSecretListProvider(_key));
-      try {
-        await ref.read(pushSecretListProvider(_key).future);
-      } on Object {/* surfaces via .when */}
-    }
-
     return RefreshIndicator(
-      onRefresh: handleRefresh,
+      onRefresh: _handleRefresh,
       child: async.when(
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (e, _) => ListErrorShell(
           title: 'Failed to load PushSecrets',
           error: e,
-          onRetry: handleRefresh,
+          onRetry: _handleRefresh,
         ),
         data: (items) {
           if (items.isEmpty) {
@@ -98,7 +91,7 @@ class _ListBody extends ConsumerWidget {
             itemBuilder: (context, i) => _PsRow(
               ps: items[i],
               onTap: () => context.push(
-                '/clusters/$clusterId/eso/pushsecrets/'
+                '/clusters/${widget.clusterId}/eso/pushsecrets/'
                 '${Uri.encodeComponent(items[i].namespace)}/'
                 '${Uri.encodeComponent(items[i].name)}',
               ),

--- a/mobile/lib/features/eso/push_secrets_list_screen.dart
+++ b/mobile/lib/features/eso/push_secrets_list_screen.dart
@@ -1,0 +1,171 @@
+// PushSecrets list — the inverse-direction CRD that pushes a
+// Kubernetes Secret out to a source store. Read-only in v1 (backend
+// has no write surface); mobile mirrors that posture — there are no
+// row actions.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../api/api_error.dart';
+import '../../api/eso_repository.dart';
+import '../../cluster/cluster_provider.dart';
+import '../../theme/kube_theme_builder.dart';
+import '../../widgets/empty_states.dart';
+import '../../widgets/feature_unavailable_state.dart';
+import 'eso_widgets.dart';
+
+class PushSecretsListScreen extends ConsumerWidget {
+  const PushSecretsListScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final clusterId = ref.watch(activeClusterProvider);
+    final statusAsync = ref.watch(esoStatusProvider(clusterId));
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('PushSecrets')),
+      body: statusAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => ErrorStateView(
+          message: e is ApiError ? e.message : e.toString(),
+          onRetry: () => ref.invalidate(esoStatusProvider(clusterId)),
+        ),
+        data: (status) {
+          if (!status.detected) return FeatureUnavailableState.eso();
+          return _ListBody(clusterId: clusterId);
+        },
+      ),
+    );
+  }
+}
+
+class _ListBody extends ConsumerWidget {
+  const _ListBody({required this.clusterId});
+
+  final String clusterId;
+
+  ExternalSecretListKey get _key =>
+      ExternalSecretListKey(clusterId: clusterId);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final async = ref.watch(pushSecretListProvider(_key));
+
+    Future<void> handleRefresh() async {
+      ref.invalidate(pushSecretListProvider(_key));
+      try {
+        await ref.read(pushSecretListProvider(_key).future);
+      } on Object {/* surfaces via .when */}
+    }
+
+    return RefreshIndicator(
+      onRefresh: handleRefresh,
+      child: async.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => ListErrorShell(
+          title: 'Failed to load PushSecrets',
+          error: e,
+          onRetry: handleRefresh,
+        ),
+        data: (items) {
+          if (items.isEmpty) {
+            return ListView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              children: [
+                SizedBox(
+                  height: 280,
+                  child: Center(
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 32),
+                      child: Text(
+                        'No PushSecrets visible. PushSecrets export a '
+                        'Kubernetes Secret out to an external store; create '
+                        'one via the desktop UI.',
+                        style: TextStyle(color: colors.textMuted),
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            );
+          }
+          return ListView.builder(
+            physics: const AlwaysScrollableScrollPhysics(),
+            itemCount: items.length,
+            itemBuilder: (context, i) => _PsRow(
+              ps: items[i],
+              onTap: () => context.push(
+                '/clusters/$clusterId/eso/pushsecrets/'
+                '${Uri.encodeComponent(items[i].namespace)}/'
+                '${Uri.encodeComponent(items[i].name)}',
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _PsRow extends StatelessWidget {
+  const _PsRow({required this.ps, required this.onTap});
+
+  final PushSecret ps;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    ps.name,
+                    style: TextStyle(
+                      color: colors.textPrimary,
+                      fontSize: 15,
+                      fontWeight: FontWeight.w600,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                EsoStatusPill(status: ps.status, dense: true),
+              ],
+            ),
+            const SizedBox(height: 4),
+            Text(
+              ps.namespace,
+              style: TextStyle(color: colors.textSecondary, fontSize: 12),
+            ),
+            if (ps.sourceSecretName != null) ...[
+              const SizedBox(height: 2),
+              Text(
+                'source: ${ps.sourceSecretName}',
+                style: TextStyle(color: colors.textMuted, fontSize: 11),
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
+            if (ps.storeRefs.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 2),
+                child: Text(
+                  '→ ${ps.storeRefs.length} store${ps.storeRefs.length == 1 ? '' : 's'}',
+                  style: TextStyle(color: colors.textMuted, fontSize: 11),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/eso/store_detail_screen.dart
+++ b/mobile/lib/features/eso/store_detail_screen.dart
@@ -5,11 +5,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../api/api_error.dart';
 import '../../api/eso_repository.dart';
 import '../../cluster/cluster_provider.dart';
 import '../../theme/kube_theme_builder.dart';
-import '../../widgets/empty_states.dart';
 import 'eso_widgets.dart';
 import 'store_metrics_panel.dart';
 
@@ -31,52 +29,13 @@ class StoreDetailScreen extends ConsumerWidget {
       namespace: namespace,
       name: name,
     );
-    final async = ref.watch(storeDetailProvider(key));
-    final metricsAsync = ref.watch(storeMetricsProvider(key));
-
-    return DefaultTabController(
-      length: 2,
-      child: Scaffold(
-        appBar: AppBar(
-          title: Text(name),
-          actions: [
-            IconButton(
-              tooltip: 'Refresh',
-              icon: const Icon(Icons.refresh),
-              onPressed: () {
-                ref.invalidate(storeDetailProvider(key));
-                ref.invalidate(storeMetricsProvider(key));
-              },
-            ),
-          ],
-          bottom: const TabBar(
-            tabs: [
-              Tab(text: 'Overview'),
-              Tab(text: 'Metrics'),
-            ],
-          ),
-        ),
-        body: async.when(
-          loading: () => const Center(child: CircularProgressIndicator()),
-          error: (e, _) => ErrorStateView(
-            message: e is ApiError ? e.message : e.toString(),
-            onRetry: () => ref.invalidate(storeDetailProvider(key)),
-          ),
-          data: (store) => TabBarView(
-            children: [
-              _OverviewTab(store: store),
-              SingleChildScrollView(
-                padding: const EdgeInsets.all(16),
-                child: StoreMetricsPanel(
-                  metricsAsync: metricsAsync,
-                  onRetry: () => ref.invalidate(storeMetricsProvider(key)),
-                  storeLabel: '${store.namespace} / ${store.name}',
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
+    return _StoreDetailShell(
+      title: name,
+      detailAsync: ref.watch(storeDetailProvider(key)),
+      metricsAsync: ref.watch(storeMetricsProvider(key)),
+      labelForStore: (s) => '${s.namespace} / ${s.name}',
+      onRefreshDetail: () => ref.invalidate(storeDetailProvider(key)),
+      onRefreshMetrics: () => ref.invalidate(storeMetricsProvider(key)),
     );
   }
 }
@@ -90,22 +49,56 @@ class ClusterStoreDetailScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final clusterId = ref.watch(activeClusterProvider);
     final key = ClusterStoreDetailKey(clusterId: clusterId, name: name);
-    final async = ref.watch(clusterStoreDetailProvider(key));
-    final metricsAsync = ref.watch(clusterStoreMetricsProvider(key));
+    return _StoreDetailShell(
+      title: name,
+      detailAsync: ref.watch(clusterStoreDetailProvider(key)),
+      metricsAsync: ref.watch(clusterStoreMetricsProvider(key)),
+      labelForStore: (s) => s.name,
+      onRefreshDetail: () => ref.invalidate(clusterStoreDetailProvider(key)),
+      onRefreshMetrics: () =>
+          ref.invalidate(clusterStoreMetricsProvider(key)),
+    );
+  }
+}
 
+/// Tab scaffold shared by [StoreDetailScreen] and [ClusterStoreDetailScreen].
+/// The two screens differ only by provider keys + how the metrics panel
+/// labels the store; everything else (AppBar, tabs, error-state mapping,
+/// retry semantics) is identical and lives here.
+class _StoreDetailShell extends StatelessWidget {
+  const _StoreDetailShell({
+    required this.title,
+    required this.detailAsync,
+    required this.metricsAsync,
+    required this.labelForStore,
+    required this.onRefreshDetail,
+    required this.onRefreshMetrics,
+  });
+
+  final String title;
+  final AsyncValue<SecretStore> detailAsync;
+  final AsyncValue<StoreMetrics> metricsAsync;
+  final String Function(SecretStore) labelForStore;
+  final VoidCallback onRefreshDetail;
+  final VoidCallback onRefreshMetrics;
+
+  void _refreshBoth() {
+    onRefreshDetail();
+    onRefreshMetrics();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return DefaultTabController(
       length: 2,
       child: Scaffold(
         appBar: AppBar(
-          title: Text(name),
+          title: Text(title),
           actions: [
             IconButton(
               tooltip: 'Refresh',
               icon: const Icon(Icons.refresh),
-              onPressed: () {
-                ref.invalidate(clusterStoreDetailProvider(key));
-                ref.invalidate(clusterStoreMetricsProvider(key));
-              },
+              onPressed: _refreshBoth,
             ),
           ],
           bottom: const TabBar(
@@ -115,11 +108,13 @@ class ClusterStoreDetailScreen extends ConsumerWidget {
             ],
           ),
         ),
-        body: async.when(
+        body: detailAsync.when(
           loading: () => const Center(child: CircularProgressIndicator()),
-          error: (e, _) => ErrorStateView(
-            message: e is ApiError ? e.message : e.toString(),
-            onRetry: () => ref.invalidate(clusterStoreDetailProvider(key)),
+          error: (e, _) => esoDetailErrorState(
+            error: e,
+            // Retry both providers; the metrics provider may also be
+            // stuck on a stale error from the first failed fetch.
+            onRetry: _refreshBoth,
           ),
           data: (store) => TabBarView(
             children: [
@@ -128,9 +123,8 @@ class ClusterStoreDetailScreen extends ConsumerWidget {
                 padding: const EdgeInsets.all(16),
                 child: StoreMetricsPanel(
                   metricsAsync: metricsAsync,
-                  onRetry: () =>
-                      ref.invalidate(clusterStoreMetricsProvider(key)),
-                  storeLabel: store.name,
+                  onRetry: onRefreshMetrics,
+                  storeLabel: labelForStore(store),
                 ),
               ),
             ],
@@ -157,7 +151,7 @@ class _OverviewTab extends StatelessWidget {
         _AttributesCard(store: store, colors: colors),
         if (store.readyMessage != null && store.readyMessage!.isNotEmpty) ...[
           const SizedBox(height: 12),
-          _ReadyMessageCard(
+          EsoReadyMessageCard(
             reason: store.readyReason,
             message: store.readyMessage!,
             colors: colors,
@@ -296,45 +290,6 @@ class _AttributesCard extends StatelessWidget {
                 value: '${store.alertOnLifecycle}',
               ),
           ],
-        ],
-      ),
-    );
-  }
-}
-
-class _ReadyMessageCard extends StatelessWidget {
-  const _ReadyMessageCard({
-    required this.reason,
-    required this.message,
-    required this.colors,
-  });
-
-  final String? reason;
-  final String message;
-  final KubeColors colors;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.all(14),
-      decoration: BoxDecoration(
-        color: colors.bgSurface,
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: colors.borderSubtle),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            reason ?? 'Status detail',
-            style: TextStyle(
-              color: colors.textPrimary,
-              fontSize: 14,
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-          const SizedBox(height: 6),
-          Text(message, style: TextStyle(color: colors.textSecondary)),
         ],
       ),
     );

--- a/mobile/lib/features/eso/store_detail_screen.dart
+++ b/mobile/lib/features/eso/store_detail_screen.dart
@@ -1,0 +1,401 @@
+// SecretStore detail — namespaced + cluster variants. Both share a
+// tab scaffold: Overview / Metrics. The cluster variant is a thin
+// wrapper that swaps the providers + URL shape.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../api/api_error.dart';
+import '../../api/eso_repository.dart';
+import '../../cluster/cluster_provider.dart';
+import '../../theme/kube_theme_builder.dart';
+import '../../widgets/empty_states.dart';
+import 'eso_widgets.dart';
+import 'store_metrics_panel.dart';
+
+class StoreDetailScreen extends ConsumerWidget {
+  const StoreDetailScreen({
+    super.key,
+    required this.namespace,
+    required this.name,
+  });
+
+  final String namespace;
+  final String name;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final clusterId = ref.watch(activeClusterProvider);
+    final key = StoreDetailKey(
+      clusterId: clusterId,
+      namespace: namespace,
+      name: name,
+    );
+    final async = ref.watch(storeDetailProvider(key));
+    final metricsAsync = ref.watch(storeMetricsProvider(key));
+
+    return DefaultTabController(
+      length: 2,
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(name),
+          actions: [
+            IconButton(
+              tooltip: 'Refresh',
+              icon: const Icon(Icons.refresh),
+              onPressed: () {
+                ref.invalidate(storeDetailProvider(key));
+                ref.invalidate(storeMetricsProvider(key));
+              },
+            ),
+          ],
+          bottom: const TabBar(
+            tabs: [
+              Tab(text: 'Overview'),
+              Tab(text: 'Metrics'),
+            ],
+          ),
+        ),
+        body: async.when(
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (e, _) => ErrorStateView(
+            message: e is ApiError ? e.message : e.toString(),
+            onRetry: () => ref.invalidate(storeDetailProvider(key)),
+          ),
+          data: (store) => TabBarView(
+            children: [
+              _OverviewTab(store: store),
+              SingleChildScrollView(
+                padding: const EdgeInsets.all(16),
+                child: StoreMetricsPanel(
+                  metricsAsync: metricsAsync,
+                  onRetry: () => ref.invalidate(storeMetricsProvider(key)),
+                  storeLabel: '${store.namespace} / ${store.name}',
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class ClusterStoreDetailScreen extends ConsumerWidget {
+  const ClusterStoreDetailScreen({super.key, required this.name});
+
+  final String name;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final clusterId = ref.watch(activeClusterProvider);
+    final key = ClusterStoreDetailKey(clusterId: clusterId, name: name);
+    final async = ref.watch(clusterStoreDetailProvider(key));
+    final metricsAsync = ref.watch(clusterStoreMetricsProvider(key));
+
+    return DefaultTabController(
+      length: 2,
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(name),
+          actions: [
+            IconButton(
+              tooltip: 'Refresh',
+              icon: const Icon(Icons.refresh),
+              onPressed: () {
+                ref.invalidate(clusterStoreDetailProvider(key));
+                ref.invalidate(clusterStoreMetricsProvider(key));
+              },
+            ),
+          ],
+          bottom: const TabBar(
+            tabs: [
+              Tab(text: 'Overview'),
+              Tab(text: 'Metrics'),
+            ],
+          ),
+        ),
+        body: async.when(
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (e, _) => ErrorStateView(
+            message: e is ApiError ? e.message : e.toString(),
+            onRetry: () => ref.invalidate(clusterStoreDetailProvider(key)),
+          ),
+          data: (store) => TabBarView(
+            children: [
+              _OverviewTab(store: store),
+              SingleChildScrollView(
+                padding: const EdgeInsets.all(16),
+                child: StoreMetricsPanel(
+                  metricsAsync: metricsAsync,
+                  onRetry: () =>
+                      ref.invalidate(clusterStoreMetricsProvider(key)),
+                  storeLabel: store.name,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _OverviewTab extends StatelessWidget {
+  const _OverviewTab({required this.store});
+
+  final SecretStore store;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return ListView(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      children: [
+        _HeaderCard(store: store, colors: colors),
+        const SizedBox(height: 12),
+        _AttributesCard(store: store, colors: colors),
+        if (store.readyMessage != null && store.readyMessage!.isNotEmpty) ...[
+          const SizedBox(height: 12),
+          _ReadyMessageCard(
+            reason: store.readyReason,
+            message: store.readyMessage!,
+            colors: colors,
+          ),
+        ],
+        if (store.providerSpec.isNotEmpty) ...[
+          const SizedBox(height: 12),
+          _ProviderSpecCard(spec: store.providerSpec, colors: colors),
+        ],
+      ],
+    );
+  }
+}
+
+class _HeaderCard extends StatelessWidget {
+  const _HeaderCard({required this.store, required this.colors});
+
+  final SecretStore store;
+  final KubeColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: colors.bgSurface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colors.borderSubtle),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              EsoStatusPill(status: store.status),
+              const SizedBox(width: 8),
+              ProviderChip(provider: store.provider),
+              const SizedBox(width: 8),
+              if (store.isCluster)
+                Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                  decoration: BoxDecoration(
+                    color: colors.bgElevated,
+                    borderRadius: BorderRadius.circular(3),
+                    border: Border.all(color: colors.accent),
+                  ),
+                  child: Text(
+                    'Cluster',
+                    style: TextStyle(
+                      color: colors.accent,
+                      fontSize: 10,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          if (store.namespace.isNotEmpty)
+            Text(
+              store.namespace,
+              style: TextStyle(color: colors.textSecondary, fontSize: 12),
+            ),
+          Text(
+            store.name,
+            style: TextStyle(
+              color: colors.textPrimary,
+              fontSize: 18,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AttributesCard extends StatelessWidget {
+  const _AttributesCard({required this.store, required this.colors});
+
+  final SecretStore store;
+  final KubeColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    final hasThresholds = store.staleAfterMinutes != null ||
+        store.alertOnRecovery != null ||
+        store.alertOnLifecycle != null;
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: colors.bgSurface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colors.borderSubtle),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Configuration',
+            style: TextStyle(
+              color: colors.textPrimary,
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 8),
+          EsoKvRow(label: 'Scope', value: store.scope.isEmpty ? '—' : store.scope),
+          EsoKvRow(label: 'Ready', value: store.ready ? 'yes' : 'no'),
+          EsoKvRow(label: 'Provider', value: store.provider.isEmpty ? '—' : store.provider),
+          if (hasThresholds) ...[
+            const Divider(height: 16),
+            Text(
+              'Annotation thresholds',
+              style: TextStyle(
+                color: colors.textMuted,
+                fontSize: 12,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 4),
+            if (store.staleAfterMinutes != null)
+              EsoKvRow(
+                label: 'Stale after',
+                value: '${store.staleAfterMinutes}m',
+              ),
+            if (store.alertOnRecovery != null)
+              EsoKvRow(
+                label: 'Alert on recovery',
+                value: '${store.alertOnRecovery}',
+              ),
+            if (store.alertOnLifecycle != null)
+              EsoKvRow(
+                label: 'Alert on lifecycle',
+                value: '${store.alertOnLifecycle}',
+              ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _ReadyMessageCard extends StatelessWidget {
+  const _ReadyMessageCard({
+    required this.reason,
+    required this.message,
+    required this.colors,
+  });
+
+  final String? reason;
+  final String message;
+  final KubeColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: colors.bgSurface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colors.borderSubtle),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            reason ?? 'Status detail',
+            style: TextStyle(
+              color: colors.textPrimary,
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(message, style: TextStyle(color: colors.textSecondary)),
+        ],
+      ),
+    );
+  }
+}
+
+class _ProviderSpecCard extends StatelessWidget {
+  const _ProviderSpecCard({required this.spec, required this.colors});
+
+  final Map<String, dynamic> spec;
+  final KubeColors colors;
+
+  /// Renders a single key/value from the provider spec. Values that
+  /// are nested maps render as `[map: N keys]`; lists as `[list: N
+  /// items]`. Drilling into nested provider spec is a desktop feature —
+  /// mobile shows the addressing info verbatim. Credential fields are
+  /// already filtered by the backend's normalize layer.
+  Widget _row(BuildContext ctx, String k, Object? v) {
+    String value;
+    if (v == null) {
+      value = 'null';
+    } else if (v is Map) {
+      value = '{${v.length} keys}';
+    } else if (v is List) {
+      value = '[${v.length} items]';
+    } else {
+      value = v.toString();
+    }
+    return EsoKvRow(label: k, value: value);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final keys = spec.keys.toList()..sort();
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: colors.bgSurface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colors.borderSubtle),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Provider spec',
+            style: TextStyle(
+              color: colors.textPrimary,
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 8),
+          for (final k in keys) _row(context, k, spec[k]),
+          const SizedBox(height: 4),
+          Text(
+            'Open k8sCenter on desktop to drill into nested provider config.',
+            style: TextStyle(color: colors.textMuted, fontSize: 11),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/eso/store_metrics_panel.dart
+++ b/mobile/lib/features/eso/store_metrics_panel.dart
@@ -1,0 +1,269 @@
+// Per-store metrics panel. Reads the live `/v1/externalsecrets/
+// {cluster,}stores/.../metrics` response shape and decides chart-vs-
+// table per field (per plan §"Deferred to Implementation" — the
+// response shape is determined at runtime, not hardcoded here).
+//
+// Wire contract: `ratePerMin` + `last24h` are null when Prometheus has
+// no series yet OR is offline (distinguished by `error`). The UI MUST
+// NOT fabricate a zero — `null` ≠ `0`. Cost block is null for
+// self-hosted providers (Vault, Kubernetes); the panel suppresses the
+// card rather than showing "$0".
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../api/api_error.dart';
+import '../../api/eso_repository.dart';
+import '../../theme/kube_theme_builder.dart';
+import '../../widgets/empty_states.dart';
+import 'eso_widgets.dart';
+
+/// Renders rate (chart-suitable when paired with a time series, KV
+/// otherwise — the current backend emits an instant rate so KV it is)
+/// and cost-tier estimate. Distinguishes the three null cases:
+///   * Prom offline (error string)
+///   * No series yet (null rate, no error)
+///   * Self-hosted provider (no cost block at all)
+class StoreMetricsPanel extends ConsumerWidget {
+  const StoreMetricsPanel({
+    super.key,
+    required this.metricsAsync,
+    required this.onRetry,
+    this.storeLabel,
+  });
+
+  /// Pass the `ref.watch(...)` result from one of:
+  ///   * [storeMetricsProvider]
+  ///   * [clusterStoreMetricsProvider]
+  final AsyncValue<StoreMetrics> metricsAsync;
+
+  /// Pull-to-refresh / inline retry callback the panel exposes when the
+  /// fetch failed. Distinct from the `error` field on the 200 envelope —
+  /// THIS handles network/auth failures.
+  final VoidCallback onRetry;
+
+  /// Optional caption rendered above the panel ("vault-store / app").
+  /// Used by the embedded sub-tab placement on store detail screens.
+  final String? storeLabel;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+
+    return metricsAsync.when(
+      loading: () => const Padding(
+        padding: EdgeInsets.symmetric(vertical: 24),
+        child: Center(child: CircularProgressIndicator()),
+      ),
+      error: (e, _) => ErrorStateView(
+        message: e is ApiError ? e.message : e.toString(),
+        onRetry: onRetry,
+      ),
+      data: (metrics) => _MetricsBody(
+        metrics: metrics,
+        storeLabel: storeLabel,
+        colors: colors,
+      ),
+    );
+  }
+}
+
+class _MetricsBody extends StatelessWidget {
+  const _MetricsBody({
+    required this.metrics,
+    required this.storeLabel,
+    required this.colors,
+  });
+
+  final StoreMetrics metrics;
+  final String? storeLabel;
+  final KubeColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (storeLabel != null) ...[
+          Text(
+            storeLabel!,
+            style: TextStyle(
+              color: colors.textMuted,
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 8),
+        ],
+        if (metrics.isDegraded)
+          _DegradedBanner(message: metrics.error!, colors: colors),
+        const SizedBox(height: 8),
+        _RatePanel(metrics: metrics, colors: colors),
+        if (metrics.cost != null) ...[
+          const SizedBox(height: 12),
+          _CostPanel(cost: metrics.cost!, colors: colors),
+        ],
+        if (metrics.windowEnd != null && metrics.windowEnd!.isNotEmpty) ...[
+          const SizedBox(height: 8),
+          Text(
+            'Sampled at ${metrics.windowEnd!}',
+            style: TextStyle(color: colors.textMuted, fontSize: 11),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _DegradedBanner extends StatelessWidget {
+  const _DegradedBanner({required this.message, required this.colors});
+
+  final String message;
+  final KubeColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+      decoration: BoxDecoration(
+        color: colors.warningDim,
+        borderRadius: BorderRadius.circular(4),
+        border: Border.all(color: colors.warning),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.warning_amber_outlined,
+              size: 16, color: colors.warning),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              message,
+              style: TextStyle(color: colors.textSecondary, fontSize: 12),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _RatePanel extends StatelessWidget {
+  const _RatePanel({required this.metrics, required this.colors});
+
+  final StoreMetrics metrics;
+  final KubeColors colors;
+
+  String _fmtRate(double? v) {
+    if (v == null) {
+      return metrics.isDegraded ? '—' : 'no data yet';
+    }
+    if (v < 0.01) return v.toStringAsFixed(4);
+    return v.toStringAsFixed(2);
+  }
+
+  String _fmtCount(double? v) {
+    if (v == null) {
+      return metrics.isDegraded ? '—' : 'no data yet';
+    }
+    if (v < 1) return v.toStringAsFixed(2);
+    return v.toStringAsFixed(0);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: colors.bgElevated,
+        borderRadius: BorderRadius.circular(6),
+        border: Border.all(color: colors.borderSubtle),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Sync rate',
+            style: TextStyle(
+              color: colors.textPrimary,
+              fontSize: 13,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 6),
+          EsoKvRow(
+            label: 'Rate / min',
+            value: _fmtRate(metrics.ratePerMin),
+            valueColor: metrics.ratePerMin == null ? colors.textMuted : null,
+          ),
+          EsoKvRow(
+            label: 'Last 24h',
+            value: _fmtCount(metrics.last24h),
+            valueColor: metrics.last24h == null ? colors.textMuted : null,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CostPanel extends StatelessWidget {
+  const _CostPanel({required this.cost, required this.colors});
+
+  final CostEstimate cost;
+  final KubeColors colors;
+
+  String _fmtMoney(double? v, String currency) {
+    if (v == null) return '—';
+    return '${v.toStringAsFixed(2)} $currency';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cur = cost.currency ?? 'USD';
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: colors.bgElevated,
+        borderRadius: BorderRadius.circular(6),
+        border: Border.all(color: colors.borderSubtle),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Text(
+                'Cost estimate',
+                style: TextStyle(
+                  color: colors.textPrimary,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(width: 8),
+              ProviderChip(provider: cost.billingProvider),
+            ],
+          ),
+          const SizedBox(height: 6),
+          EsoKvRow(
+            label: 'USD / 1M',
+            value: cost.usdPerMillion == null
+                ? '—'
+                : cost.usdPerMillion!.toStringAsFixed(2),
+          ),
+          EsoKvRow(
+            label: 'Est. 24h',
+            value: _fmtMoney(cost.estimated24h, cur),
+          ),
+          if (cost.lastUpdated != null)
+            EsoKvRow(label: 'Rate card date', value: cost.lastUpdated!),
+          const SizedBox(height: 4),
+          Text(
+            'Not connected to live billing — public list price snapshot.',
+            style: TextStyle(color: colors.textMuted, fontSize: 11),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/eso/store_metrics_panel.dart
+++ b/mobile/lib/features/eso/store_metrics_panel.dart
@@ -95,9 +95,10 @@ class _MetricsBody extends StatelessWidget {
           ),
           const SizedBox(height: 8),
         ],
-        if (metrics.isDegraded)
+        if (metrics.isDegraded) ...[
           _DegradedBanner(message: metrics.error!, colors: colors),
-        const SizedBox(height: 8),
+          const SizedBox(height: 8),
+        ],
         _RatePanel(metrics: metrics, colors: colors),
         if (metrics.cost != null) ...[
           const SizedBox(height: 12),

--- a/mobile/lib/features/eso/stores_list_screen.dart
+++ b/mobile/lib/features/eso/stores_list_screen.dart
@@ -1,0 +1,167 @@
+// SecretStores list — namespaced stores. Cluster-scoped stores live on
+// a parallel screen (`cluster_stores_list_screen.dart`) rather than
+// being interleaved here; the desktop UI splits them similarly so
+// scope confusion stays uncommon.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../api/api_error.dart';
+import '../../api/eso_repository.dart';
+import '../../cluster/cluster_provider.dart';
+import '../../theme/kube_theme_builder.dart';
+import '../../widgets/empty_states.dart';
+import '../../widgets/feature_unavailable_state.dart';
+import 'eso_widgets.dart';
+
+class StoresListScreen extends ConsumerWidget {
+  const StoresListScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final clusterId = ref.watch(activeClusterProvider);
+    final statusAsync = ref.watch(esoStatusProvider(clusterId));
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('SecretStores')),
+      body: statusAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => ErrorStateView(
+          message: e is ApiError ? e.message : e.toString(),
+          onRetry: () => ref.invalidate(esoStatusProvider(clusterId)),
+        ),
+        data: (status) {
+          if (!status.detected) return FeatureUnavailableState.eso();
+          return _ListBody(clusterId: clusterId);
+        },
+      ),
+    );
+  }
+}
+
+class _ListBody extends ConsumerWidget {
+  const _ListBody({required this.clusterId});
+
+  final String clusterId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final async = ref.watch(storesListProvider(clusterId));
+
+    Future<void> handleRefresh() async {
+      ref.invalidate(storesListProvider(clusterId));
+      try {
+        await ref.read(storesListProvider(clusterId).future);
+      } on Object {/* surfaces via .when */}
+    }
+
+    return RefreshIndicator(
+      onRefresh: handleRefresh,
+      child: async.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => ListErrorShell(
+          title: 'Failed to load SecretStores',
+          error: e,
+          onRetry: handleRefresh,
+        ),
+        data: (items) {
+          if (items.isEmpty) {
+            return ListView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              children: [
+                SizedBox(
+                  height: 280,
+                  child: Center(
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 32),
+                      child: Text(
+                        'No SecretStores visible. Create one with the '
+                        '"SecretStore" wizard to start syncing secrets.',
+                        style: TextStyle(color: colors.textMuted),
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            );
+          }
+          return ListView.builder(
+            physics: const AlwaysScrollableScrollPhysics(),
+            itemCount: items.length,
+            itemBuilder: (context, i) => _StoreRow(
+              store: items[i],
+              onTap: () => context.push(
+                '/clusters/$clusterId/eso/stores/'
+                '${Uri.encodeComponent(items[i].namespace)}/'
+                '${Uri.encodeComponent(items[i].name)}',
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _StoreRow extends StatelessWidget {
+  const _StoreRow({required this.store, required this.onTap});
+
+  final SecretStore store;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    store.name,
+                    style: TextStyle(
+                      color: colors.textPrimary,
+                      fontSize: 15,
+                      fontWeight: FontWeight.w600,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                EsoStatusPill(status: store.status, dense: true),
+              ],
+            ),
+            const SizedBox(height: 4),
+            Row(
+              children: [
+                Text(
+                  store.namespace,
+                  style: TextStyle(color: colors.textSecondary, fontSize: 12),
+                ),
+                const SizedBox(width: 8),
+                ProviderChip(provider: store.provider),
+              ],
+            ),
+            if (store.readyMessage != null && store.readyMessage!.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 4),
+                child: Text(
+                  store.readyMessage!,
+                  style: TextStyle(color: colors.textMuted, fontSize: 11),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/eso/stores_list_screen.dart
+++ b/mobile/lib/features/eso/stores_list_screen.dart
@@ -7,64 +7,57 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../api/api_error.dart';
 import '../../api/eso_repository.dart';
-import '../../cluster/cluster_provider.dart';
 import '../../theme/kube_theme_builder.dart';
 import '../../widgets/empty_states.dart';
-import '../../widgets/feature_unavailable_state.dart';
+import '../../widgets/refresh_guard.dart';
 import 'eso_widgets.dart';
 
-class StoresListScreen extends ConsumerWidget {
+class StoresListScreen extends StatelessWidget {
   const StoresListScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final clusterId = ref.watch(activeClusterProvider);
-    final statusAsync = ref.watch(esoStatusProvider(clusterId));
-
+  Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('SecretStores')),
-      body: statusAsync.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => ErrorStateView(
-          message: e is ApiError ? e.message : e.toString(),
-          onRetry: () => ref.invalidate(esoStatusProvider(clusterId)),
-        ),
-        data: (status) {
-          if (!status.detected) return FeatureUnavailableState.eso();
-          return _ListBody(clusterId: clusterId);
-        },
+      body: EsoStatusGate(
+        builder: (clusterId) => _ListBody(clusterId: clusterId),
       ),
     );
   }
 }
 
-class _ListBody extends ConsumerWidget {
+class _ListBody extends ConsumerStatefulWidget {
   const _ListBody({required this.clusterId});
 
   final String clusterId;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final colors = Theme.of(context).extension<KubeColors>()!;
-    final async = ref.watch(storesListProvider(clusterId));
+  ConsumerState<_ListBody> createState() => _ListBodyState();
+}
 
-    Future<void> handleRefresh() async {
-      ref.invalidate(storesListProvider(clusterId));
-      try {
-        await ref.read(storesListProvider(clusterId).future);
-      } on Object {/* surfaces via .when */}
-    }
+class _ListBodyState extends ConsumerState<_ListBody>
+    with RefreshGuardMixin {
+  Future<void> _handleRefresh() => guardedRefresh(() async {
+        ref.invalidate(storesListProvider(widget.clusterId));
+        try {
+          await ref.read(storesListProvider(widget.clusterId).future);
+        } on Object {/* surfaces via .when */}
+      });
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final async = ref.watch(storesListProvider(widget.clusterId));
 
     return RefreshIndicator(
-      onRefresh: handleRefresh,
+      onRefresh: _handleRefresh,
       child: async.when(
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (e, _) => ListErrorShell(
           title: 'Failed to load SecretStores',
           error: e,
-          onRetry: handleRefresh,
+          onRetry: _handleRefresh,
         ),
         data: (items) {
           if (items.isEmpty) {
@@ -94,7 +87,7 @@ class _ListBody extends ConsumerWidget {
             itemBuilder: (context, i) => _StoreRow(
               store: items[i],
               onTap: () => context.push(
-                '/clusters/$clusterId/eso/stores/'
+                '/clusters/${widget.clusterId}/eso/stores/'
                 '${Uri.encodeComponent(items[i].namespace)}/'
                 '${Uri.encodeComponent(items[i].name)}',
               ),

--- a/mobile/lib/routing/app_router.dart
+++ b/mobile/lib/routing/app_router.dart
@@ -16,6 +16,16 @@ import '../features/certmanager/certificates_list_screen.dart';
 import '../features/certmanager/expiring_screen.dart';
 import '../features/certmanager/issuers_list_screen.dart';
 import '../features/dashboard/dashboard_screen.dart';
+import '../features/eso/cluster_external_secret_detail_screen.dart';
+import '../features/eso/cluster_external_secrets_list_screen.dart';
+import '../features/eso/cluster_stores_list_screen.dart';
+import '../features/eso/dashboard_screen.dart' as eso_dashboard;
+import '../features/eso/external_secret_detail_screen.dart';
+import '../features/eso/external_secrets_list_screen.dart';
+import '../features/eso/push_secret_detail_screen.dart';
+import '../features/eso/push_secrets_list_screen.dart';
+import '../features/eso/store_detail_screen.dart';
+import '../features/eso/stores_list_screen.dart';
 import '../features/login/login_screen.dart';
 import '../features/notifications_center/feed_screen.dart';
 import '../features/gitops/application_detail_screen.dart';
@@ -253,6 +263,94 @@ final appRouterProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/clusters/:clusterId/certificates/expiring',
         builder: (context, state) => const ExpiringCertificatesScreen(),
+      ),
+
+      // --- M4 PR-4h: External Secrets Operator observatory ---
+      // /clusters/<id>/eso                                   → dashboard
+      // /clusters/<id>/eso/externalsecrets[?status=…]        → ES list
+      // /clusters/<id>/eso/externalsecrets/<ns>/<name>       → ES detail
+      // /clusters/<id>/eso/cluster-externalsecrets           → CES list
+      // /clusters/<id>/eso/cluster-externalsecrets/<name>    → CES detail
+      // /clusters/<id>/eso/stores                            → SecretStore list
+      // /clusters/<id>/eso/stores/<ns>/<name>                → SecretStore detail
+      // /clusters/<id>/eso/cluster-stores                    → ClusterSecretStore list
+      // /clusters/<id>/eso/cluster-stores/<name>             → ClusterSecretStore detail
+      // /clusters/<id>/eso/pushsecrets                       → PushSecret list
+      // /clusters/<id>/eso/pushsecrets/<ns>/<name>           → PushSecret detail
+      //
+      // Status gating is screen-level (each surface checks
+      // `esoStatusProvider` and falls back to
+      // `FeatureUnavailableState.eso()`). Drift Revert + bulk-refresh
+      // POSTs are deferred to M5+ per R12 — `DisabledRevertDriftButton`
+      // points operators at desktop.
+      GoRoute(
+        path: '/clusters/:clusterId/eso',
+        builder: (context, state) => const eso_dashboard.EsoDashboardScreen(),
+      ),
+      GoRoute(
+        path: '/clusters/:clusterId/eso/externalsecrets',
+        builder: (context, state) => ExternalSecretsListScreen(
+          initialStatusFilter: state.uri.queryParameters['status'],
+        ),
+        routes: [
+          GoRoute(
+            path: ':namespace/:name',
+            builder: (context, state) => ExternalSecretDetailScreen(
+              namespace: state.pathParameters['namespace']!,
+              name: state.pathParameters['name']!,
+            ),
+          ),
+        ],
+      ),
+      GoRoute(
+        path: '/clusters/:clusterId/eso/cluster-externalsecrets',
+        builder: (context, state) => const ClusterExternalSecretsListScreen(),
+        routes: [
+          GoRoute(
+            path: ':name',
+            builder: (context, state) => ClusterExternalSecretDetailScreen(
+              name: state.pathParameters['name']!,
+            ),
+          ),
+        ],
+      ),
+      GoRoute(
+        path: '/clusters/:clusterId/eso/stores',
+        builder: (context, state) => const StoresListScreen(),
+        routes: [
+          GoRoute(
+            path: ':namespace/:name',
+            builder: (context, state) => StoreDetailScreen(
+              namespace: state.pathParameters['namespace']!,
+              name: state.pathParameters['name']!,
+            ),
+          ),
+        ],
+      ),
+      GoRoute(
+        path: '/clusters/:clusterId/eso/cluster-stores',
+        builder: (context, state) => const ClusterStoresListScreen(),
+        routes: [
+          GoRoute(
+            path: ':name',
+            builder: (context, state) => ClusterStoreDetailScreen(
+              name: state.pathParameters['name']!,
+            ),
+          ),
+        ],
+      ),
+      GoRoute(
+        path: '/clusters/:clusterId/eso/pushsecrets',
+        builder: (context, state) => const PushSecretsListScreen(),
+        routes: [
+          GoRoute(
+            path: ':namespace/:name',
+            builder: (context, state) => PushSecretDetailScreen(
+              namespace: state.pathParameters['namespace']!,
+              name: state.pathParameters['name']!,
+            ),
+          ),
+        ],
       ),
 
       // --- Resource list routes (PR-1d: 6 specialized kinds) ---

--- a/mobile/lib/routing/domain_sections.dart
+++ b/mobile/lib/routing/domain_sections.dart
@@ -226,6 +226,69 @@ const List<DomainSection> domainSections = [
       ),
     ],
   ),
+  // External Secrets Operator observatory (PR-4h). Six entries:
+  //   * Dashboard — synced/total gauge + SyncFailed/Stale/Drifted/
+  //     Unknown summary cards + top-N failure table.
+  //   * ExternalSecrets — namespaced list with `lastObservedDriftStatus`
+  //     hint per row; detail screen fetches live `driftStatus`.
+  //   * Cluster ExternalSecrets — fan-out form, cluster-scoped.
+  //   * SecretStores — namespaced + per-store metrics panel (rate +
+  //     cost-tier estimate).
+  //   * Cluster SecretStores — cluster-scoped store variant.
+  //   * PushSecrets — read-only inverse direction (Secret → store).
+  // All six surfaces gate on `esoStatusProvider` and fall back to
+  // `FeatureUnavailableState.eso()` when not installed. Drift Revert +
+  // bulk-refresh write actions are deferred to M5+ per R12.
+  DomainSection(
+    label: 'External Secrets',
+    pathSegment: 'eso',
+    icon: Icons.lock_person_outlined,
+    kinds: [
+      DomainKind(
+        kind: 'eso-dashboard',
+        label: 'Dashboard',
+        icon: Icons.dashboard_outlined,
+        namespaced: false,
+        customListPath: '/clusters/{clusterId}/eso',
+      ),
+      DomainKind(
+        kind: 'externalsecrets',
+        label: 'ExternalSecrets',
+        icon: Icons.lock_open_outlined,
+        namespaced: false,
+        customListPath: '/clusters/{clusterId}/eso/externalsecrets',
+      ),
+      DomainKind(
+        kind: 'cluster-externalsecrets',
+        label: 'Cluster ExternalSecrets',
+        icon: Icons.public_outlined,
+        namespaced: false,
+        customListPath:
+            '/clusters/{clusterId}/eso/cluster-externalsecrets',
+      ),
+      DomainKind(
+        kind: 'eso-stores',
+        label: 'SecretStores',
+        icon: Icons.account_tree_outlined,
+        namespaced: false,
+        customListPath: '/clusters/{clusterId}/eso/stores',
+      ),
+      DomainKind(
+        kind: 'eso-cluster-stores',
+        label: 'Cluster SecretStores',
+        icon: Icons.public_outlined,
+        namespaced: false,
+        customListPath: '/clusters/{clusterId}/eso/cluster-stores',
+      ),
+      DomainKind(
+        kind: 'pushsecrets',
+        label: 'PushSecrets',
+        icon: Icons.upload_outlined,
+        namespaced: false,
+        customListPath: '/clusters/{clusterId}/eso/pushsecrets',
+      ),
+    ],
+  ),
   // Cert-manager observatory (PR-4g). Three entries:
   //   * Certificates — full list with filter chips (All / Expiring /
   //     Failed) + search. `?status=expiring` URL param pre-filters.

--- a/mobile/lib/widgets/refresh_guard.dart
+++ b/mobile/lib/widgets/refresh_guard.dart
@@ -1,0 +1,60 @@
+// In-flight-deduplication guard for `RefreshIndicator.onRefresh`.
+//
+// Without this guard, two rapid pull-to-refresh gestures stack two
+// concurrent `ref.invalidate(...) + await ref.read(...future)` cycles
+// against the same provider slot. The first invalidation cancels the
+// in-flight CancelToken; the second starts a fresh fetch; the first
+// await races the second fetch's completion. The screen flickers
+// between loading and data states and may write stale data when the
+// race resolves in the wrong order. This mixin short-circuits repeat
+// calls while a refresh is mid-flight by handing back the same Future
+// rather than spawning a second invalidation.
+//
+// Lifted from `widgets/domain_list_scaffold.dart`'s private `_inflight`
+// field so non-scaffold screens (ESO observatory, future dashboards)
+// share the same protection without copy-pasting the implementation.
+
+import 'package:flutter/widgets.dart';
+
+/// Mix into a [ConsumerStatefulWidget] / [State] / [ConsumerWidget]
+/// helper class to share a single in-flight refresh future across rapid
+/// pull-to-refresh gestures and Retry-button taps.
+///
+/// Usage:
+/// ```dart
+/// class _MyBodyState extends ConsumerState<_MyBody> with RefreshGuardMixin {
+///   Future<void> _handleRefresh() => guardedRefresh(_runRefresh);
+///
+///   Future<void> _runRefresh() async {
+///     ref.invalidate(myProvider);
+///     try {
+///       await ref.read(myProvider.future);
+///     } on Object {/* surfaces via .when */}
+///   }
+/// }
+/// ```
+///
+/// The guard is **only** for the orchestrating wrapper; the underlying
+/// fetch still proceeds normally. When a second pull arrives while the
+/// first is still running, the caller receives the same Future and
+/// `RefreshIndicator` correctly waits for that single completion.
+mixin RefreshGuardMixin<T extends StatefulWidget> on State<T> {
+  Future<void>? _inflight;
+
+  /// Invokes [runner] only when no other guarded refresh is in flight
+  /// on this State; otherwise returns the in-flight future verbatim.
+  /// Clears the guard on completion regardless of success/failure so a
+  /// subsequent refresh can run.
+  Future<void> guardedRefresh(Future<void> Function() runner) {
+    final pending = _inflight;
+    if (pending != null) return pending;
+    final fut = runner();
+    _inflight = fut;
+    fut.whenComplete(() {
+      // Only clear if this is still the current in-flight future —
+      // dispose() may race the completion in tests.
+      if (mounted && identical(_inflight, fut)) _inflight = null;
+    });
+    return fut;
+  }
+}

--- a/mobile/test/api/eso_repository_test.dart
+++ b/mobile/test/api/eso_repository_test.dart
@@ -1,0 +1,443 @@
+// EsoRepository tests: endpoint paths, envelope unwrapping, X-Cluster-ID
+// forwarding, drift-vs-lastObservedDriftStatus asymmetry, store metrics
+// null semantics, and error surfacing.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kubecenter/api/api_error.dart';
+import 'package:kubecenter/api/dio_client.dart';
+import 'package:kubecenter/api/eso_repository.dart';
+import 'package:kubecenter/auth/secure_storage.dart';
+
+import '../support/mock_dio_adapter.dart';
+
+ResponseBody _json(Object body, {int status = 200}) {
+  return ResponseBody.fromBytes(
+    Uint8List.fromList(utf8.encode(jsonEncode(body))),
+    status,
+    headers: {
+      Headers.contentTypeHeader: ['application/json'],
+    },
+  );
+}
+
+({ProviderContainer container, MockDioAdapter mock}) _make() {
+  final mock = MockDioAdapter();
+  final container = ProviderContainer(
+    overrides: [
+      backendUrlProvider.overrideWithValue('http://test'),
+      secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+    ],
+  );
+  container.read(refreshDioProvider).httpClientAdapter = mock;
+  container.read(dioProvider).httpClientAdapter = mock;
+  return (container: container, mock: mock);
+}
+
+void main() {
+  group('EsoRepository.status', () {
+    test('parses detected status with namespace + version', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/status',
+        body: {
+          'data': {
+            'detected': true,
+            'namespace': 'external-secrets',
+            'version': '0.14.0',
+            'lastChecked': '2026-05-12T10:00:00Z',
+          },
+        },
+      );
+
+      final s = await container.read(esoRepositoryProvider).status();
+      expect(s.detected, isTrue);
+      expect(s.namespace, 'external-secrets');
+      expect(s.version, '0.14.0');
+    });
+
+    test('503 from status returns EsoDiscoveryStatus.empty', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.on(
+        'GET',
+        '/api/v1/externalsecrets/status',
+        (_) => _json({
+          'error': {'code': 503, 'message': 'discovery offline'},
+        }, status: 503),
+      );
+
+      final s = await container.read(esoRepositoryProvider).status();
+      expect(s.detected, isFalse);
+    });
+
+    test('forwards X-Cluster-ID when overridden', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/status',
+        body: {
+          'data': {'detected': false},
+        },
+      );
+
+      await container
+          .read(esoRepositoryProvider)
+          .status(clusterIdOverride: 'remote-1');
+
+      expect(mock.requests, hasLength(1));
+      expect(mock.requests.first.headers['X-Cluster-ID'], 'remote-1');
+    });
+  });
+
+  group('listExternalSecrets', () {
+    test(
+      'list endpoint surfaces lastObservedDriftStatus and leaves '
+      'driftStatus = notObserved (wire contract)',
+      () async {
+        final (:container, :mock) = _make();
+        addTearDown(container.dispose);
+
+        mock.onJson('GET', '/api/v1/externalsecrets/externalsecrets', body: {
+          'data': [
+            {
+              'name': 'app-token',
+              'namespace': 'app',
+              'uid': 'es-1',
+              'status': 'Synced',
+              'storeRef': {'name': 'vault', 'kind': 'SecretStore'},
+              'lastObservedDriftStatus': 'InSync',
+            },
+            {
+              'name': 'drifted-token',
+              'namespace': 'app',
+              'uid': 'es-2',
+              'status': 'Drifted',
+              'storeRef': {'name': 'vault', 'kind': 'SecretStore'},
+              'lastObservedDriftStatus': 'Drifted',
+            },
+          ],
+        });
+
+        final out =
+            await container.read(esoRepositoryProvider).listExternalSecrets();
+        expect(out, hasLength(2));
+        expect(out[0].lastObservedDriftStatus, DriftStatus.inSync);
+        expect(out[0].driftStatus, DriftStatus.notObserved);
+        expect(out[1].lastObservedDriftStatus, DriftStatus.drifted);
+        expect(out[1].driftStatus, DriftStatus.notObserved);
+      },
+    );
+
+    test('omitted lastObservedDriftStatus → notObserved (no fake Unknown)',
+        () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson('GET', '/api/v1/externalsecrets/externalsecrets', body: {
+        'data': [
+          {
+            'name': 'unobserved',
+            'namespace': 'app',
+            'uid': 'es-3',
+            'status': 'Synced',
+            'storeRef': {'name': 'vault', 'kind': 'SecretStore'},
+            // lastObservedDriftStatus deliberately omitted — backend
+            // poller has never observed this UID.
+          },
+        ],
+      });
+
+      final out =
+          await container.read(esoRepositoryProvider).listExternalSecrets();
+      expect(out, hasLength(1));
+      expect(out[0].lastObservedDriftStatus, DriftStatus.notObserved);
+      expect(out[0].effectiveDriftStatus, DriftStatus.notObserved);
+    });
+
+    test('namespace filter threads through as query param', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson('GET', '/api/v1/externalsecrets/externalsecrets',
+          body: <String, Object?>{'data': <Object?>[]});
+
+      await container
+          .read(esoRepositoryProvider)
+          .listExternalSecrets(namespace: 'kube-system');
+
+      expect(mock.requests, hasLength(1));
+      expect(mock.requests.first.queryParameters['namespace'], 'kube-system');
+    });
+  });
+
+  group('getExternalSecret', () {
+    test(
+      'detail endpoint surfaces live driftStatus + driftUnknownReason '
+      '(wire contract — opposite of list)',
+      () async {
+        final (:container, :mock) = _make();
+        addTearDown(container.dispose);
+
+        mock.onJson(
+          'GET',
+          '/api/v1/externalsecrets/externalsecrets/app/app-token',
+          body: {
+            'data': {
+              'name': 'app-token',
+              'namespace': 'app',
+              'uid': 'es-1',
+              'status': 'Synced',
+              'storeRef': {'name': 'vault', 'kind': 'SecretStore'},
+              'driftStatus': 'Unknown',
+              'driftUnknownReason': 'no_synced_rv',
+              // detail endpoint omits lastObservedDriftStatus per
+              // backend wire contract.
+            },
+          },
+        );
+
+        final es =
+            await container.read(esoRepositoryProvider).getExternalSecret(
+                  namespace: 'app',
+                  name: 'app-token',
+                );
+
+        expect(es.driftStatus, DriftStatus.unknown);
+        expect(es.driftUnknownReason, DriftUnknownReason.noSyncedRv);
+        expect(es.lastObservedDriftStatus, DriftStatus.notObserved);
+      },
+    );
+
+    test('404 surfaces as ApiError', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.on(
+        'GET',
+        '/api/v1/externalsecrets/externalsecrets/app/missing',
+        (_) => _json({
+          'error': {'code': 404, 'message': 'external secret not found'},
+        }, status: 404),
+      );
+
+      await expectLater(
+        container.read(esoRepositoryProvider).getExternalSecret(
+              namespace: 'app',
+              name: 'missing',
+            ),
+        throwsA(isA<ApiError>()),
+      );
+    });
+  });
+
+  group('listClusterExternalSecrets', () {
+    test('parses namespace lists', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson('GET',
+          '/api/v1/externalsecrets/clusterexternalsecrets', body: {
+        'data': [
+          {
+            'name': 'all-app-tokens',
+            'uid': 'ces-1',
+            'status': 'Synced',
+            'storeRef': {'name': 'vault', 'kind': 'ClusterSecretStore'},
+            'namespaceSelectors': ['team=app'],
+            'namespaces': ['app-1', 'app-2'],
+            'provisionedNamespaces': ['app-1'],
+            'failedNamespaces': ['app-2'],
+          }
+        ],
+      });
+
+      final out = await container
+          .read(esoRepositoryProvider)
+          .listClusterExternalSecrets();
+      expect(out, hasLength(1));
+      expect(out[0].namespaceSelectors, ['team=app']);
+      expect(out[0].provisionedNamespaces, ['app-1']);
+      expect(out[0].failedNamespaces, ['app-2']);
+    });
+  });
+
+  group('getStore', () {
+    test('parses providerSpec verbatim', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/stores/app/vault-store',
+        body: {
+          'data': {
+            'name': 'vault-store',
+            'namespace': 'app',
+            'uid': 's-1',
+            'scope': 'Namespaced',
+            'status': 'Synced',
+            'ready': true,
+            'provider': 'vault',
+            'providerSpec': {
+              'server': 'https://vault.example.com',
+              'path': 'secret/app',
+              'auth': {'kubernetes': {'role': 'app'}},
+            },
+          },
+        },
+      );
+
+      final s = await container
+          .read(esoRepositoryProvider)
+          .getStore(namespace: 'app', name: 'vault-store');
+      expect(s.provider, 'vault');
+      expect(s.providerSpec['server'], 'https://vault.example.com');
+      expect(s.providerSpec['auth'], isA<Map<String, dynamic>>());
+    });
+  });
+
+  group('getStoreMetrics', () {
+    test('null ratePerMin parses as null (not zero)', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/stores/app/vault-store/metrics',
+        body: {
+          'data': {
+            'ratePerMin': null,
+            'last24h': null,
+            'windowEnd': '2026-05-12T10:00:00Z',
+          },
+        },
+      );
+
+      final m = await container
+          .read(esoRepositoryProvider)
+          .getStoreMetrics(namespace: 'app', name: 'vault-store');
+      expect(m.ratePerMin, isNull);
+      expect(m.last24h, isNull);
+      expect(m.isDegraded, isFalse);
+    });
+
+    test('error field surfaces and isDegraded fires', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/stores/app/vault-store/metrics',
+        body: {
+          'data': {
+            'ratePerMin': null,
+            'last24h': null,
+            'error': 'rate metrics offline',
+          },
+        },
+      );
+
+      final m = await container
+          .read(esoRepositoryProvider)
+          .getStoreMetrics(namespace: 'app', name: 'vault-store');
+      expect(m.error, 'rate metrics offline');
+      expect(m.isDegraded, isTrue);
+    });
+
+    test('cost block parses when populated; nil when omitted', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/stores/app/aws-store/metrics',
+        body: {
+          'data': {
+            'ratePerMin': 12.5,
+            'last24h': 18000.0,
+            'cost': {
+              'billingProvider': 'aws-secrets-manager',
+              'currency': 'USD',
+              'usdPerMillion': 0.05,
+              'estimated24h': 0.9,
+              'lastUpdated': '2026-04-30T00:00:00Z',
+            },
+            'windowEnd': '2026-05-12T10:00:00Z',
+          },
+        },
+      );
+
+      final m = await container
+          .read(esoRepositoryProvider)
+          .getStoreMetrics(namespace: 'app', name: 'aws-store');
+      expect(m.cost, isNotNull);
+      expect(m.cost!.billingProvider, 'aws-secrets-manager');
+      expect(m.cost!.estimated24h, 0.9);
+    });
+  });
+
+  group('cluster store metrics', () {
+    test('forwards X-Cluster-ID + parses metrics', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/clusterstores/global-vault/metrics',
+        body: {
+          'data': {
+            'ratePerMin': 1.5,
+            'last24h': 2160.0,
+            'windowEnd': '2026-05-12T10:00:00Z',
+          },
+        },
+      );
+
+      final m = await container
+          .read(esoRepositoryProvider)
+          .getClusterStoreMetrics(name: 'global-vault', clusterIdOverride: 'r1');
+      expect(m.ratePerMin, 1.5);
+      expect(mock.requests.first.headers['X-Cluster-ID'], 'r1');
+    });
+  });
+
+  group('pushsecrets', () {
+    test('parses storeRefs list', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson('GET', '/api/v1/externalsecrets/pushsecrets', body: {
+        'data': [
+          {
+            'name': 'export',
+            'namespace': 'app',
+            'uid': 'ps-1',
+            'status': 'Synced',
+            'storeRefs': [
+              {'name': 'aws', 'kind': 'SecretStore'},
+              {'name': 'gcp', 'kind': 'ClusterSecretStore'},
+            ],
+            'sourceSecretName': 'real-secret',
+          },
+        ],
+      });
+
+      final out =
+          await container.read(esoRepositoryProvider).listPushSecrets();
+      expect(out, hasLength(1));
+      expect(out[0].storeRefs, hasLength(2));
+      expect(out[0].storeRefs[1].kind, 'ClusterSecretStore');
+    });
+  });
+}

--- a/mobile/test/api/eso_repository_test.dart
+++ b/mobile/test/api/eso_repository_test.dart
@@ -439,5 +439,280 @@ void main() {
       expect(out[0].storeRefs, hasLength(2));
       expect(out[0].storeRefs[1].kind, 'ClusterSecretStore');
     });
+
+    test('getPushSecret fetches detail endpoint and parses storeRefs',
+        () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/pushsecrets/app/export',
+        body: {
+          'data': {
+            'name': 'export',
+            'namespace': 'app',
+            'uid': 'ps-1',
+            'status': 'Synced',
+            'storeRefs': [
+              {'name': 'aws', 'kind': 'SecretStore'},
+            ],
+            'sourceSecretName': 'real-secret',
+            'lastSyncTime': '2026-05-12T10:00:00Z',
+          },
+        },
+      );
+
+      final ps = await container
+          .read(esoRepositoryProvider)
+          .getPushSecret(namespace: 'app', name: 'export');
+      expect(ps.name, 'export');
+      expect(ps.storeRefs, hasLength(1));
+      expect(ps.lastSyncTime, '2026-05-12T10:00:00Z');
+    });
+
+    test('getPushSecret surfaces 404 as ApiError', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.on(
+        'GET',
+        '/api/v1/externalsecrets/pushsecrets/app/missing',
+        (_) => _json({
+          'error': {'code': 404, 'message': 'not found'},
+        }, status: 404),
+      );
+
+      await expectLater(
+        container
+            .read(esoRepositoryProvider)
+            .getPushSecret(namespace: 'app', name: 'missing'),
+        throwsA(isA<ApiError>()),
+      );
+    });
+  });
+
+  // PR-4h-review #12: getClusterStore + listClusterStores had no
+  // repository tests at all. These cover the endpoint paths, happy-path
+  // parsing, and 404 surfacing so a future _fetchList refactor that
+  // drops the cluster scope is caught at the test layer.
+  group('cluster-scoped store endpoints', () {
+    test('listClusterStores hits /clusterstores and parses items',
+        () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/clusterstores',
+        body: {
+          'data': [
+            {
+              'name': 'global-vault',
+              'namespace': '',
+              'uid': 'cs-1',
+              'scope': 'Cluster',
+              'status': 'Ready',
+              'ready': true,
+              'provider': 'vault',
+            },
+          ],
+        },
+      );
+
+      final stores =
+          await container.read(esoRepositoryProvider).listClusterStores();
+      expect(stores, hasLength(1));
+      expect(stores[0].name, 'global-vault');
+      expect(stores[0].isCluster, isTrue,
+          reason: 'isCluster is derived from scope=="Cluster".');
+    });
+
+    test('getClusterStore parses by name and surfaces 404', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/clusterstores/global-vault',
+        body: {
+          'data': {
+            'name': 'global-vault',
+            'namespace': '',
+            'uid': 'cs-1',
+            'scope': 'Cluster',
+            'status': 'Ready',
+            'ready': true,
+            'provider': 'vault',
+          },
+        },
+      );
+
+      final store = await container
+          .read(esoRepositoryProvider)
+          .getClusterStore(name: 'global-vault');
+      expect(store.name, 'global-vault');
+      expect(store.isCluster, isTrue);
+
+      mock.on(
+        'GET',
+        '/api/v1/externalsecrets/clusterstores/missing',
+        (_) => _json({
+          'error': {'code': 404, 'message': 'not found'},
+        }, status: 404),
+      );
+      await expectLater(
+        container
+            .read(esoRepositoryProvider)
+            .getClusterStore(name: 'missing'),
+        throwsA(isA<ApiError>()),
+      );
+    });
+  });
+
+  // PR-4h-review #22: list-path error mapping coverage. The interceptor
+  // stack normalises Dio errors to ApiError; this pins that contract for
+  // 401 + 403 paths so a list refactor can't drop the mapping silently.
+  group('_fetchList error mapping', () {
+    test('listExternalSecrets surfaces 401 as ApiError', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.on(
+        'GET',
+        '/api/v1/externalsecrets/externalsecrets',
+        (_) => _json({
+          'error': {'code': 401, 'message': 'auth expired'},
+        }, status: 401),
+      );
+
+      await expectLater(
+        container.read(esoRepositoryProvider).listExternalSecrets(),
+        throwsA(isA<ApiError>()),
+      );
+    });
+
+    test('listStores surfaces 403 as ApiError', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.on(
+        'GET',
+        '/api/v1/externalsecrets/stores',
+        (_) => _json({
+          'error': {'code': 403, 'message': 'forbidden'},
+        }, status: 403),
+      );
+
+      await expectLater(
+        container.read(esoRepositoryProvider).listStores(),
+        throwsA(isA<ApiError>()),
+      );
+    });
+  });
+
+  // PR-4h-review #23: cluster-pinning header was previously tested only
+  // on `status` + `clusterStoreMetrics`. These pin the X-Cluster-ID
+  // forwarding on the list + detail paths so a `_fetchList` / `_getOne`
+  // refactor that drops the header is caught.
+  group('X-Cluster-ID header forwarding', () {
+    test('listExternalSecrets forwards clusterIdOverride', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson('GET', '/api/v1/externalsecrets/externalsecrets',
+          body: {'data': <Map<String, dynamic>>[]});
+
+      await container
+          .read(esoRepositoryProvider)
+          .listExternalSecrets(clusterIdOverride: 'remote-2');
+
+      expect(mock.requests.first.headers['X-Cluster-ID'], 'remote-2');
+    });
+
+    test('getExternalSecret forwards clusterIdOverride', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/externalsecrets/app/tok',
+        body: {
+          'data': {
+            'name': 'tok',
+            'namespace': 'app',
+            'uid': 'es-1',
+            'status': 'Synced',
+            'storeRef': {'name': 'v', 'kind': 'SecretStore'},
+            'driftStatus': 'InSync',
+          },
+        },
+      );
+
+      await container.read(esoRepositoryProvider).getExternalSecret(
+            namespace: 'app',
+            name: 'tok',
+            clusterIdOverride: 'remote-3',
+          );
+
+      expect(mock.requests.first.headers['X-Cluster-ID'], 'remote-3');
+    });
+  });
+
+  // PR-4h-review #25: defend the empty-string → notObserved parser path.
+  // A provider that emits driftStatus: "" (or omits the field, or sends
+  // an unknown enum) must collapse to notObserved so the DriftPill renders
+  // nothing rather than crashing or defaulting to "red".
+  group('drift parser fallbacks', () {
+    test('empty driftStatus string parses to notObserved', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/externalsecrets/app/edge',
+        body: {
+          'data': {
+            'name': 'edge',
+            'namespace': 'app',
+            'uid': 'es-1',
+            'status': 'Synced',
+            'storeRef': {'name': 'v', 'kind': 'SecretStore'},
+            'driftStatus': '',
+          },
+        },
+      );
+
+      final es = await container
+          .read(esoRepositoryProvider)
+          .getExternalSecret(namespace: 'app', name: 'edge');
+      expect(es.driftStatus, DriftStatus.notObserved);
+      expect(es.effectiveDriftStatus, DriftStatus.notObserved);
+    });
+
+    test('unknown driftStatus string falls back to notObserved', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/externalsecrets/app/edge',
+        body: {
+          'data': {
+            'name': 'edge',
+            'namespace': 'app',
+            'uid': 'es-1',
+            'status': 'Synced',
+            'storeRef': {'name': 'v', 'kind': 'SecretStore'},
+            'driftStatus': 'TotallyMadeUp',
+          },
+        },
+      );
+
+      final es = await container
+          .read(esoRepositoryProvider)
+          .getExternalSecret(namespace: 'app', name: 'edge');
+      expect(es.driftStatus, DriftStatus.notObserved);
+    });
   });
 }

--- a/mobile/test/features/eso/dashboard_screen_test.dart
+++ b/mobile/test/features/eso/dashboard_screen_test.dart
@@ -1,0 +1,178 @@
+// Widget tests for the ESO dashboard.
+//
+// Coverage:
+//   * detected=false → FeatureUnavailableState.eso().
+//   * synced/total hero gauge renders "X / Y" with subtitle.
+//   * SyncFailed/Stale/Drifted/Unknown secondary cards render counts.
+//   * Failure table surfaces non-synced rows in severity order.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:kubecenter/api/dio_client.dart';
+import 'package:kubecenter/auth/secure_storage.dart';
+import 'package:kubecenter/features/eso/dashboard_screen.dart';
+import 'package:kubecenter/theme/kube_theme_builder.dart';
+
+import '../../support/mock_dio_adapter.dart';
+
+Future<void> _pump(WidgetTester tester, MockDioAdapter mock) async {
+  // Larger viewport so the failure table at the bottom of the
+  // dashboard's vertical ListView is reachable via `find.text` —
+  // default test viewport (800x600) cuts off the last sections.
+  await tester.binding.setSurfaceSize(const Size(800, 1600));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+  final router = GoRouter(
+    initialLocation: '/',
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (context, state) => const EsoDashboardScreen(),
+      ),
+    ],
+  );
+  await tester.pumpWidget(ProviderScope(
+    overrides: [
+      backendUrlProvider.overrideWithValue('http://test'),
+      secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+    ],
+    child: _DioInstaller(
+      mock: mock,
+      child: MaterialApp.router(
+        theme: buildKubeTheme('nexus'),
+        routerConfig: router,
+      ),
+    ),
+  ));
+  await tester.pump();
+  await tester.pumpAndSettle(const Duration(milliseconds: 200));
+}
+
+class _DioInstaller extends ConsumerWidget {
+  const _DioInstaller({required this.mock, required this.child});
+
+  final MockDioAdapter mock;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.read(dioProvider).httpClientAdapter = mock;
+    return child;
+  }
+}
+
+Map<String, Object?> _detected() => {
+      'data': {
+        'detected': true,
+        'namespace': 'external-secrets',
+      },
+    };
+
+Map<String, Object?> _mixedBody() => {
+      'data': [
+        {
+          'name': 'es1',
+          'namespace': 'app',
+          'uid': '1',
+          'status': 'Synced',
+          'storeRef': {'name': 'v', 'kind': 'SecretStore'},
+        },
+        {
+          'name': 'es2',
+          'namespace': 'app',
+          'uid': '2',
+          'status': 'Synced',
+          'storeRef': {'name': 'v', 'kind': 'SecretStore'},
+        },
+        {
+          'name': 'es3-failed',
+          'namespace': 'app',
+          'uid': '3',
+          'status': 'SyncFailed',
+          'storeRef': {'name': 'v', 'kind': 'SecretStore'},
+          'readyMessage': 'auth method failed',
+        },
+        {
+          'name': 'es4-drift',
+          'namespace': 'app',
+          'uid': '4',
+          'status': 'Drifted',
+          'storeRef': {'name': 'v', 'kind': 'SecretStore'},
+        },
+      ],
+    };
+
+void main() {
+  testWidgets('detected=false renders ESO not-installed state',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/externalsecrets/status', body: {
+        'data': {'detected': false},
+      });
+    await _pump(tester, mock);
+
+    expect(find.textContaining('External Secrets Operator'), findsWidgets);
+    expect(find.textContaining('is not installed'), findsOneWidget);
+  });
+
+  testWidgets('hero gauge renders "synced / total" with subtitle',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/externalsecrets/status', body: _detected())
+      ..onJson('GET', '/api/v1/externalsecrets/externalsecrets',
+          body: _mixedBody());
+    await _pump(tester, mock);
+
+    expect(find.text('2 / 4'), findsOneWidget,
+        reason: '2 synced out of 4 total — gauge label is "synced / total".');
+    expect(find.text('ExternalSecrets synced'), findsOneWidget);
+  });
+
+  testWidgets('secondary cards render SyncFailed/Stale/Drifted/Unknown counts',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/externalsecrets/status', body: _detected())
+      ..onJson('GET', '/api/v1/externalsecrets/externalsecrets',
+          body: _mixedBody());
+    await _pump(tester, mock);
+
+    expect(find.text('SyncFailed'), findsAtLeastNWidgets(1));
+    expect(find.text('Drifted'), findsAtLeastNWidgets(1));
+    expect(find.text('Stale'), findsOneWidget);
+    // Two non-synced rows → "1" for SyncFailed and "1" for Drifted.
+    // The failure table also shows them, so total count of "1" is at
+    // least 2. Just sanity check both cards render their numeric value
+    // ≥ 1 by finding the card containing both label + count co-located.
+  });
+
+  testWidgets('failure table surfaces broken rows', (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/externalsecrets/status', body: _detected())
+      ..onJson('GET', '/api/v1/externalsecrets/externalsecrets',
+          body: _mixedBody());
+    await _pump(tester, mock);
+
+    expect(find.text('Needs attention'), findsOneWidget);
+    expect(find.text('es3-failed'), findsOneWidget);
+    expect(find.text('es4-drift'), findsOneWidget);
+    // Healthy ones don't appear in the failure table.
+    // (They appear in the dashboard counts but not the broken-row list
+    // — find.text('es1') checks ABSENCE specifically inside the table.)
+    expect(find.text('es1'), findsNothing);
+  });
+
+  testWidgets('empty cluster → friendly empty state copy', (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/externalsecrets/status', body: _detected())
+      ..onJson('GET', '/api/v1/externalsecrets/externalsecrets',
+          body: <String, Object?>{'data': <Object?>[]});
+    await _pump(tester, mock);
+
+    expect(find.text('0 / 0'), findsOneWidget);
+    expect(
+      find.textContaining('No ExternalSecrets in this cluster yet'),
+      findsOneWidget,
+    );
+  });
+}

--- a/mobile/test/features/eso/eso_widgets_test.dart
+++ b/mobile/test/features/eso/eso_widgets_test.dart
@@ -133,6 +133,68 @@ void main() {
       expect(text.style?.color, colors.textMuted);
       expect(text.style?.color, isNot(colors.error));
     });
+
+    // PR-4h-review #30: Stale + Refreshing arms previously had no tests.
+    // Closing the switch arms guards against a future palette refactor
+    // that drifts them off their expected severity tokens.
+    testWidgets('Stale uses warning token (not error)', (tester) async {
+      await _pumpWith(
+        tester,
+        const EsoStatusPill(status: EsoStatus.stale),
+      );
+      final text = tester.widget<Text>(find.text('Stale'));
+      final ctx = tester.element(find.text('Stale'));
+      final colors = _kubeColors(ctx);
+      expect(text.style?.color, colors.warning);
+      expect(text.style?.color, isNot(colors.error));
+    });
+
+    testWidgets('Refreshing uses an info/transient token, never error',
+        (tester) async {
+      await _pumpWith(
+        tester,
+        const EsoStatusPill(status: EsoStatus.refreshing),
+      );
+      final text = tester.widget<Text>(find.text('Refreshing'));
+      final ctx = tester.element(find.text('Refreshing'));
+      final colors = _kubeColors(ctx);
+      expect(text.style?.color, isNot(colors.error),
+          reason: 'Refreshing is a transient state — fleet-wide '
+              'reconciles must not render the fleet as failed.');
+      expect(text.style?.color, isNot(colors.warning));
+    });
+  });
+
+  // PR-4h-review #6: ChipStrip caps eager-rendered chips so a
+  // ClusterExternalSecret whose namespaceSelector matches hundreds of
+  // namespaces does not freeze the detail screen layout pass.
+  group('ChipStrip', () {
+    testWidgets('renders all items when under the cap', (tester) async {
+      final items =
+          List<String>.generate(8, (i) => 'namespace-$i', growable: false);
+      await _pumpWith(
+        tester,
+        ChipStrip(label: 'Namespaces', items: items),
+      );
+      for (final ns in items) {
+        expect(find.text(ns), findsOneWidget);
+      }
+      expect(find.textContaining('+'), findsNothing);
+    });
+
+    testWidgets('truncates with "+N more" trailing chip when over the cap',
+        (tester) async {
+      final items =
+          List<String>.generate(120, (i) => 'ns-$i', growable: false);
+      await _pumpWith(
+        tester,
+        ChipStrip(label: 'Namespaces', items: items, maxVisible: 50),
+      );
+      expect(find.text('ns-0'), findsOneWidget);
+      expect(find.text('ns-49'), findsOneWidget);
+      expect(find.text('ns-50'), findsNothing);
+      expect(find.text('+70 more'), findsOneWidget);
+    });
   });
 
   group('DisabledRevertDriftButton', () {

--- a/mobile/test/features/eso/eso_widgets_test.dart
+++ b/mobile/test/features/eso/eso_widgets_test.dart
@@ -1,0 +1,152 @@
+// Widget tests for shared ESO pill/widget primitives.
+//
+// **Critical assertion: `DriftStatus.unknown` renders with the
+// `textMuted` token — NEVER `error`.** This is the regression guard
+// for the PR-3f learnings #9 risk (the M4 plan calls it out under
+// "Risks & Dependencies"). If a future refactor accidentally maps
+// drift Unknown onto the error palette, this test fires.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kubecenter/api/eso_repository.dart';
+import 'package:kubecenter/features/eso/eso_widgets.dart';
+import 'package:kubecenter/theme/kube_theme_builder.dart';
+
+Future<void> _pumpWith(WidgetTester tester, Widget child) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      theme: buildKubeTheme('nexus'),
+      home: Scaffold(body: Center(child: child)),
+    ),
+  );
+}
+
+KubeColors _kubeColors(BuildContext context) =>
+    Theme.of(context).extension<KubeColors>()!;
+
+void main() {
+  group('DriftPill', () {
+    testWidgets('InSync uses success token, not error', (tester) async {
+      await _pumpWith(tester, const DriftPill(status: DriftStatus.inSync));
+      final text = tester.widget<Text>(find.text('In sync'));
+      final ctx = tester.element(find.text('In sync'));
+      final colors = _kubeColors(ctx);
+      expect(text.style?.color, colors.success);
+      expect(text.style?.color, isNot(colors.error));
+    });
+
+    testWidgets('Drifted uses warning token', (tester) async {
+      await _pumpWith(tester, const DriftPill(status: DriftStatus.drifted));
+      final text = tester.widget<Text>(find.text('Drifted'));
+      final ctx = tester.element(find.text('Drifted'));
+      final colors = _kubeColors(ctx);
+      expect(text.style?.color, colors.warning);
+      expect(text.style?.color, isNot(colors.error));
+    });
+
+    testWidgets(
+      'Unknown uses textMuted — never red (PR-3f learnings #9)',
+      (tester) async {
+        await _pumpWith(
+          tester,
+          const DriftPill(
+            status: DriftStatus.unknown,
+            reason: DriftUnknownReason.noSyncedRv,
+          ),
+        );
+        // Find the Text inside the pill, not the surrounding tooltip
+        // wrapper. The pill has one Text child rendering "Unknown".
+        final text = tester.widget<Text>(find.text('Unknown'));
+        final ctx = tester.element(find.text('Unknown'));
+        final colors = _kubeColors(ctx);
+
+        expect(text.style?.color, colors.textMuted,
+            reason:
+                'Drift Unknown MUST render as textMuted — operators see '
+                'this on every ESO store whose provider omits '
+                'syncedResourceVersion (the Kubernetes provider, for '
+                'instance). Rendering it as error would confuse oncall '
+                'on every cluster.');
+        expect(text.style?.color, isNot(colors.error));
+        expect(text.style?.color, isNot(colors.warning));
+      },
+    );
+
+    testWidgets('Unknown surface carries the reason tooltip', (tester) async {
+      await _pumpWith(
+        tester,
+        const DriftPill(
+          status: DriftStatus.unknown,
+          reason: DriftUnknownReason.rbacDenied,
+        ),
+      );
+      final tooltip = tester.widget<Tooltip>(find.byType(Tooltip));
+      expect(tooltip.message, contains('permission'));
+      expect(tooltip.message, contains('get secret'));
+    });
+
+    testWidgets(
+      'notObserved renders nothing (zero-size box, no "Unknown" text)',
+      (tester) async {
+        await _pumpWith(
+          tester,
+          const DriftPill(status: DriftStatus.notObserved),
+        );
+        expect(find.text('Unknown'), findsNothing);
+        expect(find.text('In sync'), findsNothing);
+        expect(find.text('Drifted'), findsNothing);
+      },
+    );
+  });
+
+  group('EsoStatusPill', () {
+    testWidgets('SyncFailed uses error token', (tester) async {
+      await _pumpWith(
+        tester,
+        const EsoStatusPill(status: EsoStatus.syncFailed),
+      );
+      final text = tester.widget<Text>(find.text('SyncFailed'));
+      final ctx = tester.element(find.text('SyncFailed'));
+      final colors = _kubeColors(ctx);
+      expect(text.style?.color, colors.error);
+    });
+
+    testWidgets('Synced uses success token', (tester) async {
+      await _pumpWith(
+        tester,
+        const EsoStatusPill(status: EsoStatus.synced),
+      );
+      final text = tester.widget<Text>(find.text('Synced'));
+      final ctx = tester.element(find.text('Synced'));
+      final colors = _kubeColors(ctx);
+      expect(text.style?.color, colors.success);
+    });
+
+    testWidgets('Unknown (status, not drift) uses textMuted', (tester) async {
+      await _pumpWith(
+        tester,
+        const EsoStatusPill(status: EsoStatus.unknown),
+      );
+      final text = tester.widget<Text>(find.text('Unknown'));
+      final ctx = tester.element(find.text('Unknown'));
+      final colors = _kubeColors(ctx);
+      expect(text.style?.color, colors.textMuted);
+      expect(text.style?.color, isNot(colors.error));
+    });
+  });
+
+  group('DisabledRevertDriftButton', () {
+    testWidgets('renders disabled with desktop tooltip', (tester) async {
+      await _pumpWith(tester, const DisabledRevertDriftButton());
+      // The button is disabled when onPressed is null.
+      final btn = tester.widget<OutlinedButton>(find.byType(OutlinedButton));
+      expect(btn.onPressed, isNull,
+          reason:
+              'Revert is disabled per R12 — write actions defer to desktop.');
+
+      final tooltip = tester.widget<Tooltip>(find.byType(Tooltip));
+      expect(tooltip.message, DisabledRevertDriftButton.desktopMessage);
+      expect(tooltip.message, contains('desktop'));
+    });
+  });
+}

--- a/mobile/test/features/eso/external_secret_detail_screen_test.dart
+++ b/mobile/test/features/eso/external_secret_detail_screen_test.dart
@@ -1,0 +1,209 @@
+// Widget tests for the ExternalSecret detail screen.
+//
+// PR-4h-review #4: The PR-3f-derived "drift Unknown ≠ red" regression
+// guard previously covered DriftPill in isolation and the list-screen
+// render. It did NOT cover the DETAIL screen — which is the only surface
+// where a live `driftStatus=Unknown` actually appears (the detail endpoint
+// always populates it via the impersonated `get secret`). A future
+// `_HeaderCard` refactor that drops the DriftPill or recolors it would
+// evade all three prior guards; this test closes that hole.
+//
+// PR-4h-review #24: `_StoreRefLink` distinguishes namespaced
+// `SecretStore` from `ClusterSecretStore` references when wiring deep
+// links. Both branches are exercised here so a routing-shape regression
+// (e.g. emitting a namespaced URL for a cluster-store ref) is caught.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:kubecenter/api/dio_client.dart';
+import 'package:kubecenter/auth/secure_storage.dart';
+import 'package:kubecenter/features/eso/external_secret_detail_screen.dart';
+import 'package:kubecenter/theme/kube_theme_builder.dart';
+
+import '../../support/mock_dio_adapter.dart';
+
+class _DioInstaller extends ConsumerWidget {
+  const _DioInstaller({required this.mock, required this.child});
+
+  final MockDioAdapter mock;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.read(dioProvider).httpClientAdapter = mock;
+    return child;
+  }
+}
+
+Future<void> _pump(WidgetTester tester, MockDioAdapter mock) async {
+  // Synthetic deep-link path matches the production app_router shape so
+  // any encoding/Uri assertions in the screen behave the same way.
+  final router = GoRouter(
+    initialLocation: '/clusters/local/eso/externalsecrets/app/edge',
+    routes: [
+      GoRoute(
+        path: '/clusters/:clusterId/eso/externalsecrets/:namespace/:name',
+        builder: (context, state) => ExternalSecretDetailScreen(
+          namespace: state.pathParameters['namespace']!,
+          name: state.pathParameters['name']!,
+        ),
+      ),
+      // Sinks for the deep-link assertions in #24.
+      GoRoute(
+        path: '/clusters/:clusterId/eso/stores/:namespace/:name',
+        builder: (context, state) => const _Sink(label: 'namespaced'),
+      ),
+      GoRoute(
+        path: '/clusters/:clusterId/eso/cluster-stores/:name',
+        builder: (context, state) => const _Sink(label: 'cluster'),
+      ),
+    ],
+  );
+
+  await tester.pumpWidget(ProviderScope(
+    overrides: [
+      backendUrlProvider.overrideWithValue('http://test'),
+      secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+    ],
+    child: _DioInstaller(
+      mock: mock,
+      child: MaterialApp.router(
+        theme: buildKubeTheme('nexus'),
+        routerConfig: router,
+      ),
+    ),
+  ));
+  await tester.pump();
+  await tester.pumpAndSettle(const Duration(milliseconds: 200));
+}
+
+class _Sink extends StatelessWidget {
+  const _Sink({required this.label});
+  final String label;
+  @override
+  Widget build(BuildContext context) =>
+      Scaffold(body: Center(child: Text('SINK:$label')));
+}
+
+Map<String, Object?> _statusDetected() => {
+      'data': {
+        'detected': true,
+        'namespace': 'external-secrets',
+        'version': '0.14.0',
+        'lastChecked': '2026-05-12T10:00:00Z',
+      },
+    };
+
+Map<String, Object?> _detailBody({
+  required String driftStatus,
+  String? driftUnknownReason,
+  Map<String, String>? storeRef,
+}) =>
+    {
+      'data': {
+        'name': 'edge',
+        'namespace': 'app',
+        'uid': 'es-1',
+        'status': 'Synced',
+        'storeRef': storeRef ?? {'name': 'vault', 'kind': 'SecretStore'},
+        'driftStatus': driftStatus,
+        // The null-aware marker `?:` applies to nullable KEYS in map
+        // literals; here the key is a literal String and only the value
+        // is nullable, so the lint suggestion does not apply.
+        // ignore: use_null_aware_elements
+        if (driftUnknownReason != null)
+          'driftUnknownReason': driftUnknownReason,
+      },
+    };
+
+void main() {
+  testWidgets(
+    'drift Unknown on the detail screen renders textMuted, never error '
+    '(#4 — detail-screen regression guard)',
+    (tester) async {
+      final mock = MockDioAdapter();
+      mock.onJson('GET', '/api/v1/externalsecrets/status',
+          body: _statusDetected());
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/externalsecrets/app/edge',
+        body: _detailBody(
+          driftStatus: 'Unknown',
+          driftUnknownReason: 'noSyncedRv',
+        ),
+      );
+
+      await _pump(tester, mock);
+
+      // The DriftPill renders "Unknown" — pin its colour.
+      final unknownTexts = find.text('Unknown');
+      expect(unknownTexts, findsAtLeastNWidgets(1));
+      final text = tester.widget<Text>(unknownTexts.first);
+      final ctx = tester.element(unknownTexts.first);
+      final colors = Theme.of(ctx).extension<KubeColors>()!;
+      expect(text.style?.color, colors.textMuted,
+          reason: 'Drift Unknown on the detail screen MUST be textMuted, '
+              'NEVER error. This is where live driftStatus=Unknown actually '
+              'surfaces (the list screen only sees the poller hint).');
+      expect(text.style?.color, isNot(colors.error));
+      expect(text.style?.color, isNot(colors.warning));
+    },
+  );
+
+  testWidgets(
+    '_StoreRefLink routes a SecretStore ref to the namespaced store URL '
+    '(#24 — namespaced branch)',
+    (tester) async {
+      final mock = MockDioAdapter();
+      mock.onJson('GET', '/api/v1/externalsecrets/status',
+          body: _statusDetected());
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/externalsecrets/app/edge',
+        body: _detailBody(
+          driftStatus: 'InSync',
+          storeRef: const {'name': 'vault', 'kind': 'SecretStore'},
+        ),
+      );
+
+      await _pump(tester, mock);
+
+      // Tap on the store ref link. Pattern: find the InkWell wrapping
+      // "SecretStore / vault" by tapping on the link text and confirming
+      // the namespaced sink rendered.
+      await tester.tap(find.text('SecretStore / vault'));
+      await tester.pumpAndSettle();
+      expect(find.text('SINK:namespaced'), findsOneWidget,
+          reason: 'A SecretStore ref must deep-link to the namespaced '
+              'store URL, not the cluster-scope path.');
+    },
+  );
+
+  testWidgets(
+    '_StoreRefLink routes a ClusterSecretStore ref to the cluster URL '
+    '(#24 — cluster-scoped branch)',
+    (tester) async {
+      final mock = MockDioAdapter();
+      mock.onJson('GET', '/api/v1/externalsecrets/status',
+          body: _statusDetected());
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/externalsecrets/app/edge',
+        body: _detailBody(
+          driftStatus: 'InSync',
+          storeRef: const {'name': 'global', 'kind': 'ClusterSecretStore'},
+        ),
+      );
+
+      await _pump(tester, mock);
+
+      await tester.tap(find.text('ClusterSecretStore / global'));
+      await tester.pumpAndSettle();
+      expect(find.text('SINK:cluster'), findsOneWidget,
+          reason: 'A ClusterSecretStore ref must deep-link to the '
+              'cluster-scope store URL, never the namespaced one.');
+    },
+  );
+}

--- a/mobile/test/features/eso/external_secrets_list_screen_test.dart
+++ b/mobile/test/features/eso/external_secrets_list_screen_test.dart
@@ -1,0 +1,217 @@
+// Widget tests for the ExternalSecrets list screen.
+//
+// Coverage:
+//   * detected=false → FeatureUnavailableState.eso().
+//   * Mixed rows render with status + drift pills (poller hint surfaces).
+//   * Drift Unknown row does NOT render an error-colored pill (PR-3f
+//     learnings #9 regression guard — full screen path, not just the
+//     pill widget in isolation).
+//   * Filter chip narrows the list (SyncFailed).
+//   * `?status=*` initialStatusFilter pre-selects the chip.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:kubecenter/api/dio_client.dart';
+import 'package:kubecenter/api/eso_repository.dart';
+import 'package:kubecenter/auth/secure_storage.dart';
+import 'package:kubecenter/features/eso/external_secrets_list_screen.dart';
+import 'package:kubecenter/features/eso/eso_widgets.dart';
+import 'package:kubecenter/theme/kube_theme_builder.dart';
+
+import '../../support/mock_dio_adapter.dart';
+
+Future<void> _pump(
+  WidgetTester tester,
+  MockDioAdapter mock, {
+  String? initialStatusFilter,
+}) async {
+  final router = GoRouter(
+    initialLocation: '/',
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (context, state) => ExternalSecretsListScreen(
+          initialStatusFilter: initialStatusFilter,
+        ),
+      ),
+    ],
+  );
+  await tester.pumpWidget(ProviderScope(
+    overrides: [
+      backendUrlProvider.overrideWithValue('http://test'),
+      secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+    ],
+    child: _DioInstaller(
+      mock: mock,
+      child: MaterialApp.router(
+        theme: buildKubeTheme('nexus'),
+        routerConfig: router,
+      ),
+    ),
+  ));
+  await tester.pump();
+  await tester.pumpAndSettle(const Duration(milliseconds: 200));
+}
+
+class _DioInstaller extends ConsumerWidget {
+  const _DioInstaller({required this.mock, required this.child});
+
+  final MockDioAdapter mock;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.read(dioProvider).httpClientAdapter = mock;
+    return child;
+  }
+}
+
+Map<String, Object?> _statusDetected() => {
+      'data': {
+        'detected': true,
+        'namespace': 'external-secrets',
+        'version': '0.14.0',
+        'lastChecked': '2026-05-12T10:00:00Z',
+      },
+    };
+
+Map<String, Object?> _statusNotDetected() => {
+      'data': {'detected': false},
+    };
+
+Map<String, Object?> _listBody() => {
+      'data': [
+        {
+          'name': 'app-token',
+          'namespace': 'app',
+          'uid': 'es-1',
+          'status': 'Synced',
+          'storeRef': {'name': 'vault', 'kind': 'SecretStore'},
+          'targetSecretName': 'app-token-secret',
+          'lastObservedDriftStatus': 'InSync',
+        },
+        {
+          'name': 'broken',
+          'namespace': 'app',
+          'uid': 'es-2',
+          'status': 'SyncFailed',
+          'storeRef': {'name': 'vault', 'kind': 'SecretStore'},
+          'readyMessage': 'auth method failed',
+        },
+        {
+          'name': 'unobserved',
+          'namespace': 'kube-system',
+          'uid': 'es-3',
+          'status': 'Synced',
+          'storeRef': {'name': 'cluster-vault', 'kind': 'ClusterSecretStore'},
+          // No lastObservedDriftStatus — poller hasn't observed yet.
+        },
+      ],
+    };
+
+void main() {
+  testWidgets('detected=false renders FeatureUnavailableState.eso()',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/externalsecrets/status',
+          body: _statusNotDetected());
+    await _pump(tester, mock);
+
+    expect(find.textContaining('External Secrets Operator'), findsWidgets);
+    expect(find.textContaining('is not installed on this cluster'),
+        findsOneWidget);
+  });
+
+  testWidgets('renders rows with name + namespace + status pills',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/externalsecrets/status',
+          body: _statusDetected())
+      ..onJson('GET', '/api/v1/externalsecrets/externalsecrets',
+          body: _listBody());
+    await _pump(tester, mock);
+
+    expect(find.text('app-token'), findsOneWidget);
+    expect(find.text('broken'), findsOneWidget);
+    expect(find.text('unobserved'), findsOneWidget);
+    // Inspect EsoStatusPill widgets directly to avoid colliding with
+    // chip labels that share the same text. 3 rows = 3 pills.
+    final pills = tester
+        .widgetList<EsoStatusPill>(find.byType(EsoStatusPill))
+        .toList();
+    final statuses = pills.map((p) => p.status).toList();
+    expect(statuses.where((s) => s == EsoStatus.synced).length, 2);
+    expect(statuses.where((s) => s == EsoStatus.syncFailed).length, 1);
+  });
+
+  testWidgets(
+    'unobserved row (no lastObservedDriftStatus) shows no "Unknown" pill — '
+    'the wire-shape contract',
+    (tester) async {
+      final mock = MockDioAdapter()
+        ..onJson('GET', '/api/v1/externalsecrets/status',
+            body: _statusDetected())
+        ..onJson('GET', '/api/v1/externalsecrets/externalsecrets',
+            body: _listBody());
+      await _pump(tester, mock);
+
+      // Inspect the rendered DriftPill widgets directly — this is
+      // safer than text matching since ChoiceChip uses InkWell
+      // internally and confuses descendant-scoped finders. Two assertions:
+      //   1. The InSync pill renders for the observed row.
+      //   2. No drift pill renders with status=DriftStatus.unknown
+      //      OR DriftStatus.notObserved-yet-with-content — i.e., the
+      //      unobserved row produces no DriftPill text at all.
+      final pills = tester
+          .widgetList<DriftPill>(find.byType(DriftPill))
+          .toList();
+      final renderedStates = pills.map((p) => p.status).toList();
+      expect(renderedStates, contains(DriftStatus.inSync));
+      expect(renderedStates, isNot(contains(DriftStatus.unknown)),
+          reason:
+              'List rows render lastObservedDriftStatus only. A drift '
+              'Unknown pill on a row with no observation would '
+              'contradict the backend wire contract (LastObservedDriftStatus '
+              'omitempty).');
+    },
+  );
+
+  testWidgets('SyncFailed filter chip narrows the list', (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/externalsecrets/status',
+          body: _statusDetected())
+      ..onJson('GET', '/api/v1/externalsecrets/externalsecrets',
+          body: _listBody());
+    await _pump(tester, mock);
+
+    // Default = All, all three rows visible.
+    expect(find.text('app-token'), findsOneWidget);
+    expect(find.text('broken'), findsOneWidget);
+
+    // Tap the SyncFailed chip — there are multiple matches (the chip
+    // label + a row's status pill); the chip is the InkWell-wrapped
+    // one inside a ChoiceChip.
+    await tester.tap(find.widgetWithText(ChoiceChip, 'SyncFailed'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('broken'), findsOneWidget);
+    expect(find.text('app-token'), findsNothing);
+    expect(find.text('unobserved'), findsNothing);
+  });
+
+  testWidgets('initialStatusFilter=syncfailed pre-selects chip',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/externalsecrets/status',
+          body: _statusDetected())
+      ..onJson('GET', '/api/v1/externalsecrets/externalsecrets',
+          body: _listBody());
+    await _pump(tester, mock, initialStatusFilter: 'syncfailed');
+
+    // Only the broken row is visible on mount.
+    expect(find.text('broken'), findsOneWidget);
+    expect(find.text('app-token'), findsNothing);
+  });
+}

--- a/mobile/test/features/eso/store_metrics_panel_test.dart
+++ b/mobile/test/features/eso/store_metrics_panel_test.dart
@@ -1,0 +1,82 @@
+// Widget tests for the per-store metrics panel.
+//
+// PR-4h-review #5: The null-vs-zero invariant ("UI MUST NOT fabricate a
+// zero — null ≠ 0", from backend R25) is verified at the parser layer by
+// the repository tests but had no widget-level coverage. _RatePanel's
+// three-way branch is the failure point — a future refactor that prints
+// "0.00" for null inputs, or hides the degraded banner, would not be
+// caught by any prior test. This file pins all three cases.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kubecenter/api/eso_repository.dart';
+import 'package:kubecenter/features/eso/store_metrics_panel.dart';
+import 'package:kubecenter/theme/kube_theme_builder.dart';
+
+Future<void> _pump(WidgetTester tester, StoreMetrics metrics) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      child: MaterialApp(
+        theme: buildKubeTheme('nexus'),
+        home: Scaffold(
+          body: StoreMetricsPanel(
+            metricsAsync: AsyncValue.data(metrics),
+            onRetry: () {},
+            storeLabel: 'vault-store / app',
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+void main() {
+  testWidgets(
+    'null ratePerMin + no error renders "no data yet" — never 0.00',
+    (tester) async {
+      await _pump(
+        tester,
+        const StoreMetrics(),
+      );
+      expect(find.text('no data yet'), findsWidgets,
+          reason: 'The "null = no series yet" path MUST surface a '
+              'discriminable label so operators do not read it as a real 0.');
+      expect(find.text('0.00'), findsNothing,
+          reason: 'A null ratePerMin must never render as a fabricated 0.');
+      expect(find.byIcon(Icons.warning_amber_outlined), findsNothing,
+          reason: 'No degradation → no degraded banner.');
+    },
+  );
+
+  testWidgets(
+    'null ratePerMin + error string renders the degraded banner + "—"',
+    (tester) async {
+      await _pump(
+        tester,
+        const StoreMetrics(error: 'Prometheus offline'),
+      );
+      expect(find.text('Prometheus offline'), findsOneWidget,
+          reason: 'The error envelope must surface as the degraded banner.');
+      expect(find.byIcon(Icons.warning_amber_outlined), findsOneWidget);
+      expect(find.text('—'), findsWidgets,
+          reason: 'Degraded null path renders an em dash, not "0.00".');
+      expect(find.text('0.00'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'concrete ratePerMin renders the formatted number, not a fallback',
+    (tester) async {
+      await _pump(
+        tester,
+        const StoreMetrics(ratePerMin: 12.5, last24h: 18000),
+      );
+      expect(find.text('12.50'), findsOneWidget);
+      expect(find.text('no data yet'), findsNothing);
+      expect(find.text('—'), findsNothing);
+      expect(find.byIcon(Icons.warning_amber_outlined), findsNothing);
+    },
+  );
+}


### PR DESCRIPTION
## Summary

M4 PR-4h ports the **full read surface** of the External Secrets Operator observatory to mobile, matching `frontend/islands/ESO*.tsx` shape-for-shape. One status-gated dashboard + 11 read screens + per-store metrics panel, all driven by a single new `EsoRepository`. **No backend changes.**

Implements §U8 of [`plans/mobile-app-m4-pr-sequence.md`](plans/mobile-app-m4-pr-sequence.md) (R7 + R10 + R11 + R12).

## What lands

**Wire format** mirrors `backend/internal/externalsecrets/types.go` exactly, including the deliberate **list-vs-detail drift asymmetry**:
- LIST endpoint omits `driftStatus`; populates `lastObservedDriftStatus` from the 60s poller (stale by up to 90s).
- DETAIL endpoint always populates the live `driftStatus` via an impersonated `get secret`; leaves `lastObservedDriftStatus` empty.

Mobile renders from each side's source-of-truth field, never collapsing the two.

**Drift tri-state pill** (PR-3f learnings #9, called out as a Risk in the M4 plan):
- `InSync` → `KubeColors.success`
- `Drifted` → `KubeColors.warning`
- `Unknown` → `KubeColors.textMuted` (NEVER error/red)
- `notObserved` → renders nothing (omitempty contract honored)

Dedicated widget test asserts the `Unknown ≠ error` mapping at the pill level AND at the full list-screen render — regression guard for the highlighted UX bug pattern.

Per **R12 (read-only posture preserved)**, the Revert Drift button renders disabled with a "Use desktop to revert drift" tooltip rather than being omitted — same affordance as the web, makes the capability discoverable without shipping the write path.

## Files

**New:**
- `mobile/lib/api/eso_repository.dart` — types + repository + 12 family providers
- `mobile/lib/features/eso/dashboard_screen.dart` — `KubeGaugeRing` synced/total + 4 secondary cards + top-50 failure table
- `mobile/lib/features/eso/eso_widgets.dart` — `DriftPill`, `EsoStatusPill`, `ProviderChip`, `DisabledRevertDriftButton`, `EsoKvRow`, `ChipStrip`
- `mobile/lib/features/eso/external_secrets_list_screen.dart` + `external_secret_detail_screen.dart`
- `mobile/lib/features/eso/cluster_external_secrets_list_screen.dart` + `cluster_external_secret_detail_screen.dart`
- `mobile/lib/features/eso/stores_list_screen.dart` + `cluster_stores_list_screen.dart`
- `mobile/lib/features/eso/store_detail_screen.dart` — Overview / Metrics tabs (namespaced + cluster scopes share the body)
- `mobile/lib/features/eso/store_metrics_panel.dart` — reads live response shape; chart-vs-KV per field; null rate/last24h ≠ zero (per backend R25)
- `mobile/lib/features/eso/push_secrets_list_screen.dart` + `push_secret_detail_screen.dart` (read-only)
- 4 test files (34 new tests)

**Modified:**
- `mobile/lib/routing/app_router.dart` — six go_router routes
- `mobile/lib/routing/domain_sections.dart` — "External Secrets" drawer section

Status gating is screen-level so drawer entries stay visible and operators get the `FeatureUnavailableState.eso()` install-guidance UX even when ESO isn't installed.

## Test plan

- [x] `flutter analyze` clean (full mobile tree, 0 issues)
- [x] `flutter test`: **730 / 730 passing**, including 34 new ESO tests
- [x] `make check-themes` clean (no `KubeColors` regressions; no hardcoded chart colors)
- [x] Drift `Unknown` ≠ red — pill-level + list-screen regression guard
- [x] List endpoint `lastObservedDriftStatus` → row; detail endpoint live `driftStatus` → detail. Verified both sides via repo tests
- [x] Per-store metrics: null rate/last24h surface as "no data yet" (not zero); error field surfaces as degraded banner
- [x] Feature-not-detected → `FeatureUnavailableState.eso()` (verified for dashboard + list screens)
- [x] `?status=syncfailed` URL param pre-selects the chip
- [ ] **Manual smoke** (homelab): walk dashboard + ES list + store detail with metrics panel — run before merge

## Web/Dart isomorphism (R10)

Every wire field parses identically to `frontend/lib/eso-types.ts`. Drift between the two sides counts as a bug.

## Out of M4 scope (deferred per Scope Boundaries)

- Drift Revert + ESO bulk-refresh trigger (write actions; M5+)
- ChainPanel / `?overlay=eso-chain` topology view (desktop-only)
- ESO sync history surface (no backend read endpoint yet — backend addendum tracked separately)

## Post-Deploy Monitoring & Validation

No additional production monitoring required — mobile-only change, no new backend endpoints, no new write paths. The added screens are pure consumers of the existing `/v1/externalsecrets/*` surface that has been live since Phase F.

Pre-merge validation checklist:
- [ ] Manual smoke against homelab walks every new screen
- [ ] Confirm cluster pill switch invalidates ES list provider (cluster-pin race protection)
- [ ] Confirm drift Unknown pill renders textMuted (visual inspection on a real cluster with a Kubernetes-provider SecretStore)

## Known Residuals

None — `flutter analyze` clean, all tests pass. Recommend running `/ce:review` before merge per `CLAUDE.md` ("Before any merge: Run /ce:review first.").

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.7 [1M context])