### PR TITLE
feat(mobile): M5 PR-5d — wire SecureScreenMixin on SecretDetailScreen

### DIFF
--- a/mobile/lib/features/resources/secret_screens.dart
+++ b/mobile/lib/features/resources/secret_screens.dart
@@ -112,7 +112,7 @@ class _SecretDetailScreenState extends ConsumerState<SecretDetailScreen>
   final Map<String, String> _revealed = {};
   final Set<String> _revealing = {};
 
-  Future<void> _reveal(String key) async {
+  Future<void> _revealKey(String key) async {
     setState(() => _revealing.add(key));
     try {
       final value =
@@ -126,10 +126,7 @@ class _SecretDetailScreenState extends ConsumerState<SecretDetailScreen>
         _revealed[key] = value;
         _revealing.remove(key);
       });
-      // Screen carries plaintext now — flip FLAG_SECURE / arm iOS blur
-      // cover. Mixin handles idempotency, so re-entry with multiple keys
-      // already revealed is a no-op on the second call.
-      unawaited(setSensitive(_revealed.isNotEmpty));
+      _syncSensitivity();
     } on ApiError catch (e) {
       if (!mounted) return;
       setState(() => _revealing.remove(key));
@@ -139,12 +136,17 @@ class _SecretDetailScreenState extends ConsumerState<SecretDetailScreen>
     }
   }
 
-  void _hide(String key) {
+  void _concealKey(String key) {
     setState(() => _revealed.remove(key));
-    // Recompute sensitivity: stay armed while ANY other key is still
-    // revealed. Only clears once the last revealed key is hidden.
-    unawaited(setSensitive(_revealed.isNotEmpty));
+    _syncSensitivity();
   }
+
+  /// Flips FLAG_SECURE / iOS blur cover from `_revealed.isNotEmpty`. Stays
+  /// armed while any key is revealed; clears once the last one is hidden.
+  /// Mixin guards idempotency and serializes platform-channel calls — call
+  /// site stays fire-and-forget so widget rebuilds don't stall on the
+  /// FLAG_SECURE roundtrip.
+  void _syncSensitivity() => unawaited(setSensitive(_revealed.isNotEmpty));
 
   @override
   Widget build(BuildContext context) {
@@ -219,8 +221,8 @@ class _SecretDetailScreenState extends ConsumerState<SecretDetailScreen>
                               keyName: entry.key,
                               revealed: _revealed[entry.key],
                               loading: _revealing.contains(entry.key),
-                              onReveal: () => _reveal(entry.key),
-                              onHide: () => _hide(entry.key),
+                              onReveal: () => _revealKey(entry.key),
+                              onHide: () => _concealKey(entry.key),
                             ),
                         ],
                       ),

--- a/mobile/lib/features/resources/secret_screens.dart
+++ b/mobile/lib/features/resources/secret_screens.dart
@@ -8,6 +8,8 @@
 // The detail GET still returns the masked Secret (the YAML tab redacts
 // `data`/`stringData` for kind == 'Secret' — see resource_detail_scaffold.dart).
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -24,6 +26,7 @@ import '../../widgets/resource_actions_button.dart';
 import '../../widgets/resource_detail_scaffold.dart';
 import '../../widgets/resource_list_scaffold.dart';
 import '../../widgets/resource_table.dart';
