### PR TITLE
fix(mobile): harden ApiError.fromDio against non-canonical envelopes

### DIFF
--- a/mobile/lib/api/api_error.dart
+++ b/mobile/lib/api/api_error.dart
@@ -1,6 +1,12 @@
-// Typed parse of the backend's error envelope: `{error:{code, message, detail}}`.
-// Mirrors `frontend/lib/api.ts` ApiError so widget error states render
-// identical wording on both surfaces.
+// Typed parse of the backend's error envelope: `{error:{code, message, detail,
+// reason}}`. Mirrors `frontend/lib/api.ts` ApiError so widget error states
+// render identical wording on both surfaces.
+//
+// Robustness contract: `ApiError.fromDio` never lets a non-String value leak
+// into `message`, `detail`, or `reason`. Backends returning unexpected body
+// shapes (top-level fields, plain string, HTML, Map-with-no-recognized-key)
+// fall back to a friendly status-derived message rather than rendering raw
+// `Map.toString()` braces-and-commas to operators.
 
 import 'package:dio/dio.dart';
 
@@ -10,6 +16,7 @@ class ApiError implements Exception {
     required this.code,
     required this.message,
     this.detail,
+    this.reason,
   });
 
   final int statusCode;
@@ -17,35 +24,103 @@ class ApiError implements Exception {
   final String message;
   final String? detail;
 
-  /// Builds an ApiError from a DioException. When the response carries the
-  /// canonical envelope, fields populate from `error.{code,message,detail}`;
-  /// otherwise they fall back to HTTP status + Dio's default message.
+  /// Endpoint-specific reason code (e.g. "active_job_exists",
+  /// "scope_changed"). Mirrors the frontend's `ApiError.reason`.
+  final String? reason;
+
+  /// Builds an ApiError from a DioException by inspecting the response body.
+  /// Tolerates three body shapes; everything else falls back to a friendly
+  /// status-derived message:
+  ///   1. Canonical envelope: `{error: {code, message, detail, reason}}`
+  ///   2. Top-level fields: `{message, code, detail, reason}`
+  ///   3. Plain string body — used as-is when short and not HTML
   factory ApiError.fromDio(DioException e) {
     final res = e.response;
     final status = res?.statusCode ?? 0;
-
     final body = res?.data;
+
     if (body is Map) {
-      final error = body['error'];
-      if (error is Map) {
+      final nested = body['error'];
+      if (nested is Map) {
+        final msg = _asString(nested['message']);
+        if (msg != null) {
+          return ApiError(
+            statusCode: status,
+            code: _asInt(nested['code']) ?? status,
+            message: msg,
+            detail: _asString(nested['detail']),
+            reason: _asString(nested['reason']),
+          );
+        }
+      }
+
+      final topMessage = _asString(body['message']);
+      if (topMessage != null) {
         return ApiError(
           statusCode: status,
-          code: (error['code'] as int?) ?? status,
-          message: (error['message'] as String?) ?? _statusText(status),
-          detail: error['detail'] as String?,
+          code: _asInt(body['code']) ?? status,
+          message: topMessage,
+          detail: _asString(body['detail']),
+          reason: _asString(body['reason']),
         );
+      }
+    }
+
+    if (body is String) {
+      final trimmed = body.trim();
+      if (trimmed.isNotEmpty &&
+          trimmed.length <= 200 &&
+          !trimmed.startsWith('<')) {
+        return ApiError(statusCode: status, code: status, message: trimmed);
       }
     }
 
     return ApiError(
       statusCode: status,
       code: status,
-      message: e.message ?? _statusText(status),
+      message: _dioFriendlyMessage(e) ?? _statusText(status),
     );
+  }
+
+  /// Resolves any error object into a human-readable string. Use in catch
+  /// blocks where the error type isn't statically guaranteed and the previous
+  /// pattern was `error.toString()` — that fallback can leak Dio's stringified
+  /// response body for raw `DioException` instances. Prefer this helper.
+  static String messageOf(Object? error) {
+    if (error == null) return 'Unknown error';
+    if (error is ApiError) return error.message;
+    if (error is DioException) {
+      final inner = error.error;
+      if (inner is ApiError) return inner.message;
+      return _dioFriendlyMessage(error) ??
+          _statusText(error.response?.statusCode ?? 0);
+    }
+    final s = error.toString();
+    if (s.isEmpty || s.length > 500) return 'Unknown error';
+    return s;
+  }
+
+  static String? _asString(Object? v) => v is String ? v : null;
+  static int? _asInt(Object? v) => v is int ? v : null;
+
+  // Dio's default badResponse message is the internal validateStatus blurb;
+  // surface friendly status text instead.
+  static String? _dioFriendlyMessage(DioException e) {
+    final m = e.message;
+    if (m == null || m.isEmpty) return null;
+    if (m.startsWith('This exception was thrown')) return null;
+    return m;
   }
 
   static String _statusText(int status) {
     if (status == 0) return 'Network error';
+    if (status == 401) return 'Authentication required';
+    if (status == 403) return 'Permission denied';
+    if (status == 404) return 'Not found';
+    if (status == 408 || status == 504) return 'Request timed out';
+    if (status == 409) return 'Conflict';
+    if (status == 422) return 'Validation failed';
+    if (status == 429) return 'Rate limited';
     if (status >= 500) return 'Server error';
     if (status >= 400) return 'Request failed';
     return 'OK';

--- a/mobile/test/api/api_error_test.dart
+++ b/mobile/test/api/api_error_test.dart
@@ -1,0 +1,257 @@
+// Hardening guarantees for ApiError.fromDio and ApiError.messageOf.
+// See issue #261: previously, non-canonical response bodies could surface
+// `Map.toString()` braces-and-commas in user-visible error toasts.
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kubecenter/api/api_error.dart';
+
+DioException _badResponse({
+  required int status,
+  required Object? body,
+  String? message,
+}) {
+  final req = RequestOptions(path: '/api/v1/test');
+  return DioException(
+    requestOptions: req,
+    type: DioExceptionType.badResponse,
+    message:
+        message ??
+        'This exception was thrown because the response has a status code '
+            'of $status and RequestOptions.validateStatus was configured to '
+            'throw for this status code.',
+    response: Response<Object?>(
+      requestOptions: req,
+      statusCode: status,
+      data: body,
+    ),
+  );
+}
+
+void main() {
+  group('ApiError.fromDio canonical envelope', () {
+    test('reads {error:{code,message,detail}} as the canonical shape', () {
+      final err = ApiError.fromDio(
+        _badResponse(
+          status: 422,
+          body: {
+            'error': {
+              'code': 4001,
+              'message': 'Validation failed',
+              'detail': 'field name required',
+            },
+          },
+        ),
+      );
+      expect(err.statusCode, 422);
+      expect(err.code, 4001);
+      expect(err.message, 'Validation failed');
+      expect(err.detail, 'field name required');
+      expect(err.reason, isNull);
+    });
+
+    test('reads reason and ignores extra/unknown fields safely', () {
+      final err = ApiError.fromDio(
+        _badResponse(
+          status: 403,
+          body: {
+            'error': {
+              'code': 403,
+              'message': 'Forbidden',
+              'reason': 'rbac_denied',
+              'extra': {'namespace': 'default'},
+            },
+          },
+        ),
+      );
+      expect(err.message, 'Forbidden');
+      expect(err.reason, 'rbac_denied');
+    });
+  });
+
+  group('ApiError.fromDio defensive parsing', () {
+    test(
+      'non-String nested message falls back to status text, no Map leak',
+      () {
+        final err = ApiError.fromDio(
+          _badResponse(
+            status: 500,
+            body: {
+              'error': {
+                'code': 500,
+                'message': {'nested': 'object'},
+              },
+            },
+          ),
+        );
+        expect(err.message, 'Server error');
+        expect(err.message, isNot(contains('{')));
+        expect(err.message, isNot(contains('nested')));
+      },
+    );
+
+    test('non-String nested detail is dropped, not stringified', () {
+      final err = ApiError.fromDio(
+        _badResponse(
+          status: 422,
+          body: {
+            'error': {
+              'message': 'Validation failed',
+              'detail': {
+                'fields': ['name', 'age'],
+              },
+            },
+          },
+        ),
+      );
+      expect(err.message, 'Validation failed');
+      expect(err.detail, isNull);
+    });
+
+    test('top-level {message,code,detail} envelope is parsed as fallback', () {
+      final err = ApiError.fromDio(
+        _badResponse(
+          status: 503,
+          body: {
+            'message': 'Backend offline',
+            'code': 503,
+            'detail': 'circuit breaker open',
+            'reason': 'upstream_unavailable',
+          },
+        ),
+      );
+      expect(err.message, 'Backend offline');
+      expect(err.code, 503);
+      expect(err.detail, 'circuit breaker open');
+      expect(err.reason, 'upstream_unavailable');
+    });
+
+    test('Map body with no recognized shape never leaks Map.toString()', () {
+      final err = ApiError.fromDio(
+        _badResponse(
+          status: 500,
+          body: {
+            'detail': 'something happened',
+            'reason': 'unknown_problem',
+            'trace_id': 'abc123',
+          },
+        ),
+      );
+      expect(err.message, 'Server error');
+      expect(err.message, isNot(contains('{')));
+      expect(err.message, isNot(contains(',')));
+      expect(err.message, isNot(contains('trace_id')));
+    });
+
+    test('plain string body is used as message when short and non-HTML', () {
+      final err = ApiError.fromDio(
+        _badResponse(
+          status: 500,
+          body: 'Internal server error from upstream proxy',
+        ),
+      );
+      expect(err.message, 'Internal server error from upstream proxy');
+    });
+
+    test('HTML body falls back to status text', () {
+      final err = ApiError.fromDio(
+        _badResponse(
+          status: 502,
+          body: '<html><body><h1>502 Bad Gateway</h1></body></html>',
+        ),
+      );
+      expect(err.message, 'Server error');
+      expect(err.message, isNot(contains('<')));
+    });
+
+    test('very long string body falls back to status text', () {
+      final err = ApiError.fromDio(_badResponse(status: 500, body: 'x' * 500));
+      expect(err.message, 'Server error');
+    });
+
+    test('empty body falls back to status text', () {
+      final err = ApiError.fromDio(_badResponse(status: 404, body: null));
+      expect(err.message, 'Not found');
+    });
+
+    test(
+      "Dio's internal validateStatus blurb is replaced with status text",
+      () {
+        final err = ApiError.fromDio(_badResponse(status: 429, body: null));
+        expect(err.message, 'Rate limited');
+        expect(err.message, isNot(contains('validateStatus')));
+      },
+    );
+  });
+
+  group('ApiError.fromDio network failures', () {
+    test('null response surfaces Dio diagnostic message when present', () {
+      final req = RequestOptions(path: '/api/v1/test');
+      final err = ApiError.fromDio(
+        DioException(
+          requestOptions: req,
+          type: DioExceptionType.connectionError,
+          message: 'SocketException: connection refused',
+        ),
+      );
+      expect(err.statusCode, 0);
+      expect(err.message, 'SocketException: connection refused');
+    });
+
+    test('connection error with no message yields "Network error"', () {
+      final req = RequestOptions(path: '/api/v1/test');
+      final err = ApiError.fromDio(
+        DioException(
+          requestOptions: req,
+          type: DioExceptionType.connectionError,
+        ),
+      );
+      expect(err.message, 'Network error');
+    });
+
+    test('408 timeout yields friendly text', () {
+      final err = ApiError.fromDio(_badResponse(status: 408, body: null));
+      expect(err.message, 'Request timed out');
+    });
+  });
+
+  group('ApiError.messageOf', () {
+    test('returns ApiError.message for ApiError', () {
+      final e = ApiError(statusCode: 500, code: 500, message: 'boom');
+      expect(ApiError.messageOf(e), 'boom');
+    });
+
+    test('unwraps ApiError from DioException.error', () {
+      final inner = ApiError(statusCode: 500, code: 500, message: 'wrapped');
+      final req = RequestOptions(path: '/x');
+      final dio = DioException(
+        requestOptions: req,
+        type: DioExceptionType.unknown,
+        error: inner,
+      );
+      expect(ApiError.messageOf(dio), 'wrapped');
+    });
+
+    test('raw DioException with no inner ApiError uses friendly text', () {
+      final dio = _badResponse(status: 500, body: {'random': 'shape'});
+      expect(ApiError.messageOf(dio), 'Server error');
+      expect(ApiError.messageOf(dio), isNot(contains('{')));
+    });
+
+    test('null error yields "Unknown error"', () {
+      expect(ApiError.messageOf(null), 'Unknown error');
+    });
+
+    test('arbitrary string-coercible error round-trips toString', () {
+      expect(
+        ApiError.messageOf(StateError('bad state')),
+        contains('bad state'),
+      );
+    });
+
+    test('pathologically long error toString is suppressed', () {
+      final huge = Exception('x' * 1000);
+      expect(ApiError.messageOf(huge), 'Unknown error');
+    });
+  });
+}


### PR DESCRIPTION
Closes #261

## Summary

- Hardens `mobile/lib/api/api_error.dart` so non-canonical response bodies never let raw `Map.toString()` braces-and-commas leak into user-visible error toasts or cards.
- Tolerates three body shapes in order: canonical `{error:{code,message,detail,reason}}` envelope (unchanged), top-level `{message,code,detail,reason}` fields, and short plain-string bodies.
- Replaces `as String?` / `as int?` casts that could throw `TypeError` with typed `is String` / `is int` guards. Unrecognized shapes fall back to friendly status text (`"Permission denied"`, `"Rate limited"`, `"Server error"`, etc.) instead of Dio's `"This exception was thrown because..."` internal blurb.
- Adds `ApiError.messageOf(error)` as a safe replacement for the `e is ApiError ? e.message : e.toString()` pattern used across screens — unwraps `DioException.error` when it carries an `ApiError`, and suppresses pathologically long `toString()` output.
- Adds `ApiError.reason` to mirror `frontend/lib/api.ts`.

Single-file fix per the issue's "no per-repository changes needed" guidance — repositories already route through `ApiError.fromDio`, so they pick up the hardening automatically.

## Test plan

- [x] 20 new test cases in `mobile/test/api/api_error_test.dart` cover each tolerated body shape, every defensive fallback path (non-String message, non-String detail, Map with no recognized key, HTML body, oversize string, empty body, null response, timeout, validateStatus blurb), and `messageOf`.
- [x] `flutter analyze` clean (changed files + whole tree).
- [x] `flutter test` — all 863 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)