### PR TITLE
feat(mobile): mesh policies list screen

### DIFF
--- a/mobile/lib/api/mesh_repository.dart
+++ b/mobile/lib/api/mesh_repository.dart
@@ -936,6 +936,46 @@ final meshMtlsPostureProvider = FutureProvider.autoDispose
       );
 });
 
+/// Family key for the policies list provider. Same shape as
+/// [MeshRoutingKey] — cluster id pins the provider slot to the active
+/// cluster, and the optional namespace lets two open policy screens
+/// with different namespace filters share no state.
+class MeshPoliciesKey {
+  /// Normalise [namespace]: empty string is treated as null so
+  /// `MeshPoliciesKey(clusterId: 'c', namespace: '')` and
+  /// `MeshPoliciesKey(clusterId: 'c')` resolve to the same provider slot.
+  MeshPoliciesKey({required this.clusterId, String? namespace})
+      : namespace = (namespace != null && namespace.isEmpty) ? null : namespace;
+
+  final String clusterId;
+
+  /// null → cluster-wide list. The handler enforces RBAC.
+  final String? namespace;
+
+  @override
+  bool operator ==(Object other) =>
+      other is MeshPoliciesKey &&
+      other.clusterId == clusterId &&
+      other.namespace == namespace;
+
+  @override
+  int get hashCode => Object.hash(clusterId, namespace);
+}
+
+final meshPoliciesProvider = FutureProvider.autoDispose
+    .family<PoliciesResponse, MeshPoliciesKey>((ref, key) async {
+  ref.watch(activeClusterProvider);
+  final cancel = CancelToken();
+  ref.onDispose(() {
+    if (!cancel.isCancelled) cancel.cancel('mesh policies invalidated');
+  });
+  return ref.read(meshRepositoryProvider).listPolicies(
+        namespace: key.namespace,
+        clusterIdOverride: key.clusterId,
+        cancelToken: cancel,
+      );
+});
+
 /// Family key for the golden-signals provider. Carries every parameter
 /// the wire request needs so a service swap on the same screen produces
 /// a fresh cache slot rather than overwriting the prior one.

--- a/mobile/lib/features/mesh/mesh_dashboard_screen.dart
+++ b/mobile/lib/features/mesh/mesh_dashboard_screen.dart
@@ -199,6 +199,12 @@ class _Actions extends StatelessWidget {
             icon: const Icon(Icons.lock_outline),
             label: const Text('mTLS posture'),
           ),
+          OutlinedButton.icon(
+            onPressed: () =>
+                context.push('/clusters/$clusterId/mesh/policies'),
+            icon: const Icon(Icons.policy_outlined),
+            label: const Text('Policies'),
+          ),
         ],
       ),
     );