+import '../../widgets/secure_screen_mixin.dart';
 import 'k8s_helpers.dart';
 
 class _SecretRow {
@@ -101,7 +104,8 @@ class SecretDetailScreen extends ConsumerStatefulWidget {
   ConsumerState<SecretDetailScreen> createState() => _SecretDetailScreenState();
 }
 
-class _SecretDetailScreenState extends ConsumerState<SecretDetailScreen> {
+class _SecretDetailScreenState extends ConsumerState<SecretDetailScreen>
+    with SecureScreenMixin<SecretDetailScreen> {
   /// Per-key revealed value cache. State is widget-scoped — back-button
   /// out of the screen disposes State, so re-entering the detail starts
   /// fresh with everything masked again.
@@ -122,6 +126,10 @@ class _SecretDetailScreenState extends ConsumerState<SecretDetailScreen> {
         _revealed[key] = value;
         _revealing.remove(key);
       });
+      // Screen carries plaintext now — flip FLAG_SECURE / arm iOS blur
+      // cover. Mixin handles idempotency, so re-entry with multiple keys
+      // already revealed is a no-op on the second call.
+      unawaited(setSensitive(_revealed.isNotEmpty));
     } on ApiError catch (e) {
       if (!mounted) return;
       setState(() => _revealing.remove(key));
@@ -133,6 +141,9 @@ class _SecretDetailScreenState extends ConsumerState<SecretDetailScreen> {
 
   void _hide(String key) {
     setState(() => _revealed.remove(key));
+    // Recompute sensitivity: stay armed while ANY other key is still
+    // revealed. Only clears once the last revealed key is hidden.
+    unawaited(setSensitive(_revealed.isNotEmpty));
   }
 
   @override

--- a/mobile/test/features/resources/secret_screens_test.dart
+++ b/mobile/test/features/resources/secret_screens_test.dart
@@ -7,7 +7,6 @@
 // clears it, and a still-revealed sibling key keeps the flag armed when
 // any one key is hidden.
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -18,6 +17,7 @@ import 'package:kubecenter/features/resources/secret_screens.dart';
 import 'package:kubecenter/theme/kube_theme_builder.dart';
 
 import '../../support/mock_dio_adapter.dart';
+import '../../support/platform_helpers.dart';
 
 void main() {
   group('sanitizeSecretValue', () {
@@ -138,23 +138,6 @@ void main() {
           ),
         ),
       );
-    }
-
-    /// Runs [body] with the target platform overridden — needed because
-    /// the FLAG_SECURE path only fires on Android. Restores the prior
-    /// override in a `finally` block so the test framework's invariant
-    /// check sees the original state.
-    Future<void> withPlatform(
-      TargetPlatform platform,
-      Future<void> Function() body,
-    ) async {
-      final prior = debugDefaultTargetPlatformOverride;
-      debugDefaultTargetPlatformOverride = platform;
-      try {
-        await body();
-      } finally {
-        debugDefaultTargetPlatformOverride = prior;
-      }
     }
 
     /// Mocks the `flutter_windowmanager` MethodChannel and returns the
@@ -285,7 +268,149 @@ void main() {
           await tester.pumpWidget(const MaterialApp(home: SizedBox()));
           await tester.pump();
 
-          expect(calls.any((c) => c.method == 'clearFlags'), isTrue);
+          final clears = calls.where((c) => c.method == 'clearFlags').toList();
+          expect(clears, isNotEmpty);
+          expect(clears.first.arguments['flags'], 0x00002000);
+        });
+      },
+    );
+
+    testWidgets(
+      'reveal failure (500) does NOT arm FLAG_SECURE',
+      (tester) async {
+        await withPlatform(TargetPlatform.android, () async {
+          final calls = mockWindowManager();
+          final (:container, :mock) = makeContainer();
+          addTearDown(container.dispose);
+
+          mockSecret(mock);
+          // Reveal endpoint returns 500 — Dio's default validateStatus
+          // rejects 5xx → ApiError flows into the screen's catch block.
+          mock.onJson(
+            'GET',
+            '/api/v1/resources/secrets/$namespace/$name/reveal/username',
+            status: 500,
+            body: {
+              'error': {'code': 500, 'message': 'reveal failed'},
+            },
+          );
+
+          await tester.pumpWidget(harness(container));
+          await tester.pumpAndSettle();
+
+          await tester.tap(find.byKey(const ValueKey('secret-toggle-username')));
+          await tester.pumpAndSettle();
+
+          // No platform-channel traffic — sensitivity must stay false.
+          expect(calls.where((c) => c.method == 'addFlags'), isEmpty);
+          expect(calls.where((c) => c.method == 'clearFlags'), isEmpty);
+
+          // The failure snackbar should appear and the toggle button
+          // should still read 'Reveal' (state never advanced to revealed).
+          expect(find.textContaining('Reveal failed'), findsOneWidget);
+        });
+      },
+    );
+
+    testWidgets(
+      'rapid reveal/conceal/reveal toggles leave consistent state',
+      (tester) async {
+        await withPlatform(TargetPlatform.android, () async {
+          final calls = mockWindowManager();
+          final (:container, :mock) = makeContainer();
+          addTearDown(container.dispose);
+
+          mockSecret(mock);
+          mockReveal(mock, 'username', 'admin');
+
+          await tester.pumpWidget(harness(container));
+          await tester.pumpAndSettle();
+
+          // Three reveal/conceal cycles. Mixin's _inflightPlatformCall
+          // serializes the platform side; the screen must not leak
+          // orphaned addFlags/clearFlags calls.
+          for (var i = 0; i < 3; i++) {
+            await tester.tap(
+              find.byKey(const ValueKey('secret-toggle-username')),
+            );
+            await tester.pumpAndSettle();
+            await tester.tap(
+              find.byKey(const ValueKey('secret-toggle-username')),
+            );
+            await tester.pumpAndSettle();
+          }
+
+          // Final state: nothing revealed → FLAG_SECURE cleared.
+          // Each cycle contributes one addFlags + one clearFlags; mixin
+          // collapses no-op re-entries, so the totals must match.
+          final adds = calls.where((c) => c.method == 'addFlags').toList();
+          final clears = calls.where((c) => c.method == 'clearFlags').toList();
+          expect(adds, hasLength(3));
+          expect(clears, hasLength(3));
+        });
+      },
+    );
+
+    testWidgets(
+      'iOS lifecycle: inactive while revealed inserts blur overlay; '
+      'resumed removes it',
+      (tester) async {
+        await withPlatform(TargetPlatform.iOS, () async {
+          // Channel mock is unused on iOS — the mixin's iOS path uses
+          // the overlay, not platform channels. Registering anyway is
+          // safe and keeps teardown consistent across platform branches.
+          mockWindowManager();
+          final (:container, :mock) = makeContainer();
+          addTearDown(container.dispose);
+
+          mockSecret(mock);
+          mockReveal(mock, 'username', 'admin');
+
+          await tester.pumpWidget(harness(container));
+          await tester.pumpAndSettle();
+
+          // Reveal a key — arms sensitivity (iOS path arms the lifecycle
+          // observer but does not insert overlay until backgrounded).
+          await tester.tap(find.byKey(const ValueKey('secret-toggle-username')));
+          await tester.pumpAndSettle();
+          expect(find.byType(BackdropFilter), findsNothing);
+
+          TestWidgetsFlutterBinding.instance
+              .handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+          await tester.pump();
+
+          expect(find.byType(BackdropFilter), findsOneWidget);
+
+          TestWidgetsFlutterBinding.instance
+              .handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+          await tester.pump();
+
+          expect(find.byType(BackdropFilter), findsNothing);
+        });
+      },
+    );
+
+    testWidgets(
+      'iOS lifecycle: inactive while NOTHING revealed inserts no overlay',
+      (tester) async {
+        await withPlatform(TargetPlatform.iOS, () async {
+          mockWindowManager();
+          final (:container, :mock) = makeContainer();
+          addTearDown(container.dispose);
+
+          mockSecret(mock);
+
+          await tester.pumpWidget(harness(container));
+          await tester.pumpAndSettle();
+
+          // Background the app without revealing anything — the screen
+          // has no plaintext to protect, so the mixin must not insert
+          // a blur overlay.
+          TestWidgetsFlutterBinding.instance
+              .handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+          await tester.pump();
+
+          expect(find.byType(BackdropFilter), findsNothing);
         });
       },
     );

