### PR TITLE
fix(mobile): latch Golden Signals tab against transient mesh status 5xx

### DIFF
--- a/mobile/lib/features/resources/service_screens.dart
+++ b/mobile/lib/features/resources/service_screens.dart
@@ -26,10 +26,8 @@ class _ServiceRow {
   final Map<String, dynamic> raw;
   final K8sMeta meta;
 
-  String get type =>
-      readPath(raw, 'spec.type') as String? ?? 'ClusterIP';
-  String get clusterIP =>
-      readPath(raw, 'spec.clusterIP') as String? ?? '—';
+  String get type => readPath(raw, 'spec.type') as String? ?? 'ClusterIP';
+  String get clusterIP => readPath(raw, 'spec.clusterIP') as String? ?? '—';
 
   /// External IP/hostname. Joins all entries from `spec.externalIPs` and
   /// `status.loadBalancer.ingress` (post-fix: previously dropped all but
@@ -55,15 +53,18 @@ class _ServiceRow {
   String get ports {
     final list = readPath(raw, 'spec.ports') as List?;
     if (list == null || list.isEmpty) return '—';
-    return list.whereType<Map<dynamic, dynamic>>().map((p) {
-      final name = p['name'] as String?;
-      final port = p['port'];
-      final nodePort = p['nodePort'];
-      final protocol = (p['protocol'] as String?) ?? 'TCP';
-      final base = nodePort == null ? '$port' : '$port:$nodePort';
-      final body = '$base/$protocol';
-      return name == null || name.isEmpty ? body : '$name:$body';
-    }).join(', ');
+    return list
+        .whereType<Map<dynamic, dynamic>>()
+        .map((p) {
+          final name = p['name'] as String?;
+          final port = p['port'];
+          final nodePort = p['nodePort'];
+          final protocol = (p['protocol'] as String?) ?? 'TCP';
+          final base = nodePort == null ? '$port' : '$port:$nodePort';
+          final body = '$base/$protocol';
+          return name == null || name.isEmpty ? body : '$name:$body';
+        })
+        .join(', ');
   }
 }
 
@@ -91,7 +92,10 @@ class ServiceListScreen extends ConsumerWidget {
             items: rows,
             columns: [
               ResourceColumn(label: 'Name', value: (r) => r.meta.name),
-              ResourceColumn(label: 'Namespace', value: (r) => r.meta.namespace),
+              ResourceColumn(
+                label: 'Namespace',
+                value: (r) => r.meta.namespace,
+              ),
               ResourceColumn(label: 'Type', value: (r) => r.type),
               ResourceColumn(label: 'Cluster IP', value: (r) => r.clusterIP),
               ResourceColumn(label: 'External IP', value: (r) => r.externalIP),
@@ -116,7 +120,7 @@ class ServiceListScreen extends ConsumerWidget {
   }
 }
 
-class ServiceDetailScreen extends ConsumerWidget {
+class ServiceDetailScreen extends ConsumerStatefulWidget {
   const ServiceDetailScreen({
     super.key,
     required this.namespace,
@@ -127,19 +131,46 @@ class ServiceDetailScreen extends ConsumerWidget {
   final String name;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<ServiceDetailScreen> createState() =>
+      _ServiceDetailScreenState();
+}
+
+class _ServiceDetailScreenState extends ConsumerState<ServiceDetailScreen> {
+  // Latches the first observed `isInstalled` mesh status and keeps the
+  // Golden Signals tab visible for the rest of this screen's lifetime,
+  // even if subsequent mesh status polls transiently 5xx and report
+  // `MeshStatus.empty`. See issue #260: without this, an active tab
+  // selection vanishes mid-incident on a passing backend hiccup.
+  //
+  // Trade-off: a deliberate mesh uninstall while the screen is open
+  // still shows the tab until the user navigates away and back. That
+  // surface is rare and self-correcting; tab-flicker on transient 5xx
+  // is the common case and harms operator UX during incidents.
+  MeshStatus? _stableMeshStatus;
+
+  @override
+  Widget build(BuildContext context) {
     final clusterId = ref.watch(activeClusterProvider);
     final getKey = ResourceGetKey(
       clusterId: clusterId,
       kind: 'services',
-      namespace: namespace,
-      name: name,
+      namespace: widget.namespace,
+      name: widget.name,
     );
     final get = ref.watch(resourceGetProvider(getKey));
+
+    // Latch the first non-empty mesh status, then keep subsequent
+    // non-empty updates for fresh data in the tab body. Empty/null
+    // emits are ignored once we've latched, preserving tab visibility.
+    final currentMesh = ref.watch(meshStatusProvider(clusterId)).valueOrNull;
+    if (currentMesh != null && currentMesh.isInstalled) {
+      _stableMeshStatus = currentMesh;
+    }
+
     return get.when(
       loading: () => const Scaffold(body: LoadingState()),
       error: (e, _) => Scaffold(
-        appBar: AppBar(title: Text(name)),
+        appBar: AppBar(title: Text(widget.name)),
         body: ErrorStateView(
           message: e.toString(),
           onRetry: () => ref.invalidate(resourceGetProvider(getKey)),
@@ -152,16 +183,15 @@ class ServiceDetailScreen extends ConsumerWidget {
         // is installed on the cluster. The mesh status drives both tab
         // visibility and (in the tab itself) the mesh disambiguation
         // when both Istio and Linkerd are present.
-        final meshStatus =
-            ref.watch(meshStatusProvider(clusterId)).valueOrNull;
+        final stableMesh = _stableMeshStatus;
         final extraTabs = <DetailExtraTab>[
-          if (meshStatus != null && meshStatus.isInstalled)
+          if (stableMesh != null)
             DetailExtraTab(
               label: 'Golden signals',
               body: GoldenSignalsTab(
                 namespace: s.meta.namespace,
                 service: s.meta.name,
-                status: meshStatus,
+                status: stableMesh,
               ),
             ),
         ];

--- a/mobile/test/features/resources/service_screens_test.dart
+++ b/mobile/test/features/resources/service_screens_test.dart
@@ -1,0 +1,218 @@
+// Lifecycle invariants for ServiceDetailScreen — issue #260.
+//
+// The Golden Signals extraTab is gated on `meshStatusProvider`. Without
+// the latch added in this PR, a transient 5xx on `/v1/mesh/status` flips
+// `MeshStatus` to `empty`, the tab vanishes mid-session, and the user's
+// active selection resets. This test pumps an installed mesh, then
+// invalidates the provider so the mocked endpoint serves an empty
+// response, and asserts the tab survives.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kubecenter/api/dio_client.dart';
+import 'package:kubecenter/api/mesh_repository.dart';
+import 'package:kubecenter/auth/secure_storage.dart';
+import 'package:kubecenter/features/resources/service_screens.dart';
+import 'package:kubecenter/theme/kube_theme_builder.dart';
+
+import '../../support/mock_dio_adapter.dart';
+
+void main() {
+  testWidgets(
+    'Golden signals tab persists when mesh status transiently flips to empty',
+    (tester) async {
+      final mock = MockDioAdapter();
+
+      // Service detail GET — returns once and is cached.
+      mock.onJson(
+        'GET',
+        '/api/v1/resources/services/default/my-svc',
+        body: {
+          'data': {
+            'metadata': {
+              'name': 'my-svc',
+              'namespace': 'default',
+              'uid': 'uid-1',
+            },
+            'spec': {
+              'type': 'ClusterIP',
+              'clusterIP': '10.0.0.1',
+              'ports': [
+                {'name': 'http', 'port': 80, 'protocol': 'TCP'},
+              ],
+            },
+          },
+        },
+      );
+
+      // First mesh status: Istio installed → tab should appear.
+      mock.onJson(
+        'GET',
+        '/api/v1/mesh/status',
+        body: {
+          'data': {
+            'status': {
+              'detected': 'istio',
+              'istio': {'installed': true, 'version': '1.20'},
+              'linkerd': {'installed': false},
+              'lastChecked': '2026-05-16T00:00:00Z',
+            },
+          },
+        },
+      );
+      // Second mesh status (after invalidate): empty → simulates 5xx
+      // recovery returning MeshStatus.empty from the repository.
+      mock.onJson(
+        'GET',
+        '/api/v1/mesh/status',
+        body: {
+          'data': {
+            'status': {
+              'detected': '',
+              'istio': {'installed': false},
+              'linkerd': {'installed': false},
+              'lastChecked': '',
+            },
+          },
+        },
+      );
+
+      final container = ProviderContainer(
+        overrides: [
+          backendUrlProvider.overrideWithValue('http://test'),
+          secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+        ],
+      );
+      addTearDown(container.dispose);
+      container.read(dioProvider).httpClientAdapter = mock;
+      container.read(refreshDioProvider).httpClientAdapter = mock;
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(
+            theme: buildKubeTheme('nexus'),
+            home: const ServiceDetailScreen(
+              namespace: 'default',
+              name: 'my-svc',
+            ),
+          ),
+        ),
+      );
+
+      // Let the resource GET + mesh status complete.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(
+        find.text('Golden signals'),
+        findsOneWidget,
+        reason: 'Tab should appear after first installed mesh status',
+      );
+
+      // Force a refetch — the next mocked response is MeshStatus.empty,
+      // simulating the transient backend hiccup described in #260.
+      container.invalidate(meshStatusProvider('local'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(
+        find.text('Golden signals'),
+        findsOneWidget,
+        reason:
+            'Tab must survive transient mesh status empty — '
+            'a passing 5xx should not vanish an operator\'s active tab.',
+      );
+
+      // Sanity: verify both mesh status calls actually fired.
+      final meshCalls = mock.requests
+          .where((r) => r.path == '/api/v1/mesh/status')
+          .toList();
+      expect(
+        meshCalls.length,
+        greaterThanOrEqualTo(2),
+        reason:
+            'Both initial and post-invalidate mesh status calls should '
+            'have hit the mock adapter',
+      );
+    },
+  );
+
+  testWidgets(
+    'Golden signals tab is absent when mesh has never been observed installed',
+    (tester) async {
+      final mock = MockDioAdapter();
+
+      mock.onJson(
+        'GET',
+        '/api/v1/resources/services/default/my-svc',
+        body: {
+          'data': {
+            'metadata': {
+              'name': 'my-svc',
+              'namespace': 'default',
+              'uid': 'uid-1',
+            },
+            'spec': {
+              'type': 'ClusterIP',
+              'clusterIP': '10.0.0.1',
+              'ports': <dynamic>[],
+            },
+          },
+        },
+      );
+
+      // Mesh status reports empty from the start — no mesh installed.
+      mock.onJson(
+        'GET',
+        '/api/v1/mesh/status',
+        body: {
+          'data': {
+            'status': {
+              'detected': '',
+              'istio': {'installed': false},
+              'linkerd': {'installed': false},
+              'lastChecked': '',
+            },
+          },
+        },
+      );
+
+      final container = ProviderContainer(
+        overrides: [
+          backendUrlProvider.overrideWithValue('http://test'),
+          secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+        ],
+      );
+      addTearDown(container.dispose);
+      container.read(dioProvider).httpClientAdapter = mock;
+      container.read(refreshDioProvider).httpClientAdapter = mock;
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(
+            theme: buildKubeTheme('nexus'),
+            home: const ServiceDetailScreen(
+              namespace: 'default',
+              name: 'my-svc',
+            ),
+          ),
+        ),
+      );
+
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(
+        find.text('Golden signals'),
+        findsNothing,
+        reason: 'Tab should not appear when no mesh has ever been installed',
+      );
+    },
+  );
+}


### PR DESCRIPTION
Closes #260

## Summary

Converts `ServiceDetailScreen` to `ConsumerStatefulWidget` and latches the first observed `isInstalled` mesh status. The Golden Signals `extraTab` no longer vanishes mid-session when `meshStatusProvider` transiently 5xxs and flips to `MeshStatus.empty` (PR #258's intentional graceful-degradation behavior).

**Bug flow before this PR:**

1. Operator opens Service detail → mesh installed → tab visible.
2. Operator selects Golden Signals (`TabController` length 4).
3. Mesh status endpoint hiccups → 503 → `MeshStatus.empty` → `isInstalled` flips false.
4. `extraTabs` recomputes to `[]`, controller length 4 → 3, active tab index resets.

**After this PR:** once an `isInstalled=true` `MeshStatus` is observed, the latched value persists for the screen's lifetime. Subsequent `isInstalled=true` emits refresh the latched value so the tab body sees fresh data. Empty/`isInstalled=false` emits are ignored.

**Trade-off:** a deliberate mesh uninstall while the screen is open shows the tab until the user navigates away and back. That surface is rare and self-correcting; tab-flicker on transient 5xx is the common case and harms operator UX during exactly the incidents where mesh observability matters most. (Matches resolution (a) from the issue.)

Scope is limited to `ServiceDetailScreen` — that's the only `extraTabs` caller in `mobile/lib/features/resources/` that gates on a provider value. Other detail screens (`pod`, `deployment`, `daemonset`, `statefulset`, `node`, `pvc`) all pass unconditional `extraTabs`. Issue #260 mentions PR #256's Diagnose button shares the same `ResourceDetailScaffold.extraTabs` slot, but Diagnose is gated on the static `kDiagnosticsKinds` set, not a reactive provider, so it has no lifecycle bug to fix.

## Test plan

- [x] New widget test verifies the tab survives a forced `meshStatusProvider` invalidation that returns `MeshStatus.empty` on the second response.
- [x] New widget test verifies the tab stays absent when no mesh has ever been observed installed.
- [x] `flutter analyze` clean.
- [x] `flutter test` — all 845 tests pass on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)