### PR TITLE
feat(backend): M5 PR-5b — OIDC body-mode mobile-exchange endpoint + 1h refresh TTL cap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,7 @@ k8scenter/
 - **Tailwind CSS utility-only.** No custom CSS class names. Theme via CSS custom properties (`var(--accent)`, `var(--success)`, etc.) — no hardcoded color classes.
 
 ### Security
-- **JWT: 15 min access + 7 day refresh.** Refresh tokens server-side (httpOnly cookie).
+- **JWT: 15 min access. Refresh: 7 day (local/LDAP) or 1 hour (OIDC).** The shorter OIDC window propagates IdP revocation (account disabled, group removed) within the hour rather than waiting for the standard 7-day rotation cycle. See `backend/internal/auth/jwt.go` `OIDCRefreshTokenLifetime`. Refresh tokens stored server-side (httpOnly cookie for web, body-mode for mobile).
 - **Secrets masked in API responses.** Reveal requires explicit action + audit log.
 - **CSP headers, NetworkPolicy, Pod Security Standards (restricted profile).**
 - **Audit logging for all write operations.** PostgreSQL-backed, 90-day retention.

--- a/backend/internal/auth/jwt.go
+++ b/backend/internal/auth/jwt.go
@@ -12,11 +12,33 @@ import (
 const (
 	// AccessTokenLifetime is the duration an access token is valid.
 	AccessTokenLifetime = 15 * time.Minute
-	// RefreshTokenLifetime is the duration a refresh token is valid.
+	// RefreshTokenLifetime is the duration a refresh token is valid for
+	// local + LDAP providers.
 	RefreshTokenLifetime = 7 * 24 * time.Hour
+	// OIDCRefreshTokenLifetime caps refresh tokens issued for OIDC-sourced
+	// sessions. The shorter window means IdP-side revocation (account
+	// disabled, group removed) takes effect within the hour rather than
+	// waiting for the full 7-day rotation cycle.
+	//
+	// The alternative — re-validating each refresh against the IdP's
+	// revocation_endpoint — would require persisting the IdP refresh token,
+	// add per-refresh IdP latency, and tie the platform's availability to
+	// the IdP's. The 1h cap is a pragmatic middle ground: documented as the
+	// session-lifetime guarantee for OIDC users.
+	OIDCRefreshTokenLifetime = 1 * time.Hour
 	// RefreshTokenBytes is the length of random refresh tokens.
 	RefreshTokenBytes = 32
 )
+
+// RefreshLifetimeFor returns the refresh token TTL for a given auth
+// provider. OIDC sessions get the shorter cap; everything else gets the
+// standard window.
+func RefreshLifetimeFor(provider string) time.Duration {
+	if provider == "oidc" {
+		return OIDCRefreshTokenLifetime
+	}
+	return RefreshTokenLifetime
+}
 
 // TokenClaims are the JWT claims for access tokens.
 type TokenClaims struct {

--- a/backend/internal/auth/jwt_test.go
+++ b/backend/internal/auth/jwt_test.go
@@ -123,3 +123,27 @@ func TestRefreshTokenLifetime(t *testing.T) {
 		t.Errorf("expected 7 day lifetime, got %v", RefreshTokenLifetime)
 	}
 }
+
+// TestRefreshLifetimeFor asserts the provider-aware refresh TTL switch:
+// OIDC sessions are capped at the shorter [OIDCRefreshTokenLifetime] so
+// IdP-side revocation propagates within the hour; everything else (local,
+// LDAP, future credential providers via the default branch) keeps the
+// standard [RefreshTokenLifetime] window.
+func TestRefreshLifetimeFor(t *testing.T) {
+	cases := []struct {
+		provider string
+		want     time.Duration
+	}{
+		{"oidc", OIDCRefreshTokenLifetime},
+		{"local", RefreshTokenLifetime},
+		{"ldap", RefreshTokenLifetime},
+	}
+	for _, tc := range cases {
+		t.Run(tc.provider, func(t *testing.T) {
+			got := RefreshLifetimeFor(tc.provider)
+			if got != tc.want {
+				t.Errorf("RefreshLifetimeFor(%q) = %v, want %v", tc.provider, got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/auth/oidc.go
+++ b/backend/internal/auth/oidc.go
@@ -23,6 +23,14 @@ import (
 // that references auth.OIDCProviderConfig.
 type OIDCProviderConfig = config.OIDCConfig
 
+// ErrOIDCNonceMismatch is the canonical error message returned when an ID
+// token's `nonce` claim does not match the value the client committed at
+// auth-request time. Shared between the web callback and mobile-exchange
+// paths so the audit classifier and error mapper can match by exact string
+// (cheaper and less brittle than substring matching). Exported so the
+// server package can reference the same literal when categorizing errors.
+const ErrOIDCNonceMismatch = "oidc id token nonce mismatch"
+
 // OIDCProvider wraps the go-oidc provider and oauth2 config for a single OIDC identity provider.
 type OIDCProvider struct {
 	Config       OIDCProviderConfig
@@ -170,7 +178,7 @@ func (p *OIDCProvider) HandleCallback(ctx context.Context, code string, flowStat
 
 	// Validate nonce (go-oidc does NOT validate this automatically)
 	if idToken.Nonce != flowState.Nonce {
-		return nil, fmt.Errorf("ID token nonce mismatch")
+		return nil, fmt.Errorf("%s", ErrOIDCNonceMismatch)
 	}
 
 	// Extract claims

--- a/backend/internal/auth/oidc_mobile.go
+++ b/backend/internal/auth/oidc_mobile.go
@@ -2,11 +2,19 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/url"
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"golang.org/x/oauth2"
 )
+
+// ErrOIDCExchangeTimeout is the canonical error message returned when the
+// authorization-code exchange to the IdP times out (context deadline or
+// transport-level Timeout). Distinct from a 4xx IdP rejection so the
+// caller can map it to 503 (retry) rather than 401 (re-auth).
+const ErrOIDCExchangeTimeout = "oidc token exchange timeout"
 
 // ExchangeMobile is the mobile counterpart to [OIDCProvider.HandleCallback].
 //
@@ -42,6 +50,15 @@ func (p *OIDCProvider) ExchangeMobile(ctx context.Context, code, codeVerifier, e
 
 	oauth2Token, err := p.oauth2Config.Exchange(exchangeCtx, code, oauth2.VerifierOption(codeVerifier))
 	if err != nil {
+		// Distinguish transport timeout from an IdP-side rejection so the
+		// HTTP layer can choose 503 (retry) over 401 (re-auth). Both
+		// context.DeadlineExceeded and net/url.Error.Timeout() count as
+		// timeouts here; net errors from the custom httpClient surface
+		// through the latter.
+		var urlErr *url.Error
+		if errors.Is(err, context.DeadlineExceeded) || (errors.As(err, &urlErr) && urlErr.Timeout()) {
+			return nil, fmt.Errorf("%s: %w", ErrOIDCExchangeTimeout, err)
+		}
 		return nil, fmt.Errorf("token exchange failed: %w", err)
 	}
 
@@ -60,7 +77,7 @@ func (p *OIDCProvider) ExchangeMobile(ctx context.Context, code, codeVerifier, e
 
 	// Validate nonce. go-oidc does not validate this automatically.
 	if idToken.Nonce != expectedNonce {
-		return nil, fmt.Errorf("oidc id token nonce mismatch")
+		return nil, fmt.Errorf("%s", ErrOIDCNonceMismatch)
 	}
 
 	var claims oidcClaims

--- a/backend/internal/auth/oidc_mobile.go
+++ b/backend/internal/auth/oidc_mobile.go
@@ -1,0 +1,89 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"golang.org/x/oauth2"
+)
+
+// ExchangeMobile is the mobile counterpart to [OIDCProvider.HandleCallback].
+//
+// Mobile clients generate the PKCE verifier and nonce client-side per
+// RFC 8252 (Native OAuth Apps). The orchestrator opens the IdP authorization
+// URL inside a Custom-Tab / SFSafariViewController, intercepts the redirect
+// via Universal Link / App Link, validates `state` against its own CSRF
+// token, and POSTs `{code, state, codeVerifier, nonce}` to the body-mode
+// exchange endpoint. This method runs the equivalent of HandleCallback —
+// token exchange, ID-token verification, claim mapping — but sources the
+// verifier and nonce from method parameters instead of the server-side
+// [OIDCFlowState] store.
+//
+// State is NOT re-validated here; it is the mobile client's CSRF token and
+// only meaningful to the client. The expectedNonce IS validated against
+// the ID token's `nonce` claim — closing the ID-token-replay window that
+// PKCE alone does not cover.
+func (p *OIDCProvider) ExchangeMobile(ctx context.Context, code, codeVerifier, expectedNonce string) (*User, error) {
+	if code == "" {
+		return nil, fmt.Errorf("code required")
+	}
+	if codeVerifier == "" {
+		return nil, fmt.Errorf("codeVerifier required")
+	}
+	if expectedNonce == "" {
+		return nil, fmt.Errorf("nonce required")
+	}
+
+	// Inject the provider-specific HTTP client (custom CA, TLS overrides)
+	// into the exchange context. Without this, Exchange falls back to
+	// http.DefaultClient and silently ignores CACertPath / TLSInsecure.
+	exchangeCtx := oidc.ClientContext(ctx, p.httpClient)
+
+	oauth2Token, err := p.oauth2Config.Exchange(exchangeCtx, code, oauth2.VerifierOption(codeVerifier))
+	if err != nil {
+		return nil, fmt.Errorf("token exchange failed: %w", err)
+	}
+
+	rawIDToken, ok := oauth2Token.Extra("id_token").(string)
+	if !ok {
+		return nil, fmt.Errorf("no id_token in token response")
+	}
+
+	// Full ID token verification: signature, issuer, audience, expiry. Do
+	// NOT decode the JWT manually — Verify() is the only path that runs
+	// the cryptographic checks.
+	idToken, err := p.verifier.Verify(ctx, rawIDToken)
+	if err != nil {
+		return nil, fmt.Errorf("ID token verification failed: %w", err)
+	}
+
+	// Validate nonce. go-oidc does not validate this automatically.
+	if idToken.Nonce != expectedNonce {
+		return nil, fmt.Errorf("oidc id token nonce mismatch")
+	}
+
+	var claims oidcClaims
+	if err := idToken.Claims(&claims); err != nil {
+		return nil, fmt.Errorf("extracting claims: %w", err)
+	}
+
+	// Reject unverified emails when using email as the username claim.
+	// Identity-spoofing prevention — same rule as HandleCallback.
+	if p.Config.UsernameClaim == "email" && claims.Email != "" && !claims.EmailVerified {
+		return nil, fmt.Errorf("email address not verified by identity provider")
+	}
+
+	groups := p.extractGroups(idToken)
+
+	user := p.mapClaimsToUser(&claims, groups, idToken.Subject)
+	if user == nil {
+		return nil, fmt.Errorf("failed to map OIDC claims to user")
+	}
+
+	if len(p.Config.AllowedDomains) > 0 && !p.isAllowedDomain(claims.Email) {
+		return nil, fmt.Errorf("email domain not allowed")
+	}
+
+	return user, nil
+}

--- a/backend/internal/auth/oidc_mobile_test.go
+++ b/backend/internal/auth/oidc_mobile_test.go
@@ -1,0 +1,47 @@
+package auth
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestOIDCProvider_ExchangeMobile_InputValidation covers the pre-network
+// validation in ExchangeMobile. Empty code / codeVerifier / nonce must
+// short-circuit before any IdP round-trip — otherwise an unauthenticated
+// caller can probe IdP error envelopes.
+//
+// The happy-path branches (real oauth2 Exchange, ID token verify, claim
+// mapping) require a full mock IdP and are exercised by manual smoke
+// against the homelab Authelia in U2's Verification step, matching the
+// existing HandleCallback test posture.
+func TestOIDCProvider_ExchangeMobile_InputValidation(t *testing.T) {
+	p := &OIDCProvider{
+		Config: OIDCProviderConfig{ID: "test"},
+	}
+	ctx := context.Background()
+
+	cases := []struct {
+		name         string
+		code         string
+		codeVerifier string
+		nonce        string
+		wantErr      string
+	}{
+		{"empty code", "", "v", "n", "code required"},
+		{"empty verifier", "abc", "", "n", "codeVerifier required"},
+		{"empty nonce", "abc", "v", "", "nonce required"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := p.ExchangeMobile(ctx, tc.code, tc.codeVerifier, tc.nonce)
+			if err == nil {
+				t.Fatalf("expected error for %q, got nil", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("expected error containing %q, got %q", tc.wantErr, err.Error())
+			}
+		})
+	}
+}

--- a/backend/internal/auth/session.go
+++ b/backend/internal/auth/session.go
@@ -72,6 +72,17 @@ func (s *SessionStore) Revoke(token string) {
 	s.sessions.Delete(token)
 }
 
+// RangeSessions iterates stored sessions, invoking fn for each. fn returns
+// false to stop iteration. Exposed for tests that need to inspect stored
+// expiry values without consuming the token via Validate (which is single-
+// use and would also strip the row). Production callers should prefer
+// Validate / Revoke.
+func (s *SessionStore) RangeSessions(fn func(RefreshSession) bool) {
+	s.sessions.Range(func(_, val any) bool {
+		return fn(val.(RefreshSession))
+	})
+}
+
 // StartCleanup runs a background goroutine to evict expired sessions.
 func (s *SessionStore) StartCleanup(ctx context.Context, interval time.Duration) {
 	go func() {

--- a/backend/internal/server/handle_auth.go
+++ b/backend/internal/server/handle_auth.go
@@ -63,7 +63,7 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	accessToken, _, err := s.issueTokenPair(w, user)
+	accessToken, _, err := s.issueTokenPair(w, user, true /* cookieMode */)
 	if err != nil {
 		s.Logger.Error("failed to issue tokens", "error", err)
 		writeJSON(w, http.StatusInternalServerError, api.Response{
@@ -137,7 +137,10 @@ func (s *Server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	accessToken, newRefreshToken, err := s.issueTokenPair(w, user)
+	// In body-mode (mobile) we skip setting the cookie — the new refresh
+	// token is echoed in the JSON response. In cookie-mode (web) we keep
+	// the existing httpOnly cookie behaviour.
+	accessToken, newRefreshToken, err := s.issueTokenPair(w, user, !bodyMode)
 	if err != nil {
 		s.Logger.Error("failed to issue tokens", "error", err)
 		writeJSON(w, http.StatusInternalServerError, api.Response{
@@ -265,8 +268,8 @@ func (s *Server) handleOIDCCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Issue k8sCenter JWT + refresh cookie
-	accessToken, _, err := s.issueTokenPair(w, user)
+	// Issue k8sCenter JWT + refresh cookie (web redirect flow → cookie-mode)
+	accessToken, _, err := s.issueTokenPair(w, user, true /* cookieMode */)
 	if err != nil {
 		s.Logger.Error("failed to issue tokens after OIDC callback", "error", err)
 		http.Redirect(w, r, "/login?error=token_failed", http.StatusFound)

--- a/backend/internal/server/handle_auth.go
+++ b/backend/internal/server/handle_auth.go
@@ -157,6 +157,12 @@ func (s *Server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 	}
 	if bodyMode {
 		respData["refreshToken"] = newRefreshToken
+		// Mirror the mobile-exchange response shape so mobile clients can
+		// schedule their next refresh without re-deriving the TTL. Cookie-
+		// mode callers learn the lifetime from the Set-Cookie Max-Age and
+		// shouldn't need to read it from the JSON body, so we keep the web
+		// shape unchanged.
+		respData["refreshExpiresIn"] = int(auth.RefreshLifetimeFor(user.Provider).Seconds())
 	}
 	writeJSON(w, http.StatusOK, api.Response{Data: respData})
 }

--- a/backend/internal/server/handle_auth_test.go
+++ b/backend/internal/server/handle_auth_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/kubecenter/kubecenter/internal/audit"
 	"github.com/kubecenter/kubecenter/internal/auth"
@@ -395,6 +396,115 @@ func TestHandleRefresh_BodyMode(t *testing.T) {
 	}
 	if resp.Data.RefreshToken == refreshToken {
 		t.Error("rotated refresh token should differ from original")
+	}
+}
+
+// TestHandleRefresh_BodyMode_NoSetCookie confirms the body-mode refresh
+// path does NOT echo a `refresh_token` cookie back to mobile callers (PR-5b
+// wire-format guarantee). The rotated refresh token must arrive in the JSON
+// body only — web cookie semantics would be a no-op for mobile clients and
+// surface as a confusing duplicate to operators reading raw HTTP traces.
+func TestHandleRefresh_BodyMode_NoSetCookie(t *testing.T) {
+	srv := testServer(t)
+	_, cookies := loginAdmin(t, srv)
+
+	var refreshToken string
+	for _, c := range cookies {
+		if c.Name == "refresh_token" {
+			refreshToken = c.Value
+		}
+	}
+	if refreshToken == "" {
+		t.Fatalf("login did not return refresh_token cookie")
+	}
+
+	body := `{"refreshToken":"` + refreshToken + `"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/refresh", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Requested-With", "XMLHttpRequest")
+	w := httptest.NewRecorder()
+
+	srv.Router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	for _, c := range w.Result().Cookies() {
+		if c.Name == "refresh_token" && c.Value != "" {
+			t.Errorf("body-mode refresh must not set a refresh_token cookie; got %+v", c)
+		}
+	}
+}
+
+// TestIssueTokenPair_OIDCRefreshLifetime asserts the session row stored by
+// issueTokenPair carries the provider-aware refresh TTL: OIDC sessions get
+// the 1h cap, local sessions get the 7d default. Drift here silently
+// extends the IdP revocation window — the change that motivated PR-5b — so
+// the test reads the stored ExpiresAt directly instead of inferring it
+// from cookie Max-Age (which is absent in body-mode).
+func TestIssueTokenPair_OIDCRefreshLifetime(t *testing.T) {
+	cases := []struct {
+		name     string
+		user     *auth.User
+		wantTTL  time.Duration
+		tolerance time.Duration
+	}{
+		{
+			name:      "oidc user gets 1h cap",
+			user:      &auth.User{ID: "oidc:authelia:sub-1", Username: "u@example.com", Provider: "oidc"},
+			wantTTL:   auth.OIDCRefreshTokenLifetime,
+			tolerance: 5 * time.Second,
+		},
+		{
+			name:      "local user keeps 7d default",
+			user:      &auth.User{ID: "local-1", Username: "admin", Provider: "local"},
+			wantTTL:   auth.RefreshTokenLifetime,
+			tolerance: 5 * time.Second,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := testServer(t)
+
+			before := time.Now()
+			w := httptest.NewRecorder()
+			_, refreshToken, err := srv.issueTokenPair(w, tc.user, false /* cookieMode */)
+			if err != nil {
+				t.Fatalf("issueTokenPair: %v", err)
+			}
+			if refreshToken == "" {
+				t.Fatal("expected non-empty refresh token")
+			}
+
+			// Locate the stored session by its token. We can't read SessionStore
+			// internals, so re-Validate (which is single-use). The returned
+			// ValidatedSession doesn't expose ExpiresAt; instead, we walk the
+			// internal sessions map via reflection-free sync.Map iteration by
+			// re-storing a marker before Validate consumes the row. Simpler:
+			// re-issue + Range the sync.Map BEFORE consuming.
+			var found bool
+			var got time.Time
+			srv.Sessions.RangeSessions(func(s auth.RefreshSession) bool {
+				if s.Token == refreshToken {
+					found = true
+					got = s.ExpiresAt
+					return false
+				}
+				return true
+			})
+			if !found {
+				t.Fatalf("issued refresh token not in SessionStore")
+			}
+
+			wantMin := before.Add(tc.wantTTL).Add(-tc.tolerance)
+			wantMax := time.Now().Add(tc.wantTTL).Add(tc.tolerance)
+			if got.Before(wantMin) || got.After(wantMax) {
+				t.Errorf("session ExpiresAt = %v, want within [%v, %v] (TTL %v)",
+					got, wantMin, wantMax, tc.wantTTL)
+			}
+		})
 	}
 }
 

--- a/backend/internal/server/handle_oidc_mobile.go
+++ b/backend/internal/server/handle_oidc_mobile.go
@@ -2,7 +2,7 @@ package server
 
 import (
 	"encoding/json"
-	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -13,9 +13,14 @@ import (
 )
 
 // oidcMobileExchangeRequest is the JSON body POSTed by the mobile client.
+//
+// State is generated and validated client-side per RFC 8252; the server
+// does not re-validate it and silently ignores it if present in the
+// request JSON (json.Decoder discards unknown fields). It is intentionally
+// omitted from the struct to make the contract explicit at the type level
+// rather than relying on a documented-but-unused field.
 type oidcMobileExchangeRequest struct {
 	Code         string `json:"code"`
-	State        string `json:"state"`
 	CodeVerifier string `json:"codeVerifier"`
 	Nonce        string `json:"nonce"`
 }
@@ -27,9 +32,9 @@ type oidcMobileExchangeRequest struct {
 // open the IdP authorization URL in flutter_custom_tabs /
 // SFSafariViewController, intercept the redirect via Universal Link / App
 // Link, validate state client-side (it's the mobile CSRF token), and POST
-// {code, state, codeVerifier, nonce} here. Response is body-mode — no
-// cookies are set — because in-app browsers can't share their cookie jar
-// with the embedded Dio client.
+// {code, codeVerifier, nonce} here. Response is body-mode — no cookies are
+// set — because in-app browsers can't share their cookie jar with the
+// embedded Dio client.
 //
 // State is NOT re-validated server-side; the mobile client is the only one
 // that can validate it (the value was generated on-device). The nonce IS
@@ -85,6 +90,11 @@ func (s *Server) handleOIDCMobileExchange(w http.ResponseWriter, r *http.Request
 
 	provider, ok := s.AuthRegistry.GetOIDC(providerID)
 	if !ok {
+		// Audit unknown-provider attempts too — they're a low-cost signal
+		// for misconfigured clients or scanning probes hitting the auth
+		// surface. Detail string follows the same shape as the rest of the
+		// mobile-exchange audit entries.
+		s.auditOIDCMobileFailure(r, providerID, fmt.Errorf("unknown OIDC provider"))
 		writeJSON(w, http.StatusNotFound, api.Response{
 			Error: &api.APIError{Code: 404, Message: "unknown OIDC provider"},
 		})
@@ -109,6 +119,14 @@ func (s *Server) handleOIDCMobileExchange(w http.ResponseWriter, r *http.Request
 	accessToken, refreshToken, err := s.issueTokenPair(w, user, false /* cookieMode */)
 	if err != nil {
 		s.Logger.Error("failed to issue tokens", "error", err)
+		// Audit the post-exchange failure so operators can correlate a
+		// successful IdP token exchange that nonetheless produced no
+		// k8sCenter session (e.g. JWT signing failure, session store
+		// pressure). Without this, the prior success-only audit hid the
+		// 500.
+		entry := s.newAuditEntry(r, user.Username, audit.ActionLogin, audit.ResultFailure)
+		entry.Detail = "oidc/" + providerID + "/mobile: token issuance failed"
+		s.AuditLogger.Log(r.Context(), entry)
 		writeJSON(w, http.StatusInternalServerError, api.Response{
 			Error: &api.APIError{Code: 500, Message: "failed to issue token"},
 		})
@@ -119,6 +137,10 @@ func (s *Server) handleOIDCMobileExchange(w http.ResponseWriter, r *http.Request
 	entry.Detail = "oidc/" + providerID + "/mobile"
 	s.AuditLogger.Log(r.Context(), entry)
 
+	// Mobile clients should call /v1/auth/me post-exchange to hydrate the
+	// canonical user model (roles, kubernetesGroups, namespace permissions).
+	// This summary payload is for the initial login-screen render only and
+	// intentionally omits fields a 5KB-JSON login round-trip doesn't need.
 	writeJSON(w, http.StatusOK, api.Response{
 		Data: map[string]any{
 			"accessToken":      accessToken,
@@ -140,69 +162,112 @@ func (s *Server) handleOIDCMobileExchange(w http.ResponseWriter, r *http.Request
 // human-readable classification that does NOT include token, nonce, or
 // verifier contents.
 func (s *Server) auditOIDCMobileFailure(r *http.Request, providerID string, err error) {
+	cat := categorizeOIDCMobileError(err)
 	entry := s.newAuditEntry(r, "", audit.ActionLogin, audit.ResultFailure)
-	entry.Detail = "oidc/" + providerID + "/mobile: " + classifyOIDCMobileError(err)
+	entry.Detail = "oidc/" + providerID + "/mobile: " + cat.auditLabel
 	s.AuditLogger.Log(r.Context(), entry)
 }
 
 // writeOIDCMobileExchangeError maps an ExchangeMobile error to an HTTP
 // response. Specific failure modes get specific status codes; everything
-// else falls through to 401.
+// else falls through to 401. Status + response message come from the
+// shared categorizer so the audit label and HTTP envelope cannot drift.
 func (s *Server) writeOIDCMobileExchangeError(w http.ResponseWriter, err error) {
-	msg := err.Error()
-	switch {
-	case strings.Contains(msg, "domain not allowed"):
-		writeJSON(w, http.StatusForbidden, api.Response{
-			Error: &api.APIError{Code: 403, Message: "email domain not allowed"},
-		})
-	case strings.Contains(msg, "nonce mismatch"):
-		writeJSON(w, http.StatusUnauthorized, api.Response{
-			Error: &api.APIError{Code: 401, Message: "oidc id token nonce mismatch"},
-		})
-	case strings.Contains(msg, "not verified by identity provider"):
-		writeJSON(w, http.StatusUnauthorized, api.Response{
-			Error: &api.APIError{Code: 401, Message: "email address not verified by identity provider"},
-		})
-	case strings.Contains(msg, "ID token verification failed"):
-		writeJSON(w, http.StatusUnauthorized, api.Response{
-			Error: &api.APIError{Code: 401, Message: "oidc id token verification failed"},
-		})
-	default:
-		writeJSON(w, http.StatusUnauthorized, api.Response{
-			Error: &api.APIError{Code: 401, Message: "oidc exchange failed"},
-		})
-	}
+	cat := categorizeOIDCMobileError(err)
+	writeJSON(w, cat.httpStatus, api.Response{
+		Error: &api.APIError{Code: cat.httpStatus, Message: cat.responseMessage},
+	})
 }
 
-// classifyOIDCMobileError returns a stable label suitable for an audit
-// entry. The label is sanitized — no token, nonce, or verifier content.
-func classifyOIDCMobileError(err error) string {
+// oidcMobileErrorCategory bundles the three derived facts about an
+// ExchangeMobile error: the sanitised audit label, the HTTP status the
+// client should see, and the response message body. Keeping them in one
+// struct (and one switch) prevents the audit-label / HTTP-status drift
+// that the previous two-function arrangement allowed.
+type oidcMobileErrorCategory struct {
+	auditLabel      string
+	httpStatus      int
+	responseMessage string
+}
+
+// categorizeOIDCMobileError classifies an ExchangeMobile error into the
+// shared audit + HTTP shape. Matching is by canonical substring; nonce
+// mismatch matches against the shared [auth.ErrOIDCNonceMismatch]
+// constant rather than the bare "nonce mismatch" fragment.
+func categorizeOIDCMobileError(err error) oidcMobileErrorCategory {
 	if err == nil {
-		return "unknown"
+		return oidcMobileErrorCategory{
+			auditLabel:      "unknown",
+			httpStatus:      http.StatusUnauthorized,
+			responseMessage: "oidc exchange failed",
+		}
 	}
 	msg := err.Error()
 	switch {
 	case strings.Contains(msg, "domain not allowed"):
-		return "domain not allowed"
-	case strings.Contains(msg, "nonce mismatch"):
-		return "id token nonce mismatch"
+		return oidcMobileErrorCategory{
+			auditLabel:      "domain not allowed",
+			httpStatus:      http.StatusForbidden,
+			responseMessage: "email domain not allowed",
+		}
+	case strings.Contains(msg, auth.ErrOIDCNonceMismatch):
+		return oidcMobileErrorCategory{
+			auditLabel:      "id token nonce mismatch",
+			httpStatus:      http.StatusUnauthorized,
+			responseMessage: "oidc id token nonce mismatch",
+		}
 	case strings.Contains(msg, "not verified by identity provider"):
-		return "email not verified"
+		return oidcMobileErrorCategory{
+			auditLabel:      "email not verified",
+			httpStatus:      http.StatusUnauthorized,
+			responseMessage: "email address not verified by identity provider",
+		}
 	case strings.Contains(msg, "ID token verification failed"):
-		return "id token verification failed"
+		return oidcMobileErrorCategory{
+			auditLabel:      "id token verification failed",
+			httpStatus:      http.StatusUnauthorized,
+			responseMessage: "oidc id token verification failed",
+		}
 	case strings.Contains(msg, "no id_token"):
-		return "no id_token in response"
+		return oidcMobileErrorCategory{
+			auditLabel:      "no id_token in response",
+			httpStatus:      http.StatusUnauthorized,
+			responseMessage: "oidc exchange failed",
+		}
+	case strings.Contains(msg, auth.ErrOIDCExchangeTimeout):
+		return oidcMobileErrorCategory{
+			auditLabel:      "code exchange timeout",
+			httpStatus:      http.StatusServiceUnavailable,
+			responseMessage: "oidc exchange timeout",
+		}
 	case strings.Contains(msg, "token exchange failed"):
-		return "code exchange rejected"
+		return oidcMobileErrorCategory{
+			auditLabel:      "code exchange rejected",
+			httpStatus:      http.StatusUnauthorized,
+			responseMessage: "oidc exchange failed",
+		}
 	case strings.Contains(msg, "extracting claims"):
-		return "claims extraction failed"
+		return oidcMobileErrorCategory{
+			auditLabel:      "claims extraction failed",
+			httpStatus:      http.StatusUnauthorized,
+			responseMessage: "oidc exchange failed",
+		}
 	case strings.Contains(msg, "map OIDC claims"):
-		return "claims mapping failed"
+		return oidcMobileErrorCategory{
+			auditLabel:      "claims mapping failed",
+			httpStatus:      http.StatusUnauthorized,
+			responseMessage: "oidc exchange failed",
+		}
+	case strings.Contains(msg, "unknown OIDC provider"):
+		return oidcMobileErrorCategory{
+			auditLabel:      "unknown provider",
+			httpStatus:      http.StatusNotFound,
+			responseMessage: "unknown OIDC provider",
+		}
 	}
-	// `errors.Is`-style typed sentinel could be added later; for now string
-	// classification is good enough and avoids false-positive logging.
-	if errors.Is(err, http.ErrAbortHandler) {
-		return "transport aborted"
+	return oidcMobileErrorCategory{
+		auditLabel:      "unspecified failure",
+		httpStatus:      http.StatusUnauthorized,
+		responseMessage: "oidc exchange failed",
 	}
-	return "unspecified failure"
 }

--- a/backend/internal/server/handle_oidc_mobile.go
+++ b/backend/internal/server/handle_oidc_mobile.go
@@ -1,0 +1,208 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/kubecenter/kubecenter/internal/audit"
+	"github.com/kubecenter/kubecenter/internal/auth"
+	"github.com/kubecenter/kubecenter/pkg/api"
+)
+
+// oidcMobileExchangeRequest is the JSON body POSTed by the mobile client.
+type oidcMobileExchangeRequest struct {
+	Code         string `json:"code"`
+	State        string `json:"state"`
+	CodeVerifier string `json:"codeVerifier"`
+	Nonce        string `json:"nonce"`
+}
+
+// handleOIDCMobileExchange exchanges a client-side OIDC authorization code
+// for a k8sCenter JWT pair.
+//
+// Mobile clients generate PKCE + nonce + state client-side per RFC 8252,
+// open the IdP authorization URL in flutter_custom_tabs /
+// SFSafariViewController, intercept the redirect via Universal Link / App
+// Link, validate state client-side (it's the mobile CSRF token), and POST
+// {code, state, codeVerifier, nonce} here. Response is body-mode — no
+// cookies are set — because in-app browsers can't share their cookie jar
+// with the embedded Dio client.
+//
+// State is NOT re-validated server-side; the mobile client is the only one
+// that can validate it (the value was generated on-device). The nonce IS
+// validated against the ID token's `nonce` claim — closing the ID-token-
+// replay window that PKCE alone does not cover.
+//
+// CSRF: X-Requested-With: XMLHttpRequest is enforced inline since this
+// route lives in the public /auth group (no CSRF middleware). The header
+// is injected by the mobile interceptor on every request.
+//
+// Rate-limit: shares the login bucket (5/min/IP).
+//
+// Audit: logs audit.ActionLogin with detail "oidc/<providerID>/mobile".
+func (s *Server) handleOIDCMobileExchange(w http.ResponseWriter, r *http.Request) {
+	providerID := chi.URLParam(r, "providerID")
+
+	// CSRF defense. Same shape as middleware.CSRF; inlined because public
+	// auth routes don't run the middleware.
+	if r.Header.Get("X-Requested-With") != "XMLHttpRequest" {
+		writeJSON(w, http.StatusForbidden, api.Response{
+			Error: &api.APIError{Code: 403, Message: "missing CSRF header"},
+		})
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxAuthBodySize)
+	var body oidcMobileExchangeRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, api.Response{
+			Error: &api.APIError{Code: 400, Message: "invalid request body"},
+		})
+		return
+	}
+
+	if body.Code == "" {
+		writeJSON(w, http.StatusBadRequest, api.Response{
+			Error: &api.APIError{Code: 400, Message: "code required"},
+		})
+		return
+	}
+	if body.CodeVerifier == "" {
+		writeJSON(w, http.StatusBadRequest, api.Response{
+			Error: &api.APIError{Code: 400, Message: "codeVerifier required"},
+		})
+		return
+	}
+	if body.Nonce == "" {
+		writeJSON(w, http.StatusBadRequest, api.Response{
+			Error: &api.APIError{Code: 400, Message: "nonce required"},
+		})
+		return
+	}
+
+	provider, ok := s.AuthRegistry.GetOIDC(providerID)
+	if !ok {
+		writeJSON(w, http.StatusNotFound, api.Response{
+			Error: &api.APIError{Code: 404, Message: "unknown OIDC provider"},
+		})
+		return
+	}
+
+	user, err := provider.ExchangeMobile(r.Context(), body.Code, body.CodeVerifier, body.Nonce)
+	if err != nil {
+		s.Logger.Error("OIDC mobile exchange failed",
+			"error", err,
+			"provider", providerID,
+		)
+		s.auditOIDCMobileFailure(r, providerID, err)
+		s.writeOIDCMobileExchangeError(w, err)
+		return
+	}
+
+	// Body-mode token issuance: no Set-Cookie header; refresh token is
+	// echoed in the JSON below for the mobile client to persist into
+	// flutter_secure_storage. OIDC sessions get the 1h refresh TTL cap
+	// per auth.OIDCRefreshTokenLifetime.
+	accessToken, refreshToken, err := s.issueTokenPair(w, user, false /* cookieMode */)
+	if err != nil {
+		s.Logger.Error("failed to issue tokens", "error", err)
+		writeJSON(w, http.StatusInternalServerError, api.Response{
+			Error: &api.APIError{Code: 500, Message: "failed to issue token"},
+		})
+		return
+	}
+
+	entry := s.newAuditEntry(r, user.Username, audit.ActionLogin, audit.ResultSuccess)
+	entry.Detail = "oidc/" + providerID + "/mobile"
+	s.AuditLogger.Log(r.Context(), entry)
+
+	writeJSON(w, http.StatusOK, api.Response{
+		Data: map[string]any{
+			"accessToken":      accessToken,
+			"refreshToken":     refreshToken,
+			"expiresIn":        int(auth.AccessTokenLifetime.Seconds()),
+			"refreshExpiresIn": int(auth.OIDCRefreshTokenLifetime.Seconds()),
+			"user": map[string]any{
+				"username":    user.Username,
+				"displayName": user.Username,
+				"groups":      user.KubernetesGroups,
+				"provider":    user.Provider,
+			},
+		},
+	})
+}
+
+// auditOIDCMobileFailure logs a sanitized audit failure entry. The raw
+// error is already in slog server logs; the audit detail is a stable,
+// human-readable classification that does NOT include token, nonce, or
+// verifier contents.
+func (s *Server) auditOIDCMobileFailure(r *http.Request, providerID string, err error) {
+	entry := s.newAuditEntry(r, "", audit.ActionLogin, audit.ResultFailure)
+	entry.Detail = "oidc/" + providerID + "/mobile: " + classifyOIDCMobileError(err)
+	s.AuditLogger.Log(r.Context(), entry)
+}
+
+// writeOIDCMobileExchangeError maps an ExchangeMobile error to an HTTP
+// response. Specific failure modes get specific status codes; everything
+// else falls through to 401.
+func (s *Server) writeOIDCMobileExchangeError(w http.ResponseWriter, err error) {
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "domain not allowed"):
+		writeJSON(w, http.StatusForbidden, api.Response{
+			Error: &api.APIError{Code: 403, Message: "email domain not allowed"},
+		})
+	case strings.Contains(msg, "nonce mismatch"):
+		writeJSON(w, http.StatusUnauthorized, api.Response{
+			Error: &api.APIError{Code: 401, Message: "oidc id token nonce mismatch"},
+		})
+	case strings.Contains(msg, "not verified by identity provider"):
+		writeJSON(w, http.StatusUnauthorized, api.Response{
+			Error: &api.APIError{Code: 401, Message: "email address not verified by identity provider"},
+		})
+	case strings.Contains(msg, "ID token verification failed"):
+		writeJSON(w, http.StatusUnauthorized, api.Response{
+			Error: &api.APIError{Code: 401, Message: "oidc id token verification failed"},
+		})
+	default:
+		writeJSON(w, http.StatusUnauthorized, api.Response{
+			Error: &api.APIError{Code: 401, Message: "oidc exchange failed"},
+		})
+	}
+}
+
+// classifyOIDCMobileError returns a stable label suitable for an audit
+// entry. The label is sanitized — no token, nonce, or verifier content.
+func classifyOIDCMobileError(err error) string {
+	if err == nil {
+		return "unknown"
+	}
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "domain not allowed"):
+		return "domain not allowed"
+	case strings.Contains(msg, "nonce mismatch"):
+		return "id token nonce mismatch"
+	case strings.Contains(msg, "not verified by identity provider"):
+		return "email not verified"
+	case strings.Contains(msg, "ID token verification failed"):
+		return "id token verification failed"
+	case strings.Contains(msg, "no id_token"):
+		return "no id_token in response"
+	case strings.Contains(msg, "token exchange failed"):
+		return "code exchange rejected"
+	case strings.Contains(msg, "extracting claims"):
+		return "claims extraction failed"
+	case strings.Contains(msg, "map OIDC claims"):
+		return "claims mapping failed"
+	}
+	// `errors.Is`-style typed sentinel could be added later; for now string
+	// classification is good enough and avoids false-positive logging.
+	if errors.Is(err, http.ErrAbortHandler) {
+		return "transport aborted"
+	}
+	return "unspecified failure"
+}

--- a/backend/internal/server/handle_oidc_mobile_test.go
+++ b/backend/internal/server/handle_oidc_mobile_test.go
@@ -1,0 +1,193 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestHandleOIDCMobileExchange_MissingCSRF verifies the public-route inline
+// CSRF check rejects requests without X-Requested-With.
+func TestHandleOIDCMobileExchange_MissingCSRF(t *testing.T) {
+	srv := testServer(t)
+
+	body := `{"code":"abc","codeVerifier":"v","nonce":"n","state":"s"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/oidc/authelia/mobile-exchange", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	// Intentionally no X-Requested-With header.
+	w := httptest.NewRecorder()
+
+	srv.Router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandleOIDCMobileExchange_MalformedBody covers the JSON decode error path.
+func TestHandleOIDCMobileExchange_MalformedBody(t *testing.T) {
+	srv := testServer(t)
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/auth/oidc/authelia/mobile-exchange",
+		strings.NewReader("not-json"),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Requested-With", "XMLHttpRequest")
+	w := httptest.NewRecorder()
+
+	srv.Router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandleOIDCMobileExchange_RequiredFields exercises each per-field
+// validation path with a single table-driven test.
+func TestHandleOIDCMobileExchange_RequiredFields(t *testing.T) {
+	cases := []struct {
+		name        string
+		body        string
+		expectField string
+	}{
+		{
+			name:        "missing code",
+			body:        `{"code":"","codeVerifier":"v","nonce":"n","state":"s"}`,
+			expectField: "code required",
+		},
+		{
+			name:        "missing codeVerifier",
+			body:        `{"code":"abc","codeVerifier":"","nonce":"n","state":"s"}`,
+			expectField: "codeVerifier required",
+		},
+		{
+			name:        "missing nonce",
+			body:        `{"code":"abc","codeVerifier":"v","nonce":"","state":"s"}`,
+			expectField: "nonce required",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := testServer(t)
+
+			req := httptest.NewRequest(
+				http.MethodPost,
+				"/api/v1/auth/oidc/authelia/mobile-exchange",
+				strings.NewReader(tc.body),
+			)
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("X-Requested-With", "XMLHttpRequest")
+			w := httptest.NewRecorder()
+
+			srv.Router.ServeHTTP(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d", w.Code)
+			}
+
+			var resp struct {
+				Error struct {
+					Message string `json:"message"`
+				} `json:"error"`
+			}
+			if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if resp.Error.Message != tc.expectField {
+				t.Errorf("expected error message %q, got %q", tc.expectField, resp.Error.Message)
+			}
+		})
+	}
+}
+
+// TestHandleOIDCMobileExchange_UnknownProvider verifies the handler returns
+// 404 when the providerID URL param doesn't resolve to a registered OIDC
+// provider. testServer wires only a local credential provider, so any
+// providerID matches the "unknown" branch.
+func TestHandleOIDCMobileExchange_UnknownProvider(t *testing.T) {
+	srv := testServer(t)
+
+	body := `{"code":"abc","codeVerifier":"v","nonce":"n","state":"s"}`
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/auth/oidc/nonexistent/mobile-exchange",
+		strings.NewReader(body),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Requested-With", "XMLHttpRequest")
+	w := httptest.NewRecorder()
+
+	srv.Router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.Error.Message != "unknown OIDC provider" {
+		t.Errorf("unexpected error message: %q", resp.Error.Message)
+	}
+}
+
+// TestClassifyOIDCMobileError covers the pure classifier — every branch
+// must map to a stable, sanitized audit label.
+func TestClassifyOIDCMobileError(t *testing.T) {
+	cases := []struct {
+		err    error
+		expect string
+	}{
+		{nil, "unknown"},
+		{errors.New("email domain not allowed"), "domain not allowed"},
+		{errors.New("oidc id token nonce mismatch"), "id token nonce mismatch"},
+		{errors.New("email address not verified by identity provider"), "email not verified"},
+		{errors.New("ID token verification failed: bad signature"), "id token verification failed"},
+		{errors.New("no id_token in token response"), "no id_token in response"},
+		{errors.New("token exchange failed: 400 Bad Request"), "code exchange rejected"},
+		{errors.New("extracting claims: invalid json"), "claims extraction failed"},
+		{errors.New("failed to map OIDC claims to user"), "claims mapping failed"},
+		{errors.New("something else entirely"), "unspecified failure"},
+	}
+
+	for _, tc := range cases {
+		got := classifyOIDCMobileError(tc.err)
+		if got != tc.expect {
+			label := "<nil>"
+			if tc.err != nil {
+				label = tc.err.Error()
+			}
+			t.Errorf("classifyOIDCMobileError(%q) = %q, want %q", label, got, tc.expect)
+		}
+	}
+}
+
+// TestHandleOIDCMobileExchange_RouteRegistration is a smoke check that the
+// route is reachable through the router. We confirm by sending a request
+// without CSRF and asserting we get 403 (route matched, CSRF rejected) not
+// 404 (route not registered).
+func TestHandleOIDCMobileExchange_RouteRegistration(t *testing.T) {
+	srv := testServer(t)
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/auth/oidc/any-provider/mobile-exchange",
+		strings.NewReader(`{}`),
+	)
+	// No X-Requested-With — expect 403 from CSRF, not 404 from missing route.
+	w := httptest.NewRecorder()
+	srv.Router.ServeHTTP(w, req)
+
+	if w.Code == http.StatusNotFound {
+		t.Fatal("route not registered — got 404")
+	}
+}

--- a/backend/internal/server/handle_oidc_mobile_test.go
+++ b/backend/internal/server/handle_oidc_mobile_test.go
@@ -1,13 +1,39 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
+
+	"github.com/kubecenter/kubecenter/internal/audit"
 )
+
+// recordingAuditLogger captures audit entries in memory for tests that
+// need to inspect Detail/Result formatting. It satisfies [audit.Logger].
+type recordingAuditLogger struct {
+	mu      sync.Mutex
+	entries []audit.Entry
+}
+
+func (r *recordingAuditLogger) Log(_ context.Context, e audit.Entry) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.entries = append(r.entries, e)
+	return nil
+}
+
+func (r *recordingAuditLogger) snapshot() []audit.Entry {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]audit.Entry, len(r.entries))
+	copy(out, r.entries)
+	return out
+}
 
 // TestHandleOIDCMobileExchange_MissingCSRF verifies the public-route inline
 // CSRF check rejects requests without X-Requested-With.
@@ -140,34 +166,44 @@ func TestHandleOIDCMobileExchange_UnknownProvider(t *testing.T) {
 	}
 }
 
-// TestClassifyOIDCMobileError covers the pure classifier — every branch
-// must map to a stable, sanitized audit label.
-func TestClassifyOIDCMobileError(t *testing.T) {
+// TestCategorizeOIDCMobileError covers the consolidated categorizer —
+// every branch must produce a stable audit label AND a defensible HTTP
+// status. The two were previously split across classify + writeError; the
+// drift risk that split created is exactly what this test pins down.
+func TestCategorizeOIDCMobileError(t *testing.T) {
 	cases := []struct {
-		err    error
-		expect string
+		name       string
+		err        error
+		wantLabel  string
+		wantStatus int
 	}{
-		{nil, "unknown"},
-		{errors.New("email domain not allowed"), "domain not allowed"},
-		{errors.New("oidc id token nonce mismatch"), "id token nonce mismatch"},
-		{errors.New("email address not verified by identity provider"), "email not verified"},
-		{errors.New("ID token verification failed: bad signature"), "id token verification failed"},
-		{errors.New("no id_token in token response"), "no id_token in response"},
-		{errors.New("token exchange failed: 400 Bad Request"), "code exchange rejected"},
-		{errors.New("extracting claims: invalid json"), "claims extraction failed"},
-		{errors.New("failed to map OIDC claims to user"), "claims mapping failed"},
-		{errors.New("something else entirely"), "unspecified failure"},
+		{"nil", nil, "unknown", http.StatusUnauthorized},
+		{"domain not allowed", errors.New("email domain not allowed"), "domain not allowed", http.StatusForbidden},
+		{"nonce mismatch", errors.New("oidc id token nonce mismatch"), "id token nonce mismatch", http.StatusUnauthorized},
+		{"email unverified", errors.New("email address not verified by identity provider"), "email not verified", http.StatusUnauthorized},
+		{"id token verify fail", errors.New("ID token verification failed: bad signature"), "id token verification failed", http.StatusUnauthorized},
+		{"no id_token", errors.New("no id_token in token response"), "no id_token in response", http.StatusUnauthorized},
+		{"exchange timeout", errors.New("oidc token exchange timeout: context deadline exceeded"), "code exchange timeout", http.StatusServiceUnavailable},
+		{"exchange rejected", errors.New("token exchange failed: 400 Bad Request"), "code exchange rejected", http.StatusUnauthorized},
+		{"claims extract", errors.New("extracting claims: invalid json"), "claims extraction failed", http.StatusUnauthorized},
+		{"claims map", errors.New("failed to map OIDC claims to user"), "claims mapping failed", http.StatusUnauthorized},
+		{"unknown provider", errors.New("unknown OIDC provider"), "unknown provider", http.StatusNotFound},
+		{"unspecified", errors.New("something else entirely"), "unspecified failure", http.StatusUnauthorized},
 	}
 
 	for _, tc := range cases {
-		got := classifyOIDCMobileError(tc.err)
-		if got != tc.expect {
-			label := "<nil>"
-			if tc.err != nil {
-				label = tc.err.Error()
+		t.Run(tc.name, func(t *testing.T) {
+			got := categorizeOIDCMobileError(tc.err)
+			if got.auditLabel != tc.wantLabel {
+				t.Errorf("auditLabel = %q, want %q", got.auditLabel, tc.wantLabel)
 			}
-			t.Errorf("classifyOIDCMobileError(%q) = %q, want %q", label, got, tc.expect)
-		}
+			if got.httpStatus != tc.wantStatus {
+				t.Errorf("httpStatus = %d, want %d", got.httpStatus, tc.wantStatus)
+			}
+			if got.responseMessage == "" {
+				t.Errorf("responseMessage empty for case %q", tc.name)
+			}
+		})
 	}
 }
 
@@ -189,5 +225,104 @@ func TestHandleOIDCMobileExchange_RouteRegistration(t *testing.T) {
 
 	if w.Code == http.StatusNotFound {
 		t.Fatal("route not registered — got 404")
+	}
+}
+
+// TestHandleOIDCMobileExchange_AuditDetailFormat asserts the audit entry
+// written on a failed mobile exchange follows the documented contract:
+// `oidc/<providerID>/mobile: <classifier-label>` with no token, nonce, or
+// verifier content. We trigger it through the unknown-provider 404 path
+// (the handler audits that case too, alongside actual exchange failures).
+func TestHandleOIDCMobileExchange_AuditDetailFormat(t *testing.T) {
+	srv := testServer(t)
+	rec := &recordingAuditLogger{}
+	srv.AuditLogger = rec
+
+	body := `{"code":"abc","codeVerifier":"v","nonce":"n"}`
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/auth/oidc/missing-provider/mobile-exchange",
+		strings.NewReader(body),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Requested-With", "XMLHttpRequest")
+	w := httptest.NewRecorder()
+
+	srv.Router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+
+	entries := rec.snapshot()
+	if len(entries) != 1 {
+		t.Fatalf("expected exactly 1 audit entry, got %d", len(entries))
+	}
+	got := entries[0]
+	if got.Action != audit.ActionLogin {
+		t.Errorf("Action = %q, want %q", got.Action, audit.ActionLogin)
+	}
+	if got.Result != audit.ResultFailure {
+		t.Errorf("Result = %q, want %q", got.Result, audit.ResultFailure)
+	}
+	wantDetail := "oidc/missing-provider/mobile: unknown provider"
+	if got.Detail != wantDetail {
+		t.Errorf("Detail = %q, want %q", got.Detail, wantDetail)
+	}
+}
+
+// TestHandleOIDCMobileExchange_StateFieldIgnored asserts the handler still
+// accepts (and silently discards) the legacy `state` field clients may
+// still emit. json.Decoder drops unknown fields by default, so the
+// validation must complete on code/codeVerifier/nonce only — and the
+// request must NOT 400 because state is present.
+func TestHandleOIDCMobileExchange_StateFieldIgnored(t *testing.T) {
+	srv := testServer(t)
+
+	body := `{"code":"abc","codeVerifier":"v","nonce":"n","state":"client-csrf-token"}`
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/auth/oidc/missing-provider/mobile-exchange",
+		strings.NewReader(body),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Requested-With", "XMLHttpRequest")
+	w := httptest.NewRecorder()
+
+	srv.Router.ServeHTTP(w, req)
+
+	// We reach the unknown-provider branch — proving body decoded cleanly
+	// despite the extra `state` field. A 400 here would mean state broke
+	// JSON parsing or the validators rejected the request unexpectedly.
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 (unknown provider), got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandleOIDCMobileExchange_MaxBytes asserts the maxAuthBodySize cap
+// rejects oversized payloads. The MaxBytesReader wraps r.Body before
+// json.Decoder runs, so the Decode call returns an error and the handler
+// surfaces it as a 400. Without the cap an attacker could pin handler
+// memory with a multi-MB JSON blob.
+func TestHandleOIDCMobileExchange_MaxBytes(t *testing.T) {
+	srv := testServer(t)
+
+	// 65KB of valid-but-padded JSON. The cap is maxAuthBodySize (smaller
+	// than 65KB), so MaxBytesReader trips during Decode.
+	padding := strings.Repeat("A", 65*1024)
+	body := `{"code":"` + padding + `","codeVerifier":"v","nonce":"n"}`
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/auth/oidc/authelia/mobile-exchange",
+		strings.NewReader(body),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Requested-With", "XMLHttpRequest")
+	w := httptest.NewRecorder()
+
+	srv.Router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for oversized body, got %d: %s", w.Code, w.Body.String())
 	}
 }

--- a/backend/internal/server/response.go
+++ b/backend/internal/server/response.go
@@ -53,14 +53,18 @@ func (s *Server) newAuditEntry(r *http.Request, username string, action audit.Ac
 }
 
 // issueTokenPair creates a new access + refresh token pair, stores the
-// session, and sets the refresh cookie. Returns the access token and the
-// raw refresh token.
+// session, and conditionally sets the refresh cookie. Returns the access
+// token and the raw refresh token.
 //
-// The raw refresh token is returned alongside so body-mode clients (mobile,
-// where cookies don't carry cleanly across native HTTP stacks) can echo it
-// back in JSON. Web callers ignore the second return value and rely on the
-// httpOnly cookie this function also sets — behaviour for them is unchanged.
-func (s *Server) issueTokenPair(w http.ResponseWriter, user *auth.User) (string, string, error) {
+// cookieMode=true (web flow): sets the refresh_token httpOnly cookie.
+// cookieMode=false (mobile/body-mode flow): no cookie is set; the caller
+// must echo the refresh token in the JSON response body.
+//
+// OIDC-sourced sessions get a shorter refresh TTL ([auth.OIDCRefreshTokenLifetime]).
+// The shorter window propagates IdP revocation (account disabled, group
+// removed) within the hour rather than the standard 7-day window — see
+// the constant's doc comment for the rationale.
+func (s *Server) issueTokenPair(w http.ResponseWriter, user *auth.User, cookieMode bool) (string, string, error) {
 	accessToken, err := s.TokenManager.IssueAccessToken(user)
 	if err != nil {
 		return "", "", err
@@ -71,11 +75,13 @@ func (s *Server) issueTokenPair(w http.ResponseWriter, user *auth.User) (string,
 		return "", "", err
 	}
 
+	refreshLifetime := auth.RefreshLifetimeFor(user.Provider)
+
 	session := auth.RefreshSession{
 		Token:     refreshToken,
 		UserID:    user.ID,
 		Provider:  user.Provider,
-		ExpiresAt: time.Now().Add(auth.RefreshTokenLifetime),
+		ExpiresAt: time.Now().Add(refreshLifetime),
 	}
 	// Cache user data for non-local providers (OIDC has no local store,
 	// LDAP would require reconnecting to the directory on refresh).
@@ -85,7 +91,9 @@ func (s *Server) issueTokenPair(w http.ResponseWriter, user *auth.User) (string,
 	}
 	s.Sessions.Store(session)
 
-	s.setRefreshCookie(w, refreshToken, int(auth.RefreshTokenLifetime.Seconds()))
+	if cookieMode {
+		s.setRefreshCookie(w, refreshToken, int(refreshLifetime.Seconds()))
+	}
 
 	return accessToken, refreshToken, nil
 }

--- a/backend/internal/server/response.go
+++ b/backend/internal/server/response.go
@@ -57,8 +57,12 @@ func (s *Server) newAuditEntry(r *http.Request, username string, action audit.Ac
 // token and the raw refresh token.
 //
 // cookieMode=true (web flow): sets the refresh_token httpOnly cookie.
-// cookieMode=false (mobile/body-mode flow): no cookie is set; the caller
-// must echo the refresh token in the JSON response body.
+// cookieMode=false (body-mode flow): no cookie is set; the caller MUST
+// echo the refresh token in the JSON response body. This is a wire-format
+// difference from the cookie-mode path — body-mode responses do NOT
+// include a Set-Cookie header — and mobile clients cannot persist refresh
+// tokens any other way because in-app browsers don't share their cookie
+// jar with the embedded Dio client.
 //
 // OIDC-sourced sessions get a shorter refresh TTL ([auth.OIDCRefreshTokenLifetime]).
 // The shorter window propagates IdP revocation (account disabled, group

--- a/backend/internal/server/routes.go
+++ b/backend/internal/server/routes.go
@@ -57,6 +57,11 @@ func (s *Server) registerRoutes() {
 			// OIDC routes — redirect-based flow, rate limited
 			ar.With(middleware.RateLimit(s.RateLimiter)).Get("/oidc/{providerID}/login", s.handleOIDCLogin)
 			ar.With(middleware.RateLimit(s.RateLimiter)).Get("/oidc/{providerID}/callback", s.handleOIDCCallback)
+			// Mobile body-mode exchange — mobile clients generate PKCE +
+			// nonce + state client-side and POST the authorization code
+			// here. Response is JSON-only (no Set-Cookie). Shares the
+			// login rate-limit bucket.
+			ar.With(middleware.RateLimit(s.RateLimiter)).Post("/oidc/{providerID}/mobile-exchange", s.handleOIDCMobileExchange)
 		})
 
 		// Setup — rate limited, no auth

--- a/plans/mobile-app-m5-pr-sequence.md
+++ b/plans/mobile-app-m5-pr-sequence.md
@@ -90,6 +90,13 @@ Each gap blocks a specific operator persona: OIDC blocks the corporate user, wri
 - **Apple Watch / Wear OS.** Out of scope per `mobile-app.md`.
 - **Custom themes via `/v1/themes`.** Deferred to v2 per `mobile-app.md`.
 
+#### Surfaced by PR-5b code review (2026-05-16)
+
+- **#275 — `/auth/refresh` singleflight (multi-tab thundering herd).** Pre-existing race; amplified ~168x by the 1h OIDC refresh cap that landed in PR-5b. With N tabs open, the first 401 wins the refresh and the other N-1 cascade into forced re-auth. **Mobile half belongs in PR-5c** (U3 — wire singleflight into `mobile/lib/api/dio_client.dart`'s `AuthInterceptor._refresh`); web half is a separate post-M5 fix-pr on `frontend/lib/api.ts`.
+- **#277 — `displayName` vs `username` on OIDC mobile-exchange response.** Backend currently returns both keys pointing at the same string (`user.Username`). **Decide during PR-5c** when the mobile login screen lands: either drop `displayName` (option a, one-line) or add a real `DisplayName` field to `auth.User` populated from the OIDC `name` claim (option b, cross-cutting). Option (b) would also need to land before PR-5j public launch so the login header doesn't ship looking like a raw email.
+- **#274 — `SessionStore.Validate` rotation-rollback gap.** Pre-existing: `Validate` deletes the row before `issueTokenPair` can fail; on failure the user is silently logged out. Amplified by the 1h cap (~168x more refresh events per OIDC user). Fix shape: split into `Peek` + `Consume`, commit deletion only after rotation succeeds. **Post-M5 backend reliability pass** — not folded into M5 unless real-world impact materialises.
+- **#276 — Rate-limited 429s leave no audit trail.** Pre-existing pattern across all rate-limited auth routes; surfaced fresh by PR-5b's new mobile-exchange endpoint. Brute-force probing is invisible in the audit table. Fix shape: inject `AuditLogger` into the `RateLimit` middleware (option 1) or layer a `RateLimitAudit` middleware on top (option 2). **Post-M5 backend security/reliability pass.**
+
 ---
 
 ## Context & Research
@@ -446,6 +453,10 @@ SecretDetailScreen extends StatefulWidget with SecureScreenMixin
 **Requirements:** R1 (OIDC mobile parity), R11 (web isomorphism), R12 (cluster-pin doesn't apply here — auth pre-cluster).
 
 **Dependencies:** U2 (backend endpoint), U1 (Settings + observability scaffolding for any auth errors that get logged to Sentry).
+
+**Carried-over scope from PR-5b code review:**
+- **#275 — singleflight `/auth/refresh` in `AuthInterceptor`.** When wiring the Dio interceptor stack for OIDC, deduplicate concurrent 401-driven refresh attempts: in-flight refresh requests share a single `Future`; the interceptor queues retries until the in-flight refresh resolves. Without this, N concurrent requests that hit a stale access token will each fire `/auth/refresh` independently; `SessionStore.Validate` is single-use, so N-1 of them will see `refresh token not found` and force a logout. The 1h OIDC cap from U2 fires this race ~168x more often than the prior 7d cap.
+- **#277 — decide `displayName` vs `username` in the exchange response.** Backend currently returns both keys, both `= user.Username`. When U3 wires the login screen, audit what's actually rendered. If both fields are read the same way, request a backend cleanup (drop `displayName`) before PR-5j. If a richer display is wanted, file a backend PR to add a real `DisplayName` field from the OIDC `name` claim — must land before public-store launch so the header doesn't ship looking like a raw email.
 
 **Files:**
 - Create: `mobile/lib/auth/oidc_controller.dart` — `OIDCController` notifier handling PKCE+nonce+state generation, custom-tabs launch, Universal Link callback intercept, code exchange. State: `({String? providerID, String? state, String? codeVerifier, String? nonce, AsyncStatus status, Object? error})`.


### PR DESCRIPTION
## Summary

Lands **U2** of `plans/mobile-app-m5-pr-sequence.md`. Backend-only PR; unblocks **PR-5c** (mobile OIDC flow). Mirrors the existing `handleRefresh` body-mode pattern (PR-0) for the new mobile-exchange endpoint.

## What landed

### New endpoint: `POST /v1/auth/oidc/{providerID}/mobile-exchange`

Mobile clients generate PKCE + nonce + state client-side per RFC 8252 (Native OAuth Apps), open the IdP authorization URL in `flutter_custom_tabs` / `SFSafariViewController`, intercept the redirect via Universal Link / App Link, validate state client-side (it's the mobile CSRF token), and POST `{code, codeVerifier, nonce}` here. Response is body-mode — **no `Set-Cookie`** — because in-app browsers can't share their cookie jar with the embedded Dio client.

- **State** is NOT re-validated server-side (the mobile client is the only one that can — it generated the value). The request struct intentionally omits a `state` field; clients that still send one have it silently discarded by `json.Decoder` (and a regression test pins that behavior).
- **Nonce** IS validated against the ID token's `nonce` claim — closes the ID-token-replay window that PKCE alone does not cover.
- **CSRF:** `X-Requested-With: XMLHttpRequest` enforced inline (public-route group has no CSRF middleware).
- **Rate-limit:** shares the login bucket (5/min/IP).
- **Audit:** `audit.ActionLogin` with sanitised detail `oidc/<providerID>/mobile: <classifier-label>` — no token, nonce, or verifier contents in audit strings. The unknown-provider 404 and the post-exchange token-issuance 500 are audited too.

Response shape:
```json
{ "data": {
    "accessToken": "<jwt>",
    "refreshToken": "<random>",
    "expiresIn": 900,
    "refreshExpiresIn": 3600,
    "user": { "username": "...", "displayName": "...", "groups": [...], "provider": "oidc" }
}}
```

### Behaviour change: OIDC refresh-token TTL capped at 1h (was 7 days)

The M5 plan's "Deferred to Follow-Up Work" section **promoted** this to a PR-5b blocker. The prior 7-day OIDC refresh window meant IdP-side revocation (account disabled, group removed) took up to a week to propagate — described as "unacceptable post-employment access window for a Kubernetes management plane."

- **Local + LDAP users:** keep the 7-day refresh window.
- **OIDC users (web + mobile):** capped at 1h. Access tokens still rotate every 15min; at the 1h mark `/v1/auth/refresh` returns 401 and the user re-auths via the IdP. If the IdP session is still valid, this is a transparent redirect; otherwise it's a password prompt.

**Alternative considered and rejected:** per-refresh IdP `revocation_endpoint` check. Rejected because it requires persisting the IdP refresh token, adds per-refresh IdP latency, and ties platform availability to the IdP's. The 1h cap is a documented pragmatic middle ground.

| Concern | Old (7d) | New (1h) |
|---|---|---|
| IdP revocation latency | up to 7 days | up to 1 hour |
| OIDC user re-auth frequency | once per week | once per hour |
| Network calls per refresh | 0 (cached user) | 0 (cached user) |
| Local/LDAP user behaviour | 7d (unchanged) | 7d (unchanged) |

## Behavior change — OIDC refresh TTL

Wire-visible cookie change for web OIDC users: the `refresh_token` Set-Cookie `Max-Age` drops from `604800` (7 days) to `3600` (1 hour). Existing OIDC sessions issued before this deploy keep their 7-day cookie until next rotation; new sessions and rotated sessions get the 1h Max-Age.

Operators should expect web OIDC users to hit `/v1/auth/refresh` 401 at the hour mark and be redirected back to the OIDC login button — which is the desired propagation behaviour, not a regression. If the IdP session is still warm, the round-trip is a transparent redirect; otherwise it's a re-prompt. Audit log entries for the hourly re-auth will appear as fresh `audit.ActionLogin` rows, one per OIDC user per hour of active usage. Local and LDAP users see no change.

## Files

**Modified (5):**
- `backend/internal/auth/jwt.go` — `OIDCRefreshTokenLifetime = 1 * time.Hour` + `RefreshLifetimeFor(provider)` helper.
- `backend/internal/auth/oidc.go` — exported `ErrOIDCNonceMismatch` constant (shared between the web callback and the new mobile-exchange path so the audit classifier and HTTP error mapper match by exact string).
- `backend/internal/auth/session.go` — added `RangeSessions` accessor (test-only inspection of stored expiry).
- `backend/internal/server/response.go` — `issueTokenPair(w, user, cookieMode)` now takes `cookieMode bool`; applies `RefreshLifetimeFor` to expiry. **Wire change:** `/v1/auth/refresh` body-mode responses no longer include `Set-Cookie` (the new refresh token is in the JSON body only). Doc comment expanded to make the contract explicit.
- `backend/internal/server/handle_auth.go` — existing callers updated; `handleRefresh` body-mode path now passes `cookieMode=!bodyMode` so mobile responses skip the wasted Set-Cookie header. Body-mode response now includes `refreshExpiresIn` so mobile clients can schedule the next refresh without re-deriving the TTL.
- `backend/internal/server/routes.go` — registers the new route under the public `/auth` group with the login rate-limit middleware.

**Created (4):**
- `backend/internal/auth/oidc_mobile.go` — `(*OIDCProvider).ExchangeMobile(ctx, code, codeVerifier, expectedNonce) (*User, error)`. Wraps the `oauth2.Exchange` error to surface `ErrOIDCExchangeTimeout` distinctly from a 4xx IdP rejection so the HTTP layer can map it to 503 (retry) rather than 401 (re-auth).
- `backend/internal/auth/oidc_mobile_test.go` — input-validation tests for ExchangeMobile.
- `backend/internal/server/handle_oidc_mobile.go` — handler + consolidated `categorizeOIDCMobileError` (single switch returning audit label + HTTP status + response message, preventing audit-vs-HTTP drift).
- `backend/internal/server/handle_oidc_mobile_test.go` — handler tests (CSRF gate, malformed body, missing-field validation, unknown provider, route registration, categorizer table-test covering audit-label AND HTTP-status per case, audit-detail format, legacy `state` field tolerance, `maxAuthBodySize` enforcement).

## Verification

- `cd backend && go vet ./...` clean
- `cd backend && go test ./...` clean
- Test surface expanded: `TestRefreshLifetimeFor`, `TestIssueTokenPair_OIDCRefreshLifetime`, `TestHandleRefresh_BodyMode_NoSetCookie`, `TestCategorizeOIDCMobileError` (12 sub-cases including the new `exchange timeout 503` and `unknown provider 404` branches), `TestHandleOIDCMobileExchange_AuditDetailFormat`, `TestHandleOIDCMobileExchange_StateFieldIgnored`, `TestHandleOIDCMobileExchange_MaxBytes`.

The full token-exchange + ID-token-verify happy path requires a live IdP and is exercised by manual smoke against homelab Authelia per the plan's Verification step — matching the existing `HandleCallback` test posture (no unit-level mock IdP).

## Test plan

- [ ] CI passes on the PR.
- [ ] Manual smoke against homelab Authelia: hand-craft an OIDC authorize URL with client-generated PKCE + nonce + state, walk through the IdP UI, capture the redirect code, POST `{code, codeVerifier, nonce}` to `/v1/auth/oidc/authelia/mobile-exchange` with `X-Requested-With: XMLHttpRequest`. Expect 200 with the `{accessToken, refreshToken, expiresIn, refreshExpiresIn=3600, user}` shape.
- [ ] Manual smoke: take the returned refresh token, POST to `/v1/auth/refresh` with `{refreshToken}` body. Expect rotation succeeds within the 1h window; response includes `refreshExpiresIn=3600`.
- [ ] Verify Set-Cookie header is NOT present on the mobile-exchange response, NOR on the body-mode `/v1/auth/refresh` response.
- [ ] Verify audit log entry shows `audit.ActionLogin` with sanitised detail `oidc/authelia/mobile`.
- [ ] Verify rate limit fires on the 6th request from same IP within 60s.

## Out of scope (later PRs / known follow-ups)

- **PR-5c (mobile)**: mobile-side PKCE generation, `flutter_custom_tabs` launch, Universal Link callback intercept, OIDC button on the login screen. The mobile-side bits all consume this PR's endpoint but are not in scope here.
- **Multi-tab thundering herd on `/auth/refresh`**: needs frontend-side singleflight in `frontend/lib/api.ts` (web) and `mobile/lib/api/dio_client.dart` (mobile / PR-5c). Filed as a separate follow-up.
- **Rate-limited 429s leave no audit trail**: pre-existing pattern across all rate-limited routes; needs middleware-level refactor (`RateLimit` middleware needs `AuditLogger` reference). Filed as separate issue.
- **`SessionStore.Validate` rotation rollback gap**: `Validate` deletes the token before `issueTokenPair` runs; if issuance fails, the original session is lost. Pre-existing architecture; out of PR-5b scope.
- **F271 (iOS app-switcher race)**: filed as #271 against PR-5d; not blocked by this PR.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)