--- a/mobile/test/features/resources/secret_screens_test.dart
+++ b/mobile/test/features/resources/secret_screens_test.dart
@@ -1,9 +1,23 @@
 // Sanitization + redaction guarantees on the Secret detail flow.
 // Tests use String.fromCharCode for control characters so the source
 // file stays printable and editor-safe.
+//
+// Widget-level coverage verifies the FLAG_SECURE wiring added in PR-5d:
+// revealing a key arms the secure-screen flag, concealing the last key
+// clears it, and a still-revealed sibling key keeps the flag armed when
+// any one key is hidden.
 
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:kubecenter/api/dio_client.dart';
+import 'package:kubecenter/auth/secure_storage.dart';
 import 'package:kubecenter/features/resources/secret_screens.dart';
+import 'package:kubecenter/theme/kube_theme_builder.dart';
+
+import '../../support/mock_dio_adapter.dart';
 
 void main() {
   group('sanitizeSecretValue', () {
@@ -53,5 +67,227 @@ void main() {
       const input = 'pwd-🔒';
       expect(sanitizeSecretValue(input), input);
     });
+  });
+
+  group('SecretDetailScreen FLAG_SECURE wiring (PR-5d)', () {
+    const namespace = 'default';
+    const name = 'app-credentials';
+
+    // Two-key Secret. Values are base64 placeholders — the screen masks
+    // them anyway; only the reveal endpoint surfaces plaintext.
+    final secretBody = {
+      'data': {
+        'kind': 'Secret',
+        'type': 'Opaque',
+        'metadata': {
+          'name': name,
+          'namespace': namespace,
+          'uid': 'sec-uid-1',
+          'creationTimestamp': '2026-04-01T00:00:00Z',
+        },
+        'data': {
+          'username': 'YWRtaW4=', // "admin"
+          'password': 'aHVudGVyMg==', // "hunter2"
+        },
+      },
+    };
+
+    void mockSecret(MockDioAdapter mock) {
+      mock.onJson(
+        'GET',
+        '/api/v1/resources/secrets/$namespace/$name',
+        body: secretBody,
+      );
+    }
+
+    void mockReveal(
+      MockDioAdapter mock,
+      String key,
+      String value,
+    ) {
+      mock.onJson(
+        'GET',
+        '/api/v1/resources/secrets/$namespace/$name/reveal/$key',
+        body: {
+          'data': {'value': value},
+        },
+      );
+    }
+
+    ({ProviderContainer container, MockDioAdapter mock}) makeContainer() {
+      final mock = MockDioAdapter();
+      final container = ProviderContainer(
+        overrides: [
+          backendUrlProvider.overrideWithValue('http://test'),
+          secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+        ],
+      );
+      container.read(dioProvider).httpClientAdapter = mock;
+      container.read(refreshDioProvider).httpClientAdapter = mock;
+      return (container: container, mock: mock);
+    }
+
+    Widget harness(ProviderContainer container) {
+      return UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          theme: buildKubeTheme('nexus'),
+          home: const SecretDetailScreen(
+            namespace: namespace,
+            name: name,
+          ),
+        ),
+      );
+    }
+
+    /// Runs [body] with the target platform overridden — needed because
+    /// the FLAG_SECURE path only fires on Android. Restores the prior
+    /// override in a `finally` block so the test framework's invariant
+    /// check sees the original state.
+    Future<void> withPlatform(
+      TargetPlatform platform,
+      Future<void> Function() body,
+    ) async {
+      final prior = debugDefaultTargetPlatformOverride;
+      debugDefaultTargetPlatformOverride = platform;
+      try {
+        await body();
+      } finally {
+        debugDefaultTargetPlatformOverride = prior;
+      }
+    }
+
+    /// Mocks the `flutter_windowmanager` MethodChannel and returns the
+    /// captured calls list for assertions. Caller is responsible for
+    /// `addTearDown` cleanup (registered here).
+    List<MethodCall> mockWindowManager() {
+      final calls = <MethodCall>[];
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        const MethodChannel('flutter_windowmanager'),
+        (call) async {
+          calls.add(call);
+          return true;
+        },
+      );
+      addTearDown(() {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+          const MethodChannel('flutter_windowmanager'),
+          null,
+        );
+      });
+      return calls;
+    }
+
+    testWidgets(
+      'revealing a key adds FLAG_SECURE; concealing the last key clears it',
+      (tester) async {
+        await withPlatform(TargetPlatform.android, () async {
+          final calls = mockWindowManager();
+          final (:container, :mock) = makeContainer();
+          addTearDown(container.dispose);
+
+          mockSecret(mock);
+          mockReveal(mock, 'username', 'admin');
+
+          await tester.pumpWidget(harness(container));
+          await tester.pumpAndSettle();
+
+          // Initial render: nothing revealed, no FLAG_SECURE traffic yet.
+          expect(calls, isEmpty);
+
+          // Tap the Reveal button for the `username` key.
+          await tester.tap(find.byKey(const ValueKey('secret-toggle-username')));
+          await tester.pumpAndSettle();
+
+          // FLAG_SECURE added once.
+          final adds = calls.where((c) => c.method == 'addFlags').toList();
+          expect(adds, hasLength(1));
+          expect(adds.single.arguments['flags'], 0x00002000);
+
+          // Now Hide the key — last revealed key concealed → clear.
+          calls.clear();
+          await tester.tap(find.byKey(const ValueKey('secret-toggle-username')));
+          await tester.pumpAndSettle();
+
+          final clears = calls.where((c) => c.method == 'clearFlags').toList();
+          expect(clears, hasLength(1));
+          expect(clears.single.arguments['flags'], 0x00002000);
+        });
+      },
+    );
+
+    testWidgets(
+      'FLAG_SECURE stays added while any other key remains revealed',
+      (tester) async {
+        await withPlatform(TargetPlatform.android, () async {
+          final calls = mockWindowManager();
+          final (:container, :mock) = makeContainer();
+          addTearDown(container.dispose);
+
+          mockSecret(mock);
+          mockReveal(mock, 'username', 'admin');
+          mockReveal(mock, 'password', 'hunter2');
+
+          await tester.pumpWidget(harness(container));
+          await tester.pumpAndSettle();
+
+          // Reveal both keys.
+          await tester.tap(find.byKey(const ValueKey('secret-toggle-username')));
+          await tester.pumpAndSettle();
+          await tester.tap(find.byKey(const ValueKey('secret-toggle-password')));
+          await tester.pumpAndSettle();
+
+          // First reveal adds; second is idempotent — no second addFlags.
+          expect(calls.where((c) => c.method == 'addFlags'), hasLength(1));
+          expect(calls.where((c) => c.method == 'clearFlags'), isEmpty);
+
+          // Conceal `username` only — `password` still revealed, must
+          // NOT clear FLAG_SECURE.
+          calls.clear();
+          await tester.tap(find.byKey(const ValueKey('secret-toggle-username')));
+          await tester.pumpAndSettle();
+
+          expect(calls.where((c) => c.method == 'clearFlags'), isEmpty);
+          expect(calls.where((c) => c.method == 'addFlags'), isEmpty);
+
+          // Conceal the last revealed key — now it clears.
+          await tester.tap(find.byKey(const ValueKey('secret-toggle-password')));
+          await tester.pumpAndSettle();
+
+          expect(calls.where((c) => c.method == 'clearFlags'), hasLength(1));
+        });
+      },
+    );
+
+    testWidgets(
+      'route disposal while a key is revealed clears FLAG_SECURE',
+      (tester) async {
+        await withPlatform(TargetPlatform.android, () async {
+          final calls = mockWindowManager();
+          final (:container, :mock) = makeContainer();
+          addTearDown(container.dispose);
+
+          mockSecret(mock);
+          mockReveal(mock, 'username', 'admin');
+
+          await tester.pumpWidget(harness(container));
+          await tester.pumpAndSettle();
+
+          await tester.tap(find.byKey(const ValueKey('secret-toggle-username')));
+          await tester.pumpAndSettle();
+          expect(calls.where((c) => c.method == 'addFlags'), hasLength(1));
+
+          // Replace the entire app with an empty shell — disposes the
+          // detail State, which clears via the mixin's dispose path.
+          calls.clear();
+          await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+          await tester.pump();
+
+          expect(calls.any((c) => c.method == 'clearFlags'), isTrue);
+        });
+      },
+    );
   });
 }

