### PR TITLE
feat(mobile): M4 PR-4i — policy compliance + violations browser

### DIFF
--- a/mobile/lib/api/policy_repository.dart
+++ b/mobile/lib/api/policy_repository.dart
@@ -1,0 +1,795 @@
+// Mobile-side wrapper over the backend policy API at
+// `/v1/policies/{status,(list),violations,compliance,compliance/history}`.
+// Wire types mirror `backend/internal/policy/types.go` exactly.
+// Web parallel: `frontend/islands/PolicyDashboard.tsx`,
+// `frontend/components/k8s/ComplianceDashboard.tsx`,
+// `frontend/components/k8s/ComplianceTrendChart.tsx`.
+//
+// Engine field semantics (open enum on the wire). Treated as a raw string
+// so a future engine name (e.g., Kyverno-Constraint) doesn't crash the
+// parser. UI rendering branches on the [PolicyEngine] enum, with
+// [PolicyEngine.unknown] for unrecognised values.
+//
+// Cluster pinning: every call accepts `clusterIdOverride` and forwards it
+// as an explicit `X-Cluster-ID` header. The PR-3c interceptor invariant
+// (only injects when absent) is the live contract — so the wire header
+// always matches whichever family-key slot the caller writes back into.
+//
+// 503 distinguished-error path for `complianceHistory`: when the backend
+// reports `compliance history requires a database` (PostgreSQL not
+// configured), this is a permanent "feature not configured" state — UI
+// must render a non-retryable empty state. Other 503s (network blips,
+// rolling restarts) stay retry-able. The discriminator is the substring
+// "requires a database" anywhere in the error message; see
+// `backend/internal/policy/handler.go::HandleComplianceHistory` for the
+// canonical wording.
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../cluster/cluster_provider.dart';
+import 'api_error.dart';
+import 'dio_client.dart';
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+/// Policy engine. Open enum on the wire — older / future policy responses
+/// may add engines, so [unknown] is the explicit fallback rather than
+/// crashing the parser.
+enum PolicyEngine { kyverno, gatekeeper, unknown }
+
+PolicyEngine _engineFromJson(Object? v) {
+  if (v is! String) return PolicyEngine.unknown;
+  switch (v) {
+    case 'kyverno':
+      return PolicyEngine.kyverno;
+    case 'gatekeeper':
+      return PolicyEngine.gatekeeper;
+    default:
+      return PolicyEngine.unknown;
+  }
+}
+
+String policyEngineLabel(PolicyEngine e) => switch (e) {
+      PolicyEngine.kyverno => 'Kyverno',
+      PolicyEngine.gatekeeper => 'Gatekeeper',
+      PolicyEngine.unknown => 'Unknown',
+    };
+
+/// Severity weights mirror `backend/internal/policy/types.go::severityWeights`.
+/// Used for client-side severity ordering when the list endpoint is consumed
+/// without a re-sort (the backend sorts by severity weight on its side, but
+/// filtered subsets re-sort on the client).
+const Map<String, int> kPolicySeverityWeights = {
+  'critical': 10,
+  'high': 5,
+  'medium': 2,
+  'low': 1,
+};
+
+/// Default severity applied when a policy declares no severity. Mirrors
+/// `defaultSeverity` in `backend/internal/policy/types.go`.
+const String kPolicyDefaultSeverity = 'medium';
+
+// ---------------------------------------------------------------------------
+// Wire-format value types
+// ---------------------------------------------------------------------------
+
+/// Decoded `/v1/policies/status` response. Mirrors `EngineStatus` in
+/// `backend/internal/policy/types.go`. Distinct from the wizard-side
+/// [PolicyEngineStatus] in `mobile/lib/wizards/types/policy/` — that
+/// shape is the wizard's bootstrap view; this is the observatory view
+/// (same payload, slightly different downstream usage).
+class PolicyDiscoveryStatus {
+  const PolicyDiscoveryStatus({
+    required this.detected,
+    required this.kyvernoAvailable,
+    required this.gatekeeperAvailable,
+    this.kyvernoNamespace,
+    this.gatekeeperNamespace,
+    this.kyvernoWebhooks = 0,
+    this.gatekeeperWebhooks = 0,
+    this.lastChecked = '',
+    this.serviceUnavailable = false,
+  });
+
+  /// True when at least one engine is detected. Drives
+  /// `FeatureUnavailableState.policy()` rendering on every policy surface.
+  final bool detected;
+
+  final bool kyvernoAvailable;
+  final bool gatekeeperAvailable;
+
+  /// Namespace where Kyverno is installed. Admin-only — stripped to null
+  /// for non-admin users by the backend handler. Used for "installed in
+  /// kube-system" hint copy.
+  final String? kyvernoNamespace;
+
+  /// Namespace where Gatekeeper is installed. Same admin gating as
+  /// [kyvernoNamespace].
+  final String? gatekeeperNamespace;
+
+  final int kyvernoWebhooks;
+  final int gatekeeperWebhooks;
+
+  /// RFC-3339 timestamp; empty when the first probe hasn't completed.
+  final String lastChecked;
+
+  /// True when the backend status endpoint returned 5xx — distinguishes
+  /// "backend was unreachable" from "backend says no engine installed".
+  /// Both flow through `detected: false` so the install-guidance UI
+  /// renders; consumers that want to nudge toward retry can branch on
+  /// this flag.
+  final bool serviceUnavailable;
+
+  factory PolicyDiscoveryStatus.fromJson(Map<String, dynamic> json) {
+    String? s(Object? v) => v is String && v.isNotEmpty ? v : null;
+    int i(Object? v) => v is num ? v.toInt() : 0;
+    final kyvernoBlock = json['kyverno'] as Map<String, dynamic>?;
+    final gkBlock = json['gatekeeper'] as Map<String, dynamic>?;
+    final kyvernoAvail = kyvernoBlock?['available'] == true;
+    final gkAvail = gkBlock?['available'] == true;
+    final detected = kyvernoAvail || gkAvail;
+    return PolicyDiscoveryStatus(
+      detected: detected,
+      kyvernoAvailable: kyvernoAvail,
+      gatekeeperAvailable: gkAvail,
+      kyvernoNamespace: s(kyvernoBlock?['namespace']),
+      gatekeeperNamespace: s(gkBlock?['namespace']),
+      kyvernoWebhooks: i(kyvernoBlock?['webhooks']),
+      gatekeeperWebhooks: i(gkBlock?['webhooks']),
+      lastChecked: json['lastChecked'] as String? ?? '',
+    );
+  }
+
+  static const empty = PolicyDiscoveryStatus(
+    detected: false,
+    kyvernoAvailable: false,
+    gatekeeperAvailable: false,
+  );
+
+  static const unreachable = PolicyDiscoveryStatus(
+    detected: false,
+    kyvernoAvailable: false,
+    gatekeeperAvailable: false,
+    serviceUnavailable: true,
+  );
+}
+
+/// One normalized policy row. Mirrors `NormalizedPolicy` in
+/// `backend/internal/policy/types.go`.
+///
+/// Composite ID: `engine:namespace:kind:name` per the Key Conventions
+/// section of CLAUDE.md. The backend's [id] field already encodes this,
+/// but mobile derives + validates it via [PolicyId] so callers can drill
+/// into the canonical pieces without re-parsing the wire format.
+class PolicyItem {
+  const PolicyItem({
+    required this.id,
+    required this.name,
+    required this.namespace,
+    required this.kind,
+    required this.action,
+    required this.severity,
+    required this.engine,
+    required this.blocking,
+    required this.ready,
+    required this.ruleCount,
+    required this.violationCount,
+    this.category,
+    this.description,
+    this.nativeAction,
+    this.targetKinds = const [],
+  });
+
+  final String id;
+  final String name;
+
+  /// Namespaced policies have a value; cluster-scoped policies leave this
+  /// empty (the backend's `omitempty` field unwinds to "").
+  final String namespace;
+
+  final String kind;
+
+  /// Normalized action: typically `audit` / `enforce` / `warn`. Open enum
+  /// on the wire — render verbatim, no parsing.
+  final String action;
+
+  /// One of `critical|high|medium|low` (lowercase per the backend weight
+  /// table). Anything else falls through to the default
+  /// [kPolicyDefaultSeverity] when computing weights.
+  final String severity;
+
+  final PolicyEngine engine;
+
+  /// True when the policy blocks the admission request on violation
+  /// (Kyverno `enforce`, Gatekeeper `deny`). False for audit-only.
+  final bool blocking;
+
+  /// True when the policy is currently active. False means the engine has
+  /// reported it as not yet reconciled or as failing to compile.
+  final bool ready;
+
+  final int ruleCount;
+  final int violationCount;
+
+  final String? category;
+  final String? description;
+  final String? nativeAction;
+  final List<String> targetKinds;
+
+  factory PolicyItem.fromJson(Map<String, dynamic> json) {
+    int i(Object? v) => v is num ? v.toInt() : 0;
+    return PolicyItem(
+      id: json['id'] as String? ?? '',
+      name: json['name'] as String? ?? '',
+      namespace: json['namespace'] as String? ?? '',
+      kind: json['kind'] as String? ?? '',
+      action: json['action'] as String? ?? '',
+      severity: (json['severity'] as String? ?? kPolicyDefaultSeverity)
+          .toLowerCase(),
+      engine: _engineFromJson(json['engine']),
+      blocking: json['blocking'] == true,
+      ready: json['ready'] == true,
+      ruleCount: i(json['ruleCount']),
+      violationCount: i(json['violationCount']),
+      category: json['category'] as String?,
+      description: json['description'] as String?,
+      nativeAction: json['nativeAction'] as String?,
+      targetKinds: ((json['targetKinds'] as List?) ?? const [])
+          .whereType<String>()
+          .toList(),
+    );
+  }
+}
+
+/// One normalized violation row. Mirrors `NormalizedViolation` in
+/// `backend/internal/policy/types.go`.
+///
+/// Wire shape has NO server-side `id` field — violations are derived
+/// from controller events. Mobile constructs a stable key via
+/// [stableKey] for `ListView.builder` and detail-screen lookup, since the
+/// list endpoint is the only source of truth (no GET-by-id violation
+/// endpoint exists; detail is a client-side filter of the list).
+class PolicyViolation {
+  const PolicyViolation({
+    required this.policy,
+    required this.severity,
+    required this.action,
+    required this.message,
+    required this.kind,
+    required this.name,
+    required this.engine,
+    required this.blocking,
+    this.rule = '',
+    this.namespace = '',
+    this.timestamp = '',
+  });
+
+  /// MatchKey of the violating policy. Joins to [PolicyItem.id] (well,
+  /// to MatchKey, which the backend exposes as `id` post-normalization
+  /// when the two match — for Kyverno they always do, for Gatekeeper the
+  /// id is `kind/name` and policy joins read MatchKey directly per
+  /// `backend/internal/policy/types.go::NormalizedPolicy.MatchKey`).
+  final String policy;
+
+  /// Sub-rule name when the engine separates rules within a policy
+  /// (Kyverno does; Gatekeeper does not). Empty when absent.
+  final String rule;
+
+  final String severity;
+  final String action;
+  final String message;
+
+  /// Empty for cluster-scoped target resources.
+  final String namespace;
+
+  final String kind;
+  final String name;
+
+  /// RFC-3339 timestamp from the controller event; empty when the engine
+  /// didn't emit one. Used for sort tiebreakers.
+  final String timestamp;
+
+  final PolicyEngine engine;
+  final bool blocking;
+
+  factory PolicyViolation.fromJson(Map<String, dynamic> json) {
+    return PolicyViolation(
+      policy: json['policy'] as String? ?? '',
+      rule: json['rule'] as String? ?? '',
+      severity: (json['severity'] as String? ?? kPolicyDefaultSeverity)
+          .toLowerCase(),
+      action: json['action'] as String? ?? '',
+      message: json['message'] as String? ?? '',
+      namespace: json['namespace'] as String? ?? '',
+      kind: json['kind'] as String? ?? '',
+      name: json['name'] as String? ?? '',
+      timestamp: json['timestamp'] as String? ?? '',
+      engine: _engineFromJson(json['engine']),
+      blocking: json['blocking'] == true,
+    );
+  }
+
+  /// Stable identifier for `ListView.builder` keys + detail-screen
+  /// lookup. The server has no id; this tuple is the unique signature
+  /// per CLAUDE.md: `(policy, rule, namespace, kind, name)`.
+  String get stableKey => '$policy|$rule|$namespace|$kind|$name';
+}
+
+/// Per-severity pass/fail breakdown. Mirrors `SeverityCounts`.
+class PolicySeverityCounts {
+  const PolicySeverityCounts({
+    required this.pass,
+    required this.fail,
+    required this.total,
+  });
+
+  final int pass;
+  final int fail;
+  final int total;
+
+  factory PolicySeverityCounts.fromJson(Map<String, dynamic> json) {
+    int i(Object? v) => v is num ? v.toInt() : 0;
+    return PolicySeverityCounts(
+      pass: i(json['pass']),
+      fail: i(json['fail']),
+      total: i(json['total']),
+    );
+  }
+}
+
+/// Aggregate compliance score. Mirrors `ComplianceScore`.
+class ComplianceScore {
+  const ComplianceScore({
+    required this.scope,
+    required this.score,
+    required this.pass,
+    required this.fail,
+    required this.warn,
+    required this.total,
+    this.bySeverity = const {},
+  });
+
+  /// Namespace filter applied; empty string means cluster-wide.
+  final String scope;
+
+  /// 0-100 weighted score. `total == 0` yields 100 (no policies = vacuous
+  /// compliance) per the backend.
+  final double score;
+
+  final int pass;
+  final int fail;
+  final int warn;
+  final int total;
+
+  /// Severity → counts. Key is lowercase severity label.
+  final Map<String, PolicySeverityCounts> bySeverity;
+
+  factory ComplianceScore.fromJson(Map<String, dynamic> json) {
+    int i(Object? v) => v is num ? v.toInt() : 0;
+    double d(Object? v) {
+      if (v is num) return v.toDouble();
+      if (v is String) return double.tryParse(v) ?? 0;
+      return 0;
+    }
+
+    final raw = json['bySeverity'];
+    final bs = <String, PolicySeverityCounts>{};
+    if (raw is Map) {
+      for (final entry in raw.entries) {
+        final k = entry.key.toString();
+        final v = entry.value;
+        if (v is Map) {
+          bs[k] = PolicySeverityCounts.fromJson(Map<String, dynamic>.from(v));
+        }
+      }
+    }
+
+    return ComplianceScore(
+      scope: json['scope'] as String? ?? '',
+      score: d(json['score']),
+      pass: i(json['pass']),
+      fail: i(json['fail']),
+      warn: i(json['warn']),
+      total: i(json['total']),
+      bySeverity: bs,
+    );
+  }
+
+  static const empty = ComplianceScore(
+    scope: '',
+    score: 100,
+    pass: 0,
+    fail: 0,
+    warn: 0,
+    total: 0,
+  );
+}
+
+/// One historical compliance datapoint. Mirrors the inline
+/// `historyPoint` struct returned by `HandleComplianceHistory`. Date is
+/// a yyyy-MM-dd string; score is 0-100.
+class ComplianceHistoryPoint {
+  const ComplianceHistoryPoint({
+    required this.date,
+    required this.score,
+    required this.pass,
+    required this.fail,
+    required this.warn,
+    required this.total,
+  });
+
+  /// yyyy-MM-dd, UTC. Mobile parses to [DateTime] lazily for axis
+  /// rendering; raw string kept for clean serialization round-trips.
+  final String date;
+
+  final double score;
+  final int pass;
+  final int fail;
+  final int warn;
+  final int total;
+
+  factory ComplianceHistoryPoint.fromJson(Map<String, dynamic> json) {
+    int i(Object? v) => v is num ? v.toInt() : 0;
+    double d(Object? v) {
+      if (v is num) return v.toDouble();
+      if (v is String) return double.tryParse(v) ?? 0;
+      return 0;
+    }
+
+    return ComplianceHistoryPoint(
+      date: json['date'] as String? ?? '',
+      score: d(json['score']),
+      pass: i(json['pass']),
+      fail: i(json['fail']),
+      warn: i(json['warn']),
+      total: i(json['total']),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Composite-ID helper
+// ---------------------------------------------------------------------------
+
+/// Composite policy id parser. The backend's [PolicyItem.id] field is
+/// `engine:namespace:kind:name` (with empty namespace segment for
+/// cluster-scoped policies). [PolicyId.tryParse] handles malformed input
+/// without throwing so callers can short-circuit to a "not found" detail
+/// screen rather than 500-ing.
+class PolicyId {
+  const PolicyId({
+    required this.engine,
+    required this.namespace,
+    required this.kind,
+    required this.name,
+  });
+
+  final String engine;
+  final String namespace;
+  final String kind;
+  final String name;
+
+  /// Parses `engine:namespace:kind:name`. Returns null on any segment
+  /// shape mismatch. The namespace segment may be empty (cluster-scoped
+  /// policies); name + kind + engine must all be non-empty.
+  static PolicyId? tryParse(String raw) {
+    final parts = raw.split(':');
+    if (parts.length != 4) return null;
+    if (parts[0].isEmpty || parts[2].isEmpty || parts[3].isEmpty) return null;
+    return PolicyId(
+      engine: parts[0],
+      namespace: parts[1],
+      kind: parts[2],
+      name: parts[3],
+    );
+  }
+
+  String get raw => '$engine:$namespace:$kind:$name';
+}
+
+// ---------------------------------------------------------------------------
+// 503 distinguisher
+// ---------------------------------------------------------------------------
+
+/// True when [error] is a 503 carrying the backend's distinguished
+/// "compliance history requires a database" message. UI routes this to a
+/// non-retryable empty state rather than the generic retry-able 503
+/// surface. See `backend/internal/policy/handler.go::HandleComplianceHistory`.
+///
+/// The detection is by substring match on the message body so a future
+/// punctuation tweak ("compliance history requires a database to record
+/// snapshots") still routes correctly.
+bool isComplianceHistoryNotConfigured(Object error) {
+  if (error is! ApiError) return false;
+  if (error.statusCode != 503) return false;
+  final msg = error.message.toLowerCase();
+  return msg.contains('requires a database');
+}
+
+// ---------------------------------------------------------------------------
+// Repository
+// ---------------------------------------------------------------------------
+
+/// Stateless wrapper over `/v1/policies/*`. Cluster pinning threads
+/// through `clusterIdOverride` so the wire header always matches the
+/// family-key slot the caller writes back into.
+class PolicyRepository {
+  PolicyRepository(this._dio);
+
+  final Dio _dio;
+
+  /// Fetches policy-engine discovery status. Returns
+  /// [PolicyDiscoveryStatus.unreachable] on 5xx so the surface keeps
+  /// rendering install-guidance copy without flashing an error card;
+  /// `serviceUnavailable: true` lets the UI add a transient-error nuance
+  /// if it wants (e.g., during rolling restarts).
+  Future<PolicyDiscoveryStatus> status({
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) async {
+    try {
+      final res = await _dio.get<Map<String, dynamic>>(
+        '/api/v1/policies/status',
+        options: _opts(clusterIdOverride),
+        cancelToken: cancelToken,
+      );
+      final data = res.data?['data'];
+      if (data is Map) {
+        return PolicyDiscoveryStatus.fromJson(Map<String, dynamic>.from(data));
+      }
+      return PolicyDiscoveryStatus.empty;
+    } on DioException catch (e) {
+      if (CancelToken.isCancel(e)) rethrow;
+      final code = e.response?.statusCode ?? 0;
+      if (code >= 500 && code < 600) return PolicyDiscoveryStatus.unreachable;
+      final err = e.error;
+      throw err is ApiError ? err : ApiError.fromDio(e);
+    }
+  }
+
+  /// Lists all normalized policies. Server already RBAC-filters and sorts
+  /// by severity weight desc, name asc; no client re-sort needed unless
+  /// the caller applies its own filters.
+  Future<List<PolicyItem>> listPolicies({
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) =>
+      _fetchList<PolicyItem>(
+        path: '/api/v1/policies/',
+        parse: PolicyItem.fromJson,
+        clusterIdOverride: clusterIdOverride,
+        cancelToken: cancelToken,
+      );
+
+  /// Lists violations. RBAC-filtered (user must `list pods` in the
+  /// namespace to see its violations). Cluster-scoped violations are
+  /// admin-only.
+  Future<List<PolicyViolation>> listViolations({
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) =>
+      _fetchList<PolicyViolation>(
+        path: '/api/v1/policies/violations',
+        parse: PolicyViolation.fromJson,
+        clusterIdOverride: clusterIdOverride,
+        cancelToken: cancelToken,
+      );
+
+  /// Fetches the weighted compliance score. [scopeNamespace] is null /
+  /// empty for cluster-wide; otherwise filters violations to that
+  /// namespace (RBAC still applies on top).
+  Future<ComplianceScore> compliance({
+    String? scopeNamespace,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) async {
+    try {
+      final res = await _dio.get<Map<String, dynamic>>(
+        '/api/v1/policies/compliance',
+        queryParameters: (scopeNamespace != null && scopeNamespace.isNotEmpty)
+            ? {'namespace': scopeNamespace}
+            : null,
+        options: _opts(clusterIdOverride),
+        cancelToken: cancelToken,
+      );
+      final data = res.data?['data'];
+      if (data is Map) {
+        return ComplianceScore.fromJson(Map<String, dynamic>.from(data));
+      }
+      return ComplianceScore.empty;
+    } on DioException catch (e) {
+      if (CancelToken.isCancel(e)) rethrow;
+      final err = e.error;
+      throw err is ApiError ? err : ApiError.fromDio(e);
+    }
+  }
+
+  /// Admin-only. Fetches historical compliance snapshots over a sliding
+  /// window. Backend clamps [days] to [1, 90]; 30 is the default.
+  ///
+  /// 503 with "requires a database" body indicates the ComplianceStore
+  /// PostgreSQL persistence isn't configured — surface via
+  /// [isComplianceHistoryNotConfigured] check at the call site, and
+  /// render a non-retryable empty state. Other 503s stay retry-able.
+  Future<List<ComplianceHistoryPoint>> complianceHistory({
+    int days = 30,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) =>
+      _fetchList<ComplianceHistoryPoint>(
+        path: '/api/v1/policies/compliance/history',
+        query: {'days': '$days'},
+        parse: ComplianceHistoryPoint.fromJson,
+        clusterIdOverride: clusterIdOverride,
+        cancelToken: cancelToken,
+      );
+
+  // -------------------------------------------------------------------------
+  // Internals
+  // -------------------------------------------------------------------------
+
+  Options? _opts(String? clusterIdOverride) => clusterIdOverride == null
+      ? null
+      : Options(headers: {'X-Cluster-ID': clusterIdOverride});
+
+  Future<List<T>> _fetchList<T>({
+    required String path,
+    Map<String, String>? query,
+    required T Function(Map<String, dynamic>) parse,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) async {
+    try {
+      final res = await _dio.get<Map<String, dynamic>>(
+        path,
+        queryParameters: query,
+        options: _opts(clusterIdOverride),
+        cancelToken: cancelToken,
+      );
+      final data = res.data?['data'];
+      if (data is List) {
+        return data
+            .whereType<Map<dynamic, dynamic>>()
+            .map((m) => parse(Map<String, dynamic>.from(m)))
+            .toList();
+      }
+      return <T>[];
+    } on DioException catch (e) {
+      if (CancelToken.isCancel(e)) rethrow;
+      final err = e.error;
+      throw err is ApiError ? err : ApiError.fromDio(e);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Providers
+// ---------------------------------------------------------------------------
+
+final policyRepositoryProvider = Provider<PolicyRepository>((ref) {
+  return PolicyRepository(ref.watch(dioProvider));
+});
+
+/// Per-cluster policy discovery status. Drives
+/// `FeatureUnavailableState.policy()` on every observatory surface.
+///
+/// Distinct from `wizards/types/policy/policy_engine_status.dart` —
+/// that provider hits the same endpoint but uses a different family key
+/// type for the wizard's bootstrap. Two providers share the cache slot
+/// per cluster (one keyed by `String`, one by `PolicyEngineStatusKey`),
+/// which is fine because Dio's response body is the same JSON either
+/// way — the duplication is one extra HTTP round-trip per surface, which
+/// matches what the ESO and cert-manager observatories pay.
+final policyStatusProvider = FutureProvider.autoDispose
+    .family<PolicyDiscoveryStatus, String>((ref, clusterId) async {
+  ref.watch(activeClusterProvider);
+  final cancel = CancelToken();
+  ref.onDispose(() {
+    if (!cancel.isCancelled) cancel.cancel('policy status invalidated');
+  });
+  return ref.read(policyRepositoryProvider).status(
+        clusterIdOverride: clusterId,
+        cancelToken: cancel,
+      );
+});
+
+final policiesListProvider = FutureProvider.autoDispose
+    .family<List<PolicyItem>, String>((ref, clusterId) async {
+  ref.watch(activeClusterProvider);
+  final cancel = CancelToken();
+  ref.onDispose(() {
+    if (!cancel.isCancelled) cancel.cancel('policies list invalidated');
+  });
+  return ref.read(policyRepositoryProvider).listPolicies(
+        clusterIdOverride: clusterId,
+        cancelToken: cancel,
+      );
+});
+
+final violationsListProvider = FutureProvider.autoDispose
+    .family<List<PolicyViolation>, String>((ref, clusterId) async {
+  ref.watch(activeClusterProvider);
+  final cancel = CancelToken();
+  ref.onDispose(() {
+    if (!cancel.isCancelled) cancel.cancel('violations list invalidated');
+  });
+  return ref.read(policyRepositoryProvider).listViolations(
+        clusterIdOverride: clusterId,
+        cancelToken: cancel,
+      );
+});
+
+/// Compliance score. Key holds optional namespace scope so two screens
+/// open against different scopes don't share state.
+class ComplianceScoreKey {
+  /// Normalise [scopeNamespace]: empty string is treated as null so two
+  /// ostensibly-equal keys collapse to the same slot.
+  ComplianceScoreKey({required this.clusterId, String? scopeNamespace})
+      : scopeNamespace =
+            (scopeNamespace != null && scopeNamespace.isEmpty)
+                ? null
+                : scopeNamespace;
+
+  final String clusterId;
+  final String? scopeNamespace;
+
+  @override
+  bool operator ==(Object other) =>
+      other is ComplianceScoreKey &&
+      other.clusterId == clusterId &&
+      other.scopeNamespace == scopeNamespace;
+
+  @override
+  int get hashCode => Object.hash(clusterId, scopeNamespace);
+}
+
+final complianceScoreProvider = FutureProvider.autoDispose
+    .family<ComplianceScore, ComplianceScoreKey>((ref, key) async {
+  ref.watch(activeClusterProvider);
+  final cancel = CancelToken();
+  ref.onDispose(() {
+    if (!cancel.isCancelled) cancel.cancel('compliance score invalidated');
+  });
+  return ref.read(policyRepositoryProvider).compliance(
+        scopeNamespace: key.scopeNamespace,
+        clusterIdOverride: key.clusterId,
+        cancelToken: cancel,
+      );
+});
+
+/// Compliance history. Window is fixed at 30 days for M4; custom ranges
+/// are deferred to M5 polish per the plan's Scope Boundaries section.
+class ComplianceHistoryKey {
+  const ComplianceHistoryKey({required this.clusterId, this.days = 30});
+
+  final String clusterId;
+  final int days;
+
+  @override
+  bool operator ==(Object other) =>
+      other is ComplianceHistoryKey &&
+      other.clusterId == clusterId &&
+      other.days == days;
+
+  @override
+  int get hashCode => Object.hash(clusterId, days);
+}
+
+final complianceHistoryProvider = FutureProvider.autoDispose
+    .family<List<ComplianceHistoryPoint>, ComplianceHistoryKey>(
+        (ref, key) async {
+  ref.watch(activeClusterProvider);
+  final cancel = CancelToken();
+  ref.onDispose(() {
+    if (!cancel.isCancelled) cancel.cancel('compliance history invalidated');
+  });
+  return ref.read(policyRepositoryProvider).complianceHistory(
+        days: key.days,
+        clusterIdOverride: key.clusterId,
+        cancelToken: cancel,
+      );
+});

--- a/mobile/lib/api/policy_repository.dart
+++ b/mobile/lib/api/policy_repository.dart
@@ -380,7 +380,14 @@ class ComplianceScore {
     final bs = <String, PolicySeverityCounts>{};
     if (raw is Map) {
       for (final entry in raw.entries) {
-        final k = entry.key.toString();
+        // PolicyItem.severity / PolicyViolation.severity lowercase on
+        // parse so `kPolicySeverityWeights` lookups and `kSeverityOrder`
+        // comparisons work consistently. Mirror that here — without the
+        // lowercase a future engine emitting `Critical` would sort to
+        // the end of the by-severity breakdown via the unknown-key
+        // alphabetic-tiebreaker branch, contradicting the rest of the
+        // pipeline.
+        final k = entry.key.toString().toLowerCase();
         final v = entry.value;
         if (v is Map) {
           bs[k] = PolicySeverityCounts.fromJson(Map<String, dynamic>.from(v));
@@ -449,46 +456,6 @@ class ComplianceHistoryPoint {
       total: i(json['total']),
     );
   }
-}
-
-// ---------------------------------------------------------------------------
-// Composite-ID helper
-// ---------------------------------------------------------------------------
-
-/// Composite policy id parser. The backend's [PolicyItem.id] field is
-/// `engine:namespace:kind:name` (with empty namespace segment for
-/// cluster-scoped policies). [PolicyId.tryParse] handles malformed input
-/// without throwing so callers can short-circuit to a "not found" detail
-/// screen rather than 500-ing.
-class PolicyId {
-  const PolicyId({
-    required this.engine,
-    required this.namespace,
-    required this.kind,
-    required this.name,
-  });
-
-  final String engine;
-  final String namespace;
-  final String kind;
-  final String name;
-
-  /// Parses `engine:namespace:kind:name`. Returns null on any segment
-  /// shape mismatch. The namespace segment may be empty (cluster-scoped
-  /// policies); name + kind + engine must all be non-empty.
-  static PolicyId? tryParse(String raw) {
-    final parts = raw.split(':');
-    if (parts.length != 4) return null;
-    if (parts[0].isEmpty || parts[2].isEmpty || parts[3].isEmpty) return null;
-    return PolicyId(
-      engine: parts[0],
-      namespace: parts[1],
-      kind: parts[2],
-      name: parts[3],
-    );
-  }
-
-  String get raw => '$engine:$namespace:$kind:$name';
 }
 
 // ---------------------------------------------------------------------------
@@ -609,7 +576,9 @@ class PolicyRepository {
   }
 
   /// Admin-only. Fetches historical compliance snapshots over a sliding
-  /// window. Backend clamps [days] to [1, 90]; 30 is the default.
+  /// window. Backend clamps [days] to [1, 90]; 30 is the default. The
+  /// client-side assertion documents the constraint so a future caller
+  /// passing 0 or 365 fails loud rather than getting silently remapped.
   ///
   /// 503 with "requires a database" body indicates the ComplianceStore
   /// PostgreSQL persistence isn't configured — surface via
@@ -619,14 +588,20 @@ class PolicyRepository {
     int days = 30,
     String? clusterIdOverride,
     CancelToken? cancelToken,
-  }) =>
-      _fetchList<ComplianceHistoryPoint>(
-        path: '/api/v1/policies/compliance/history',
-        query: {'days': '$days'},
-        parse: ComplianceHistoryPoint.fromJson,
-        clusterIdOverride: clusterIdOverride,
-        cancelToken: cancelToken,
-      );
+  }) {
+    assert(
+      days >= 1 && days <= 90,
+      'complianceHistory(days:) must be in [1, 90]; backend clamps '
+      'silently otherwise. Got $days.',
+    );
+    return _fetchList<ComplianceHistoryPoint>(
+      path: '/api/v1/policies/compliance/history',
+      query: {'days': '$days'},
+      parse: ComplianceHistoryPoint.fromJson,
+      clusterIdOverride: clusterIdOverride,
+      cancelToken: cancelToken,
+    );
+  }
 
   // -------------------------------------------------------------------------
   // Internals

--- a/mobile/lib/features/policy/compliance_history_screen.dart
+++ b/mobile/lib/features/policy/compliance_history_screen.dart
@@ -137,12 +137,19 @@ class _HistoryChart extends StatelessWidget {
     // dashboard gauge).
     final latest = points.isNotEmpty ? points.last.score : 100.0;
     final tier = complianceScoreTier(latest, colors);
+    // Build the chart points and track how many were silently dropped
+    // due to unparseable dates. Surfacing the drop count below the
+    // chart prevents the operator from misreading a gapped chart as a
+    // sparse-data signal when the real cause is malformed backend output.
+    final chartPoints = <MetricsPoint>[];
+    for (final p in points) {
+      final t = _tryParseDate(p.date);
+      if (t != null) chartPoints.add((t: t, v: p.score));
+    }
+    final droppedDates = points.length - chartPoints.length;
     final scoreSeries = (
       label: 'Compliance %',
-      points: <MetricsPoint>[
-        for (final p in points)
-          if (_tryParseDate(p.date) case final t?) (t: t, v: p.score),
-      ],
+      points: chartPoints,
       severity: latest >= 90
           ? KubeChartSeverity.success
           : (latest >= 70
@@ -186,6 +193,18 @@ class _HistoryChart extends StatelessWidget {
               ),
               const SizedBox(height: 12),
               KubeLineChart(series: [scoreSeries], height: 200),
+              if (droppedDates > 0)
+                Padding(
+                  padding: const EdgeInsets.only(top: 8),
+                  child: Text(
+                    droppedDates == 1
+                        ? '1 datapoint dropped from the chart due to an '
+                            'unparseable date.'
+                        : '$droppedDates datapoints dropped from the '
+                            'chart due to unparseable dates.',
+                    style: TextStyle(color: colors.warning, fontSize: 11),
+                  ),
+                ),
             ],
           ),
         ),
@@ -261,9 +280,14 @@ class _HistoryChart extends StatelessWidget {
 /// Parses a `yyyy-MM-dd` string into UTC midnight. Returns null on
 /// malformed input rather than throwing, so a single corrupt datapoint
 /// from the backend doesn't blank the entire chart.
+///
+/// `DateTime.parse('2026-05-01')` without a timezone suffix yields a
+/// local-time DateTime — on a device in UTC+8 the point nominally for
+/// `2026-05-01` becomes 2026-04-30T16:00Z, misaligning the chart axis
+/// against the label row. Anchoring with a `T00:00:00Z` suffix forces UTC.
 DateTime? _tryParseDate(String s) {
   try {
-    return DateTime.parse(s);
+    return DateTime.parse('${s}T00:00:00Z');
   } on FormatException {
     return null;
   }

--- a/mobile/lib/features/policy/compliance_history_screen.dart
+++ b/mobile/lib/features/policy/compliance_history_screen.dart
@@ -1,0 +1,270 @@
+// Compliance history — admin-only line chart over
+// `GET /v1/policies/compliance/history`. Fixed 30-day window in M4 (per
+// Scope Boundaries — custom ranges deferred to M5 polish).
+//
+// 503 distinguished-error path: when the backend responds 503 with body
+// "requires a database", that's the ComplianceStore PostgreSQL persistence
+// being unconfigured. Surface as a permanent (non-retry-able) empty state
+// — pointing the operator at desktop setup rather than offering a Retry
+// button that will deterministically fail again. Other 503s (rolling
+// restarts, network blips) stay retry-able.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../api/api_error.dart';
+import '../../api/policy_repository.dart';
+import '../../auth/auth_repository.dart';
+import '../../auth/auth_state.dart';
+import '../../theme/kube_theme_builder.dart';
+import '../../widgets/empty_states.dart';
+import '../../widgets/feature_unavailable_state.dart';
+import '../../widgets/kube_line_chart.dart';
+import 'policy_widgets.dart';
+
+class ComplianceHistoryScreen extends ConsumerWidget {
+  const ComplianceHistoryScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final auth = ref.watch(authRepositoryProvider);
+    final isAdmin = auth is AuthAuthenticated ? auth.user.isAdmin : false;
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Compliance history')),
+      // Admin gate is the first check — non-admin users hit the route via
+      // a deep link should see an explicit "admin only" empty state rather
+      // than the policy status / database 503 surfaces under it. Backend
+      // also enforces via `RequireAdmin` so this is defence-in-depth.
+      body: !isAdmin
+          ? const EmptyState(
+              title: 'Admin only',
+              message:
+                  'Compliance history is restricted to cluster administrators. '
+                  'Switch to an admin account to view trend data.',
+              icon: Icons.lock_outline,
+            )
+          : PolicyStatusGate(
+              builder: (clusterId, _) =>
+                  _HistoryBody(clusterId: clusterId),
+            ),
+    );
+  }
+}
+
+class _HistoryBody extends ConsumerWidget {
+  const _HistoryBody({required this.clusterId});
+
+  final String clusterId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final async = ref.watch(
+      complianceHistoryProvider(ComplianceHistoryKey(clusterId: clusterId)),
+    );
+
+    return async.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (e, _) => _ErrorOrUnconfigured(
+        error: e,
+        onRetry: () => ref.invalidate(
+          complianceHistoryProvider(ComplianceHistoryKey(clusterId: clusterId)),
+        ),
+      ),
+      data: (points) {
+        if (points.isEmpty) {
+          return const EmptyState(
+            title: 'No compliance snapshots yet',
+            message:
+                'The compliance store is configured but has not recorded any '
+                'snapshots yet. The first datapoint will appear on the next '
+                'daily aggregation.',
+            icon: Icons.timeline_outlined,
+          );
+        }
+        return _HistoryChart(points: points, colors: colors);
+      },
+    );
+  }
+}
+
+/// Routes the error envelope to either the permanent "database not
+/// configured" empty state or the retry-able generic error view. The
+/// discriminator is the substring match exposed by
+/// [isComplianceHistoryNotConfigured] — both forms hit 503 but only one
+/// should be retried.
+class _ErrorOrUnconfigured extends StatelessWidget {
+  const _ErrorOrUnconfigured({required this.error, required this.onRetry});
+
+  final Object error;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    if (isComplianceHistoryNotConfigured(error)) {
+      // Permanent empty state — no Retry button. The backend will
+      // deterministically return 503 with the same message until
+      // PostgreSQL is configured server-side, which the operator cannot
+      // fix from the phone.
+      return const FeatureUnavailableState(
+        featureName: 'Compliance history',
+        helpMessage:
+            'Compliance history requires database storage on the k8sCenter '
+            'backend. Configure PostgreSQL persistence in the Helm values '
+            'to enable historical trend tracking.',
+        icon: Icons.storage_outlined,
+      );
+    }
+    return ErrorStateView(
+      message: error is ApiError ? (error as ApiError).message : error.toString(),
+      onRetry: onRetry,
+    );
+  }
+}
+
+class _HistoryChart extends StatelessWidget {
+  const _HistoryChart({required this.points, required this.colors});
+
+  final List<ComplianceHistoryPoint> points;
+  final KubeColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    // Score series — single line with severity coloured by the latest
+    // tier (KubeChartSeverity is per-series, so picking the colour from
+    // the most recent datapoint keeps the chart consistent with the
+    // dashboard gauge).
+    final latest = points.isNotEmpty ? points.last.score : 100.0;
+    final tier = complianceScoreTier(latest, colors);
+    final scoreSeries = (
+      label: 'Compliance %',
+      points: <MetricsPoint>[
+        for (final p in points)
+          if (_tryParseDate(p.date) case final t?) (t: t, v: p.score),
+      ],
+      severity: latest >= 90
+          ? KubeChartSeverity.success
+          : (latest >= 70
+              ? KubeChartSeverity.warning
+              : KubeChartSeverity.error),
+    );
+
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        Container(
+          padding: const EdgeInsets.all(14),
+          decoration: BoxDecoration(
+            color: colors.bgSurface,
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(color: colors.borderSubtle),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Text(
+                    'Last ${points.length} ${points.length == 1 ? 'day' : 'days'}',
+                    style: TextStyle(
+                      color: colors.textPrimary,
+                      fontSize: 14,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const Spacer(),
+                  Text(
+                    'Latest: ${latest.toStringAsFixed(0)}% · ${tier.label}',
+                    style: TextStyle(
+                      color: tier.fg,
+                      fontSize: 12,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              KubeLineChart(series: [scoreSeries], height: 200),
+            ],
+          ),
+        ),
+        const SizedBox(height: 12),
+        Container(
+          padding: const EdgeInsets.all(14),
+          decoration: BoxDecoration(
+            color: colors.bgSurface,
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(color: colors.borderSubtle),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Daily pass/fail',
+                style: TextStyle(
+                  color: colors.textPrimary,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: 8),
+              for (final p in points.reversed.take(7))
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 4),
+                  child: Row(
+                    children: [
+                      SizedBox(
+                        width: 88,
+                        child: Text(
+                          p.date,
+                          style: TextStyle(
+                            color: colors.textMuted,
+                            fontSize: 12,
+                            fontFeatures: const [FontFeature.tabularFigures()],
+                          ),
+                        ),
+                      ),
+                      SizedBox(
+                        width: 56,
+                        child: Text(
+                          '${p.score.toStringAsFixed(0)}%',
+                          style: TextStyle(
+                            color: colors.textPrimary,
+                            fontSize: 12,
+                            fontWeight: FontWeight.w600,
+                            fontFeatures: const [FontFeature.tabularFigures()],
+                          ),
+                        ),
+                      ),
+                      Expanded(
+                        child: Text(
+                          '${p.pass} pass · ${p.fail} fail · ${p.warn} warn',
+                          style: TextStyle(
+                            color: colors.textSecondary,
+                            fontSize: 12,
+                          ),
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Parses a `yyyy-MM-dd` string into UTC midnight. Returns null on
+/// malformed input rather than throwing, so a single corrupt datapoint
+/// from the backend doesn't blank the entire chart.
+DateTime? _tryParseDate(String s) {
+  try {
+    return DateTime.parse(s);
+  } on FormatException {
+    return null;
+  }
+}

--- a/mobile/lib/features/policy/dashboard_screen.dart
+++ b/mobile/lib/features/policy/dashboard_screen.dart
@@ -1,0 +1,505 @@
+// Policy compliance dashboard — KubeGaugeRing hero score + by-engine
+// cards (Kyverno + Gatekeeper) + by-severity breakdown + browse tiles to
+// the policies + violations + compliance-history surfaces. Mirrors
+// `frontend/islands/PolicyDashboard.tsx` and
+// `frontend/islands/ComplianceDashboard.tsx` rolled into a single mobile
+// screen (the web has two; phone-size doesn't need the split).
+//
+// Status gating: `PolicyStatusGate` gates the surface — when neither
+// engine is detected the operator sees `FeatureUnavailableState.policy()`
+// rather than an empty dashboard.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../api/policy_repository.dart';
+import '../../auth/auth_repository.dart';
+import '../../auth/auth_state.dart';
+import '../../theme/kube_theme_builder.dart';
+import '../../widgets/empty_states.dart';
+import '../../widgets/kube_gauge_ring.dart';
+import '../../widgets/kube_line_chart.dart' show KubeChartSeverity;
+import '../../widgets/refresh_guard.dart';
+import 'policy_widgets.dart';
+
+class PolicyDashboardScreen extends StatelessWidget {
+  const PolicyDashboardScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Policy & Compliance')),
+      body: PolicyStatusGate(
+        builder: (clusterId, status) => _DashboardBody(
+          clusterId: clusterId,
+          status: status,
+        ),
+      ),
+    );
+  }
+}
+
+class _DashboardBody extends ConsumerStatefulWidget {
+  const _DashboardBody({required this.clusterId, required this.status});
+
+  final String clusterId;
+  final PolicyDiscoveryStatus status;
+
+  @override
+  ConsumerState<_DashboardBody> createState() => _DashboardBodyState();
+}
+
+class _DashboardBodyState extends ConsumerState<_DashboardBody>
+    with RefreshGuardMixin {
+  ComplianceScoreKey get _scoreKey =>
+      ComplianceScoreKey(clusterId: widget.clusterId);
+
+  /// Refresh entry point shared by the RefreshIndicator pull-down and the
+  /// ListErrorShell retry. The guard collapses concurrent calls into the
+  /// in-flight future so rapid pulls don't stack invalidations.
+  Future<void> _handleRefresh() => guardedRefresh(() async {
+        ref.invalidate(complianceScoreProvider(_scoreKey));
+        ref.invalidate(policiesListProvider(widget.clusterId));
+        ref.invalidate(violationsListProvider(widget.clusterId));
+        try {
+          await Future.wait([
+            ref.read(complianceScoreProvider(_scoreKey).future),
+            ref.read(policiesListProvider(widget.clusterId).future),
+            ref.read(violationsListProvider(widget.clusterId).future),
+          ]);
+        } on Object {
+          // Surfaces via .when error branch.
+        }
+      });
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final scoreAsync = ref.watch(complianceScoreProvider(_scoreKey));
+    final policiesAsync = ref.watch(policiesListProvider(widget.clusterId));
+
+    return RefreshIndicator(
+      onRefresh: _handleRefresh,
+      child: scoreAsync.when(
+        loading: () => const _ScrollableShell(child: LoadingState()),
+        error: (e, _) => ListErrorShell(
+          title: 'Failed to load compliance score',
+          error: e,
+          onRetry: _handleRefresh,
+        ),
+        data: (score) => _DashboardContent(
+          clusterId: widget.clusterId,
+          status: widget.status,
+          score: score,
+          policiesAsync: policiesAsync,
+          colors: colors,
+        ),
+      ),
+    );
+  }
+}
+
+class _DashboardContent extends ConsumerWidget {
+  const _DashboardContent({
+    required this.clusterId,
+    required this.status,
+    required this.score,
+    required this.policiesAsync,
+    required this.colors,
+  });
+
+  final String clusterId;
+  final PolicyDiscoveryStatus status;
+  final ComplianceScore score;
+  final AsyncValue<List<PolicyItem>> policiesAsync;
+  final KubeColors colors;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final auth = ref.watch(authRepositoryProvider);
+    final isAdmin =
+        auth is AuthAuthenticated ? auth.user.isAdmin : false;
+
+    final pctFraction = (score.score / 100).clamp(0.0, 1.0);
+    final chartSeverity = score.total == 0
+        ? KubeChartSeverity.info
+        : (score.score >= 90
+            ? KubeChartSeverity.success
+            : (score.score >= 70
+                ? KubeChartSeverity.warning
+                : KubeChartSeverity.error));
+    final tier = complianceScoreTier(score.score, colors);
+
+    return ListView(
+      physics: const AlwaysScrollableScrollPhysics(),
+      padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
+      children: [
+        Center(
+          child: KubeGaugeRing(
+            percentage: pctFraction,
+            centerLabel: '${score.score.toStringAsFixed(0)}%',
+            subtitle: tier.label,
+            severity: chartSeverity,
+            size: 160,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Center(
+          child: Text(
+            score.total == 0
+                ? 'No policies defined yet.'
+                : '${score.pass}/${score.total} policies passing'
+                    '${score.warn > 0 ? ' · ${score.warn} audit warn' : ''}',
+            style: TextStyle(color: colors.textMuted, fontSize: 13),
+            textAlign: TextAlign.center,
+          ),
+        ),
+        const SizedBox(height: 16),
+        _EngineCards(status: status, policiesAsync: policiesAsync, colors: colors),
+        const SizedBox(height: 16),
+        if (score.bySeverity.isNotEmpty)
+          _SeverityBreakdown(score: score, colors: colors),
+        const SizedBox(height: 16),
+        _BrowseLinks(
+          clusterId: clusterId,
+          isAdmin: isAdmin,
+          colors: colors,
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Engine cards (Kyverno + Gatekeeper)
+// ---------------------------------------------------------------------------
+
+class _EngineCards extends StatelessWidget {
+  const _EngineCards({
+    required this.status,
+    required this.policiesAsync,
+    required this.colors,
+  });
+
+  final PolicyDiscoveryStatus status;
+  final AsyncValue<List<PolicyItem>> policiesAsync;
+  final KubeColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    // Per-engine policy counts. When the policies fetch errored or is
+    // loading, render the cards with a null count (renders as "—").
+    int? kyvernoPolicyCount;
+    int? gatekeeperPolicyCount;
+    policiesAsync.whenData((policies) {
+      kyvernoPolicyCount = policies
+          .where((p) => p.engine == PolicyEngine.kyverno)
+          .length;
+      gatekeeperPolicyCount = policies
+          .where((p) => p.engine == PolicyEngine.gatekeeper)
+          .length;
+    });
+
+    return GridView.count(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      crossAxisCount: 2,
+      mainAxisSpacing: 8,
+      crossAxisSpacing: 8,
+      childAspectRatio: 1.5,
+      children: [
+        _EngineCard(
+          engine: PolicyEngine.kyverno,
+          available: status.kyvernoAvailable,
+          webhooks: status.kyvernoWebhooks,
+          namespace: status.kyvernoNamespace,
+          policyCount: kyvernoPolicyCount,
+          colors: colors,
+        ),
+        _EngineCard(
+          engine: PolicyEngine.gatekeeper,
+          available: status.gatekeeperAvailable,
+          webhooks: status.gatekeeperWebhooks,
+          namespace: status.gatekeeperNamespace,
+          policyCount: gatekeeperPolicyCount,
+          colors: colors,
+        ),
+      ],
+    );
+  }
+}
+
+class _EngineCard extends StatelessWidget {
+  const _EngineCard({
+    required this.engine,
+    required this.available,
+    required this.webhooks,
+    required this.namespace,
+    required this.policyCount,
+    required this.colors,
+  });
+
+  final PolicyEngine engine;
+  final bool available;
+  final int webhooks;
+  final String? namespace;
+
+  /// Null when the policies fetch hasn't completed.
+  final int? policyCount;
+  final KubeColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: colors.bgSurface,
+        borderRadius: BorderRadius.circular(6),
+        border: Border.all(color: colors.borderSubtle),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              EngineBadge(engine: engine, dense: true),
+              const Spacer(),
+              Icon(
+                available ? Icons.check_circle_outline : Icons.cancel_outlined,
+                size: 16,
+                color: available ? colors.success : colors.textMuted,
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(
+            available ? 'Installed' : 'Not installed',
+            style: TextStyle(
+              color: colors.textPrimary,
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          if (available) ...[
+            const SizedBox(height: 2),
+            Text(
+              policyCount == null
+                  ? '— policies'
+                  : '$policyCount ${policyCount == 1 ? 'policy' : 'policies'}',
+              style: TextStyle(color: colors.textSecondary, fontSize: 12),
+            ),
+            Text(
+              '$webhooks ${webhooks == 1 ? 'webhook' : 'webhooks'}'
+              '${namespace != null ? ' · $namespace' : ''}',
+              style: TextStyle(color: colors.textMuted, fontSize: 11),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Severity breakdown
+// ---------------------------------------------------------------------------
+
+class _SeverityBreakdown extends StatelessWidget {
+  const _SeverityBreakdown({required this.score, required this.colors});
+
+  final ComplianceScore score;
+  final KubeColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    // Ordered by severity weight desc — critical first. Unknown severities
+    // (anything outside kSeverityOrder) are sorted alphabetically at the
+    // end to stay deterministic across renders.
+    final entries = score.bySeverity.entries.toList()
+      ..sort((a, b) {
+        final ai = kSeverityOrder.indexOf(a.key);
+        final bi = kSeverityOrder.indexOf(b.key);
+        if (ai != bi) {
+          if (ai == -1) return 1;
+          if (bi == -1) return -1;
+          return ai.compareTo(bi);
+        }
+        return a.key.compareTo(b.key);
+      });
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: colors.bgSurface,
+        borderRadius: BorderRadius.circular(6),
+        border: Border.all(color: colors.borderSubtle),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'By severity',
+            style: TextStyle(
+              color: colors.textPrimary,
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 10),
+          for (final e in entries) ...[
+            _SeverityRow(severity: e.key, counts: e.value, colors: colors),
+            const SizedBox(height: 8),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _SeverityRow extends StatelessWidget {
+  const _SeverityRow({
+    required this.severity,
+    required this.counts,
+    required this.colors,
+  });
+
+  final String severity;
+  final PolicySeverityCounts counts;
+  final KubeColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    final fg = policySeverityColor(severity, colors);
+    final pct = counts.total > 0 ? counts.pass / counts.total : 1.0;
+    return Row(
+      children: [
+        SizedBox(
+          width: 64,
+          child: Text(
+            policySeverityLabel(severity),
+            style: TextStyle(
+              color: fg,
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+        Expanded(
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(3),
+            child: LinearProgressIndicator(
+              value: pct,
+              minHeight: 6,
+              backgroundColor: colors.bgElevated,
+              valueColor: AlwaysStoppedAnimation<Color>(fg),
+            ),
+          ),
+        ),
+        const SizedBox(width: 8),
+        SizedBox(
+          width: 72,
+          child: Text(
+            '${counts.pass}/${counts.total}',
+            textAlign: TextAlign.right,
+            style: TextStyle(
+              color: colors.textMuted,
+              fontSize: 11,
+              fontFeatures: const [FontFeature.tabularFigures()],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Browse links
+// ---------------------------------------------------------------------------
+
+class _BrowseLinks extends StatelessWidget {
+  const _BrowseLinks({
+    required this.clusterId,
+    required this.isAdmin,
+    required this.colors,
+  });
+
+  final String clusterId;
+  final bool isAdmin;
+  final KubeColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    Widget tile(String label, IconData icon, String path) => Expanded(
+          child: InkWell(
+            onTap: () => context.push(path),
+            child: Container(
+              padding: const EdgeInsets.symmetric(vertical: 12),
+              decoration: BoxDecoration(
+                color: colors.bgSurface,
+                borderRadius: BorderRadius.circular(6),
+                border: Border.all(color: colors.borderSubtle),
+              ),
+              child: Column(
+                children: [
+                  Icon(icon, color: colors.accent, size: 22),
+                  const SizedBox(height: 6),
+                  Text(
+                    label,
+                    style: TextStyle(
+                      color: colors.textPrimary,
+                      fontSize: 12,
+                      fontWeight: FontWeight.w600,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+
+    return Row(
+      children: [
+        tile('Policies', Icons.list_alt_outlined,
+            '/clusters/$clusterId/policy/policies'),
+        const SizedBox(width: 8),
+        tile('Violations', Icons.report_problem_outlined,
+            '/clusters/$clusterId/policy/violations'),
+        const SizedBox(width: 8),
+        // Compliance history is admin-only — backend route guard returns
+        // 403 for non-admins. Hiding the tile rather than rendering a
+        // disabled card keeps the dashboard from advertising a feature
+        // the operator cannot reach. Admins still tap through to the
+        // 503-distinguished-error path when the database isn't configured.
+        if (isAdmin)
+          tile('History', Icons.timeline_outlined,
+              '/clusters/$clusterId/policy/compliance-history')
+        else
+          Expanded(
+            child: SizedBox(
+              height: 0,
+              child: const SizedBox.shrink(),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _ScrollableShell extends StatelessWidget {
+  const _ScrollableShell({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      physics: const AlwaysScrollableScrollPhysics(),
+      children: [SizedBox(height: 280, child: child)],
+    );
+  }
+}

--- a/mobile/lib/features/policy/dashboard_screen.dart
+++ b/mobile/lib/features/policy/dashboard_screen.dart
@@ -58,18 +58,52 @@ class _DashboardBodyState extends ConsumerState<_DashboardBody>
   /// Refresh entry point shared by the RefreshIndicator pull-down and the
   /// ListErrorShell retry. The guard collapses concurrent calls into the
   /// in-flight future so rapid pulls don't stack invalidations.
+  ///
+  /// `policyStatusProvider` is invalidated here so the dashboard reflects
+  /// engine-availability changes (engine uninstalled, second engine added)
+  /// on pull-to-refresh — without this, the engine cards stay stale until
+  /// provider autodispose tears down the cache.
+  ///
+  /// Partial-failure surfacing: the dashboard's `.when` only watches
+  /// `complianceScoreProvider` so a violations or policies fetch failure
+  /// would otherwise be silent. Track per-provider failure names and
+  /// surface them in a SnackBar so the operator knows the underlying
+  /// dataset is stale even though the dashboard rendered cleanly.
   Future<void> _handleRefresh() => guardedRefresh(() async {
+        ref.invalidate(policyStatusProvider(widget.clusterId));
         ref.invalidate(complianceScoreProvider(_scoreKey));
         ref.invalidate(policiesListProvider(widget.clusterId));
         ref.invalidate(violationsListProvider(widget.clusterId));
-        try {
-          await Future.wait([
-            ref.read(complianceScoreProvider(_scoreKey).future),
-            ref.read(policiesListProvider(widget.clusterId).future),
-            ref.read(violationsListProvider(widget.clusterId).future),
-          ]);
-        } on Object {
-          // Surfaces via .when error branch.
+        final fetches = <(String, Future<Object>)>[
+          ('status', ref.read(policyStatusProvider(widget.clusterId).future)),
+          ('compliance', ref.read(complianceScoreProvider(_scoreKey).future)),
+          ('policies', ref.read(policiesListProvider(widget.clusterId).future)),
+          ('violations', ref.read(violationsListProvider(widget.clusterId).future)),
+        ];
+        final failed = <String>[];
+        for (final (name, fut) in fetches) {
+          try {
+            await fut;
+          } on Object {
+            failed.add(name);
+          }
+        }
+        if (failed.isNotEmpty && mounted) {
+          // Compliance score failure already surfaces via the scoreAsync
+          // .when branch as a ListErrorShell; if compliance was the only
+          // failure, suppress the SnackBar (it would be redundant).
+          final extras =
+              failed.where((n) => n != 'compliance').toList();
+          if (extras.isNotEmpty) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text(
+                  'Some data is stale — ${extras.join(', ')} fetch failed.',
+                ),
+                duration: const Duration(seconds: 4),
+              ),
+            );
+          }
         }
       });
 
@@ -462,6 +496,13 @@ class _BrowseLinks extends StatelessWidget {
           ),
         );
 
+    // Compliance history is admin-only — backend route guard returns 403
+    // for non-admins. Hiding the tile rather than rendering a disabled card
+    // keeps the dashboard from advertising a feature the operator cannot
+    // reach. Admins still tap through to the 503-distinguished-error path
+    // when the database isn't configured. The spread-conditional omits the
+    // tile entirely for non-admins so the remaining two tiles each get 1/2
+    // of the row width instead of 1/3 with a phantom flex slot.
     return Row(
       children: [
         tile('Policies', Icons.list_alt_outlined,
@@ -469,22 +510,11 @@ class _BrowseLinks extends StatelessWidget {
         const SizedBox(width: 8),
         tile('Violations', Icons.report_problem_outlined,
             '/clusters/$clusterId/policy/violations'),
-        const SizedBox(width: 8),
-        // Compliance history is admin-only — backend route guard returns
-        // 403 for non-admins. Hiding the tile rather than rendering a
-        // disabled card keeps the dashboard from advertising a feature
-        // the operator cannot reach. Admins still tap through to the
-        // 503-distinguished-error path when the database isn't configured.
-        if (isAdmin)
+        if (isAdmin) ...[
+          const SizedBox(width: 8),
           tile('History', Icons.timeline_outlined,
-              '/clusters/$clusterId/policy/compliance-history')
-        else
-          Expanded(
-            child: SizedBox(
-              height: 0,
-              child: const SizedBox.shrink(),
-            ),
-          ),
+              '/clusters/$clusterId/policy/compliance-history'),
+        ],
       ],
     );
   }

--- a/mobile/lib/features/policy/policies_list_screen.dart
+++ b/mobile/lib/features/policy/policies_list_screen.dart
@@ -122,6 +122,16 @@ class _ListBodyState extends ConsumerState<_ListBody> with RefreshGuardMixin {
   List<PolicyItem>? _lastItems;
   List<String>? _haystacks;
 
+  // Filtered result cache: (items, engine, severity, blocking, search)
+  // → filtered list. Invalidated whenever any cache-key field changes.
+  // Without this cache, each build allocates a fresh list and re-runs
+  // 4 predicate checks across every row.
+  List<PolicyItem>? _cachedFiltered;
+  PolicyEngineFilter? _cachedFilterEngine;
+  PolicySeverityFilter? _cachedFilterSeverity;
+  PolicyBlockingFilter? _cachedFilterBlocking;
+  String? _cachedFilterSearch;
+
   Future<void> _handleRefresh() => guardedRefresh(() async {
         ref.invalidate(policiesListProvider(widget.clusterId));
         try {
@@ -221,7 +231,8 @@ class _ListBodyState extends ConsumerState<_ListBody> with RefreshGuardMixin {
     final q = widget.search.trim().toLowerCase();
 
     // Refresh the haystack cache only when the underlying items list
-    // changes identity (refresh, cluster switch).
+    // changes identity (refresh, cluster switch). Invalidate downstream
+    // filtered-result cache at the same time.
     if (!identical(_lastItems, items)) {
       _lastItems = items;
       _haystacks = items
@@ -233,6 +244,16 @@ class _ListBodyState extends ConsumerState<_ListBody> with RefreshGuardMixin {
                 p.description ?? '',
               ].join(' ').toLowerCase())
           .toList();
+      _cachedFiltered = null;
+    }
+
+    // Reuse the previous filtered result when nothing relevant changed.
+    if (_cachedFiltered != null &&
+        _cachedFilterEngine == widget.engineFilter &&
+        _cachedFilterSeverity == widget.severityFilter &&
+        _cachedFilterBlocking == widget.blockingFilter &&
+        _cachedFilterSearch == q) {
+      return _cachedFiltered!;
     }
 
     final hs = _haystacks!;
@@ -245,6 +266,12 @@ class _ListBodyState extends ConsumerState<_ListBody> with RefreshGuardMixin {
       if (q.isNotEmpty && !hs[i].contains(q)) continue;
       out.add(p);
     }
+
+    _cachedFiltered = out;
+    _cachedFilterEngine = widget.engineFilter;
+    _cachedFilterSeverity = widget.severityFilter;
+    _cachedFilterBlocking = widget.blockingFilter;
+    _cachedFilterSearch = q;
     return out;
   }
 
@@ -319,78 +346,57 @@ class _FilterStrip extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 8),
+          // Filter chip groups — record-loop pattern keeps the three
+          // groups (engine / severity / blocking) symmetric with
+          // violations_list_screen.dart's inline form rather than
+          // splaying out a private wrapper class per enum.
           SingleChildScrollView(
             scrollDirection: Axis.horizontal,
             child: Row(
               children: [
-                _EngineChip(
-                  value: PolicyEngineFilter.all,
-                  current: engineFilter,
-                  label: 'All',
-                  onChanged: onEngineChanged,
-                ),
-                _EngineChip(
-                  value: PolicyEngineFilter.kyverno,
-                  current: engineFilter,
-                  label: 'Kyverno',
-                  onChanged: onEngineChanged,
-                ),
-                _EngineChip(
-                  value: PolicyEngineFilter.gatekeeper,
-                  current: engineFilter,
-                  label: 'Gatekeeper',
-                  onChanged: onEngineChanged,
-                ),
+                for (final tuple in [
+                  (PolicyEngineFilter.all, 'All'),
+                  (PolicyEngineFilter.kyverno, 'Kyverno'),
+                  (PolicyEngineFilter.gatekeeper, 'Gatekeeper'),
+                ])
+                  Padding(
+                    padding: const EdgeInsets.only(right: 6),
+                    child: ChoiceChip(
+                      selected: tuple.$1 == engineFilter,
+                      label: Text(tuple.$2),
+                      onSelected: (_) => onEngineChanged(tuple.$1),
+                    ),
+                  ),
                 const SizedBox(width: 12),
-                _SeverityChip(
-                  value: PolicySeverityFilter.all,
-                  current: severityFilter,
-                  label: 'Any severity',
-                  onChanged: onSeverityChanged,
-                ),
-                _SeverityChip(
-                  value: PolicySeverityFilter.critical,
-                  current: severityFilter,
-                  label: 'Critical',
-                  onChanged: onSeverityChanged,
-                ),
-                _SeverityChip(
-                  value: PolicySeverityFilter.high,
-                  current: severityFilter,
-                  label: 'High',
-                  onChanged: onSeverityChanged,
-                ),
-                _SeverityChip(
-                  value: PolicySeverityFilter.medium,
-                  current: severityFilter,
-                  label: 'Medium',
-                  onChanged: onSeverityChanged,
-                ),
-                _SeverityChip(
-                  value: PolicySeverityFilter.low,
-                  current: severityFilter,
-                  label: 'Low',
-                  onChanged: onSeverityChanged,
-                ),
+                for (final tuple in [
+                  (PolicySeverityFilter.all, 'Any severity'),
+                  (PolicySeverityFilter.critical, 'Critical'),
+                  (PolicySeverityFilter.high, 'High'),
+                  (PolicySeverityFilter.medium, 'Medium'),
+                  (PolicySeverityFilter.low, 'Low'),
+                ])
+                  Padding(
+                    padding: const EdgeInsets.only(right: 6),
+                    child: ChoiceChip(
+                      selected: tuple.$1 == severityFilter,
+                      label: Text(tuple.$2),
+                      onSelected: (_) => onSeverityChanged(tuple.$1),
+                    ),
+                  ),
                 const SizedBox(width: 12),
-                _BlockingChip(
-                  value: PolicyBlockingFilter.all,
-                  current: blockingFilter,
-                  label: 'All actions',
-                  onChanged: onBlockingChanged,
-                ),
-                _BlockingChip(
-                  value: PolicyBlockingFilter.blocking,
-                  current: blockingFilter,
-                  label: 'Blocking',
-                  onChanged: onBlockingChanged,
-                ),
-                _BlockingChip(
-                  value: PolicyBlockingFilter.audit,
-                  current: blockingFilter,
-                  label: 'Audit',
-                  onChanged: onBlockingChanged,
-                ),
+                for (final tuple in [
+                  (PolicyBlockingFilter.all, 'All actions'),
+                  (PolicyBlockingFilter.blocking, 'Blocking'),
+                  (PolicyBlockingFilter.audit, 'Audit'),
+                ])
+                  Padding(
+                    padding: const EdgeInsets.only(right: 6),
+                    child: ChoiceChip(
+                      selected: tuple.$1 == blockingFilter,
+                      label: Text(tuple.$2),
+                      onSelected: (_) => onBlockingChanged(tuple.$1),
+                    ),
+                  ),
               ],
             ),
           ),
@@ -402,84 +408,6 @@ class _FilterStrip extends StatelessWidget {
             style: TextStyle(color: colors.textMuted, fontSize: 11),
           ),
         ],
-      ),
-    );
-  }
-}
-
-class _EngineChip extends StatelessWidget {
-  const _EngineChip({
-    required this.value,
-    required this.current,
-    required this.label,
-    required this.onChanged,
-  });
-
-  final PolicyEngineFilter value;
-  final PolicyEngineFilter current;
-  final String label;
-  final ValueChanged<PolicyEngineFilter> onChanged;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(right: 6),
-      child: ChoiceChip(
-        selected: value == current,
-        label: Text(label),
-        onSelected: (_) => onChanged(value),
-      ),
-    );
-  }
-}
-
-class _SeverityChip extends StatelessWidget {
-  const _SeverityChip({
-    required this.value,
-    required this.current,
-    required this.label,
-    required this.onChanged,
-  });
-
-  final PolicySeverityFilter value;
-  final PolicySeverityFilter current;
-  final String label;
-  final ValueChanged<PolicySeverityFilter> onChanged;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(right: 6),
-      child: ChoiceChip(
-        selected: value == current,
-        label: Text(label),
-        onSelected: (_) => onChanged(value),
-      ),
-    );
-  }
-}
-
-class _BlockingChip extends StatelessWidget {
-  const _BlockingChip({
-    required this.value,
-    required this.current,
-    required this.label,
-    required this.onChanged,
-  });
-
-  final PolicyBlockingFilter value;
-  final PolicyBlockingFilter current;
-  final String label;
-  final ValueChanged<PolicyBlockingFilter> onChanged;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(right: 6),
-      child: ChoiceChip(
-        selected: value == current,
-        label: Text(label),
-        onSelected: (_) => onChanged(value),
       ),
     );
   }

--- a/mobile/lib/features/policy/policies_list_screen.dart
+++ b/mobile/lib/features/policy/policies_list_screen.dart
@@ -1,0 +1,564 @@
+// Policies list — every normalized policy across both engines, filtered
+// by chips (engine / severity / blocking) + free-text search.
+//
+// Engine availability: if a policy reports `engine: kyverno` but the
+// cluster only has Gatekeeper installed (no `kyvernoAvailable`), the row
+// surfaces an "Engine not installed" tooltip on the badge. PR-3f's
+// engine-intersection learning generalises: the policy CRD could exist
+// on the cluster even when the engine pod is unhealthy or absent.
+//
+// Status gating: `PolicyStatusGate` gates the surface —
+// `FeatureUnavailableState.policy()` when neither engine is detected.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../api/policy_repository.dart';
+import '../../cluster/cluster_provider.dart';
+import '../../theme/kube_theme_builder.dart';
+import '../../widgets/empty_states.dart';
+import '../../widgets/refresh_guard.dart';
+import 'policy_widgets.dart';
+
+/// Engine filter chip values. Mirrors web's PolicyDashboard filterEngine.
+enum PolicyEngineFilter { all, kyverno, gatekeeper }
+
+/// Blocking filter chip values. `all` plus the two action modes.
+enum PolicyBlockingFilter { all, blocking, audit }
+
+class PoliciesListScreen extends ConsumerStatefulWidget {
+  const PoliciesListScreen({super.key});
+
+  @override
+  ConsumerState<PoliciesListScreen> createState() =>
+      _PoliciesListScreenState();
+}
+
+class _PoliciesListScreenState extends ConsumerState<PoliciesListScreen> {
+  PolicyEngineFilter _engineFilter = PolicyEngineFilter.all;
+  PolicySeverityFilter _severityFilter = PolicySeverityFilter.all;
+  PolicyBlockingFilter _blockingFilter = PolicyBlockingFilter.all;
+  String _search = '';
+  final _searchCtl = TextEditingController();
+
+  @override
+  void dispose() {
+    _searchCtl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    ref.listen<String>(activeClusterProvider, (previous, next) {
+      if (previous != next) {
+        setState(() {
+          _engineFilter = PolicyEngineFilter.all;
+          _severityFilter = PolicySeverityFilter.all;
+          _blockingFilter = PolicyBlockingFilter.all;
+          _search = '';
+          _searchCtl.clear();
+        });
+      }
+    });
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Policies')),
+      body: PolicyStatusGate(
+        builder: (clusterId, status) => _ListBody(
+          clusterId: clusterId,
+          status: status,
+          engineFilter: _engineFilter,
+          severityFilter: _severityFilter,
+          blockingFilter: _blockingFilter,
+          search: _search,
+          searchCtl: _searchCtl,
+          onEngineChanged: (v) => setState(() => _engineFilter = v),
+          onSeverityChanged: (v) => setState(() => _severityFilter = v),
+          onBlockingChanged: (v) => setState(() => _blockingFilter = v),
+          onSearchChanged: (v) => setState(() => _search = v),
+        ),
+      ),
+    );
+  }
+}
+
+class _ListBody extends ConsumerStatefulWidget {
+  const _ListBody({
+    required this.clusterId,
+    required this.status,
+    required this.engineFilter,
+    required this.severityFilter,
+    required this.blockingFilter,
+    required this.search,
+    required this.searchCtl,
+    required this.onEngineChanged,
+    required this.onSeverityChanged,
+    required this.onBlockingChanged,
+    required this.onSearchChanged,
+  });
+
+  final String clusterId;
+  final PolicyDiscoveryStatus status;
+  final PolicyEngineFilter engineFilter;
+  final PolicySeverityFilter severityFilter;
+  final PolicyBlockingFilter blockingFilter;
+  final String search;
+  final TextEditingController searchCtl;
+  final ValueChanged<PolicyEngineFilter> onEngineChanged;
+  final ValueChanged<PolicySeverityFilter> onSeverityChanged;
+  final ValueChanged<PolicyBlockingFilter> onBlockingChanged;
+  final ValueChanged<String> onSearchChanged;
+
+  @override
+  ConsumerState<_ListBody> createState() => _ListBodyState();
+}
+
+class _ListBodyState extends ConsumerState<_ListBody> with RefreshGuardMixin {
+  // Cached lower-cased search haystack ("name kind category description")
+  // parallel to [_lastItems]. Rebuilt only when the items list reference
+  // changes — keystroke rebuilds reuse the cache, dropping the per-
+  // keystroke cost from O(N) `toLowerCase` calls to a constant array
+  // lookup. Same pattern as ExternalSecretsListScreen.
+  List<PolicyItem>? _lastItems;
+  List<String>? _haystacks;
+
+  Future<void> _handleRefresh() => guardedRefresh(() async {
+        ref.invalidate(policiesListProvider(widget.clusterId));
+        try {
+          await ref.read(policiesListProvider(widget.clusterId).future);
+        } on Object {
+          // surfaces via .when
+        }
+      });
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final async = ref.watch(policiesListProvider(widget.clusterId));
+
+    return RefreshIndicator(
+      onRefresh: _handleRefresh,
+      child: async.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => ListErrorShell(
+          title: 'Failed to load policies',
+          error: e,
+          onRetry: _handleRefresh,
+        ),
+        data: (items) {
+          final filtered = _applyFilters(items);
+          return CustomScrollView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            slivers: [
+              SliverToBoxAdapter(
+                child: _FilterStrip(
+                  engineFilter: widget.engineFilter,
+                  severityFilter: widget.severityFilter,
+                  blockingFilter: widget.blockingFilter,
+                  searchCtl: widget.searchCtl,
+                  totalVisible: filtered.length,
+                  totalAll: items.length,
+                  onEngineChanged: widget.onEngineChanged,
+                  onSeverityChanged: widget.onSeverityChanged,
+                  onBlockingChanged: widget.onBlockingChanged,
+                  onSearchChanged: widget.onSearchChanged,
+                ),
+              ),
+              if (filtered.isEmpty)
+                SliverToBoxAdapter(
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 16,
+                      vertical: 32,
+                    ),
+                    child: Center(
+                      child: Text(
+                        items.isEmpty
+                            ? 'No policies defined on this cluster. The '
+                                'policy engine will populate the list once '
+                                'a ClusterPolicy or ConstraintTemplate is '
+                                'created.'
+                            : 'No policies match the current filters.',
+                        style: TextStyle(color: colors.textMuted),
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                  ),
+                )
+              else
+                SliverList(
+                  delegate: SliverChildBuilderDelegate(
+                    (context, index) => _PolicyRow(
+                      policy: filtered[index],
+                      engineAvailable:
+                          _isEngineAvailable(filtered[index].engine),
+                    ),
+                    childCount: filtered.length,
+                  ),
+                ),
+              const SliverPadding(padding: EdgeInsets.only(bottom: 8)),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  bool _isEngineAvailable(PolicyEngine engine) {
+    switch (engine) {
+      case PolicyEngine.kyverno:
+        return widget.status.kyvernoAvailable;
+      case PolicyEngine.gatekeeper:
+        return widget.status.gatekeeperAvailable;
+      case PolicyEngine.unknown:
+        // Unknown engines render with no availability tooltip — there is
+        // no install action we can suggest for an engine we don't recognise.
+        return true;
+    }
+  }
+
+  List<PolicyItem> _applyFilters(List<PolicyItem> items) {
+    final q = widget.search.trim().toLowerCase();
+
+    // Refresh the haystack cache only when the underlying items list
+    // changes identity (refresh, cluster switch).
+    if (!identical(_lastItems, items)) {
+      _lastItems = items;
+      _haystacks = items
+          .map((p) => [
+                p.name,
+                p.kind,
+                p.namespace,
+                p.category ?? '',
+                p.description ?? '',
+              ].join(' ').toLowerCase())
+          .toList();
+    }
+
+    final hs = _haystacks!;
+    final out = <PolicyItem>[];
+    for (var i = 0; i < items.length; i++) {
+      final p = items[i];
+      if (!_matchesEngine(p)) continue;
+      if (!_matchesSeverity(p)) continue;
+      if (!_matchesBlocking(p)) continue;
+      if (q.isNotEmpty && !hs[i].contains(q)) continue;
+      out.add(p);
+    }
+    return out;
+  }
+
+  bool _matchesEngine(PolicyItem p) => switch (widget.engineFilter) {
+        PolicyEngineFilter.all => true,
+        PolicyEngineFilter.kyverno => p.engine == PolicyEngine.kyverno,
+        PolicyEngineFilter.gatekeeper => p.engine == PolicyEngine.gatekeeper,
+      };
+
+  bool _matchesSeverity(PolicyItem p) => switch (widget.severityFilter) {
+        PolicySeverityFilter.all => true,
+        PolicySeverityFilter.critical => p.severity == 'critical',
+        PolicySeverityFilter.high => p.severity == 'high',
+        PolicySeverityFilter.medium => p.severity == 'medium',
+        PolicySeverityFilter.low => p.severity == 'low',
+      };
+
+  bool _matchesBlocking(PolicyItem p) => switch (widget.blockingFilter) {
+        PolicyBlockingFilter.all => true,
+        PolicyBlockingFilter.blocking => p.blocking,
+        PolicyBlockingFilter.audit => !p.blocking,
+      };
+}
+
+// ---------------------------------------------------------------------------
+// Filter strip
+// ---------------------------------------------------------------------------
+
+class _FilterStrip extends StatelessWidget {
+  const _FilterStrip({
+    required this.engineFilter,
+    required this.severityFilter,
+    required this.blockingFilter,
+    required this.searchCtl,
+    required this.totalVisible,
+    required this.totalAll,
+    required this.onEngineChanged,
+    required this.onSeverityChanged,
+    required this.onBlockingChanged,
+    required this.onSearchChanged,
+  });
+
+  final PolicyEngineFilter engineFilter;
+  final PolicySeverityFilter severityFilter;
+  final PolicyBlockingFilter blockingFilter;
+  final TextEditingController searchCtl;
+  final int totalVisible;
+  final int totalAll;
+  final ValueChanged<PolicyEngineFilter> onEngineChanged;
+  final ValueChanged<PolicySeverityFilter> onSeverityChanged;
+  final ValueChanged<PolicyBlockingFilter> onBlockingChanged;
+  final ValueChanged<String> onSearchChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 12, 12, 4),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          TextField(
+            controller: searchCtl,
+            onChanged: onSearchChanged,
+            decoration: InputDecoration(
+              prefixIcon: const Icon(Icons.search, size: 18),
+              hintText: 'Search policies',
+              isDense: true,
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(6),
+              ),
+            ),
+          ),
+          const SizedBox(height: 8),
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: Row(
+              children: [
+                _EngineChip(
+                  value: PolicyEngineFilter.all,
+                  current: engineFilter,
+                  label: 'All',
+                  onChanged: onEngineChanged,
+                ),
+                _EngineChip(
+                  value: PolicyEngineFilter.kyverno,
+                  current: engineFilter,
+                  label: 'Kyverno',
+                  onChanged: onEngineChanged,
+                ),
+                _EngineChip(
+                  value: PolicyEngineFilter.gatekeeper,
+                  current: engineFilter,
+                  label: 'Gatekeeper',
+                  onChanged: onEngineChanged,
+                ),
+                const SizedBox(width: 12),
+                _SeverityChip(
+                  value: PolicySeverityFilter.all,
+                  current: severityFilter,
+                  label: 'Any severity',
+                  onChanged: onSeverityChanged,
+                ),
+                _SeverityChip(
+                  value: PolicySeverityFilter.critical,
+                  current: severityFilter,
+                  label: 'Critical',
+                  onChanged: onSeverityChanged,
+                ),
+                _SeverityChip(
+                  value: PolicySeverityFilter.high,
+                  current: severityFilter,
+                  label: 'High',
+                  onChanged: onSeverityChanged,
+                ),
+                _SeverityChip(
+                  value: PolicySeverityFilter.medium,
+                  current: severityFilter,
+                  label: 'Medium',
+                  onChanged: onSeverityChanged,
+                ),
+                _SeverityChip(
+                  value: PolicySeverityFilter.low,
+                  current: severityFilter,
+                  label: 'Low',
+                  onChanged: onSeverityChanged,
+                ),
+                const SizedBox(width: 12),
+                _BlockingChip(
+                  value: PolicyBlockingFilter.all,
+                  current: blockingFilter,
+                  label: 'All actions',
+                  onChanged: onBlockingChanged,
+                ),
+                _BlockingChip(
+                  value: PolicyBlockingFilter.blocking,
+                  current: blockingFilter,
+                  label: 'Blocking',
+                  onChanged: onBlockingChanged,
+                ),
+                _BlockingChip(
+                  value: PolicyBlockingFilter.audit,
+                  current: blockingFilter,
+                  label: 'Audit',
+                  onChanged: onBlockingChanged,
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            totalVisible == totalAll
+                ? '$totalAll ${totalAll == 1 ? 'policy' : 'policies'}'
+                : 'Showing $totalVisible of $totalAll policies',
+            style: TextStyle(color: colors.textMuted, fontSize: 11),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EngineChip extends StatelessWidget {
+  const _EngineChip({
+    required this.value,
+    required this.current,
+    required this.label,
+    required this.onChanged,
+  });
+
+  final PolicyEngineFilter value;
+  final PolicyEngineFilter current;
+  final String label;
+  final ValueChanged<PolicyEngineFilter> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(right: 6),
+      child: ChoiceChip(
+        selected: value == current,
+        label: Text(label),
+        onSelected: (_) => onChanged(value),
+      ),
+    );
+  }
+}
+
+class _SeverityChip extends StatelessWidget {
+  const _SeverityChip({
+    required this.value,
+    required this.current,
+    required this.label,
+    required this.onChanged,
+  });
+
+  final PolicySeverityFilter value;
+  final PolicySeverityFilter current;
+  final String label;
+  final ValueChanged<PolicySeverityFilter> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(right: 6),
+      child: ChoiceChip(
+        selected: value == current,
+        label: Text(label),
+        onSelected: (_) => onChanged(value),
+      ),
+    );
+  }
+}
+
+class _BlockingChip extends StatelessWidget {
+  const _BlockingChip({
+    required this.value,
+    required this.current,
+    required this.label,
+    required this.onChanged,
+  });
+
+  final PolicyBlockingFilter value;
+  final PolicyBlockingFilter current;
+  final String label;
+  final ValueChanged<PolicyBlockingFilter> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(right: 6),
+      child: ChoiceChip(
+        selected: value == current,
+        label: Text(label),
+        onSelected: (_) => onChanged(value),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Row
+// ---------------------------------------------------------------------------
+
+class _PolicyRow extends StatelessWidget {
+  const _PolicyRow({required this.policy, required this.engineAvailable});
+
+  final PolicyItem policy;
+  final bool engineAvailable;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        border: Border(bottom: BorderSide(color: colors.borderSubtle)),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  policy.name,
+                  style: TextStyle(
+                    color: colors.textPrimary,
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                  ),
+                  overflow: TextOverflow.ellipsis,
+                ),
+                const SizedBox(height: 2),
+                Wrap(
+                  spacing: 6,
+                  runSpacing: 4,
+                  crossAxisAlignment: WrapCrossAlignment.center,
+                  children: [
+                    EngineBadge(
+                      engine: policy.engine,
+                      dense: true,
+                      showUnavailableHint: !engineAvailable,
+                    ),
+                    SeverityBadge(severity: policy.severity, dense: true),
+                    BlockingBadge(blocking: policy.blocking, dense: true),
+                    if (policy.violationCount > 0)
+                      Text(
+                        '${policy.violationCount} '
+                        '${policy.violationCount == 1 ? 'violation' : 'violations'}',
+                        style: TextStyle(
+                          color: colors.error,
+                          fontSize: 11,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                  ],
+                ),
+                if (policy.description != null &&
+                    policy.description!.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 4),
+                    child: Text(
+                      policy.description!,
+                      style: TextStyle(color: colors.textMuted, fontSize: 11),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/policy/policy_widgets.dart
+++ b/mobile/lib/features/policy/policy_widgets.dart
@@ -1,0 +1,252 @@
+// Shared pill + small-widget helpers consumed by every policy surface
+// (dashboard, lists, detail, compliance history). Keeping the engine /
+// severity / blocking pills in one file is what enforces R10 (web/dart
+// isomorphism) for the policy domain — a future regression where
+// `medium` rendered as `error` instead of `warning` would have to land
+// here first.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../api/api_error.dart';
+import '../../api/policy_repository.dart';
+import '../../cluster/cluster_provider.dart';
+import '../../theme/kube_theme_builder.dart';
+import '../../widgets/empty_states.dart';
+import '../../widgets/feature_unavailable_state.dart';
+
+/// Wraps a per-cluster policy surface body in the standard discovery-status
+/// gate. The outer ConsumerWidget watches `policyStatusProvider(clusterId)`,
+/// handles loading / error / not-detected uniformly, and only calls
+/// [builder] when at least one engine is detected. Mirrors `EsoStatusGate`
+/// from PR-4h.
+class PolicyStatusGate extends ConsumerWidget {
+  const PolicyStatusGate({super.key, required this.builder});
+
+  /// Called with the current activeClusterId once status resolves to
+  /// `detected: true`. Implementations typically return the screen's
+  /// per-cluster body widget.
+  final Widget Function(String clusterId, PolicyDiscoveryStatus status) builder;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final clusterId = ref.watch(activeClusterProvider);
+    final statusAsync = ref.watch(policyStatusProvider(clusterId));
+    return statusAsync.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (e, _) => ErrorStateView(
+        message: e is ApiError ? e.message : e.toString(),
+        onRetry: () => ref.invalidate(policyStatusProvider(clusterId)),
+      ),
+      data: (status) {
+        if (!status.detected) return FeatureUnavailableState.policy();
+        return builder(clusterId, status);
+      },
+    );
+  }
+}
+
+/// Severity → KubeColors mapping. The mapping is the only place severity
+/// colours live across all policy surfaces — chips, badges, severity-
+/// breakdown bars, violation cards all read from here.
+///
+/// Web parallel: `frontend/components/ui/PolicyBadges.tsx::SEVERITY_COLORS`.
+Color policySeverityColor(String severity, KubeColors colors) {
+  switch (severity.toLowerCase()) {
+    case 'critical':
+      return colors.error;
+    case 'high':
+      return colors.warning;
+    case 'medium':
+      // medium maps to accent in the web (`var(--brand)`); we use accent
+      // for the same hue continuity.
+      return colors.accent;
+    case 'low':
+      return colors.success;
+    default:
+      return colors.textMuted;
+  }
+}
+
+/// Background tint paired with [policySeverityColor]. Used by chip
+/// renderers that need a fill colour distinct from the border / text.
+Color policySeverityDim(String severity, KubeColors colors) {
+  switch (severity.toLowerCase()) {
+    case 'critical':
+      return colors.errorDim;
+    case 'high':
+      return colors.warningDim;
+    case 'medium':
+      return colors.accentDim;
+    case 'low':
+      return colors.successDim;
+    default:
+      return colors.bgSurface;
+  }
+}
+
+/// Human label for a severity string. Capitalises so `critical` reads as
+/// `Critical` — UI consistency with the web side's `<SeverityBadge>`.
+String policySeverityLabel(String severity) {
+  if (severity.isEmpty) return 'Unknown';
+  return severity.substring(0, 1).toUpperCase() + severity.substring(1);
+}
+
+/// Severity ordering desc (critical first, low last). Used by sort
+/// comparators on the policies / violations list when a chip filter
+/// changes the displayed subset.
+const List<String> kSeverityOrder = ['critical', 'high', 'medium', 'low'];
+
+/// Severity filter chip values shared between the policies list and
+/// the violations list. `all` plus the four canonical severities.
+enum PolicySeverityFilter { all, critical, high, medium, low }
+
+/// Severity pill. Always renders even for unknown severities so callers
+/// don't accidentally drop a row when the engine emits an unfamiliar
+/// label.
+class SeverityBadge extends StatelessWidget {
+  const SeverityBadge({
+    super.key,
+    required this.severity,
+    this.dense = false,
+  });
+
+  final String severity;
+
+  /// Dense mode shrinks padding + font for embedding inside list rows
+  /// next to the resource name.
+  final bool dense;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final fg = policySeverityColor(severity, colors);
+    final bg = policySeverityDim(severity, colors);
+    return Container(
+      padding: EdgeInsets.symmetric(
+        horizontal: dense ? 6 : 8,
+        vertical: dense ? 2 : 3,
+      ),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(dense ? 3 : 4),
+        border: Border.all(color: fg),
+      ),
+      child: Text(
+        policySeverityLabel(severity),
+        style: TextStyle(
+          color: fg,
+          fontSize: dense ? 10 : 11,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+/// Engine pill. Distinct color per engine for visual scan-ability across
+/// mixed-engine clusters. [showUnavailableHint] adds a "Engine not
+/// installed" subtitle when the engine isn't detected on this cluster —
+/// per PR-3f's engine-intersection learning.
+class EngineBadge extends StatelessWidget {
+  const EngineBadge({
+    super.key,
+    required this.engine,
+    this.dense = false,
+    this.showUnavailableHint = false,
+  });
+
+  final PolicyEngine engine;
+  final bool dense;
+  final bool showUnavailableHint;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    // KubeColors exposes `info` (foreground) without a paired `infoDim` —
+    // pair with bgSurface and let the coloured border carry the engine
+    // identity. Same compromise used by `EsoStatusPill` for tones outside
+    // the success/warning/error/accent set.
+    final (fg, bg) = switch (engine) {
+      PolicyEngine.kyverno => (colors.info, colors.bgSurface),
+      PolicyEngine.gatekeeper => (colors.accent, colors.accentDim),
+      PolicyEngine.unknown => (colors.textMuted, colors.bgSurface),
+    };
+    final pill = Container(
+      padding: EdgeInsets.symmetric(
+        horizontal: dense ? 6 : 8,
+        vertical: dense ? 2 : 3,
+      ),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(dense ? 3 : 4),
+        border: Border.all(color: fg),
+      ),
+      child: Text(
+        policyEngineLabel(engine),
+        style: TextStyle(
+          color: fg,
+          fontSize: dense ? 10 : 11,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+    if (showUnavailableHint) {
+      return Tooltip(
+        message: 'Engine not installed on this cluster',
+        child: Opacity(opacity: 0.6, child: pill),
+      );
+    }
+    return pill;
+  }
+}
+
+/// Blocking / Audit pill. Mirrors the web's `<BlockingBadge>`.
+class BlockingBadge extends StatelessWidget {
+  const BlockingBadge({
+    super.key,
+    required this.blocking,
+    this.dense = false,
+  });
+
+  final bool blocking;
+  final bool dense;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final (fg, bg) = blocking
+        ? (colors.error, colors.errorDim)
+        : (colors.textMuted, colors.bgSurface);
+    return Container(
+      padding: EdgeInsets.symmetric(
+        horizontal: dense ? 6 : 8,
+        vertical: dense ? 2 : 3,
+      ),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(dense ? 3 : 4),
+        border: Border.all(color: fg),
+      ),
+      child: Text(
+        blocking ? 'Blocking' : 'Audit',
+        style: TextStyle(
+          color: fg,
+          fontSize: dense ? 10 : 11,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+/// Determine the severity tier for a 0-100 compliance score. Same
+/// thresholds as the web's `lib/health-score.ts::scoreColor`.
+({Color fg, String label}) complianceScoreTier(
+  double score,
+  KubeColors colors,
+) {
+  if (score >= 90) return (fg: colors.success, label: 'Healthy');
+  if (score >= 70) return (fg: colors.warning, label: 'At risk');
+  return (fg: colors.error, label: 'Critical');
+}

--- a/mobile/lib/features/policy/policy_widgets.dart
+++ b/mobile/lib/features/policy/policy_widgets.dart
@@ -25,7 +25,13 @@ class PolicyStatusGate extends ConsumerWidget {
 
   /// Called with the current activeClusterId once status resolves to
   /// `detected: true`. Implementations typically return the screen's
-  /// per-cluster body widget.
+  /// per-cluster body widget. The [PolicyDiscoveryStatus] is exposed
+  /// because two consumers need it: the dashboard renders per-engine
+  /// install state + webhook counts on the engine cards, and the
+  /// policies list applies the engine-availability tooltip via
+  /// [PolicyDiscoveryStatus.kyvernoAvailable] / `gatekeeperAvailable`
+  /// (PR-3f intersection learning). Consumers that don't need the
+  /// status are free to ignore it via the `_` pattern.
   final Widget Function(String clusterId, PolicyDiscoveryStatus status) builder;
 
   @override
@@ -39,6 +45,21 @@ class PolicyStatusGate extends ConsumerWidget {
         onRetry: () => ref.invalidate(policyStatusProvider(clusterId)),
       ),
       data: (status) {
+        // Transient backend 5xx — the repository collapses 5xx to a
+        // detected:false sentinel with serviceUnavailable:true. Distinct
+        // from "engine not installed": the operator needs a retry path
+        // (the backend will return when the rolling restart settles),
+        // not install-guidance copy. Without this branch the dashboard
+        // and lists wedge the operator on install-Kyverno copy until
+        // they kill the app.
+        if (status.serviceUnavailable) {
+          return ErrorStateView(
+            message:
+                'Policy backend temporarily unavailable. Retry once the '
+                'cluster settles.',
+            onRetry: () => ref.invalidate(policyStatusProvider(clusterId)),
+          );
+        }
         if (!status.detected) return FeatureUnavailableState.policy();
         return builder(clusterId, status);
       },

--- a/mobile/lib/features/policy/violation_detail_screen.dart
+++ b/mobile/lib/features/policy/violation_detail_screen.dart
@@ -1,0 +1,295 @@
+// Single-violation context. Backend has no GET-by-id endpoint for
+// violations, so this screen reads the violations list and filters by
+// the stable key `policy|rule|namespace|kind|name`. When the list no
+// longer contains the violation (e.g., remediated since the page was
+// captured), the screen renders a "violation not found" empty state
+// rather than a confusing blank tab.
+//
+// Target-resource link: routed through the generic catch-all
+// (`/clusters/<id>/generic/<kind>/<ns>/<name>`) since policy targets may
+// be CRDs outside `domainSections`. Users tapping a Pod / Deployment /
+// Service violation still land on a working detail screen via the
+// generic fallback.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../api/policy_repository.dart';
+import '../../routing/domain_sections.dart';
+import '../../theme/kube_theme_builder.dart';
+import '../../widgets/empty_states.dart';
+import 'policy_widgets.dart';
+
+class ViolationDetailScreen extends ConsumerWidget {
+  const ViolationDetailScreen({super.key, required this.stableKey});
+
+  /// `policy|rule|namespace|kind|name` — round-trips via
+  /// `PolicyViolation.stableKey`. Empty fields are preserved (the rule
+  /// segment is empty for Gatekeeper violations).
+  final String stableKey;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Violation')),
+      body: PolicyStatusGate(
+        builder: (clusterId, _) =>
+            _DetailBody(clusterId: clusterId, stableKey: stableKey),
+      ),
+    );
+  }
+}
+
+class _DetailBody extends ConsumerWidget {
+  const _DetailBody({required this.clusterId, required this.stableKey});
+
+  final String clusterId;
+  final String stableKey;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final async = ref.watch(violationsListProvider(clusterId));
+    final colors = Theme.of(context).extension<KubeColors>()!;
+
+    return async.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (e, _) => ErrorStateView(
+        message: e.toString(),
+        onRetry: () => ref.invalidate(violationsListProvider(clusterId)),
+      ),
+      data: (items) {
+        PolicyViolation? violation;
+        for (final v in items) {
+          if (v.stableKey == stableKey) {
+            violation = v;
+            break;
+          }
+        }
+        if (violation == null) {
+          return EmptyState(
+            title: 'Violation not found',
+            message:
+                'This violation may have been remediated. Pull-to-refresh '
+                'the violations list to confirm.',
+            icon: Icons.check_circle_outline,
+          );
+        }
+        return _DetailContent(
+          clusterId: clusterId,
+          violation: violation,
+          colors: colors,
+        );
+      },
+    );
+  }
+}
+
+class _DetailContent extends StatelessWidget {
+  const _DetailContent({
+    required this.clusterId,
+    required this.violation,
+    required this.colors,
+  });
+
+  final String clusterId;
+  final PolicyViolation violation;
+  final KubeColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        _Section(
+          title: violation.policy,
+          colors: colors,
+          children: [
+            if (violation.rule.isNotEmpty)
+              _LabelValue(label: 'Rule', value: violation.rule, colors: colors),
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 6),
+              child: Wrap(
+                spacing: 6,
+                runSpacing: 4,
+                children: [
+                  EngineBadge(engine: violation.engine),
+                  SeverityBadge(severity: violation.severity),
+                  BlockingBadge(blocking: violation.blocking),
+                ],
+              ),
+            ),
+            if (violation.message.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 6),
+                child: Text(
+                  violation.message,
+                  style: TextStyle(color: colors.textPrimary, fontSize: 13),
+                ),
+              ),
+            if (violation.timestamp.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 6),
+                child: Text(
+                  'Reported ${violation.timestamp}',
+                  style: TextStyle(color: colors.textMuted, fontSize: 11),
+                ),
+              ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        _Section(
+          title: 'Target resource',
+          colors: colors,
+          children: [
+            _LabelValue(label: 'Kind', value: violation.kind, colors: colors),
+            _LabelValue(
+              label: 'Namespace',
+              value: violation.namespace.isEmpty
+                  ? '(cluster-scoped)'
+                  : violation.namespace,
+              colors: colors,
+            ),
+            _LabelValue(label: 'Name', value: violation.name, colors: colors),
+            const SizedBox(height: 8),
+            FilledButton.icon(
+              onPressed: violation.name.isEmpty
+                  ? null
+                  : () => context.push(_targetResourcePath()),
+              icon: const Icon(Icons.open_in_new, size: 16),
+              label: const Text('View target resource'),
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        _Section(
+          title: 'Remediation',
+          colors: colors,
+          children: [
+            Text(
+              _remediationHint(violation),
+              style: TextStyle(color: colors.textSecondary, fontSize: 13),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  String _targetResourcePath() {
+    // Route through the generic catch-all so any kind (including CRDs
+    // outside `domainSections`) resolves to a working detail screen.
+    // Cluster-scoped resources use the sentinel namespace segment.
+    final ns = violation.namespace.isEmpty
+        ? clusterScopedNamespaceSentinel
+        : Uri.encodeComponent(violation.namespace);
+    return '/clusters/$clusterId/generic/'
+        '${Uri.encodeComponent(violation.kind)}/'
+        '$ns/${Uri.encodeComponent(violation.name)}';
+  }
+}
+
+/// Best-effort remediation copy derived from the engine + action. The
+/// backend's `message` carries the rule-specific detail; this is the
+/// generic "how to address" hint that sits next to it.
+String _remediationHint(PolicyViolation v) {
+  if (v.blocking) {
+    return 'This is a blocking violation — the workload was rejected at '
+        'admission. Update the manifest to satisfy the policy before '
+        're-applying. View the policy detail to inspect the rule body.';
+  }
+  if (v.engine == PolicyEngine.kyverno) {
+    return 'Audit-only violation. Kyverno is recording this for the '
+        'compliance score but is not blocking writes. Update the manifest '
+        'to satisfy the policy or switch the policy to enforce mode if '
+        'you want admission rejected on the next write.';
+  }
+  if (v.engine == PolicyEngine.gatekeeper) {
+    return 'Audit-only violation. Gatekeeper is recording this against '
+        'the constraint without blocking admission. Update the manifest '
+        'to satisfy the constraint or set `enforcementAction: deny` on '
+        'the constraint to block future writes.';
+  }
+  return 'Update the manifest to satisfy the policy. The `message` field '
+      'above carries the engine-specific reason.';
+}
+
+// ---------------------------------------------------------------------------
+// Section + label helpers
+// ---------------------------------------------------------------------------
+
+class _Section extends StatelessWidget {
+  const _Section({
+    required this.title,
+    required this.colors,
+    required this.children,
+  });
+
+  final String title;
+  final KubeColors colors;
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: colors.bgSurface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colors.borderSubtle),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: TextStyle(
+              color: colors.textPrimary,
+              fontSize: 16,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 8),
+          ...children,
+        ],
+      ),
+    );
+  }
+}
+
+class _LabelValue extends StatelessWidget {
+  const _LabelValue({
+    required this.label,
+    required this.value,
+    required this.colors,
+  });
+
+  final String label;
+  final String value;
+  final KubeColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 88,
+            child: Text(
+              label,
+              style: TextStyle(color: colors.textMuted, fontSize: 12),
+            ),
+          ),
+          Expanded(
+            child: Text(
+              value,
+              style: TextStyle(color: colors.textPrimary, fontSize: 13),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/policy/violations_list_screen.dart
+++ b/mobile/lib/features/policy/violations_list_screen.dart
@@ -113,6 +113,21 @@ class _ListBodyState extends ConsumerState<_ListBody> with RefreshGuardMixin {
   List<PolicyViolation>? _lastItems;
   List<String>? _haystacks;
 
+  // Distinct namespaces cached against the items reference — only
+  // rebuilt when the underlying list identity changes (refresh, cluster
+  // switch). Per-keystroke builds reuse the cached list.
+  List<String>? _cachedNamespaces;
+
+  // Filtered result cache: (items, namespace, severity, search) →
+  // filtered list. Invalidated whenever any cache-key field changes.
+  // Without this cache, each rebuild allocates a fresh list and re-runs
+  // 3 predicate checks across every row — O(N) on every keystroke, chip
+  // tap, or scroll frame.
+  List<PolicyViolation>? _cachedFiltered;
+  String? _cachedFilterNamespace;
+  PolicySeverityFilter? _cachedFilterSeverity;
+  String? _cachedFilterSearch;
+
   Future<void> _handleRefresh() => guardedRefresh(() async {
         ref.invalidate(violationsListProvider(widget.clusterId));
         try {
@@ -124,13 +139,19 @@ class _ListBodyState extends ConsumerState<_ListBody> with RefreshGuardMixin {
 
   /// Set of distinct namespaces from the unfiltered response. Used to
   /// populate the namespace dropdown. Sorted ascending so the picker
-  /// scans alphabetically.
+  /// scans alphabetically. Cached against [_lastItems] identity so
+  /// keystroke rebuilds don't allocate a fresh Set + sorted List each
+  /// frame.
   List<String> _namespaces(List<PolicyViolation> items) {
+    if (identical(_lastItems, items) && _cachedNamespaces != null) {
+      return _cachedNamespaces!;
+    }
     final set = <String>{};
     for (final v in items) {
       if (v.namespace.isNotEmpty) set.add(v.namespace);
     }
     final out = set.toList()..sort();
+    _cachedNamespaces = out;
     return out;
   }
 
@@ -149,8 +170,22 @@ class _ListBodyState extends ConsumerState<_ListBody> with RefreshGuardMixin {
           onRetry: _handleRefresh,
         ),
         data: (items) {
-          final filtered = _applyFilters(items);
           final namespaces = _namespaces(items);
+          // Reset the namespace filter when the post-refresh data no
+          // longer contains the previously-selected namespace (e.g.,
+          // every violation in that namespace was remediated). Without
+          // this, the dropdown guard would render "All" but the filter
+          // would still apply the stale namespace and the list would
+          // show a misleading "no violations match" empty state. Defer
+          // the reset to post-frame so we don't call setState during
+          // build.
+          if (widget.namespaceFilter.isNotEmpty &&
+              !namespaces.contains(widget.namespaceFilter)) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              if (mounted) widget.onNamespaceChanged('');
+            });
+          }
+          final filtered = _applyFilters(items);
           return CustomScrollView(
             physics: const AlwaysScrollableScrollPhysics(),
             slivers: [
@@ -226,6 +261,21 @@ class _ListBodyState extends ConsumerState<_ListBody> with RefreshGuardMixin {
                 v.message,
               ].join(' ').toLowerCase())
           .toList();
+      // Invalidate downstream caches whenever the items identity flips
+      // (refresh, cluster switch).
+      _cachedFiltered = null;
+      _cachedNamespaces = null;
+    }
+
+    // Reuse the previous result when nothing relevant changed —
+    // RefreshIndicator + Riverpod rebuilds re-enter build() many times
+    // per second on a single scroll frame; at 1000 violations the
+    // unfiltered 3000-predicate loop adds up quickly.
+    if (_cachedFiltered != null &&
+        _cachedFilterNamespace == widget.namespaceFilter &&
+        _cachedFilterSeverity == widget.severityFilter &&
+        _cachedFilterSearch == q) {
+      return _cachedFiltered!;
     }
 
     final hs = _haystacks!;
@@ -240,6 +290,11 @@ class _ListBodyState extends ConsumerState<_ListBody> with RefreshGuardMixin {
       if (q.isNotEmpty && !hs[i].contains(q)) continue;
       out.add(v);
     }
+
+    _cachedFiltered = out;
+    _cachedFilterNamespace = widget.namespaceFilter;
+    _cachedFilterSeverity = widget.severityFilter;
+    _cachedFilterSearch = q;
     return out;
   }
 

--- a/mobile/lib/features/policy/violations_list_screen.dart
+++ b/mobile/lib/features/policy/violations_list_screen.dart
@@ -1,0 +1,455 @@
+// Violations list — every policy violation the active user can read
+// (RBAC-filtered server-side by `list pods` namespace access). Filter
+// chips on namespace + severity; free-text search across policy / rule
+// / target name. Virtual scroll via `SliverList.builder` to handle
+// 1000+-violation responses on busy clusters.
+//
+// Tapping a row routes to the detail screen at
+// `/clusters/<id>/policy/violations/<stableKey>`. The stable key is
+// `policy|rule|namespace|kind|name` — there is no server-side id field
+// on violations, so this is the only durable identifier.
+//
+// Status gating: `PolicyStatusGate` gates the surface —
+// `FeatureUnavailableState.policy()` when neither engine is detected.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../api/policy_repository.dart';
+import '../../cluster/cluster_provider.dart';
+import '../../theme/kube_theme_builder.dart';
+import '../../widgets/empty_states.dart';
+import '../../widgets/refresh_guard.dart';
+import 'policy_widgets.dart';
+
+class ViolationsListScreen extends ConsumerStatefulWidget {
+  const ViolationsListScreen({super.key, this.initialNamespace});
+
+  /// Seed the namespace filter on mount. Drawer deep-links leave this
+  /// null; deep-links from a workload's namespace summary pass a value.
+  final String? initialNamespace;
+
+  @override
+  ConsumerState<ViolationsListScreen> createState() =>
+      _ViolationsListScreenState();
+}
+
+class _ViolationsListScreenState extends ConsumerState<ViolationsListScreen> {
+  late String _namespaceFilter;
+  PolicySeverityFilter _severityFilter = PolicySeverityFilter.all;
+  String _search = '';
+  final _searchCtl = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _namespaceFilter = widget.initialNamespace ?? '';
+  }
+
+  @override
+  void dispose() {
+    _searchCtl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    ref.listen<String>(activeClusterProvider, (previous, next) {
+      if (previous != next) {
+        setState(() {
+          _namespaceFilter = '';
+          _severityFilter = PolicySeverityFilter.all;
+          _search = '';
+          _searchCtl.clear();
+        });
+      }
+    });
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Violations')),
+      body: PolicyStatusGate(
+        builder: (clusterId, _) => _ListBody(
+          clusterId: clusterId,
+          namespaceFilter: _namespaceFilter,
+          severityFilter: _severityFilter,
+          search: _search,
+          searchCtl: _searchCtl,
+          onNamespaceChanged: (v) => setState(() => _namespaceFilter = v),
+          onSeverityChanged: (v) => setState(() => _severityFilter = v),
+          onSearchChanged: (v) => setState(() => _search = v),
+        ),
+      ),
+    );
+  }
+}
+
+class _ListBody extends ConsumerStatefulWidget {
+  const _ListBody({
+    required this.clusterId,
+    required this.namespaceFilter,
+    required this.severityFilter,
+    required this.search,
+    required this.searchCtl,
+    required this.onNamespaceChanged,
+    required this.onSeverityChanged,
+    required this.onSearchChanged,
+  });
+
+  final String clusterId;
+  final String namespaceFilter;
+  final PolicySeverityFilter severityFilter;
+  final String search;
+  final TextEditingController searchCtl;
+  final ValueChanged<String> onNamespaceChanged;
+  final ValueChanged<PolicySeverityFilter> onSeverityChanged;
+  final ValueChanged<String> onSearchChanged;
+
+  @override
+  ConsumerState<_ListBody> createState() => _ListBodyState();
+}
+
+class _ListBodyState extends ConsumerState<_ListBody> with RefreshGuardMixin {
+  List<PolicyViolation>? _lastItems;
+  List<String>? _haystacks;
+
+  Future<void> _handleRefresh() => guardedRefresh(() async {
+        ref.invalidate(violationsListProvider(widget.clusterId));
+        try {
+          await ref.read(violationsListProvider(widget.clusterId).future);
+        } on Object {
+          // surfaces via .when
+        }
+      });
+
+  /// Set of distinct namespaces from the unfiltered response. Used to
+  /// populate the namespace dropdown. Sorted ascending so the picker
+  /// scans alphabetically.
+  List<String> _namespaces(List<PolicyViolation> items) {
+    final set = <String>{};
+    for (final v in items) {
+      if (v.namespace.isNotEmpty) set.add(v.namespace);
+    }
+    final out = set.toList()..sort();
+    return out;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final async = ref.watch(violationsListProvider(widget.clusterId));
+
+    return RefreshIndicator(
+      onRefresh: _handleRefresh,
+      child: async.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => ListErrorShell(
+          title: 'Failed to load violations',
+          error: e,
+          onRetry: _handleRefresh,
+        ),
+        data: (items) {
+          final filtered = _applyFilters(items);
+          final namespaces = _namespaces(items);
+          return CustomScrollView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            slivers: [
+              SliverToBoxAdapter(
+                child: _FilterStrip(
+                  namespaceFilter: widget.namespaceFilter,
+                  namespaces: namespaces,
+                  severityFilter: widget.severityFilter,
+                  searchCtl: widget.searchCtl,
+                  totalVisible: filtered.length,
+                  totalAll: items.length,
+                  onNamespaceChanged: widget.onNamespaceChanged,
+                  onSeverityChanged: widget.onSeverityChanged,
+                  onSearchChanged: widget.onSearchChanged,
+                ),
+              ),
+              if (filtered.isEmpty)
+                SliverToBoxAdapter(
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 16,
+                      vertical: 32,
+                    ),
+                    child: Center(
+                      child: Text(
+                        items.isEmpty
+                            ? 'No policy violations reported. The cluster '
+                                'is currently compliant with every defined '
+                                'policy.'
+                            : 'No violations match the current filters.',
+                        style: TextStyle(color: colors.textMuted),
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                  ),
+                )
+              else
+                SliverList(
+                  // Virtual scroll via SliverChildBuilderDelegate handles
+                  // 1000+-violation responses without dropping frames —
+                  // only the visible rows are constructed.
+                  delegate: SliverChildBuilderDelegate(
+                    (context, index) => _ViolationRow(
+                      violation: filtered[index],
+                      onTap: () => context.push(
+                        '/clusters/${widget.clusterId}/policy/violations/'
+                        '${Uri.encodeComponent(filtered[index].stableKey)}',
+                      ),
+                    ),
+                    childCount: filtered.length,
+                  ),
+                ),
+              const SliverPadding(padding: EdgeInsets.only(bottom: 8)),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  List<PolicyViolation> _applyFilters(List<PolicyViolation> items) {
+    final q = widget.search.trim().toLowerCase();
+
+    if (!identical(_lastItems, items)) {
+      _lastItems = items;
+      _haystacks = items
+          .map((v) => [
+                v.policy,
+                v.rule,
+                v.namespace,
+                v.kind,
+                v.name,
+                v.message,
+              ].join(' ').toLowerCase())
+          .toList();
+    }
+
+    final hs = _haystacks!;
+    final out = <PolicyViolation>[];
+    for (var i = 0; i < items.length; i++) {
+      final v = items[i];
+      if (widget.namespaceFilter.isNotEmpty &&
+          v.namespace != widget.namespaceFilter) {
+        continue;
+      }
+      if (!_matchesSeverity(v)) continue;
+      if (q.isNotEmpty && !hs[i].contains(q)) continue;
+      out.add(v);
+    }
+    return out;
+  }
+
+  bool _matchesSeverity(PolicyViolation v) => switch (widget.severityFilter) {
+        PolicySeverityFilter.all => true,
+        PolicySeverityFilter.critical => v.severity == 'critical',
+        PolicySeverityFilter.high => v.severity == 'high',
+        PolicySeverityFilter.medium => v.severity == 'medium',
+        PolicySeverityFilter.low => v.severity == 'low',
+      };
+}
+
+// ---------------------------------------------------------------------------
+// Filter strip
+// ---------------------------------------------------------------------------
+
+class _FilterStrip extends StatelessWidget {
+  const _FilterStrip({
+    required this.namespaceFilter,
+    required this.namespaces,
+    required this.severityFilter,
+    required this.searchCtl,
+    required this.totalVisible,
+    required this.totalAll,
+    required this.onNamespaceChanged,
+    required this.onSeverityChanged,
+    required this.onSearchChanged,
+  });
+
+  final String namespaceFilter;
+  final List<String> namespaces;
+  final PolicySeverityFilter severityFilter;
+  final TextEditingController searchCtl;
+  final int totalVisible;
+  final int totalAll;
+  final ValueChanged<String> onNamespaceChanged;
+  final ValueChanged<PolicySeverityFilter> onSeverityChanged;
+  final ValueChanged<String> onSearchChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    // Guard against a stale namespace filter that's no longer in the
+    // current data set (e.g., cluster switch landed mid-build before
+    // ref.listen has fired). Dropdown raises on missing value otherwise.
+    final dropdownValue = namespaceFilter.isEmpty ||
+            namespaces.contains(namespaceFilter)
+        ? namespaceFilter
+        : '';
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 12, 12, 4),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          TextField(
+            controller: searchCtl,
+            onChanged: onSearchChanged,
+            decoration: InputDecoration(
+              prefixIcon: const Icon(Icons.search, size: 18),
+              hintText: 'Search violations',
+              isDense: true,
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(6),
+              ),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              Expanded(
+                child: DropdownButtonFormField<String>(
+                  initialValue: dropdownValue,
+                  isDense: true,
+                  decoration: InputDecoration(
+                    labelText: 'Namespace',
+                    isDense: true,
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(6),
+                    ),
+                  ),
+                  items: [
+                    const DropdownMenuItem(value: '', child: Text('All')),
+                    for (final ns in namespaces)
+                      DropdownMenuItem(value: ns, child: Text(ns)),
+                  ],
+                  onChanged: (v) => onNamespaceChanged(v ?? ''),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: Row(
+              children: [
+                // Const records aren't allowed when the field is an enum
+                // value — dropping the `const` lets the literal stay
+                // inline without lifting a private const helper.
+                for (final tuple in [
+                  (PolicySeverityFilter.all, 'Any severity'),
+                  (PolicySeverityFilter.critical, 'Critical'),
+                  (PolicySeverityFilter.high, 'High'),
+                  (PolicySeverityFilter.medium, 'Medium'),
+                  (PolicySeverityFilter.low, 'Low'),
+                ])
+                  Padding(
+                    padding: const EdgeInsets.only(right: 6),
+                    child: ChoiceChip(
+                      selected: tuple.$1 == severityFilter,
+                      label: Text(tuple.$2),
+                      onSelected: (_) => onSeverityChanged(tuple.$1),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            totalVisible == totalAll
+                ? '$totalAll ${totalAll == 1 ? 'violation' : 'violations'}'
+                : 'Showing $totalVisible of $totalAll violations',
+            style: TextStyle(color: colors.textMuted, fontSize: 11),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Row
+// ---------------------------------------------------------------------------
+
+class _ViolationRow extends StatelessWidget {
+  const _ViolationRow({required this.violation, required this.onTap});
+
+  final PolicyViolation violation;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final target = '${violation.kind}/${violation.name}';
+    final scope = violation.namespace.isEmpty
+        ? 'cluster-scoped'
+        : violation.namespace;
+
+    return InkWell(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+        decoration: BoxDecoration(
+          border: Border(bottom: BorderSide(color: colors.borderSubtle)),
+        ),
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    violation.policy,
+                    style: TextStyle(
+                      color: colors.textPrimary,
+                      fontSize: 13,
+                      fontWeight: FontWeight.w600,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  if (violation.rule.isNotEmpty)
+                    Text(
+                      'rule: ${violation.rule}',
+                      style:
+                          TextStyle(color: colors.textSecondary, fontSize: 11),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  const SizedBox(height: 2),
+                  Text(
+                    '$target · $scope',
+                    style: TextStyle(color: colors.textSecondary, fontSize: 12),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  if (violation.message.isNotEmpty)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 4),
+                      child: Text(
+                        violation.message,
+                        style: TextStyle(color: colors.textMuted, fontSize: 11),
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                  const SizedBox(height: 4),
+                  Wrap(
+                    spacing: 6,
+                    runSpacing: 4,
+                    children: [
+                      EngineBadge(engine: violation.engine, dense: true),
+                      SeverityBadge(severity: violation.severity, dense: true),
+                      BlockingBadge(blocking: violation.blocking, dense: true),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 8),
+            Icon(Icons.chevron_right, size: 16, color: colors.textMuted),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/routing/app_router.dart
+++ b/mobile/lib/routing/app_router.dart
@@ -40,6 +40,11 @@ import '../features/observability/diagnostics/diagnostics_screen.dart';
 import '../features/observability/diagnostics/namespace_summary_screen.dart';
 import '../features/observability/logs/log_search_screen.dart';
 import '../features/observability/logs/log_tail_screen.dart';
+import '../features/policy/compliance_history_screen.dart';
+import '../features/policy/dashboard_screen.dart' as policy_dashboard;
+import '../features/policy/policies_list_screen.dart';
+import '../features/policy/violation_detail_screen.dart';
+import '../features/policy/violations_list_screen.dart';
 import '../notifications/deep_link_handler.dart';
 import '../notifications/fcm_registration.dart';
 import '../features/resources/configmap_screens.dart';
@@ -518,6 +523,51 @@ final appRouterProvider = Provider<GoRouter>((ref) {
             builder: (context, state) => NamespaceDetailScreen(
               name: state.pathParameters['name']!,
             ),
+          ),
+        ],
+      ),
+
+      // --- M4 PR-4i: policy compliance + violations ---
+      // /clusters/<id>/policy                          → compliance dashboard
+      // /clusters/<id>/policy/policies                 → policies list
+      // /clusters/<id>/policy/violations               → violations list
+      // /clusters/<id>/policy/violations/<stable-key>  → violation detail
+      // /clusters/<id>/policy/compliance-history       → admin-only history
+      //
+      // Status gating is screen-level (each surface checks
+      // `policyStatusProvider` and falls back to
+      // `FeatureUnavailableState.policy()`). Compliance history additionally
+      // gates on `user.isAdmin` at the route body; backend's `RequireAdmin`
+      // middleware enforces server-side.
+      //
+      // Violation `stableKey` is `policy|rule|namespace|kind|name` — the
+      // backend has no GET-by-id endpoint, so detail looks up by stable
+      // key against the cached violations list provider.
+      GoRoute(
+        path: '/clusters/:clusterId/policy',
+        builder: (context, state) => const policy_dashboard.PolicyDashboardScreen(),
+        routes: [
+          GoRoute(
+            path: 'policies',
+            builder: (context, state) => const PoliciesListScreen(),
+          ),
+          GoRoute(
+            path: 'violations',
+            builder: (context, state) => ViolationsListScreen(
+              initialNamespace: state.uri.queryParameters['namespace'],
+            ),
+            routes: [
+              GoRoute(
+                path: ':stableKey',
+                builder: (context, state) => ViolationDetailScreen(
+                  stableKey: state.pathParameters['stableKey']!,
+                ),
+              ),
+            ],
+          ),
+          GoRoute(
+            path: 'compliance-history',
+            builder: (context, state) => const ComplianceHistoryScreen(),
           ),
         ],
       ),

--- a/mobile/lib/routing/domain_sections.dart
+++ b/mobile/lib/routing/domain_sections.dart
@@ -289,6 +289,47 @@ const List<DomainSection> domainSections = [
       ),
     ],
   ),
+  // Policy compliance browser (PR-4i). Three entries:
+  //   * Dashboard — compliance score (KubeGaugeRing) + by-engine cards
+  //     + by-severity breakdown + browse tiles.
+  //   * Policies — full list with engine / severity / blocking chips +
+  //     search. Engine-availability badges (per PR-3f intersection
+  //     learning) on rows whose engine isn't installed.
+  //   * Violations — RBAC-filtered violations list with namespace +
+  //     severity filters; virtual scroll for 1000+-violation responses.
+  // All three surfaces gate on `policyStatusProvider` and fall back to
+  // `FeatureUnavailableState.policy()` when neither engine is detected.
+  // Compliance history (admin-only) is reachable from the dashboard
+  // browse tiles rather than as a top-level drawer entry — it's a niche
+  // workflow that doesn't deserve permanent drawer real estate.
+  DomainSection(
+    label: 'Policy',
+    pathSegment: 'policy',
+    icon: Icons.policy_outlined,
+    kinds: [
+      DomainKind(
+        kind: 'policy-dashboard',
+        label: 'Dashboard',
+        icon: Icons.dashboard_outlined,
+        namespaced: false,
+        customListPath: '/clusters/{clusterId}/policy',
+      ),
+      DomainKind(
+        kind: 'policies',
+        label: 'Policies',
+        icon: Icons.list_alt_outlined,
+        namespaced: false,
+        customListPath: '/clusters/{clusterId}/policy/policies',
+      ),
+      DomainKind(
+        kind: 'violations',
+        label: 'Violations',
+        icon: Icons.report_problem_outlined,
+        namespaced: false,
+        customListPath: '/clusters/{clusterId}/policy/violations',
+      ),
+    ],
+  ),
   // Cert-manager observatory (PR-4g). Three entries:
   //   * Certificates — full list with filter chips (All / Expiring /
   //     Failed) + search. `?status=expiring` URL param pre-filters.

--- a/mobile/lib/wizards/types/policy/policy_engine_status.dart
+++ b/mobile/lib/wizards/types/policy/policy_engine_status.dart
@@ -1,23 +1,21 @@
-// Engine auto-detect for the Policy wizard. Wraps `GET /v1/policies/status`.
-// Mirrors `frontend/islands/PolicyWizard.tsx`'s engine bootstrap.
+// Engine auto-detect for the Policy wizard. Wraps the M4 observatory's
+// `policyStatusProvider` rather than re-fetching `/v1/policies/status`
+// independently — one HTTP round-trip per cluster serves both the
+// observatory dashboard and the wizard. Mirrors
+// `frontend/islands/PolicyWizard.tsx`'s engine bootstrap.
 //
-// Response shape (from backend/internal/policy/types.go EngineStatus):
-//   {
-//     detected: "kyverno" | "gatekeeper" | "both" | "",
-//     kyverno?:    { available, namespace?, webhooks },
-//     gatekeeper?: { available, namespace?, webhooks },
-//     lastChecked: <RFC3339>,
-//   }
-//
-// The wizard renders an EmptyState when neither engine is detected
-// and no fallback list — the registry is server-driven.
+// The wizard renders an EmptyState when neither engine is detected and
+// no fallback list — the registry is server-driven.
 
-import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../../api/api_error.dart';
-import '../../../api/dio_client.dart';
+import '../../../api/policy_repository.dart';
 
+/// Wizard-facing projection over [PolicyDiscoveryStatus]. The wizard
+/// only consumes `availableEngines` to intersect against template
+/// engines; the wider observatory fields (webhooks, namespace,
+/// serviceUnavailable) are not relevant here, so the projection keeps
+/// the wizard call sites unchanged while sharing the underlying fetch.
 class PolicyEngineStatus {
   const PolicyEngineStatus({
     required this.detected,
@@ -25,20 +23,19 @@ class PolicyEngineStatus {
     required this.gatekeeperAvailable,
   });
 
-  /// Raw `detected` value: "kyverno" | "gatekeeper" | "both" | "".
+  /// Backwards-compat raw `detected` value: "kyverno" | "gatekeeper" |
+  /// "both" | "". Computed from the per-engine availability rather than
+  /// surfaced from the backend's `detected` field — keeps the wizard's
+  /// existing semantics intact even though the observatory's
+  /// [PolicyDiscoveryStatus] models `detected` as a bool.
   final String detected;
 
-  /// Convenience: was Kyverno discovered (either alone or as part of
-  /// `both`)?
   final bool kyvernoAvailable;
-
-  /// Convenience: was Gatekeeper discovered (either alone or as part
-  /// of `both`)?
   final bool gatekeeperAvailable;
 
   /// Engines available to pick from in the wizard. Empty list means
-  /// neither engine is installed — wizard renders an EmptyState.
-  /// Order is informational only; engine resolution within
+  /// neither engine is installed — wizard renders an EmptyState. Order
+  /// is informational only; engine resolution within
   /// `PolicyWizardController.pickTemplate` intersects this list with
   /// the template's supported engines and respects the operator's
   /// already-picked engine when applicable.
@@ -47,6 +44,24 @@ class PolicyEngineStatus {
     if (kyvernoAvailable) out.add('kyverno');
     if (gatekeeperAvailable) out.add('gatekeeper');
     return out;
+  }
+
+  factory PolicyEngineStatus.fromDiscovery(PolicyDiscoveryStatus s) {
+    final String detected;
+    if (s.kyvernoAvailable && s.gatekeeperAvailable) {
+      detected = 'both';
+    } else if (s.kyvernoAvailable) {
+      detected = 'kyverno';
+    } else if (s.gatekeeperAvailable) {
+      detected = 'gatekeeper';
+    } else {
+      detected = '';
+    }
+    return PolicyEngineStatus(
+      detected: detected,
+      kyvernoAvailable: s.kyvernoAvailable,
+      gatekeeperAvailable: s.gatekeeperAvailable,
+    );
   }
 }
 
@@ -64,38 +79,12 @@ class PolicyEngineStatusKey {
   int get hashCode => clusterId.hashCode;
 }
 
+/// Wizard-facing provider. Watches the observatory's
+/// [policyStatusProvider] so both surfaces share the same fetch slot
+/// per cluster — adding a second wizard surface no longer doubles the
+/// HTTP cost.
 final policyEngineStatusProvider = FutureProvider.autoDispose
     .family<PolicyEngineStatus, PolicyEngineStatusKey>((ref, key) async {
-  final dio = ref.watch(dioProvider);
-  try {
-    final res = await dio.get<Map<String, dynamic>>(
-      '/api/v1/policies/status',
-      options: Options(headers: {'X-Cluster-ID': key.clusterId}),
-    );
-    final data = res.data?['data'];
-    if (data is! Map<String, dynamic>) {
-      return const PolicyEngineStatus(
-        detected: '',
-        kyvernoAvailable: false,
-        gatekeeperAvailable: false,
-      );
-    }
-    final detected = (data['detected'] as String?) ?? '';
-    final kyvernoBlock = data['kyverno'] as Map<String, dynamic>?;
-    final gkBlock = data['gatekeeper'] as Map<String, dynamic>?;
-    final kyvernoAvail = kyvernoBlock != null &&
-        kyvernoBlock['available'] == true;
-    final gkAvail = gkBlock != null && gkBlock['available'] == true;
-    // The `detected` field is informational; rely on per-engine
-    // `available: true` for the actual decision so a future server
-    // change to `detected` semantics doesn't cascade.
-    return PolicyEngineStatus(
-      detected: detected,
-      kyvernoAvailable: kyvernoAvail,
-      gatekeeperAvailable: gkAvail,
-    );
-  } on DioException catch (e) {
-    final err = e.error;
-    throw err is ApiError ? err : ApiError.fromDio(e);
-  }
+  final status = await ref.watch(policyStatusProvider(key.clusterId).future);
+  return PolicyEngineStatus.fromDiscovery(status);
 });

--- a/mobile/test/api/policy_repository_test.dart
+++ b/mobile/test/api/policy_repository_test.dart
@@ -1,0 +1,474 @@
+// PolicyRepository tests: endpoint paths, envelope unwrapping,
+// X-Cluster-ID forwarding, status 5xx → unreachable, severity parsing,
+// composite-id round-trip, and the 503 distinguished-error discriminator
+// for compliance history.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kubecenter/api/api_error.dart';
+import 'package:kubecenter/api/dio_client.dart';
+import 'package:kubecenter/api/policy_repository.dart';
+import 'package:kubecenter/auth/secure_storage.dart';
+
+import '../support/mock_dio_adapter.dart';
+
+ResponseBody _json(Object body, {int status = 200}) {
+  return ResponseBody.fromBytes(
+    Uint8List.fromList(utf8.encode(jsonEncode(body))),
+    status,
+    headers: {
+      Headers.contentTypeHeader: ['application/json'],
+    },
+  );
+}
+
+({ProviderContainer container, MockDioAdapter mock}) _make() {
+  final mock = MockDioAdapter();
+  final container = ProviderContainer(
+    overrides: [
+      backendUrlProvider.overrideWithValue('http://test'),
+      secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+    ],
+  );
+  container.read(refreshDioProvider).httpClientAdapter = mock;
+  container.read(dioProvider).httpClientAdapter = mock;
+  return (container: container, mock: mock);
+}
+
+void main() {
+  group('PolicyRepository.status', () {
+    test('parses detected status with both engines available', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson('GET', '/api/v1/policies/status', body: {
+        'data': {
+          'detected': 'both',
+          'kyverno': {
+            'available': true,
+            'namespace': 'kyverno',
+            'webhooks': 3,
+          },
+          'gatekeeper': {
+            'available': true,
+            'namespace': 'gatekeeper-system',
+            'webhooks': 2,
+          },
+          'lastChecked': '2026-05-12T10:00:00Z',
+        },
+      });
+
+      final s = await container.read(policyRepositoryProvider).status();
+      expect(s.detected, isTrue);
+      expect(s.kyvernoAvailable, isTrue);
+      expect(s.gatekeeperAvailable, isTrue);
+      expect(s.kyvernoNamespace, 'kyverno');
+      expect(s.kyvernoWebhooks, 3);
+      expect(s.gatekeeperWebhooks, 2);
+    });
+
+    test('detected=false when neither engine available', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson('GET', '/api/v1/policies/status', body: {
+        'data': {'detected': ''},
+      });
+
+      final s = await container.read(policyRepositoryProvider).status();
+      expect(s.detected, isFalse);
+      expect(s.kyvernoAvailable, isFalse);
+      expect(s.gatekeeperAvailable, isFalse);
+    });
+
+    test('503 from status returns PolicyDiscoveryStatus.unreachable', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.on(
+        'GET',
+        '/api/v1/policies/status',
+        (_) => _json({
+          'error': {'code': 503, 'message': 'discovery offline'},
+        }, status: 503),
+      );
+
+      final s = await container.read(policyRepositoryProvider).status();
+      expect(s.detected, isFalse);
+      expect(s.serviceUnavailable, isTrue,
+          reason:
+              '5xx must round-trip through `unreachable` so the UI can '
+              'distinguish "policy engine not installed" from "backend '
+              'temporarily unreachable".');
+    });
+
+    test('forwards X-Cluster-ID when overridden', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson('GET', '/api/v1/policies/status', body: {
+        'data': {'detected': ''},
+      });
+
+      await container
+          .read(policyRepositoryProvider)
+          .status(clusterIdOverride: 'remote-1');
+
+      expect(mock.requests, hasLength(1));
+      expect(mock.requests.first.headers['X-Cluster-ID'], 'remote-1');
+    });
+  });
+
+  group('listPolicies', () {
+    test('parses severity, engine, blocking, violationCount', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson('GET', '/api/v1/policies/', body: {
+        'data': [
+          {
+            'id': 'kyverno::ClusterPolicy:require-labels',
+            'name': 'require-labels',
+            'kind': 'ClusterPolicy',
+            'action': 'enforce',
+            'severity': 'high',
+            'engine': 'kyverno',
+            'blocking': true,
+            'ready': true,
+            'ruleCount': 1,
+            'violationCount': 4,
+          },
+          {
+            'id': 'gatekeeper::K8sRequiredLabels:require-team-label',
+            'name': 'require-team-label',
+            'kind': 'K8sRequiredLabels',
+            'action': 'dryrun',
+            'severity': 'medium',
+            'engine': 'gatekeeper',
+            'blocking': false,
+            'ready': true,
+            'ruleCount': 1,
+            'violationCount': 0,
+          },
+        ],
+      });
+
+      final out =
+          await container.read(policyRepositoryProvider).listPolicies();
+      expect(out, hasLength(2));
+      expect(out[0].engine, PolicyEngine.kyverno);
+      expect(out[0].severity, 'high');
+      expect(out[0].blocking, isTrue);
+      expect(out[0].violationCount, 4);
+      expect(out[1].engine, PolicyEngine.gatekeeper);
+      expect(out[1].blocking, isFalse);
+    });
+
+    test('unknown engine string falls through to PolicyEngine.unknown',
+        () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson('GET', '/api/v1/policies/', body: {
+        'data': [
+          {
+            'id': 'newengine::Whatever:foo',
+            'name': 'foo',
+            'kind': 'Whatever',
+            'action': 'audit',
+            'severity': 'low',
+            'engine': 'newengine-2027',
+            'blocking': false,
+            'ready': true,
+            'ruleCount': 1,
+            'violationCount': 0,
+          },
+        ],
+      });
+
+      final out =
+          await container.read(policyRepositoryProvider).listPolicies();
+      expect(out, hasLength(1));
+      expect(out[0].engine, PolicyEngine.unknown,
+          reason: 'Future engine names must not crash the parser.');
+    });
+  });
+
+  group('listViolations', () {
+    test('stableKey derives from policy|rule|namespace|kind|name', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson('GET', '/api/v1/policies/violations', body: {
+        'data': [
+          {
+            'policy': 'require-labels',
+            'rule': 'check-team',
+            'namespace': 'default',
+            'kind': 'Pod',
+            'name': 'app-abc',
+            'severity': 'high',
+            'action': 'enforce',
+            'message': 'team label required',
+            'engine': 'kyverno',
+            'blocking': true,
+          },
+          {
+            'policy': 'K8sRequiredLabels/team',
+            // Gatekeeper violations have no rule sub-name
+            'namespace': '',
+            'kind': 'Namespace',
+            'name': 'ns-1',
+            'severity': 'medium',
+            'action': 'dryrun',
+            'message': 'namespace missing label',
+            'engine': 'gatekeeper',
+            'blocking': false,
+          },
+        ],
+      });
+
+      final out =
+          await container.read(policyRepositoryProvider).listViolations();
+      expect(out, hasLength(2));
+      expect(
+        out[0].stableKey,
+        'require-labels|check-team|default|Pod|app-abc',
+      );
+      expect(
+        out[1].stableKey,
+        'K8sRequiredLabels/team|||Namespace|ns-1',
+        reason: 'empty rule and namespace segments are preserved verbatim '
+            'so two violations with different fields cannot collide.',
+      );
+    });
+
+    test('cluster-scoped violation has empty namespace', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson('GET', '/api/v1/policies/violations', body: {
+        'data': [
+          {
+            'policy': 'p',
+            'kind': 'ClusterRole',
+            'name': 'cr-1',
+            'severity': 'low',
+            'action': 'audit',
+            'message': '',
+            'engine': 'kyverno',
+            'blocking': false,
+          },
+        ],
+      });
+
+      final out =
+          await container.read(policyRepositoryProvider).listViolations();
+      expect(out, hasLength(1));
+      expect(out[0].namespace, '');
+    });
+  });
+
+  group('compliance', () {
+    test('parses score + bySeverity breakdown', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson('GET', '/api/v1/policies/compliance', body: {
+        'data': {
+          'scope': '',
+          'score': 87.5,
+          'pass': 14,
+          'fail': 2,
+          'warn': 0,
+          'total': 16,
+          'bySeverity': {
+            'critical': {'pass': 2, 'fail': 0, 'total': 2},
+            'high': {'pass': 5, 'fail': 1, 'total': 6},
+            'medium': {'pass': 5, 'fail': 1, 'total': 6},
+            'low': {'pass': 2, 'fail': 0, 'total': 2},
+          },
+        },
+      });
+
+      final s = await container.read(policyRepositoryProvider).compliance();
+      expect(s.score, 87.5);
+      expect(s.pass, 14);
+      expect(s.fail, 2);
+      expect(s.total, 16);
+      expect(s.bySeverity, hasLength(4));
+      expect(s.bySeverity['critical']!.total, 2);
+      expect(s.bySeverity['high']!.fail, 1);
+    });
+
+    test('namespace scope forwards as query param', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson('GET', '/api/v1/policies/compliance', body: {
+        'data': {'scope': 'app', 'score': 100, 'pass': 0, 'fail': 0,
+            'warn': 0, 'total': 0},
+      });
+
+      await container
+          .read(policyRepositoryProvider)
+          .compliance(scopeNamespace: 'app');
+
+      expect(mock.requests, hasLength(1));
+      expect(mock.requests.first.queryParameters['namespace'], 'app');
+    });
+  });
+
+  group('complianceHistory', () {
+    test('parses datapoint array', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson('GET', '/api/v1/policies/compliance/history', body: {
+        'data': [
+          {
+            'date': '2026-05-01',
+            'score': 80.0,
+            'pass': 8,
+            'fail': 2,
+            'warn': 0,
+            'total': 10,
+          },
+          {
+            'date': '2026-05-02',
+            'score': 90.0,
+            'pass': 9,
+            'fail': 1,
+            'warn': 0,
+            'total': 10,
+          },
+        ],
+      });
+
+      final out = await container
+          .read(policyRepositoryProvider)
+          .complianceHistory();
+      expect(out, hasLength(2));
+      expect(out[0].date, '2026-05-01');
+      expect(out[1].score, 90.0);
+    });
+
+    test('days param forwards as query param', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/policies/compliance/history',
+        body: {'data': <Object>[]},
+      );
+
+      await container
+          .read(policyRepositoryProvider)
+          .complianceHistory(days: 7);
+
+      expect(mock.requests, hasLength(1));
+      expect(mock.requests.first.queryParameters['days'], '7');
+    });
+
+    test('503 with "requires a database" surfaces via the discriminator',
+        () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.on(
+        'GET',
+        '/api/v1/policies/compliance/history',
+        (_) => _json({
+          'error': {
+            'code': 503,
+            'message': 'compliance history requires a database',
+          },
+        }, status: 503),
+      );
+
+      Object? caught;
+      try {
+        await container
+            .read(policyRepositoryProvider)
+            .complianceHistory();
+      } on Object catch (e) {
+        caught = e;
+      }
+      expect(caught, isNotNull);
+      expect(caught, isA<ApiError>());
+      expect(
+        isComplianceHistoryNotConfigured(caught!),
+        isTrue,
+        reason: 'The discriminator must recognise the canonical backend '
+            'wording so the UI routes to the permanent empty state.',
+      );
+    });
+
+    test('503 with non-database wording stays retry-able', () async {
+      final apiErrorNetworkDown = ApiError(
+        statusCode: 503,
+        code: 503,
+        message: 'backend temporarily unreachable',
+      );
+      expect(isComplianceHistoryNotConfigured(apiErrorNetworkDown), isFalse,
+          reason: 'Generic 503 must not collapse to the permanent empty '
+              'state — the operator should be able to retry.');
+    });
+
+    test('non-503 ApiErrors never trigger the discriminator', () async {
+      final apiError500 = ApiError(
+        statusCode: 500,
+        code: 500,
+        message: 'compliance history requires a database',
+      );
+      expect(
+        isComplianceHistoryNotConfigured(apiError500),
+        isFalse,
+        reason: 'Only 503s with the database wording route to the empty '
+            'state. A 500 with the same wording is a backend bug — '
+            'operator should see a retry-able error.',
+      );
+    });
+
+    test('non-ApiError errors never trigger the discriminator', () async {
+      expect(
+        isComplianceHistoryNotConfigured(StateError('something else')),
+        isFalse,
+      );
+    });
+  });
+
+  group('PolicyId.tryParse', () {
+    test('parses well-formed engine:namespace:kind:name', () {
+      final id = PolicyId.tryParse('kyverno:default:ClusterPolicy:require');
+      expect(id, isNotNull);
+      expect(id!.engine, 'kyverno');
+      expect(id.namespace, 'default');
+      expect(id.kind, 'ClusterPolicy');
+      expect(id.name, 'require');
+      expect(id.raw, 'kyverno:default:ClusterPolicy:require');
+    });
+
+    test('parses cluster-scoped policy (empty namespace segment)', () {
+      final id = PolicyId.tryParse('kyverno::ClusterPolicy:cluster-policy');
+      expect(id, isNotNull);
+      expect(id!.namespace, '');
+    });
+
+    test('rejects malformed segment count', () {
+      expect(PolicyId.tryParse('kyverno:default'), isNull);
+      expect(PolicyId.tryParse('a:b:c:d:e'), isNull);
+    });
+
+    test('rejects empty engine / kind / name segments', () {
+      expect(PolicyId.tryParse(':default:ClusterPolicy:foo'), isNull);
+      expect(PolicyId.tryParse('kyverno:default::foo'), isNull);
+      expect(PolicyId.tryParse('kyverno:default:ClusterPolicy:'), isNull);
+    });
+  });
+}

--- a/mobile/test/api/policy_repository_test.dart
+++ b/mobile/test/api/policy_repository_test.dart
@@ -443,32 +443,7 @@ void main() {
     });
   });
 
-  group('PolicyId.tryParse', () {
-    test('parses well-formed engine:namespace:kind:name', () {
-      final id = PolicyId.tryParse('kyverno:default:ClusterPolicy:require');
-      expect(id, isNotNull);
-      expect(id!.engine, 'kyverno');
-      expect(id.namespace, 'default');
-      expect(id.kind, 'ClusterPolicy');
-      expect(id.name, 'require');
-      expect(id.raw, 'kyverno:default:ClusterPolicy:require');
-    });
-
-    test('parses cluster-scoped policy (empty namespace segment)', () {
-      final id = PolicyId.tryParse('kyverno::ClusterPolicy:cluster-policy');
-      expect(id, isNotNull);
-      expect(id!.namespace, '');
-    });
-
-    test('rejects malformed segment count', () {
-      expect(PolicyId.tryParse('kyverno:default'), isNull);
-      expect(PolicyId.tryParse('a:b:c:d:e'), isNull);
-    });
-
-    test('rejects empty engine / kind / name segments', () {
-      expect(PolicyId.tryParse(':default:ClusterPolicy:foo'), isNull);
-      expect(PolicyId.tryParse('kyverno:default::foo'), isNull);
-      expect(PolicyId.tryParse('kyverno:default:ClusterPolicy:'), isNull);
-    });
-  });
+  // PolicyId parsing lives in mobile/lib/util/composite_id.dart; tests for
+  // it live in mobile/test/util/composite_id_test.dart. Do not duplicate
+  // here.
 }

--- a/mobile/test/features/policy/compliance_history_screen_test.dart
+++ b/mobile/test/features/policy/compliance_history_screen_test.dart
@@ -1,0 +1,209 @@
+// Widget tests for ComplianceHistoryScreen.
+//
+// Required by the plan as a dedicated 503-distinguished-error path
+// regression test. The screen must:
+//   * Render the line chart when the backend returns datapoints.
+//   * Surface a NON-RETRYABLE empty state when the backend returns 503
+//     with body "requires a database" (PostgreSQL not configured).
+//   * Surface a RETRY-able error state when the backend returns 503 with
+//     any other wording (rolling restart, network issue).
+//   * Render an Admin-only empty state when the user is not an admin.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:kubecenter/api/dio_client.dart';
+import 'package:kubecenter/auth/auth_repository.dart';
+import 'package:kubecenter/auth/auth_state.dart';
+import 'package:kubecenter/auth/secure_storage.dart';
+import 'package:kubecenter/auth/user.dart';
+import 'package:kubecenter/features/policy/compliance_history_screen.dart';
+import 'package:kubecenter/theme/kube_theme_builder.dart';
+
+import '../../support/mock_dio_adapter.dart';
+
+class _FakeAuth extends AuthRepository {
+  _FakeAuth(this._initial);
+  final AuthState _initial;
+  @override
+  AuthState build() => _initial;
+}
+
+Future<void> _pump(
+  WidgetTester tester,
+  MockDioAdapter mock, {
+  bool admin = true,
+}) async {
+  await tester.binding.setSurfaceSize(const Size(800, 1600));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+
+  final user = UserInfo(
+    id: 'u1',
+    username: admin ? 'admin' : 'viewer',
+    provider: 'local',
+    roles: admin ? const ['admin'] : const ['viewer'],
+  );
+
+  final router = GoRouter(
+    initialLocation: '/',
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (context, state) => const ComplianceHistoryScreen(),
+      ),
+    ],
+  );
+
+  await tester.pumpWidget(ProviderScope(
+    overrides: [
+      backendUrlProvider.overrideWithValue('http://test'),
+      secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+      authRepositoryProvider.overrideWith(
+        () => _FakeAuth(
+          AuthAuthenticated(
+            user: user,
+            rbac: const RBACSummary(),
+          ),
+        ),
+      ),
+    ],
+    child: _DioInstaller(
+      mock: mock,
+      child: MaterialApp.router(
+        theme: buildKubeTheme('nexus'),
+        routerConfig: router,
+      ),
+    ),
+  ));
+  await tester.pump();
+  await tester.pumpAndSettle(const Duration(milliseconds: 200));
+}
+
+class _DioInstaller extends ConsumerWidget {
+  const _DioInstaller({required this.mock, required this.child});
+
+  final MockDioAdapter mock;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.read(dioProvider).httpClientAdapter = mock;
+    return child;
+  }
+}
+
+Map<String, Object?> _detected() => {
+      'data': {
+        'detected': 'both',
+        'kyverno': {'available': true, 'webhooks': 1},
+        'gatekeeper': {'available': true, 'webhooks': 1},
+      },
+    };
+
+void main() {
+  testWidgets('renders line chart when datapoints are returned',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/policies/status', body: _detected())
+      ..onJson('GET', '/api/v1/policies/compliance/history', body: {
+        'data': [
+          {
+            'date': '2026-05-01',
+            'score': 80.0,
+            'pass': 8,
+            'fail': 2,
+            'warn': 0,
+            'total': 10,
+          },
+          {
+            'date': '2026-05-02',
+            'score': 92.0,
+            'pass': 9,
+            'fail': 0,
+            'warn': 1,
+            'total': 10,
+          },
+        ],
+      });
+    await _pump(tester, mock);
+
+    expect(find.text('Compliance history'), findsAtLeastNWidgets(1));
+    expect(find.text('Last 2 days'), findsOneWidget);
+    expect(find.textContaining('Latest: 92%'), findsOneWidget);
+    // Latest row table should surface the dates verbatim.
+    expect(find.text('2026-05-02'), findsOneWidget);
+    expect(find.text('2026-05-01'), findsOneWidget);
+  });
+
+  testWidgets(
+    '503 with "requires a database" → NON-RETRYABLE empty state '
+    '(no Retry button)',
+    (tester) async {
+      final mock = MockDioAdapter()
+        ..onJson('GET', '/api/v1/policies/status', body: _detected())
+        ..onJson(
+          'GET',
+          '/api/v1/policies/compliance/history',
+          status: 503,
+          body: {
+            'error': {
+              'code': 503,
+              'message': 'compliance history requires a database',
+            },
+          },
+        );
+      await _pump(tester, mock);
+
+      // The FeatureUnavailableState wording.
+      expect(find.text('Compliance history'), findsAtLeastNWidgets(1));
+      expect(find.textContaining('database storage'), findsOneWidget);
+      expect(find.textContaining('is not installed'), findsOneWidget);
+
+      // The critical contract: NO Retry button. A retry button would
+      // deterministically hit 503 again until the operator configures
+      // PostgreSQL server-side, which they cannot do from the phone.
+      expect(find.widgetWithText(FilledButton, 'Retry'), findsNothing,
+          reason:
+              'Permanent empty state must not offer Retry — it would '
+              'mislead operators about whether the issue is transient.');
+      expect(find.widgetWithText(OutlinedButton, 'Retry'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    '503 with non-database wording → RETRY-able error state '
+    '(Retry button present)',
+    (tester) async {
+      final mock = MockDioAdapter()
+        ..onJson('GET', '/api/v1/policies/status', body: _detected())
+        ..onJson(
+          'GET',
+          '/api/v1/policies/compliance/history',
+          status: 503,
+          body: {
+            'error': {
+              'code': 503,
+              'message': 'backend temporarily unreachable',
+            },
+          },
+        );
+      await _pump(tester, mock);
+
+      // Generic ErrorStateView — has a Retry button.
+      expect(find.text('Retry'), findsOneWidget,
+          reason:
+              'Generic 503 must stay retry-able — operator should be '
+              'able to recover after a rolling restart.');
+    },
+  );
+
+  testWidgets('non-admin user sees Admin-only empty state', (tester) async {
+    final mock = MockDioAdapter();
+    // No need for status or history — admin gate fires first.
+    await _pump(tester, mock, admin: false);
+
+    expect(find.text('Admin only'), findsOneWidget);
+    expect(find.textContaining('cluster administrators'), findsOneWidget);
+  });
+}

--- a/mobile/test/features/policy/compliance_history_screen_test.dart
+++ b/mobile/test/features/policy/compliance_history_screen_test.dart
@@ -155,10 +155,12 @@ void main() {
         );
       await _pump(tester, mock);
 
-      // The FeatureUnavailableState wording.
+      // The FeatureUnavailableState wording: the database-not-configured
+      // helpMessage MUST appear so operators see the actual remediation
+      // (configure PostgreSQL), not the generic install-Kyverno guidance.
       expect(find.text('Compliance history'), findsAtLeastNWidgets(1));
       expect(find.textContaining('database storage'), findsOneWidget);
-      expect(find.textContaining('is not installed'), findsOneWidget);
+      expect(find.textContaining('PostgreSQL'), findsOneWidget);
 
       // The critical contract: NO Retry button. A retry button would
       // deterministically hit 503 again until the operator configures

--- a/mobile/test/features/policy/dashboard_screen_test.dart
+++ b/mobile/test/features/policy/dashboard_screen_test.dart
@@ -1,0 +1,271 @@
+// Widget tests for the Policy dashboard.
+//
+// Coverage:
+//   * detected=false → FeatureUnavailableState.policy().
+//   * compliance score + tier label render.
+//   * engine cards render install state + webhook count.
+//   * severity breakdown renders ordered desc.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:kubecenter/api/dio_client.dart';
+import 'package:kubecenter/auth/auth_repository.dart';
+import 'package:kubecenter/auth/auth_state.dart';
+import 'package:kubecenter/auth/secure_storage.dart';
+import 'package:kubecenter/auth/user.dart';
+import 'package:kubecenter/features/policy/dashboard_screen.dart';
+import 'package:kubecenter/theme/kube_theme_builder.dart';
+
+import '../../support/mock_dio_adapter.dart';
+
+class _FakeAuth extends AuthRepository {
+  _FakeAuth(this._initial);
+  final AuthState _initial;
+  @override
+  AuthState build() => _initial;
+}
+
+Future<void> _pump(
+  WidgetTester tester,
+  MockDioAdapter mock, {
+  bool admin = true,
+}) async {
+  await tester.binding.setSurfaceSize(const Size(800, 1600));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+
+  final user = UserInfo(
+    id: 'u1',
+    username: admin ? 'admin' : 'viewer',
+    provider: 'local',
+    roles: admin ? const ['admin'] : const ['viewer'],
+  );
+
+  final router = GoRouter(
+    initialLocation: '/',
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (context, state) => const PolicyDashboardScreen(),
+      ),
+    ],
+  );
+
+  await tester.pumpWidget(ProviderScope(
+    overrides: [
+      backendUrlProvider.overrideWithValue('http://test'),
+      secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+      authRepositoryProvider.overrideWith(
+        () => _FakeAuth(
+          AuthAuthenticated(
+            user: user,
+            rbac: const RBACSummary(),
+          ),
+        ),
+      ),
+    ],
+    child: _DioInstaller(
+      mock: mock,
+      child: MaterialApp.router(
+        theme: buildKubeTheme('nexus'),
+        routerConfig: router,
+      ),
+    ),
+  ));
+  await tester.pump();
+  await tester.pumpAndSettle(const Duration(milliseconds: 200));
+}
+
+class _DioInstaller extends ConsumerWidget {
+  const _DioInstaller({required this.mock, required this.child});
+
+  final MockDioAdapter mock;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.read(dioProvider).httpClientAdapter = mock;
+    return child;
+  }
+}
+
+Map<String, Object?> _detectedBoth() => {
+      'data': {
+        'detected': 'both',
+        'kyverno': {
+          'available': true,
+          'namespace': 'kyverno',
+          'webhooks': 3,
+        },
+        'gatekeeper': {
+          'available': true,
+          'namespace': 'gatekeeper-system',
+          'webhooks': 2,
+        },
+        'lastChecked': '2026-05-12T10:00:00Z',
+      },
+    };
+
+Map<String, Object?> _detectedKyvernoOnly() => {
+      'data': {
+        'detected': 'kyverno',
+        'kyverno': {
+          'available': true,
+          'namespace': 'kyverno',
+          'webhooks': 3,
+        },
+        'gatekeeper': {'available': false, 'webhooks': 0},
+      },
+    };
+
+Map<String, Object?> _samplePolicies() => {
+      'data': [
+        {
+          'id': 'kyverno::ClusterPolicy:require-labels',
+          'name': 'require-labels',
+          'kind': 'ClusterPolicy',
+          'action': 'enforce',
+          'severity': 'high',
+          'engine': 'kyverno',
+          'blocking': true,
+          'ready': true,
+          'ruleCount': 1,
+          'violationCount': 0,
+        },
+        {
+          'id': 'kyverno::ClusterPolicy:require-team',
+          'name': 'require-team',
+          'kind': 'ClusterPolicy',
+          'action': 'audit',
+          'severity': 'medium',
+          'engine': 'kyverno',
+          'blocking': false,
+          'ready': true,
+          'ruleCount': 1,
+          'violationCount': 2,
+        },
+      ],
+    };
+
+Map<String, Object?> _sampleCompliance() => {
+      'data': {
+        'scope': '',
+        'score': 87.5,
+        'pass': 14,
+        'fail': 2,
+        'warn': 0,
+        'total': 16,
+        'bySeverity': {
+          'critical': {'pass': 2, 'fail': 0, 'total': 2},
+          'high': {'pass': 5, 'fail': 1, 'total': 6},
+          'medium': {'pass': 5, 'fail': 1, 'total': 6},
+          'low': {'pass': 2, 'fail': 0, 'total': 2},
+        },
+      },
+    };
+
+void main() {
+  testWidgets('detected=false renders policy not-installed state',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/policies/status', body: {
+        'data': {'detected': ''},
+      });
+    await _pump(tester, mock);
+
+    expect(find.textContaining('policy engine'), findsOneWidget);
+    expect(find.textContaining('is not installed'), findsOneWidget);
+  });
+
+  testWidgets('renders compliance score with tier label', (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/policies/status', body: _detectedBoth())
+      ..onJson('GET', '/api/v1/policies/', body: _samplePolicies())
+      ..onJson('GET', '/api/v1/policies/violations', body: {'data': <Object>[]})
+      ..onJson('GET', '/api/v1/policies/compliance',
+          body: _sampleCompliance());
+    await _pump(tester, mock);
+
+    // 87% is below the healthy threshold (90) but above at-risk (70).
+    expect(find.text('88%'), findsOneWidget,
+        reason: 'gauge label is rounded to nearest int — 87.5 → 88.');
+    expect(find.text('At risk'), findsAtLeastNWidgets(1));
+    expect(find.textContaining('14/16'), findsOneWidget);
+  });
+
+  testWidgets('engine cards show install state + webhook counts',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/policies/status', body: _detectedBoth())
+      ..onJson('GET', '/api/v1/policies/', body: _samplePolicies())
+      ..onJson('GET', '/api/v1/policies/violations', body: {'data': <Object>[]})
+      ..onJson('GET', '/api/v1/policies/compliance',
+          body: _sampleCompliance());
+    await _pump(tester, mock);
+
+    expect(find.text('Kyverno'), findsAtLeastNWidgets(1));
+    expect(find.text('Gatekeeper'), findsAtLeastNWidgets(1));
+    expect(find.text('Installed'), findsNWidgets(2));
+    expect(find.textContaining('3 webhooks'), findsOneWidget);
+    expect(find.textContaining('2 webhooks'), findsOneWidget);
+  });
+
+  testWidgets('gatekeeper-only cluster shows Gatekeeper as Not installed',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/policies/status',
+          body: _detectedKyvernoOnly())
+      ..onJson('GET', '/api/v1/policies/', body: _samplePolicies())
+      ..onJson('GET', '/api/v1/policies/violations', body: {'data': <Object>[]})
+      ..onJson('GET', '/api/v1/policies/compliance',
+          body: _sampleCompliance());
+    await _pump(tester, mock);
+
+    expect(find.text('Not installed'), findsOneWidget,
+        reason: 'Gatekeeper card surfaces install state when absent.');
+  });
+
+  testWidgets('severity breakdown renders ordered desc', (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/policies/status', body: _detectedBoth())
+      ..onJson('GET', '/api/v1/policies/', body: _samplePolicies())
+      ..onJson('GET', '/api/v1/policies/violations', body: {'data': <Object>[]})
+      ..onJson('GET', '/api/v1/policies/compliance',
+          body: _sampleCompliance());
+    await _pump(tester, mock);
+
+    final critical = find.text('Critical');
+    final high = find.text('High');
+    final medium = find.text('Medium');
+    final low = find.text('Low');
+    expect(critical, findsOneWidget);
+    expect(high, findsOneWidget);
+    expect(medium, findsOneWidget);
+    expect(low, findsOneWidget);
+
+    // Critical must appear above Low in the layout — y-coordinate check
+    // confirms the desc ordering matches the policy weight table.
+    final criticalY = tester.getTopLeft(critical).dy;
+    final lowY = tester.getTopLeft(low).dy;
+    expect(criticalY < lowY, isTrue,
+        reason: 'Critical row must render above Low.');
+  });
+
+  testWidgets('non-admin hides the compliance-history browse tile',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/policies/status', body: _detectedBoth())
+      ..onJson('GET', '/api/v1/policies/', body: _samplePolicies())
+      ..onJson('GET', '/api/v1/policies/violations', body: {'data': <Object>[]})
+      ..onJson('GET', '/api/v1/policies/compliance',
+          body: _sampleCompliance());
+    await _pump(tester, mock, admin: false);
+
+    // History tile must not appear; Policies + Violations remain.
+    expect(find.text('Policies'), findsAtLeastNWidgets(1));
+    expect(find.text('Violations'), findsOneWidget);
+    expect(find.text('History'), findsNothing,
+        reason: 'Non-admin operators must not see a tile they cannot use.');
+  });
+}

--- a/mobile/test/features/policy/policies_list_screen_test.dart
+++ b/mobile/test/features/policy/policies_list_screen_test.dart
@@ -1,0 +1,278 @@
+// Widget tests for the Policies list.
+//
+// Coverage:
+//   * row renders name, engine/severity/blocking badges, violation count.
+//   * engine-availability badge — Kyverno policy on Gatekeeper-only cluster
+//     surfaces the "Engine not installed" tooltip (plan §U9 line 640).
+//   * engine filter chip narrows the list.
+//   * severity filter chip narrows the list.
+//   * blocking filter chip narrows the list.
+//   * free-text search narrows the list.
+//   * empty-data copy and no-matches copy.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:kubecenter/api/dio_client.dart';
+import 'package:kubecenter/auth/secure_storage.dart';
+import 'package:kubecenter/features/policy/policies_list_screen.dart';
+import 'package:kubecenter/theme/kube_theme_builder.dart';
+
+import '../../support/mock_dio_adapter.dart';
+
+Future<void> _pump(WidgetTester tester, MockDioAdapter mock) async {
+  // 1600dp wide so the horizontal chip scroll-view fits every chip on
+  // screen (3 engine + 5 severity + 3 blocking ≈ 11 chips at ~80dp each
+  // including spacing — narrower viewports push the later chips off the
+  // right edge where `tester.tap` cannot reach them without a scroll
+  // gesture).
+  await tester.binding.setSurfaceSize(const Size(1600, 1600));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+
+  final router = GoRouter(
+    initialLocation: '/',
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (context, state) => const PoliciesListScreen(),
+      ),
+    ],
+  );
+
+  await tester.pumpWidget(ProviderScope(
+    overrides: [
+      backendUrlProvider.overrideWithValue('http://test'),
+      secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+    ],
+    child: _DioInstaller(
+      mock: mock,
+      child: MaterialApp.router(
+        theme: buildKubeTheme('nexus'),
+        routerConfig: router,
+      ),
+    ),
+  ));
+  await tester.pump();
+  await tester.pumpAndSettle(const Duration(milliseconds: 200));
+}
+
+class _DioInstaller extends ConsumerWidget {
+  const _DioInstaller({required this.mock, required this.child});
+
+  final MockDioAdapter mock;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.read(dioProvider).httpClientAdapter = mock;
+    return child;
+  }
+}
+
+Map<String, Object?> _detectedBoth() => {
+      'data': {
+        'detected': 'both',
+        'kyverno': {'available': true, 'webhooks': 1},
+        'gatekeeper': {'available': true, 'webhooks': 1},
+      },
+    };
+
+Map<String, Object?> _detectedGatekeeperOnly() => {
+      'data': {
+        'detected': 'gatekeeper',
+        'kyverno': {'available': false, 'webhooks': 0},
+        'gatekeeper': {'available': true, 'webhooks': 1},
+      },
+    };
+
+Map<String, Object?> _mixedPolicies() => {
+      'data': [
+        {
+          'id': 'kyverno::require-labels',
+          'name': 'require-labels',
+          'kind': 'ClusterPolicy',
+          'action': 'enforce',
+          'severity': 'critical',
+          'engine': 'kyverno',
+          'blocking': true,
+          'ready': true,
+          'ruleCount': 1,
+          'violationCount': 4,
+          'description': 'team label must be present',
+        },
+        {
+          'id': 'kyverno::audit-priv',
+          'name': 'audit-priv',
+          'kind': 'ClusterPolicy',
+          'action': 'audit',
+          'severity': 'medium',
+          'engine': 'kyverno',
+          'blocking': false,
+          'ready': true,
+          'ruleCount': 1,
+          'violationCount': 0,
+        },
+        {
+          'id': 'gatekeeper::K8sRequiredLabels/team',
+          'name': 'team-label-constraint',
+          'kind': 'K8sRequiredLabels',
+          'action': 'deny',
+          'severity': 'high',
+          'engine': 'gatekeeper',
+          'blocking': true,
+          'ready': true,
+          'ruleCount': 1,
+          'violationCount': 2,
+        },
+      ],
+    };
+
+void main() {
+  testWidgets('detected=false renders policy not-installed state',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/policies/status', body: {
+        'data': {'detected': ''},
+      });
+    await _pump(tester, mock);
+
+    expect(find.textContaining('policy engine'), findsOneWidget);
+    expect(find.textContaining('is not installed'), findsOneWidget);
+  });
+
+  testWidgets('row renders name + badges + violation count', (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/policies/status', body: _detectedBoth())
+      ..onJson('GET', '/api/v1/policies/', body: _mixedPolicies());
+    await _pump(tester, mock);
+
+    expect(find.text('require-labels'), findsOneWidget);
+    expect(find.text('audit-priv'), findsOneWidget);
+    expect(find.text('team-label-constraint'), findsOneWidget);
+    // Severity + engine pills render in the row.
+    expect(find.text('Critical'), findsAtLeastNWidgets(1));
+    expect(find.text('Kyverno'), findsAtLeastNWidgets(1));
+    expect(find.text('Gatekeeper'), findsAtLeastNWidgets(1));
+    // Violation counts surface as ergonomic copy on rows with > 0.
+    expect(find.textContaining('4 violations'), findsOneWidget);
+    expect(find.textContaining('2 violations'), findsOneWidget);
+    // Description renders when present.
+    expect(find.text('team label must be present'), findsOneWidget);
+  });
+
+  testWidgets(
+    'Kyverno-engined policy on Gatekeeper-only cluster surfaces the '
+    'Engine not installed tooltip (plan §U9 line 640)',
+    (tester) async {
+      final mock = MockDioAdapter()
+        ..onJson('GET', '/api/v1/policies/status',
+            body: _detectedGatekeeperOnly())
+        ..onJson('GET', '/api/v1/policies/', body: _mixedPolicies());
+      await _pump(tester, mock);
+
+      // Long-press surfaces the Tooltip message; locate Tooltip widgets
+      // by their message text since the Tooltip child contains the
+      // EngineBadge but the message is what tells the operator the
+      // engine isn't installed.
+      final tooltips = find.byWidgetPredicate((w) {
+        return w is Tooltip &&
+            w.message == 'Engine not installed on this cluster';
+      });
+      expect(
+        tooltips,
+        findsAtLeastNWidgets(2),
+        reason:
+            'Both Kyverno-engined policies (require-labels, audit-priv) '
+            'must carry the install-state tooltip on a Gatekeeper-only '
+            'cluster; the Gatekeeper-engined row must not.',
+      );
+    },
+  );
+
+  testWidgets('engine filter chip narrows the list', (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/policies/status', body: _detectedBoth())
+      ..onJson('GET', '/api/v1/policies/', body: _mixedPolicies());
+    await _pump(tester, mock);
+
+    expect(find.text('require-labels'), findsOneWidget);
+    expect(find.text('team-label-constraint'), findsOneWidget);
+
+    await tester.tap(find.widgetWithText(ChoiceChip, 'Kyverno'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('require-labels'), findsOneWidget);
+    expect(find.text('audit-priv'), findsOneWidget);
+    expect(find.text('team-label-constraint'), findsNothing,
+        reason: 'Gatekeeper-engined policy must drop out when Kyverno '
+            'chip is selected.');
+  });
+
+  testWidgets('severity filter chip narrows the list', (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/policies/status', body: _detectedBoth())
+      ..onJson('GET', '/api/v1/policies/', body: _mixedPolicies());
+    await _pump(tester, mock);
+
+    await tester.tap(find.widgetWithText(ChoiceChip, 'Critical'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('require-labels'), findsOneWidget);
+    expect(find.text('audit-priv'), findsNothing);
+    expect(find.text('team-label-constraint'), findsNothing);
+  });
+
+  testWidgets('blocking filter chip narrows the list', (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/policies/status', body: _detectedBoth())
+      ..onJson('GET', '/api/v1/policies/', body: _mixedPolicies());
+    await _pump(tester, mock);
+
+    await tester.tap(find.widgetWithText(ChoiceChip, 'Audit'));
+    await tester.pumpAndSettle();
+
+    // Only audit-priv is non-blocking.
+    expect(find.text('audit-priv'), findsOneWidget);
+    expect(find.text('require-labels'), findsNothing);
+    expect(find.text('team-label-constraint'), findsNothing);
+  });
+
+  testWidgets('free-text search narrows the list', (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/policies/status', body: _detectedBoth())
+      ..onJson('GET', '/api/v1/policies/', body: _mixedPolicies());
+    await _pump(tester, mock);
+
+    await tester.enterText(find.byType(TextField), 'audit');
+    await tester.pumpAndSettle();
+
+    expect(find.text('audit-priv'), findsOneWidget);
+    expect(find.text('require-labels'), findsNothing);
+    expect(find.text('team-label-constraint'), findsNothing);
+  });
+
+  testWidgets('empty data renders compliance-friendly copy', (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/policies/status', body: _detectedBoth())
+      ..onJson('GET', '/api/v1/policies/', body: {'data': <Object>[]});
+    await _pump(tester, mock);
+
+    expect(find.textContaining('No policies defined'), findsOneWidget);
+  });
+
+  testWidgets('non-empty data with no chip matches shows no-matches copy',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/policies/status', body: _detectedBoth())
+      ..onJson('GET', '/api/v1/policies/', body: _mixedPolicies());
+    await _pump(tester, mock);
+
+    // Filter to a severity that has zero matches in the fixture
+    // (low severity not present in _mixedPolicies).
+    await tester.tap(find.widgetWithText(ChoiceChip, 'Low'));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('No policies match'), findsOneWidget);
+  });
+}

--- a/mobile/test/features/policy/violation_detail_screen_test.dart
+++ b/mobile/test/features/policy/violation_detail_screen_test.dart
@@ -1,0 +1,279 @@
+// Widget tests for the Violation detail screen.
+//
+// The screen has no GET-by-id endpoint — it reads from the cached
+// violationsListProvider and matches by stable key
+// `policy|rule|namespace|kind|name`. Coverage:
+//   * stable-key found → _DetailContent renders with target + remediation
+//   * stable-key not found → "Violation not found" empty state
+//   * cluster-scoped resource: target-resource path uses the namespace
+//     sentinel (`_`) so generic-detail routing resolves cleanly
+//   * remediation hint copy varies by blocking + engine
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:kubecenter/api/dio_client.dart';
+import 'package:kubecenter/auth/secure_storage.dart';
+import 'package:kubecenter/features/policy/violation_detail_screen.dart';
+import 'package:kubecenter/theme/kube_theme_builder.dart';
+
+import '../../support/mock_dio_adapter.dart';
+
+class _NavObserver extends NavigatorObserver {
+  final List<Route<dynamic>> pushed = [];
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    pushed.add(route);
+    super.didPush(route, previousRoute);
+  }
+}
+
+Future<({_NavObserver observer, GoRouter router})> _pump(
+  WidgetTester tester,
+  MockDioAdapter mock, {
+  required String stableKey,
+}) async {
+  await tester.binding.setSurfaceSize(const Size(800, 1600));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+
+  final observer = _NavObserver();
+  final router = GoRouter(
+    initialLocation: '/',
+    observers: [observer],
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (context, state) =>
+            ViolationDetailScreen(stableKey: stableKey),
+      ),
+      // Stub the generic-detail catch-all so the "View target resource"
+      // button has somewhere to land. Capture the path-parameters via
+      // the observer to assert against.
+      GoRoute(
+        path: '/clusters/:clusterId/generic/:kind/:namespace/:name',
+        builder: (context, state) => Scaffold(
+          body: Text(
+            'generic:${state.pathParameters['kind']}:'
+            '${state.pathParameters['namespace']}:'
+            '${state.pathParameters['name']}',
+          ),
+        ),
+      ),
+    ],
+  );
+
+  await tester.pumpWidget(ProviderScope(
+    overrides: [
+      backendUrlProvider.overrideWithValue('http://test'),
+      secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+    ],
+    child: _DioInstaller(
+      mock: mock,
+      child: MaterialApp.router(
+        theme: buildKubeTheme('nexus'),
+        routerConfig: router,
+      ),
+    ),
+  ));
+  await tester.pump();
+  await tester.pumpAndSettle(const Duration(milliseconds: 200));
+
+  return (observer: observer, router: router);
+}
+
+class _DioInstaller extends ConsumerWidget {
+  const _DioInstaller({required this.mock, required this.child});
+
+  final MockDioAdapter mock;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.read(dioProvider).httpClientAdapter = mock;
+    return child;
+  }
+}
+
+Map<String, Object?> _detected() => {
+      'data': {
+        'detected': 'both',
+        'kyverno': {'available': true, 'webhooks': 1},
+        'gatekeeper': {'available': true, 'webhooks': 1},
+      },
+    };
+
+Map<String, Object?> _violations() => {
+      'data': [
+        {
+          'policy': 'require-labels',
+          'rule': 'check-team',
+          'namespace': 'app',
+          'kind': 'Pod',
+          'name': 'web-1',
+          'severity': 'high',
+          'action': 'enforce',
+          'message': 'team label required',
+          'engine': 'kyverno',
+          'blocking': true,
+        },
+        {
+          'policy': 'audit-priv',
+          'rule': '',
+          'namespace': 'app',
+          'kind': 'Pod',
+          'name': 'sidecar-2',
+          'severity': 'medium',
+          'action': 'audit',
+          'message': 'privilege flagged',
+          'engine': 'kyverno',
+          'blocking': false,
+        },
+        {
+          'policy': 'K8sRequiredLabels/team',
+          'namespace': '',
+          'kind': 'Namespace',
+          'name': 'demo',
+          'severity': 'low',
+          'action': 'dryrun',
+          'message': 'namespace missing label',
+          'engine': 'gatekeeper',
+          'blocking': false,
+        },
+      ],
+    };
+
+void main() {
+  testWidgets(
+    'stableKey found → renders policy + target + remediation sections',
+    (tester) async {
+      final mock = MockDioAdapter()
+        ..onJson('GET', '/api/v1/policies/status', body: _detected())
+        ..onJson('GET', '/api/v1/policies/violations', body: _violations());
+      await _pump(
+        tester,
+        mock,
+        stableKey: 'require-labels|check-team|app|Pod|web-1',
+      );
+
+      expect(find.text('require-labels'), findsOneWidget);
+      expect(find.textContaining('Rule'), findsOneWidget);
+      expect(find.text('check-team'), findsOneWidget);
+      expect(find.text('team label required'), findsOneWidget);
+      // Target resource section + labels.
+      expect(find.text('Target resource'), findsOneWidget);
+      expect(find.text('Pod'), findsOneWidget);
+      expect(find.text('app'), findsOneWidget);
+      expect(find.text('web-1'), findsOneWidget);
+      // Remediation section.
+      expect(find.text('Remediation'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'stableKey absent from list → "Violation not found" empty state',
+    (tester) async {
+      final mock = MockDioAdapter()
+        ..onJson('GET', '/api/v1/policies/status', body: _detected())
+        ..onJson('GET', '/api/v1/policies/violations', body: _violations());
+      await _pump(
+        tester,
+        mock,
+        stableKey: 'phantom-policy||Namespace|missing',
+      );
+
+      expect(find.text('Violation not found'), findsOneWidget);
+      expect(
+        find.textContaining('may have been remediated'),
+        findsOneWidget,
+        reason:
+            'Operator should learn the most-likely cause (remediated since '
+            'the list was cached) rather than a generic error.',
+      );
+    },
+  );
+
+  testWidgets(
+    'cluster-scoped resource: View-target navigates to generic detail '
+    'with the namespace sentinel "_"',
+    (tester) async {
+      final mock = MockDioAdapter()
+        ..onJson('GET', '/api/v1/policies/status', body: _detected())
+        ..onJson('GET', '/api/v1/policies/violations', body: _violations());
+      await _pump(
+        tester,
+        mock,
+        stableKey: 'K8sRequiredLabels/team|||Namespace|demo',
+      );
+
+      // Tap the "View target resource" FilledButton.
+      await tester.tap(find.widgetWithText(FilledButton, 'View target resource'));
+      await tester.pumpAndSettle();
+
+      // The generic-detail stub renders "generic:<kind>:<ns>:<name>".
+      // Namespace sentinel "_" must appear because the violation is
+      // cluster-scoped (empty namespace on wire).
+      expect(find.text('generic:Namespace:_:demo'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'namespaced resource: View-target uses real namespace, not sentinel',
+    (tester) async {
+      final mock = MockDioAdapter()
+        ..onJson('GET', '/api/v1/policies/status', body: _detected())
+        ..onJson('GET', '/api/v1/policies/violations', body: _violations());
+      await _pump(
+        tester,
+        mock,
+        stableKey: 'require-labels|check-team|app|Pod|web-1',
+      );
+
+      await tester.tap(find.widgetWithText(FilledButton, 'View target resource'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('generic:Pod:app:web-1'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'remediation copy differentiates blocking vs Kyverno-audit vs '
+    'Gatekeeper-audit',
+    (tester) async {
+      // Three sub-cases, all reading the same mocked violation list but
+      // with different stable keys.
+      Future<void> testCopyAt(
+        String stableKey,
+        String expectedFragment,
+      ) async {
+        final mock = MockDioAdapter()
+          ..onJson('GET', '/api/v1/policies/status', body: _detected())
+          ..onJson('GET', '/api/v1/policies/violations',
+              body: _violations());
+        await _pump(tester, mock, stableKey: stableKey);
+
+        expect(
+          find.textContaining(expectedFragment),
+          findsOneWidget,
+          reason:
+              'Remediation copy must surface the engine-/blocking-'
+              'specific guidance.',
+        );
+      }
+
+      await testCopyAt(
+        'require-labels|check-team|app|Pod|web-1',
+        'blocking violation',
+      );
+      await testCopyAt(
+        'audit-priv||app|Pod|sidecar-2',
+        'Kyverno is recording',
+      );
+      await testCopyAt(
+        'K8sRequiredLabels/team|||Namespace|demo',
+        'Gatekeeper is recording',
+      );
+    },
+  );
+}

--- a/mobile/test/features/policy/violations_list_screen_test.dart
+++ b/mobile/test/features/policy/violations_list_screen_test.dart
@@ -1,0 +1,228 @@
+// Widget tests for the Violations list.
+//
+// Coverage:
+//   * row renders policy + rule + target + message.
+//   * severity chip filters the list.
+//   * empty data renders the "no violations" message.
+//   * virtual-scroll (`SliverChildBuilderDelegate`) handles 500+ rows
+//     without constructing every widget.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:kubecenter/api/dio_client.dart';
+import 'package:kubecenter/auth/secure_storage.dart';
+import 'package:kubecenter/features/policy/violations_list_screen.dart';
+import 'package:kubecenter/theme/kube_theme_builder.dart';
+
+import '../../support/mock_dio_adapter.dart';
+
+Future<void> _pump(WidgetTester tester, MockDioAdapter mock) async {
+  await tester.binding.setSurfaceSize(const Size(800, 1600));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+
+  final router = GoRouter(
+    initialLocation: '/',
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (context, state) => const ViolationsListScreen(),
+      ),
+      // Stub detail route so taps don't 404 the test router.
+      GoRoute(
+        path: '/clusters/:clusterId/policy/violations/:stableKey',
+        builder: (context, state) => const Scaffold(body: Text('detail')),
+      ),
+    ],
+  );
+
+  await tester.pumpWidget(ProviderScope(
+    overrides: [
+      backendUrlProvider.overrideWithValue('http://test'),
+      secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+    ],
+    child: _DioInstaller(
+      mock: mock,
+      child: MaterialApp.router(
+        theme: buildKubeTheme('nexus'),
+        routerConfig: router,
+      ),
+    ),
+  ));
+  await tester.pump();
+  await tester.pumpAndSettle(const Duration(milliseconds: 200));
+}
+
+class _DioInstaller extends ConsumerWidget {
+  const _DioInstaller({required this.mock, required this.child});
+
+  final MockDioAdapter mock;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.read(dioProvider).httpClientAdapter = mock;
+    return child;
+  }
+}
+
+Map<String, Object?> _detected() => {
+      'data': {
+        'detected': 'both',
+        'kyverno': {'available': true, 'webhooks': 1},
+        'gatekeeper': {'available': true, 'webhooks': 1},
+      },
+    };
+
+void main() {
+  testWidgets('row renders policy + target + message', (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/policies/status', body: _detected())
+      ..onJson('GET', '/api/v1/policies/violations', body: {
+        'data': [
+          {
+            'policy': 'require-labels',
+            'rule': 'check-team',
+            'namespace': 'default',
+            'kind': 'Pod',
+            'name': 'app-abc',
+            'severity': 'high',
+            'action': 'enforce',
+            'message': 'team label required',
+            'engine': 'kyverno',
+            'blocking': true,
+          },
+        ],
+      });
+    await _pump(tester, mock);
+
+    expect(find.text('require-labels'), findsOneWidget);
+    expect(find.textContaining('rule: check-team'), findsOneWidget);
+    expect(find.textContaining('Pod/app-abc'), findsOneWidget);
+    expect(find.text('team label required'), findsOneWidget);
+  });
+
+  testWidgets('severity chip filters the list', (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/policies/status', body: _detected())
+      ..onJson('GET', '/api/v1/policies/violations', body: {
+        'data': [
+          {
+            'policy': 'p1-critical',
+            'kind': 'Pod',
+            'name': 'a',
+            'severity': 'critical',
+            'action': 'enforce',
+            'message': '',
+            'engine': 'kyverno',
+            'blocking': true,
+            'namespace': 'ns1',
+          },
+          {
+            'policy': 'p2-low',
+            'kind': 'Pod',
+            'name': 'b',
+            'severity': 'low',
+            'action': 'audit',
+            'message': '',
+            'engine': 'kyverno',
+            'blocking': false,
+            'namespace': 'ns1',
+          },
+        ],
+      });
+    await _pump(tester, mock);
+
+    // Both visible initially.
+    expect(find.text('p1-critical'), findsOneWidget);
+    expect(find.text('p2-low'), findsOneWidget);
+
+    // Tap the "Critical" chip — only p1 remains.
+    await tester.tap(find.widgetWithText(ChoiceChip, 'Critical'));
+    await tester.pumpAndSettle();
+    expect(find.text('p1-critical'), findsOneWidget);
+    expect(find.text('p2-low'), findsNothing);
+  });
+
+  testWidgets('empty data renders compliant copy', (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/policies/status', body: _detected())
+      ..onJson('GET', '/api/v1/policies/violations', body: {'data': <Object>[]});
+    await _pump(tester, mock);
+
+    expect(find.textContaining('currently compliant'), findsOneWidget);
+  });
+
+  testWidgets('virtual scroll handles large response without building all',
+      (tester) async {
+    // 200 rows is large enough to overflow the viewport (each row is
+    // ≥60dp; 800x1600 viewport fits roughly 25 rows). The plan calls
+    // out a 1000-violation perf check; that scale is exercised by
+    // headless benchmark separately so the widget test stays fast.
+    final rows = List<Map<String, Object?>>.generate(200, (i) {
+      return {
+        'policy': 'p$i',
+        'kind': 'Pod',
+        'name': 'pod-$i',
+        'severity': i % 4 == 0 ? 'critical' : 'medium',
+        'action': 'audit',
+        'message': '',
+        'engine': 'kyverno',
+        'blocking': false,
+        'namespace': 'ns${i % 5}',
+      };
+    });
+
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/policies/status', body: _detected())
+      ..onJson('GET', '/api/v1/policies/violations',
+          body: {'data': rows});
+    // Use bounded pumps rather than pumpAndSettle — the lengthy list
+    // can keep the framework "busy" for longer than the default 10-
+    // minute pumpAndSettle timeout when measured against the test clock.
+    await tester.binding.setSurfaceSize(const Size(800, 1600));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    final router = GoRouter(
+      initialLocation: '/',
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (context, state) => const ViolationsListScreen(),
+        ),
+        GoRoute(
+          path: '/clusters/:clusterId/policy/violations/:stableKey',
+          builder: (context, state) => const Scaffold(body: Text('detail')),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(ProviderScope(
+      overrides: [
+        backendUrlProvider.overrideWithValue('http://test'),
+        secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+      ],
+      child: _DioInstaller(
+        mock: mock,
+        child: MaterialApp.router(
+          theme: buildKubeTheme('nexus'),
+          routerConfig: router,
+        ),
+      ),
+    ));
+    // A handful of bounded pumps is enough to settle status fetch +
+    // violations fetch + first paint without giving the framework a
+    // chance to spin on residual animations.
+    for (var i = 0; i < 5; i++) {
+      await tester.pump(const Duration(milliseconds: 100));
+    }
+
+    // First row is visible; row 199 is below the fold and must NOT have
+    // been built by SliverChildBuilderDelegate.
+    expect(find.text('p0'), findsOneWidget);
+    expect(find.text('p199'), findsNothing,
+        reason: 'Virtual scroll must not construct the entire list '
+            'eagerly — only viewport rows.');
+  });
+}

--- a/mobile/test/features/policy/violations_list_screen_test.dart
+++ b/mobile/test/features/policy/violations_list_screen_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:kubecenter/api/dio_client.dart';
 import 'package:kubecenter/auth/secure_storage.dart';
+import 'package:kubecenter/cluster/cluster_provider.dart';
 import 'package:kubecenter/features/policy/violations_list_screen.dart';
 import 'package:kubecenter/theme/kube_theme_builder.dart';
 
@@ -225,4 +226,116 @@ void main() {
         reason: 'Virtual scroll must not construct the entire list '
             'eagerly — only viewport rows.');
   });
+
+  testWidgets(
+    'cluster switch resets namespace + severity filters mid-screen '
+    '(plan §U9 line 644 cluster-pin discipline)',
+    (tester) async {
+      // The provider is keyed on clusterId via family, so each cluster
+      // gets its own slot. The screen's ref.listen<String>(active...) is
+      // the discipline being tested — when active cluster changes, the
+      // screen MUST reset the filter chips to avoid applying a stale
+      // namespace filter from cluster A against cluster B's data.
+      await tester.binding.setSurfaceSize(const Size(1600, 1600));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final mock = MockDioAdapter()
+        ..onJson('GET', '/api/v1/policies/status', body: _detected())
+        // Both clusters' /policies/status mocked above (any X-Cluster-ID
+        // hits the same handler). Per-cluster violations:
+        ..onJson('GET', '/api/v1/policies/violations', body: {
+          'data': [
+            {
+              'policy': 'cluster-A-policy',
+              'kind': 'Pod',
+              'name': 'a-pod',
+              'severity': 'critical',
+              'action': 'enforce',
+              'message': '',
+              'engine': 'kyverno',
+              'blocking': true,
+              'namespace': 'team-a',
+            },
+            {
+              'policy': 'cluster-B-policy',
+              'kind': 'Pod',
+              'name': 'b-pod',
+              'severity': 'low',
+              'action': 'audit',
+              'message': '',
+              'engine': 'kyverno',
+              'blocking': false,
+              'namespace': 'team-b',
+            },
+          ],
+        });
+
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (context, state) =>
+                const ViolationsListScreen(initialNamespace: 'team-a'),
+          ),
+          GoRoute(
+            path: '/clusters/:clusterId/policy/violations/:stableKey',
+            builder: (context, state) =>
+                const Scaffold(body: Text('detail')),
+          ),
+        ],
+      );
+
+      final container = ProviderContainer(
+        overrides: [
+          backendUrlProvider.overrideWithValue('http://test'),
+          secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+        ],
+      );
+      addTearDown(container.dispose);
+      container.read(dioProvider).httpClientAdapter = mock;
+      // Start on cluster A with the screen seeded to namespace=team-a.
+      container.read(activeClusterProvider.notifier).setCluster('cluster-a');
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp.router(
+            theme: buildKubeTheme('nexus'),
+            routerConfig: router,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle(const Duration(milliseconds: 200));
+
+      // Filter was seeded to team-a → cluster-A-policy visible,
+      // cluster-B-policy hidden.
+      expect(find.text('cluster-A-policy'), findsOneWidget);
+      expect(find.text('cluster-B-policy'), findsNothing);
+
+      // Flip the active cluster — ref.listen<String>(activeClusterProvider)
+      // fires inside ViolationsListScreen and must reset _namespaceFilter
+      // to '' so the new cluster's violations aren't filtered against the
+      // stale team-a namespace.
+      container.read(activeClusterProvider.notifier).setCluster('cluster-b');
+      await tester.pumpAndSettle(const Duration(milliseconds: 200));
+
+      // Both violations now visible (filter cleared) — the screen is
+      // showing cluster B's data with no namespace filter applied.
+      expect(find.text('cluster-A-policy'), findsOneWidget);
+      expect(find.text('cluster-B-policy'), findsOneWidget);
+
+      // Confirm the dispatched X-Cluster-ID headers reflect the two
+      // different cluster IDs — the repository was called once per
+      // cluster, never under the wrong pin.
+      final clusterIds = mock.requests
+          .where((r) => r.path == '/api/v1/policies/violations')
+          .map((r) => r.headers['X-Cluster-ID'])
+          .toSet();
+      expect(clusterIds, containsAll(<String>['cluster-a', 'cluster-b']),
+          reason:
+              'Each cluster slot must fetch under its own pin — never '
+              'mix a request for cluster B under cluster A\'s pin.');
+    },
+  );
 }


### PR DESCRIPTION
## Summary

Mobile M4 PR-4i — ports `frontend/islands/{PolicyDashboard,ComplianceDashboard,ComplianceTrendChart}.tsx` to the Flutter app as a compliance dashboard, policies list, violations browser, violation detail, and admin-only compliance-history surface. No new backend.

Origin: `plans/mobile-app-m4-pr-sequence.md` §U9.

## What lands

- **`PolicyRepository`** over `/v1/policies/{status,/(list),violations,compliance,compliance/history}` with open-enum severity / engine parsing, per-cluster providers, `clusterIdOverride` threading + `CancelToken` on every Dio call.
- **`PolicyId` helper** for the `engine:namespace:kind:name` composite (CLAUDE.md Key Conventions).
- **`isComplianceHistoryNotConfigured`** discriminator on the 503 envelope — substring match against `requires a database` so a future punctuation tweak still routes correctly.
- **Dashboard** — `KubeGaugeRing` hero score + tier label, Kyverno + Gatekeeper engine cards (install state + webhook count + per-engine policy count), by-severity breakdown ordered desc, browse tiles. Compliance-history tile hidden for non-admin operators.
- **Policies list** — search + engine / severity / blocking chips. `Engine not installed` tooltip on rows whose engine is absent (PR-3f intersection learning generalised — the CRD can exist on a cluster whose engine pod isn't healthy).
- **Violations list** — namespace dropdown + severity chips + search. Virtual scroll via `SliverChildBuilderDelegate`. Stable key `policy|rule|namespace|kind|name` because the wire has no server id — controller events.
- **Violation detail** — reads from the cached violations list (no GET-by-id endpoint). Target-resource link routes through the generic catch-all so policy targets that are CRDs outside `domainSections` still resolve.
- **Compliance history (admin-only)** — `KubeLineChart` over `/policies/compliance/history`. **503 with body `requires a database` → permanent `FeatureUnavailableState` with no Retry button.** Other 503s remain retry-able. Admin gate at route body + backend `RequireAdmin` defence-in-depth.
- **Routing + drawer** — new `Policy` section (`Dashboard` / `Policies` / `Violations`). Compliance-history reachable from dashboard browse tiles.

## Invariants honoured (per `plans/mobile-app.md`)

- All reads pin the active cluster via `X-Cluster-ID` and re-check pin on result arrival (`policyRepositoryProvider` family keyed on `clusterId`).
- **Read-only posture preserved** (R12) — no write surfaces added.
- Web/Dart isomorphism (R10) — wire types mirror `backend/internal/policy/types.go` exactly.
- Engine-availability check on policy rows mirrors PR-3f's `pickTemplate` intersection.

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test` 784 / 784 pass (33 new policy tests including the dedicated 503-distinguished-error path test required by the plan)
- [x] `go vet ./... && go test ./...` clean
- [x] `make check-themes` in sync
- [ ] Smoke against homelab (Kyverno installed): walk dashboard + violations + drill into one
- [ ] Smoke compliance history 503 path with PostgreSQL persistence disabled in Helm values

## Out of scope

- Compliance history time-range picker (fixed 30-day default; per Scope Boundaries, custom ranges land in M5 polish)
- Drift Revert + bulk-refresh write actions — `FeatureUnavailableState`-style tooltip not needed here since the dashboard surfaces no write affordance

🤖 Generated with [Claude Code](https://claude.com/claude-code)