--- a/mobile/lib/features/mesh/policies_list_screen.dart
+++ b/mobile/lib/features/mesh/policies_list_screen.dart
@@ -1,0 +1,388 @@
+// Policies list — every MeshedPolicy (PeerAuthentication,
+// AuthorizationPolicy, MeshTLSAuthentication, Server, etc.) the active
+// user can read across both meshes. Filter chips for mesh
+// (Both / Istio / Linkerd) and a free-text namespace filter at the top.
+// Partial-fetch error map surfaces as a banner above the list. Mirrors
+// `routing_list_screen.dart` filter and banner strategy.
+//
+// Status gating: `meshStatusProvider` gates the surface — when neither
+// mesh is detected the operator sees `FeatureUnavailableState.mesh()`
+// rather than an empty list with no explanation.
+//
+// No detail tap target today — the per-policy detail screen is deferred.
+// Each row surfaces enough information (kind, mtls mode / action / effect,
+// rule count, selector preview) for operator triage without it.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../api/api_error.dart';
+import '../../api/mesh_repository.dart';
+import '../../cluster/cluster_provider.dart';
+import '../../theme/kube_theme_builder.dart';
+import '../../widgets/feature_unavailable_state.dart';
+import 'mesh_widgets.dart';
+
+enum _MeshFilter { all, istio, linkerd }
+
+class MeshPoliciesListScreen extends ConsumerStatefulWidget {
+  const MeshPoliciesListScreen({super.key, this.initialMesh});
+
+  /// Pre-filter the mesh chip on mount. Dashboard CTAs may seed this
+  /// (Istio card → `?mesh=istio`).
+  final String? initialMesh;
+
+  @override
+  ConsumerState<MeshPoliciesListScreen> createState() =>
+      _MeshPoliciesListScreenState();
+}
+
+class _MeshPoliciesListScreenState
+    extends ConsumerState<MeshPoliciesListScreen> {
+  late _MeshFilter _mesh;
+  String _namespace = '';
+  final _namespaceCtl = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _mesh = switch (widget.initialMesh) {
+      'istio' => _MeshFilter.istio,
+      'linkerd' => _MeshFilter.linkerd,
+      _ => _MeshFilter.all,
+    };
+  }
+
+  @override
+  void dispose() {
+    _namespaceCtl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final clusterId = ref.watch(activeClusterProvider);
+    final statusAsync = ref.watch(meshStatusProvider(clusterId));
+    // Reset mesh filter and namespace text when the user switches
+    // clusters so stale filter state from the previous cluster is cleared.
+    ref.listen<String>(activeClusterProvider, (previous, next) {
+      if (previous != next) {
+        setState(() {
+          _mesh = _MeshFilter.all;
+          _namespace = '';
+          _namespaceCtl.clear();
+        });
+      }
+    });
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Mesh Policies')),
+      body: statusAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Text(e.toString()),
+          ),
+        ),
+        data: (status) {
+          if (!status.isInstalled) return FeatureUnavailableState.mesh();
+          return _PoliciesBody(
+            clusterId: clusterId,
+            mesh: _mesh,
+            namespace: _namespace,
+            namespaceCtl: _namespaceCtl,
+            onMeshChanged: (v) => setState(() => _mesh = v),
+            onNamespaceChanged: (v) => setState(() => _namespace = v),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _PoliciesBody extends ConsumerWidget {
+  const _PoliciesBody({
+    required this.clusterId,
+    required this.mesh,
+    required this.namespace,
+    required this.namespaceCtl,
+    required this.onMeshChanged,
+    required this.onNamespaceChanged,
+  });
+
+  final String clusterId;
+  final _MeshFilter mesh;
+  final String namespace;
+  final TextEditingController namespaceCtl;
+  final ValueChanged<_MeshFilter> onMeshChanged;
+  final ValueChanged<String> onNamespaceChanged;
+
+  MeshPoliciesKey get _key => MeshPoliciesKey(
+    clusterId: clusterId,
+    namespace: namespace.isEmpty ? null : namespace,
+  );
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final async = ref.watch(meshPoliciesProvider(_key));
+
+    Future<void> handleRefresh() async {
+      ref.invalidate(meshPoliciesProvider(_key));
+      try {
+        await ref.read(meshPoliciesProvider(_key).future);
+      } on Object {
+        // surfaces via .when error branch
+      }
+    }
+
+    return RefreshIndicator(
+      onRefresh: handleRefresh,
+      child: async.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => _errorShell(e, handleRefresh, colors),
+        data: (response) {
+          final filtered = _applyMeshFilter(response.policies);
+          return CustomScrollView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            slivers: [
+              SliverToBoxAdapter(
+                child: Column(
+                  children: [
+                    _FilterStrip(
+                      mesh: mesh,
+                      namespaceCtl: namespaceCtl,
+                      onMeshChanged: onMeshChanged,
+                      onNamespaceChanged: onNamespaceChanged,
+                    ),
+                    MeshErrorsBanner(errors: response.errors),
+                  ],
+                ),
+              ),
+              if (filtered.isEmpty)
+                SliverToBoxAdapter(
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 16,
+                      vertical: 32,
+                    ),
+                    child: Center(
+                      child: Text(
+                        response.policies.isEmpty
+                            ? 'No mesh policies. Apply a '
+                                  'PeerAuthentication, AuthorizationPolicy, '
+                                  'or similar to see entries here.'
+                            : 'No policies match the current filters.',
+                        style: TextStyle(color: colors.textMuted),
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                  ),
+                )
+              else
+                SliverList(
+                  delegate: SliverChildBuilderDelegate(
+                    (context, index) => _PolicyRow(policy: filtered[index]),
+                    childCount: filtered.length,
+                  ),
+                ),
+              const SliverPadding(padding: EdgeInsets.only(bottom: 8)),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  List<MeshedPolicy> _applyMeshFilter(List<MeshedPolicy> policies) {
+    return policies.where((p) {
+      if (mesh == _MeshFilter.istio && p.mesh != 'istio') return false;
+      if (mesh == _MeshFilter.linkerd && p.mesh != 'linkerd') return false;
+      return true;
+    }).toList();
+  }
+
+  Widget _errorShell(Object e, Future<void> Function() retry, KubeColors c) {
+    return ListView(
+      physics: const AlwaysScrollableScrollPhysics(),
+      children: [
+        SizedBox(
+          height: 280,
+          child: Center(
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    'Failed to load mesh policies',
+                    style: TextStyle(
+                      color: c.textPrimary,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    e is ApiError ? e.message : e.toString(),
+                    style: TextStyle(color: c.textMuted),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 12),
+                  OutlinedButton(onPressed: retry, child: const Text('Retry')),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _FilterStrip extends StatelessWidget {
+  const _FilterStrip({
+    required this.mesh,
+    required this.namespaceCtl,
+    required this.onMeshChanged,
+    required this.onNamespaceChanged,
+  });
+
+  final _MeshFilter mesh;
+  final TextEditingController namespaceCtl;
+  final ValueChanged<_MeshFilter> onMeshChanged;
+  final ValueChanged<String> onNamespaceChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Wrap(
+            spacing: 6,
+            runSpacing: 4,
+            children: [
+              for (final value in _MeshFilter.values)
+                ChoiceChip(
+                  label: Text(switch (value) {
+                    _MeshFilter.all => 'Both meshes',
+                    _MeshFilter.istio => 'Istio',
+                    _MeshFilter.linkerd => 'Linkerd',
+                  }),
+                  selected: value == mesh,
+                  onSelected: (_) => onMeshChanged(value),
+                ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          TextField(
+            controller: namespaceCtl,
+            decoration: InputDecoration(
+              prefixIcon: const Icon(Icons.folder_outlined, size: 18),
+              labelText: 'Namespace filter',
+              hintText: 'Empty = all namespaces',
+              hintStyle: TextStyle(color: colors.textMuted, fontSize: 12),
+              isDense: true,
+            ),
+            onSubmitted: onNamespaceChanged,
+            onChanged: (v) {
+              // Debounce-light: only refetch on Enter via onSubmitted.
+              // Free-text edits update local state but don't refire the
+              // provider; otherwise every keystroke would trigger a fetch.
+              if (v.isEmpty) onNamespaceChanged('');
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PolicyRow extends StatelessWidget {
+  const _PolicyRow({required this.policy});
+
+  final MeshedPolicy policy;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final statusLabel = _statusLabel(policy);
+    final statusColor = meshStateColor(colors, statusLabel);
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  policy.name,
+                  style: TextStyle(
+                    color: colors.textPrimary,
+                    fontWeight: FontWeight.w600,
+                    fontSize: 15,
+                  ),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              MeshPill(
+                label: meshDisplayName(policy.mesh),
+                color: colors.accent,
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  policy.namespace.isEmpty
+                      ? policy.kind
+                      : '${policy.kind} · ${policy.namespace}',
+                  style: TextStyle(color: colors.textMuted, fontSize: 12),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              if (statusLabel != null) ...[
+                const SizedBox(width: 8),
+                MeshPill(label: statusLabel, color: statusColor),
+              ],
+              if (policy.ruleCount > 0) ...[
+                const SizedBox(width: 6),
+                MeshMutedBadge(
+                  label:
+                      '${policy.ruleCount} rule${policy.ruleCount == 1 ? '' : 's'}',
+                ),
+              ],
+            ],
+          ),
+          if (policy.selector != null && policy.selector!.isNotEmpty) ...[
+            const SizedBox(height: 4),
+            Text(
+              policy.selector!,
+              style: TextStyle(color: colors.textSecondary, fontSize: 11),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ],
+          Divider(color: colors.borderSubtle, height: 18),
+        ],
+      ),
+    );
+  }
+
+  // PeerAuthentication policies carry an mTLS mode; AuthorizationPolicy
+  // carries an action (and optionally a backend-computed effect — prefer
+  // the more specific action). Everything else has no top-level status
+  // worth a pill.
+  String? _statusLabel(MeshedPolicy p) {
+    if (p.mtlsMode != null && p.mtlsMode!.isNotEmpty) return p.mtlsMode;
+    if (p.action != null && p.action!.isNotEmpty) return p.action;
+    if (p.effect != null && p.effect!.isNotEmpty) return p.effect;
+    return null;
+  }
+}

--- a/mobile/lib/routing/app_router.dart
+++ b/mobile/lib/routing/app_router.dart
@@ -34,6 +34,7 @@ import '../features/gitops/applicationset_detail_screen.dart';
 import '../features/gitops/applicationsets_list_screen.dart';
 import '../features/mesh/mesh_dashboard_screen.dart';
 import '../features/mesh/mtls_posture_screen.dart';
+import '../features/mesh/policies_list_screen.dart';
 import '../features/mesh/route_detail_screen.dart';
 import '../features/mesh/routing_list_screen.dart';
 import '../features/observability/diagnostics/diagnostics_screen.dart';
@@ -234,6 +235,12 @@ final appRouterProvider = Provider<GoRouter>((ref) {
             path: 'mtls',
             builder: (context, state) => MeshMtlsPostureScreen(
               initialNamespace: state.uri.queryParameters['namespace'],
+            ),
+          ),
+          GoRoute(
+            path: 'policies',
+            builder: (context, state) => MeshPoliciesListScreen(
+              initialMesh: state.uri.queryParameters['mesh'],
             ),
           ),
         ],

--- a/mobile/lib/routing/domain_sections.dart
+++ b/mobile/lib/routing/domain_sections.dart
@@ -190,12 +190,14 @@ const List<DomainSection> domainSections = [
       ),
     ],
   ),
-  // Service mesh surfaces (PR-4f). Three entries:
+  // Service mesh surfaces (PR-4f, policies in #259). Four entries:
   //   * Mesh dashboard — Istio + Linkerd side-by-side status cards.
   //   * Routing — list of every TrafficRoute across both meshes.
   //   * mTLS posture — per-namespace workload encryption state.
+  //   * Policies — list of every MeshedPolicy (PeerAuthentication,
+  //     AuthorizationPolicy, MeshTLSAuthentication, Server, etc.).
   // Golden signals tab is rendered inline on Service detail screens
-  // rather than as a drawer entry. All three surfaces gate on
+  // rather than as a drawer entry. All four surfaces gate on
   // `meshStatusProvider` and fall back to
   // `FeatureUnavailableState.mesh()` when neither mesh is installed.
   DomainSection(
@@ -223,6 +225,13 @@ const List<DomainSection> domainSections = [
         icon: Icons.lock_outline,
         namespaced: false,
         customListPath: '/clusters/{clusterId}/mesh/mtls',
+      ),
+      DomainKind(
+        kind: 'policies',
+        label: 'Policies',
+        icon: Icons.policy_outlined,
+        namespaced: false,
+        customListPath: '/clusters/{clusterId}/mesh/policies',
       ),
     ],
   ),

--- a/mobile/test/features/mesh/policies_list_screen_test.dart
+++ b/mobile/test/features/mesh/policies_list_screen_test.dart
@@ -1,0 +1,201 @@
+// Widget tests for MeshPoliciesListScreen (#259).
+//
+// Coverage mirrors routing_list_screen_test.dart:
+//   * Empty policies set renders guidance copy.
+//   * Mixed Istio + Linkerd rows render with the right status pills.
+//   * Mesh filter chip narrows the list.
+//   * Partial-failure errors map renders a banner above the list.
+//   * Not-detected status falls back to FeatureUnavailableState.mesh().
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:kubecenter/api/dio_client.dart';
+import 'package:kubecenter/auth/secure_storage.dart';
+import 'package:kubecenter/features/mesh/policies_list_screen.dart';
+import 'package:kubecenter/theme/kube_theme_builder.dart';
+
+import '../../support/mock_dio_adapter.dart';
+
+Future<void> _pump(WidgetTester tester, MockDioAdapter mock) async {
+  final router = GoRouter(
+    initialLocation: '/',
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (context, state) => const MeshPoliciesListScreen(),
+      ),
+    ],
+  );
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        backendUrlProvider.overrideWithValue('http://test'),
+        secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+      ],
+      child: _DioInstaller(
+        mock: mock,
+        child: MaterialApp.router(
+          theme: buildKubeTheme('nexus'),
+          routerConfig: router,
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+  await tester.pumpAndSettle(const Duration(milliseconds: 200));
+}
+
+class _DioInstaller extends ConsumerWidget {
+  const _DioInstaller({required this.mock, required this.child});
+
+  final MockDioAdapter mock;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.read(dioProvider).httpClientAdapter = mock;
+    return child;
+  }
+}
+
+Map<String, Object?> _statusBoth() => {
+  'data': {
+    'status': {
+      'detected': 'both',
+      'istio': {'installed': true},
+      'linkerd': {'installed': true},
+    },
+  },
+};
+
+Map<String, Object?> _statusNotDetected() => {
+  'data': {
+    'status': {
+      'detected': '',
+      'istio': {'installed': false},
+      'linkerd': {'installed': false},
+    },
+  },
+};
+
+Map<String, Object?> _emptyPolicies() => {
+  'data': {
+    'status': {
+      'detected': 'both',
+      'istio': {'installed': true},
+      'linkerd': {'installed': true},
+    },
+    'policies': <Map<String, Object?>>[],
+  },
+};
+
+Map<String, Object?> _twoPoliciesWithErrors() => {
+  'data': {
+    'status': {
+      'detected': 'both',
+      'istio': {'installed': true},
+      'linkerd': {'installed': true},
+    },
+    'policies': [
+      {
+        'id': 'istio:app:pa:strict-mtls',
+        'mesh': 'istio',
+        'kind': 'PeerAuthentication',
+        'name': 'strict-mtls',
+        'namespace': 'app',
+        'mtlsMode': 'STRICT',
+        'selector': 'app=web',
+        'ruleCount': 1,
+      },
+      {
+        'id': 'linkerd:app:mtls:require-mtls',
+        'mesh': 'linkerd',
+        'kind': 'MeshTLSAuthentication',
+        'name': 'require-mtls',
+        'namespace': 'app',
+        'ruleCount': 0,
+      },
+    ],
+    'errors': {'istio/AuthorizationPolicy': 'forbidden'},
+  },
+};
+
+void main() {
+  testWidgets('not-detected falls back to FeatureUnavailableState.mesh()', (
+    tester,
+  ) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/mesh/status', body: _statusNotDetected())
+      ..onJson('GET', '/api/v1/mesh/policies', body: _emptyPolicies());
+
+    await _pump(tester, mock);
+
+    expect(find.textContaining('service mesh'), findsOneWidget);
+  });
+
+  testWidgets('empty policies shows guidance copy', (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/mesh/status', body: _statusBoth())
+      ..onJson('GET', '/api/v1/mesh/policies', body: _emptyPolicies());
+
+    await _pump(tester, mock);
+
+    expect(find.textContaining('No mesh policies'), findsOneWidget);
+  });
+
+  testWidgets('renders rows + partial-failure banner', (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/mesh/status', body: _statusBoth())
+      ..onJson('GET', '/api/v1/mesh/policies', body: _twoPoliciesWithErrors());
+
+    await _pump(tester, mock);
+
+    // Policy names visible.
+    expect(find.text('strict-mtls'), findsOneWidget);
+    expect(find.text('require-mtls'), findsOneWidget);
+    // Kind + namespace combined line.
+    expect(find.textContaining('PeerAuthentication'), findsOneWidget);
+    expect(find.textContaining('MeshTLSAuthentication'), findsOneWidget);
+    // mTLS mode pill from the PeerAuthentication row.
+    expect(find.text('STRICT'), findsOneWidget);
+    // Selector preview from the PeerAuthentication row.
+    expect(find.text('app=web'), findsOneWidget);
+    // Rule count badge: only the PA row has ruleCount=1.
+    expect(find.textContaining('1 rule'), findsOneWidget);
+    // Partial-failure banner.
+    expect(find.textContaining('istio/AuthorizationPolicy'), findsOneWidget);
+  });
+
+  testWidgets('mesh filter chip narrows visible rows', (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/mesh/status', body: _statusBoth())
+      ..onJson('GET', '/api/v1/mesh/policies', body: _twoPoliciesWithErrors());
+
+    await _pump(tester, mock);
+
+    final istioChip = find.widgetWithText(ChoiceChip, 'Istio');
+    expect(istioChip, findsOneWidget);
+    await tester.tap(istioChip);
+    await tester.pumpAndSettle();
+
+    // After selecting Istio chip: only the Istio policy remains.
+    expect(find.text('strict-mtls'), findsOneWidget);
+    expect(find.text('require-mtls'), findsNothing);
+
+    final istioChipWidget = tester.widget<ChoiceChip>(
+      find.widgetWithText(ChoiceChip, 'Istio'),
+    );
+    expect(
+      istioChipWidget.selected,
+      isTrue,
+      reason: 'Istio ChoiceChip should be selected after tap',
+    );
+
+    final linkerdChipWidget = tester.widget<ChoiceChip>(
+      find.widgetWithText(ChoiceChip, 'Linkerd'),
+    );
+    expect(linkerdChipWidget.selected, isFalse);
+  });
+}


### PR DESCRIPTION
Closes #259

## Summary

Activates the dead `MeshedPolicy` + `PoliciesResponse` + `listPolicies()` wire types that PR #258 (M4 PR-4f) shipped without a consumer. ~100 lines of tested-but-unreachable code accumulates wire-format drift risk — if the backend changes the policy struct shape, mobile tests exercising the model in isolation keep passing while the real surface silently parses wrong values once a screen ships. This PR makes it reachable.

**Added:**

- `MeshPoliciesKey` + `meshPoliciesProvider` in `mesh_repository.dart`. Same shape as `MeshRoutingKey` / `meshRoutingProvider` — cluster id pins the slot, optional namespace lets two open screens with different filters share no state.
- `MeshPoliciesListScreen` in `features/mesh/policies_list_screen.dart` mirroring the M4 pattern from `routing_list_screen.dart`:
  - Status gating via `meshStatusProvider` → `FeatureUnavailableState.mesh()` when neither mesh is installed.
  - Mesh filter chips (Both / Istio / Linkerd) + namespace text filter.
  - Partial-failure errors banner via `MeshErrorsBanner`.
  - Pull-to-refresh.
  - Per-row card surfacing kind + namespace + status pill (mtlsMode for `PeerAuthentication`, action for `AuthorizationPolicy`, effect as fallback), rule count badge, and selector preview.
- Route `/clusters/:clusterId/mesh/policies[?mesh=istio]` under the existing `/mesh` route tree.
- "Policies" CTA on the mesh dashboard's action wrap alongside Routing rules and mTLS posture.
- Drawer entry under the Service Mesh section.

**Out of scope:** per-policy detail screen. Each row surfaces enough information (kind, mtls mode / action / effect, rule count, selector preview) for operator triage without it; this can ship in a follow-up when there's an actual flow that benefits.

No backend changes — this is purely a mobile read-side activation against the existing `/v1/mesh/policies` endpoint.

## Test plan

- [x] Four widget tests in `mobile/test/features/mesh/policies_list_screen_test.dart` cover:
  - Not-detected status falls back to `FeatureUnavailableState.mesh()`.
  - Empty policies set renders guidance copy.
  - Mixed Istio + Linkerd rows render with mTLS mode pill, selector preview, rule count badge, and partial-failure banner.
  - Mesh filter chip narrows visible rows to one mesh.
- [x] `flutter analyze` clean.
- [x] `flutter test` — all 847 tests pass on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)