--- a/mobile/test/support/platform_helpers.dart
+++ b/mobile/test/support/platform_helpers.dart
@@ -1,0 +1,20 @@
+// Shared helpers for widget tests that need to drive Flutter's platform
+// override. `withPlatform` sets `debugDefaultTargetPlatformOverride` for
+// the duration of [body] and restores the prior value in a `finally`
+// block so the framework's invariant check (which runs BEFORE `tearDown`)
+// sees the original state.
+
+import 'package:flutter/foundation.dart';
+
+Future<void> withPlatform(
+  TargetPlatform platform,
+  Future<void> Function() body,
+) async {
+  final prior = debugDefaultTargetPlatformOverride;
+  debugDefaultTargetPlatformOverride = platform;
+  try {
+    await body();
+  } finally {
+    debugDefaultTargetPlatformOverride = prior;
+  }
+}

--- a/mobile/test/widgets/secure_screen_mixin_test.dart
+++ b/mobile/test/widgets/secure_screen_mixin_test.dart
@@ -4,22 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kubecenter/widgets/secure_screen_mixin.dart';
 
-/// Runs [body] with [debugDefaultTargetPlatformOverride] set, restoring
-/// the prior value in a `finally` block so the test framework's
-/// invariant check (which runs BEFORE `tearDown`) sees the original
-/// state.
-Future<void> _withPlatform(
-  TargetPlatform platform,
-  Future<void> Function() body,
-) async {
-  final prior = debugDefaultTargetPlatformOverride;
-  debugDefaultTargetPlatformOverride = platform;
-  try {
-    await body();
-  } finally {
-    debugDefaultTargetPlatformOverride = prior;
-  }
-}
+import '../support/platform_helpers.dart';
 
 void main() {
   // `kIgnoreDebugForTests` defaults to `kDebugMode`, which is `true` in
@@ -51,7 +36,7 @@ void main() {
     });
 
     testWidgets('setSensitive(true) adds FLAG_SECURE', (tester) async {
-      await _withPlatform(TargetPlatform.android, () async {
+      await withPlatform(TargetPlatform.android, () async {
         await tester.pumpWidget(const MaterialApp(home: _Host()));
         final state = tester.state<_HostState>(find.byType(_Host));
 
@@ -65,7 +50,7 @@ void main() {
     });
 
     testWidgets('setSensitive(false) clears FLAG_SECURE', (tester) async {
-      await _withPlatform(TargetPlatform.android, () async {
+      await withPlatform(TargetPlatform.android, () async {
         await tester.pumpWidget(const MaterialApp(home: _Host()));
         final state = tester.state<_HostState>(find.byType(_Host));
 
@@ -80,7 +65,7 @@ void main() {
 
     testWidgets('idempotent — repeat setSensitive(true) is a no-op',
         (tester) async {
-      await _withPlatform(TargetPlatform.android, () async {
+      await withPlatform(TargetPlatform.android, () async {
         await tester.pumpWidget(const MaterialApp(home: _Host()));
         final state = tester.state<_HostState>(find.byType(_Host));
 
@@ -94,7 +79,7 @@ void main() {
 
     testWidgets('dispose clears FLAG_SECURE if sensitive was true',
         (tester) async {
-      await _withPlatform(TargetPlatform.android, () async {
+      await withPlatform(TargetPlatform.android, () async {
         await tester.pumpWidget(const MaterialApp(home: _Host()));
         final state = tester.state<_HostState>(find.byType(_Host));
 
@@ -113,7 +98,7 @@ void main() {
     testWidgets(
         'AppLifecycleState.inactive inserts blur overlay when sensitive',
         (tester) async {
-      await _withPlatform(TargetPlatform.iOS, () async {
+      await withPlatform(TargetPlatform.iOS, () async {
         await tester.pumpWidget(const MaterialApp(home: _Host()));
         final state = tester.state<_HostState>(find.byType(_Host));
 
@@ -131,7 +116,7 @@ void main() {
     testWidgets(
         'AppLifecycleState.resumed removes the blur overlay',
         (tester) async {
-      await _withPlatform(TargetPlatform.iOS, () async {
+      await withPlatform(TargetPlatform.iOS, () async {
         await tester.pumpWidget(const MaterialApp(home: _Host()));
         final state = tester.state<_HostState>(find.byType(_Host));
 
@@ -149,7 +134,7 @@ void main() {
 
     testWidgets('no blur when sensitive == false and app backgrounded',
         (tester) async {
-      await _withPlatform(TargetPlatform.iOS, () async {
+      await withPlatform(TargetPlatform.iOS, () async {
         await tester.pumpWidget(const MaterialApp(home: _Host()));
         final state = tester.state<_HostState>(find.byType(_Host));
 
@@ -164,7 +149,7 @@ void main() {
     testWidgets(
         'rapid inactive-resumed-inactive cycles leave no orphans',
         (tester) async {
-      await _withPlatform(TargetPlatform.iOS, () async {
+      await withPlatform(TargetPlatform.iOS, () async {
         await tester.pumpWidget(const MaterialApp(home: _Host()));
         final state = tester.state<_HostState>(find.byType(_Host));
 
@@ -182,7 +167,7 @@ void main() {
     });
 
     testWidgets('paused fires the same insertion as inactive', (tester) async {
-      await _withPlatform(TargetPlatform.iOS, () async {
+      await withPlatform(TargetPlatform.iOS, () async {
         await tester.pumpWidget(const MaterialApp(home: _Host()));
         final state = tester.state<_HostState>(find.byType(_Host));
 
@@ -196,7 +181,7 @@ void main() {
 
     testWidgets('hidden fires the same insertion as inactive',
         (tester) async {
-      await _withPlatform(TargetPlatform.iOS, () async {
+      await withPlatform(TargetPlatform.iOS, () async {
         await tester.pumpWidget(const MaterialApp(home: _Host()));
         final state = tester.state<_HostState>(find.byType(_Host));
 
@@ -211,7 +196,7 @@ void main() {
     testWidgets(
         'lifecycle event after dispose does not insert overlay or throw',
         (tester) async {
-      await _withPlatform(TargetPlatform.iOS, () async {
+      await withPlatform(TargetPlatform.iOS, () async {
         await tester.pumpWidget(const MaterialApp(home: _Host()));
         final state = tester.state<_HostState>(find.byType(_Host));
         await state.setSensitive(true);
@@ -246,7 +231,7 @@ void main() {
         return;
       }
 
-      await _withPlatform(TargetPlatform.android, () async {
+      await withPlatform(TargetPlatform.android, () async {
         final platformCalls = <MethodCall>[];
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
             .setMockMethodCallHandler(


### PR DESCRIPTION
## Summary

- Mix `SecureScreenMixin<SecretDetailScreen>` into `_SecretDetailScreenState`. After every reveal or conceal, recompute `_revealed.isNotEmpty` and call `setSensitive(...)` — Android adds/clears `FLAG_SECURE`, iOS arms/disarms the lifecycle blur cover.
- Sensitive flag stays armed while ANY key remains revealed; clears only when the last revealed key is hidden. Route pop / back-button clears via the mixin's existing `dispose` chain.
- Widget tests pump the screen under `TargetPlatform.android` with a mocked `flutter_windowmanager` channel and a `MockDioAdapter` serving the GET + `/reveal/:key` endpoints; assert the addFlags / clearFlags traffic across the four state transitions.

## Operator impact

Reveals a Secret value, switches apps — the OS app-switcher snapshot no longer surfaces the plaintext:

- **Android:** `FLAG_SECURE` blocks the snapshot entirely; screenshots / screen recording also blocked while the flag is set.
- **iOS:** the mixin's blur overlay lands on `AppLifecycleState.inactive` (which fires BEFORE the OS captures the app-switcher tile) and lifts on `.resumed`.

## Test plan

- [x] `cd mobile && flutter analyze` — clean (repo-wide).
- [x] `cd mobile && flutter test` — 996/996 pass.
- [x] New `SecretDetailScreen FLAG_SECURE wiring` group covers: reveal → addFlags / conceal-last → clearFlags / multi-key stays armed until last hide / route disposal clears.
- [ ] **Manual smoke (reviewer)** on iOS Simulator — reveal a Secret value, swipe to app-switcher, verify the blur cover appears instead of plaintext.
- [ ] **Manual smoke (reviewer)** on Android Emulator — reveal a Secret value, swipe to recents, verify the screen is blocked (black/theme-colored placeholder per `FLAG_SECURE`).

## Plan reference

`plans/mobile-app-m5-pr-sequence.md` — U4. PR-5d — Secret screen FLAG_SECURE + iOS blur cover.

Closes the operator persona gap "security-conscious user with a phone they sometimes hand to others" from the M5 plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)