### PR TITLE
feat(mobile): M5 PR-5e — ESO Force Sync + Bulk Refresh write parity (local-cluster)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,7 +334,7 @@ Keep below the static sections so the prompt cache prefix stays warm.
 
 ### Mobile invariants (M3+ work must respect)
 
-- All writes route through `executeAction` or YAML/wizard controllers and **pin the active cluster**; mismatch aborts. Wizard preview + apply requests send explicit `X-Cluster-ID`; `ClusterInterceptor` only injects when header is absent.
+- All writes route through `executeAction`, YAML/wizard controllers, **OR** domain-specific `AutoDisposeFamilyNotifier` controllers mixing in `RefreshableController` (e.g., ESO Force Sync, ESO Bulk Refresh) and **pin the active cluster**; mismatch aborts. Domain-specific controllers MUST: (1) accept a cluster identity at construction (typically via the family key) and pass it on every backend call as `clusterIdOverride`; (2) call `clusterStillPinned(ref)` after every async await and surface `pinnedMismatchMessage(PinPhase.postEmission)` on mismatch before any state write; (3) document the cluster-pinning contract in their class docstring. Wizard preview + apply requests send explicit `X-Cluster-ID`; `ClusterInterceptor` only injects when header is absent.
 - Type-to-confirm sheet (`confirm_sheet.dart`) is the single confirmation surface; mirrors web `ConfirmDialog.tsx`.
 - Web/Dart action maps must stay isomorphic — `frontend/lib/action-handlers.ts` is the parallel-edit target for `resource_actions.dart`.
 - **Secret-data destruction defense:** `data`/`stringData` are masked on Secret GETs; any Secret edit path MUST `stripSensitiveDataFields: true` on the editor seed before SSA, or apply will overwrite real credentials with `"****"`.

--- a/frontend/lib/action-handlers.ts
+++ b/frontend/lib/action-handlers.ts
@@ -1,6 +1,22 @@
 /**
  * Resource action handlers — maps action IDs to API calls.
  * Used by ResourceTable's kebab menu.
+ *
+ * Isomorphism contract: this file is the parallel-edit target for
+ * `mobile/lib/api/resource_actions.dart`. ActionId variants and the
+ * `ACTIONS_BY_KIND` map must stay in sync across both files.
+ *
+ * Domain-specific writes intentionally OUTSIDE this map (PR-5e-review #20):
+ *   - ESO Force Sync (`ESOExternalSecretDetail.tsx` → `esoApi.forceSync*`)
+ *   - ESO Bulk Refresh (`ESOBulkRefreshDialog.tsx` → bulk-refresh routes)
+ * These live on their own domain controllers (mobile equivalents:
+ * `force_sync_controller.dart`, `bulk_refresh_controller.dart`) and
+ * are launched from per-detail / per-dashboard buttons rather than the
+ * generic kebab menu. The rationale is documented in the CLAUDE.md
+ * mobile invariant covering domain-specific `AutoDisposeFamilyNotifier`
+ * write controllers. Do NOT migrate them into the action map — the
+ * scope-resolve + poll-loop shape doesn't fit the single-shot
+ * `executeAction` contract.
  */
 import { apiDelete, apiPost } from "@/lib/api.ts";
 import type { K8sResource, RBACSummary } from "@/lib/k8s-types.ts";

--- a/mobile/lib/api/api_error.dart
+++ b/mobile/lib/api/api_error.dart
@@ -17,6 +17,7 @@ class ApiError implements Exception {
     required this.message,
     this.detail,
     this.reason,
+    this.extra,
   });
 
   final int statusCode;
@@ -28,11 +29,25 @@ class ApiError implements Exception {
   /// "scope_changed"). Mirrors the frontend's `ApiError.reason`.
   final String? reason;
 
+  /// Endpoint-specific structured detail (e.g. `{jobId: "..."}` on
+  /// `active_job_exists`, `{added: [...], removed: [...]}` on
+  /// `scope_changed`). Mirrors the frontend's `ApiError.body.error.extra`.
+  /// Prefer the [extraString] helper over reading the map directly.
+  final Map<String, dynamic>? extra;
+
+  /// Returns the `extra[key]` value as a String, or null when the key is
+  /// missing or non-string. Mirrors `errorExtra(err, key)` in the web
+  /// `api.ts`. Use for 409 `active_job_exists.jobId` and similar.
+  String? extraString(String key) {
+    final v = extra?[key];
+    return v is String ? v : null;
+  }
+
   /// Builds an ApiError from a DioException by inspecting the response body.
   /// Tolerates three body shapes; everything else falls back to a friendly
   /// status-derived message:
-  ///   1. Canonical envelope: `{error: {code, message, detail, reason}}`
-  ///   2. Top-level fields: `{message, code, detail, reason}`
+  ///   1. Canonical envelope: `{error: {code, message, detail, reason, extra}}`
+  ///   2. Top-level fields: `{message, code, detail, reason, extra}`
   ///   3. Plain string body — used as-is when short and not HTML
   factory ApiError.fromDio(DioException e) {
     final res = e.response;
@@ -50,6 +65,7 @@ class ApiError implements Exception {
             message: msg,
             detail: _asString(nested['detail']),
             reason: _asString(nested['reason']),
+            extra: _asExtra(nested['extra']),
           );
         }
       }
@@ -62,6 +78,7 @@ class ApiError implements Exception {
           message: topMessage,
           detail: _asString(body['detail']),
           reason: _asString(body['reason']),
+          extra: _asExtra(body['extra']),
         );
       }
     }
@@ -102,6 +119,8 @@ class ApiError implements Exception {
 
   static String? _asString(Object? v) => v is String ? v : null;
   static int? _asInt(Object? v) => v is int ? v : null;
+  static Map<String, dynamic>? _asExtra(Object? v) =>
+      v is Map ? Map<String, dynamic>.from(v) : null;
 
   // Dio's default badResponse message is the internal validateStatus blurb;
   // surface friendly status text instead.

--- a/mobile/lib/api/eso_repository.dart
+++ b/mobile/lib/api/eso_repository.dart
@@ -691,6 +691,16 @@ enum BulkRefreshAction {
   store,
   clusterStore,
   namespace,
+
+  /// Open-enum sentinel for wire values the mobile client doesn't yet
+  /// recognise (e.g., a newer backend introducing a `refresh_push_secret`
+  /// variant). Surfaces alongside other ESO open-enum parsers
+  /// (`EsoStatus`, `DriftStatus`, `EsoThresholdSource`) rather than
+  /// throwing an `ArgumentError` that propagates to Sentry as an
+  /// unhandled crash. Consumers should treat this as a non-routable
+  /// action (the controller's catch-all surfaces it through the normal
+  /// error state).
+  unknown,
 }
 
 BulkRefreshAction _bulkRefreshActionFromJson(Object? v) {
@@ -702,12 +712,12 @@ BulkRefreshAction _bulkRefreshActionFromJson(Object? v) {
     case 'refresh_namespace':
       return BulkRefreshAction.namespace;
     default:
-      // Defensive: an unknown wire value would be a backend bug, but
-      // collapsing to `namespace` would silently mis-route. Throw so
-      // the parse error surfaces clearly in the failure state.
-      throw ArgumentError(
-        'Unknown BulkRefreshAction: $v',
-      );
+      // Open-enum fallback. Throwing here would propagate as an
+      // unhandled exception (Sentry crash) on any backend that
+      // introduces a new variant before mobile catches up. Mirrors the
+      // EsoStatus / DriftStatus / EsoThresholdSource patterns in this
+      // same file.
+      return BulkRefreshAction.unknown;
   }
 }
 
@@ -1247,6 +1257,10 @@ class EsoRepository {
       );
 
   /// POST /externalsecrets/refresh-namespace/{namespace} (no trailing path).
+  ///
+  // Namespace POST omits /refresh-all suffix (matches backend routes.go:674);
+  // store + clusterstore variants append it. Do NOT "normalize" this — the
+  // asymmetry is intentional and aligns with the web client.
   Future<BulkRefreshSubmitResponse> bulkRefreshNamespace({
     required String namespace,
     required List<String> targetUIDs,
@@ -1263,10 +1277,17 @@ class EsoRepository {
 
   /// GET /externalsecrets/bulk-refresh-jobs/{jobId}. Caller polls every
   /// 2s until `completedAt` is non-null.
+  ///
+  /// [receiveTimeout] caps the per-poll wait — bulk refresh jobs on
+  /// large scopes commonly exceed 30s server-side, so the controller
+  /// passes a tighter 10s window so a wedged kube-apiserver doesn't
+  /// hold the loop hostage. Defaults to Dio's ambient receiveTimeout
+  /// when omitted (most other call sites).
   Future<BulkRefreshJob> getBulkRefreshJob({
     required String jobId,
     String? clusterIdOverride,
     CancelToken? cancelToken,
+    Duration? receiveTimeout,
   }) =>
       _getOne<BulkRefreshJob>(
         path: '/api/v1/externalsecrets/bulk-refresh-jobs/'
@@ -1275,6 +1296,7 @@ class EsoRepository {
         notFoundMessage: 'Bulk refresh job $jobId not found',
         clusterIdOverride: clusterIdOverride,
         cancelToken: cancelToken,
+        receiveTimeout: receiveTimeout,
       );
 
   Future<BulkRefreshSubmitResponse> _submitBulkRefresh({
@@ -1312,9 +1334,15 @@ class EsoRepository {
   // Internals
   // -------------------------------------------------------------------------
 
-  Options? _opts(String? clusterIdOverride) => clusterIdOverride == null
-      ? null
-      : Options(headers: {'X-Cluster-ID': clusterIdOverride});
+  Options? _opts(String? clusterIdOverride, {Duration? receiveTimeout}) {
+    if (clusterIdOverride == null && receiveTimeout == null) return null;
+    return Options(
+      headers: clusterIdOverride == null
+          ? null
+          : {'X-Cluster-ID': clusterIdOverride},
+      receiveTimeout: receiveTimeout,
+    );
+  }
 
   Future<List<T>> _fetchList<T>({
     required String path,
@@ -1351,11 +1379,12 @@ class EsoRepository {
     required String notFoundMessage,
     String? clusterIdOverride,
     CancelToken? cancelToken,
+    Duration? receiveTimeout,
   }) async {
     try {
       final res = await _dio.get<Map<String, dynamic>>(
         path,
-        options: _opts(clusterIdOverride),
+        options: _opts(clusterIdOverride, receiveTimeout: receiveTimeout),
         cancelToken: cancelToken,
       );
       final data = res.data?['data'];
@@ -1523,21 +1552,53 @@ final clusterExternalSecretDetailProvider = FutureProvider.autoDispose.family<
       );
 });
 
-/// Standalone provider for namespaced stores keyed by clusterId — this
-/// is distinct from `wizards/widgets/store_picker.dart`'s
-/// `storeListProvider` (which pairs namespaced + cluster lists into a
-/// `_StoreLists` struct for the picker dropdown). PR-4h's read-side
-/// screens need separate stream slots per scope, so they don't share
-/// the picker's combined family.
+/// Family key for the namespaced SecretStore list provider. Mirrors the
+/// shape of [ExternalSecretListKey] so an empty-string namespace
+/// normalises to null and collapses two ostensibly-equal keys onto the
+/// same slot (avoids splitting cluster-wide list caches across callers
+/// that pass `''` vs `null` for "no namespace filter").
+class StoresListKey {
+  /// Normalise [namespace]: empty string is treated as null so two
+  /// equal keys map to one cache slot.
+  StoresListKey({required this.clusterId, String? namespace})
+      : namespace = (namespace != null && namespace.isEmpty) ? null : namespace;
+
+  final String clusterId;
+
+  /// When non-null, the list is filtered server-side to the given
+  /// namespace via the `?namespace=` query param. Null returns
+  /// cluster-wide stores (subject to RBAC).
+  final String? namespace;
+
+  @override
+  bool operator ==(Object other) =>
+      other is StoresListKey &&
+      other.clusterId == clusterId &&
+      other.namespace == namespace;
+
+  @override
+  int get hashCode => Object.hash(clusterId, namespace);
+}
+
+/// Standalone provider for namespaced stores. Keyed by [StoresListKey] so
+/// callers can request a server-side namespace filter (used by the bulk
+/// refresh scope picker's store variant) or omit it for cluster-wide
+/// listing (dashboard, stores list screen).
+///
+/// Distinct from `wizards/widgets/store_picker.dart`'s `storeListProvider`
+/// (which pairs namespaced + cluster lists into a `_StoreLists` struct
+/// for the picker dropdown). Read-side screens need separate stream slots
+/// per scope, so they don't share the picker's combined family.
 final storesListProvider = FutureProvider.autoDispose
-    .family<List<SecretStore>, String>((ref, clusterId) async {
+    .family<List<SecretStore>, StoresListKey>((ref, key) async {
   ref.watch(activeClusterProvider);
   final cancel = CancelToken();
   ref.onDispose(() {
     if (!cancel.isCancelled) cancel.cancel('stores list invalidated');
   });
   return ref.read(esoRepositoryProvider).listStores(
-        clusterIdOverride: clusterId,
+        namespace: key.namespace,
+        clusterIdOverride: key.clusterId,
         cancelToken: cancel,
       );
 });

--- a/mobile/lib/api/eso_repository.dart
+++ b/mobile/lib/api/eso_repository.dart
@@ -676,6 +676,222 @@ class StoreMetrics {
 }
 
 // ---------------------------------------------------------------------------
+// Phase E bulk-refresh wire types (PR-5e)
+// ---------------------------------------------------------------------------
+//
+// Mirror `backend/internal/externalsecrets/bulk.go` BulkScopeResponse,
+// BulkScopeTarget, BulkNamespaceCount, BulkRefreshJobResponse, and
+// `frontend/lib/eso-types.ts` BulkScope* / BulkRefresh* / BulkRefreshAction.
+// Drift between these three definitions is a wire-shape bug.
+
+/// Which bulk-refresh endpoint family a request targets. Wire enum on
+/// `BulkScopeResponse.action`; the mobile controller also uses it to
+/// pick the matching submit endpoint.
+enum BulkRefreshAction {
+  store,
+  clusterStore,
+  namespace,
+}
+
+BulkRefreshAction _bulkRefreshActionFromJson(Object? v) {
+  switch (v) {
+    case 'refresh_store':
+      return BulkRefreshAction.store;
+    case 'refresh_cluster_store':
+      return BulkRefreshAction.clusterStore;
+    case 'refresh_namespace':
+      return BulkRefreshAction.namespace;
+    default:
+      // Defensive: an unknown wire value would be a backend bug, but
+      // collapsing to `namespace` would silently mis-route. Throw so
+      // the parse error surfaces clearly in the failure state.
+      throw ArgumentError(
+        'Unknown BulkRefreshAction: $v',
+      );
+  }
+}
+
+/// One ExternalSecret entry in a resolved scope. UID is what the bulk
+/// submit POST echoes back to pin scope; namespace + name are for the
+/// confirm-phase breakdown rendering.
+class BulkScopeTarget {
+  const BulkScopeTarget({
+    required this.namespace,
+    required this.name,
+    required this.uid,
+  });
+
+  final String namespace;
+  final String name;
+  final String uid;
+
+  factory BulkScopeTarget.fromJson(Map<String, dynamic> json) =>
+      BulkScopeTarget(
+        namespace: json['namespace'] as String? ?? '',
+        name: json['name'] as String? ?? '',
+        uid: json['uid'] as String? ?? '',
+      );
+}
+
+/// Per-namespace breakdown row used by the confirm-phase UI.
+class BulkNamespaceCount {
+  const BulkNamespaceCount({required this.namespace, required this.count});
+
+  final String namespace;
+  final int count;
+
+  factory BulkNamespaceCount.fromJson(Map<String, dynamic> json) =>
+      BulkNamespaceCount(
+        namespace: json['namespace'] as String? ?? '',
+        count: (json['count'] as num?)?.toInt() ?? 0,
+      );
+}
+
+/// GET refresh-scope payload. `restricted` is true when SA-view total
+/// exceeds what the operator can refresh; the confirm-phase UI surfaces
+/// this as the "Showing only resources you can refresh" RBAC notice.
+class BulkScopeResponse {
+  const BulkScopeResponse({
+    required this.action,
+    required this.scopeTarget,
+    required this.totalCount,
+    required this.totalNamespaces,
+    required this.visibleCount,
+    required this.restricted,
+    required this.targets,
+    required this.byNamespace,
+  });
+
+  final BulkRefreshAction action;
+  final String scopeTarget;
+  final int totalCount;
+  final int totalNamespaces;
+  final int visibleCount;
+  final bool restricted;
+  final List<BulkScopeTarget> targets;
+  final List<BulkNamespaceCount> byNamespace;
+
+  factory BulkScopeResponse.fromJson(Map<String, dynamic> json) {
+    final targets = (json['targets'] as List?)
+            ?.whereType<Map<dynamic, dynamic>>()
+            .map((m) => BulkScopeTarget.fromJson(Map<String, dynamic>.from(m)))
+            .toList() ??
+        const <BulkScopeTarget>[];
+    final byNs = (json['byNamespace'] as List?)
+            ?.whereType<Map<dynamic, dynamic>>()
+            .map((m) =>
+                BulkNamespaceCount.fromJson(Map<String, dynamic>.from(m)))
+            .toList() ??
+        const <BulkNamespaceCount>[];
+    return BulkScopeResponse(
+      action: _bulkRefreshActionFromJson(json['action']),
+      scopeTarget: json['scopeTarget'] as String? ?? '',
+      totalCount: (json['totalCount'] as num?)?.toInt() ?? 0,
+      totalNamespaces: (json['totalNamespaces'] as num?)?.toInt() ?? 0,
+      visibleCount: (json['visibleCount'] as num?)?.toInt() ?? 0,
+      restricted: json['restricted'] as bool? ?? false,
+      targets: targets,
+      byNamespace: byNs,
+    );
+  }
+}
+
+/// 202 response from a bulk-refresh submit POST.
+class BulkRefreshSubmitResponse {
+  const BulkRefreshSubmitResponse({
+    required this.jobId,
+    required this.targetCount,
+  });
+
+  final String jobId;
+  final int targetCount;
+
+  factory BulkRefreshSubmitResponse.fromJson(Map<String, dynamic> json) =>
+      BulkRefreshSubmitResponse(
+        jobId: json['jobId'] as String? ?? '',
+        targetCount: (json['targetCount'] as num?)?.toInt() ?? 0,
+      );
+}
+
+/// One entry in `BulkRefreshJob.failed` / `BulkRefreshJob.skipped`.
+class BulkRefreshOutcome {
+  const BulkRefreshOutcome({required this.uid, required this.reason});
+
+  final String uid;
+  final String reason;
+
+  factory BulkRefreshOutcome.fromJson(Map<String, dynamic> json) =>
+      BulkRefreshOutcome(
+        uid: json['uid'] as String? ?? '',
+        reason: json['reason'] as String? ?? '',
+      );
+}
+
+/// GET bulk-refresh-jobs/{jobId} payload. `completedAt != null` is the
+/// terminal signal; the poll loop stops then.
+class BulkRefreshJob {
+  const BulkRefreshJob({
+    required this.jobId,
+    required this.clusterId,
+    required this.requestedBy,
+    required this.action,
+    required this.scopeTarget,
+    required this.targetCount,
+    required this.createdAt,
+    this.completedAt,
+    required this.succeeded,
+    required this.failed,
+    required this.skipped,
+  });
+
+  final String jobId;
+  final String clusterId;
+  final String requestedBy;
+  final BulkRefreshAction action;
+  final String scopeTarget;
+  final int targetCount;
+  final String createdAt;
+  final String? completedAt;
+  final List<String> succeeded;
+  final List<BulkRefreshOutcome> failed;
+  final List<BulkRefreshOutcome> skipped;
+
+  bool get isDone => completedAt != null && completedAt!.isNotEmpty;
+
+  /// Total processed = succeeded + failed + skipped. Used for the poll-
+  /// phase progress UI (`processed / targetCount`).
+  int get processed => succeeded.length + failed.length + skipped.length;
+
+  factory BulkRefreshJob.fromJson(Map<String, dynamic> json) {
+    List<T> parseList<T>(Object? raw, T Function(Map<String, dynamic>) fromJson) {
+      if (raw is! List) return <T>[];
+      return raw
+          .whereType<Map<dynamic, dynamic>>()
+          .map((m) => fromJson(Map<String, dynamic>.from(m)))
+          .toList();
+    }
+
+    final completed = json['completedAt'];
+    return BulkRefreshJob(
+      jobId: json['jobId'] as String? ?? '',
+      clusterId: json['clusterId'] as String? ?? '',
+      requestedBy: json['requestedBy'] as String? ?? '',
+      action: _bulkRefreshActionFromJson(json['action']),
+      scopeTarget: json['scopeTarget'] as String? ?? '',
+      targetCount: (json['targetCount'] as num?)?.toInt() ?? 0,
+      createdAt: json['createdAt'] as String? ?? '',
+      completedAt: completed is String && completed.isNotEmpty ? completed : null,
+      succeeded: (json['succeeded'] as List?)
+              ?.whereType<String>()
+              .toList() ??
+          const <String>[],
+      failed: parseList(json['failed'], BulkRefreshOutcome.fromJson),
+      skipped: parseList(json['skipped'], BulkRefreshOutcome.fromJson),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Repository
 // ---------------------------------------------------------------------------
 
@@ -904,6 +1120,193 @@ class EsoRepository {
         clusterIdOverride: clusterIdOverride,
         cancelToken: cancelToken,
       );
+
+  // -------------------------------------------------------------------------
+  // Phase E writes (PR-5e)
+  // -------------------------------------------------------------------------
+  //
+  // Force-sync + bulk-refresh routes are local-cluster only on the backend
+  // (`backend/internal/externalsecrets/actions.go:66` rejects X-Cluster-ID
+  // != "local" with 501). Mobile gates the buttons up front; these methods
+  // still forward `clusterIdOverride` so the 501 surfaces as a clean
+  // ApiError if the gate is bypassed.
+
+  /// POST /externalsecrets/externalsecrets/{ns}/{name}/force-sync.
+  /// Returns immediately (202); ESO performs the actual sync async. The
+  /// backend response body is `{ "data": { "status": "force-syncing" } }`
+  /// and there are no fields the UI needs — success is signaled by the
+  /// absence of an [ApiError]. Caller invalidates
+  /// [externalSecretDetailProvider] to surface the new drift state.
+  ///
+  /// 409 with `reason: "already_refreshing"` means a sync landed within
+  /// the backend's 30s in-flight window; the controller surfaces this
+  /// without re-triggering.
+  Future<void> forceSync({
+    required String namespace,
+    required String name,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) async {
+    try {
+      await _dio.post<Map<String, dynamic>>(
+        '/api/v1/externalsecrets/externalsecrets/'
+        '${Uri.encodeComponent(namespace)}/${Uri.encodeComponent(name)}/'
+        'force-sync',
+        options: _opts(clusterIdOverride),
+        cancelToken: cancelToken,
+      );
+    } on DioException catch (e) {
+      if (CancelToken.isCancel(e)) rethrow;
+      final err = e.error;
+      throw err is ApiError ? err : ApiError.fromDio(e);
+    }
+  }
+
+  /// GET /externalsecrets/stores/{ns}/{name}/refresh-scope.
+  Future<BulkScopeResponse> resolveStoreScope({
+    required String namespace,
+    required String name,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) =>
+      _getOne<BulkScopeResponse>(
+        path: '/api/v1/externalsecrets/stores/'
+            '${Uri.encodeComponent(namespace)}/'
+            '${Uri.encodeComponent(name)}/refresh-scope',
+        parse: BulkScopeResponse.fromJson,
+        notFoundMessage:
+            'Could not resolve refresh scope for store $namespace/$name',
+        clusterIdOverride: clusterIdOverride,
+        cancelToken: cancelToken,
+      );
+
+  /// GET /externalsecrets/clusterstores/{name}/refresh-scope.
+  Future<BulkScopeResponse> resolveClusterStoreScope({
+    required String name,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) =>
+      _getOne<BulkScopeResponse>(
+        path: '/api/v1/externalsecrets/clusterstores/'
+            '${Uri.encodeComponent(name)}/refresh-scope',
+        parse: BulkScopeResponse.fromJson,
+        notFoundMessage:
+            'Could not resolve refresh scope for cluster store $name',
+        clusterIdOverride: clusterIdOverride,
+        cancelToken: cancelToken,
+      );
+
+  /// GET /externalsecrets/refresh-namespace/{namespace}/refresh-scope.
+  Future<BulkScopeResponse> resolveNamespaceScope({
+    required String namespace,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) =>
+      _getOne<BulkScopeResponse>(
+        path: '/api/v1/externalsecrets/refresh-namespace/'
+            '${Uri.encodeComponent(namespace)}/refresh-scope',
+        parse: BulkScopeResponse.fromJson,
+        notFoundMessage:
+            'Could not resolve refresh scope for namespace $namespace',
+        clusterIdOverride: clusterIdOverride,
+        cancelToken: cancelToken,
+      );
+
+  /// POST /externalsecrets/stores/{ns}/{name}/refresh-all.
+  /// `targetUIDs` MUST be the UIDs from a fresh resolveStoreScope; the
+  /// backend rejects empty / drifted bodies with 400 / 409 scope_changed.
+  Future<BulkRefreshSubmitResponse> bulkRefreshStore({
+    required String namespace,
+    required String name,
+    required List<String> targetUIDs,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) =>
+      _submitBulkRefresh(
+        path: '/api/v1/externalsecrets/stores/'
+            '${Uri.encodeComponent(namespace)}/'
+            '${Uri.encodeComponent(name)}/refresh-all',
+        targetUIDs: targetUIDs,
+        clusterIdOverride: clusterIdOverride,
+        cancelToken: cancelToken,
+      );
+
+  /// POST /externalsecrets/clusterstores/{name}/refresh-all.
+  Future<BulkRefreshSubmitResponse> bulkRefreshClusterStore({
+    required String name,
+    required List<String> targetUIDs,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) =>
+      _submitBulkRefresh(
+        path: '/api/v1/externalsecrets/clusterstores/'
+            '${Uri.encodeComponent(name)}/refresh-all',
+        targetUIDs: targetUIDs,
+        clusterIdOverride: clusterIdOverride,
+        cancelToken: cancelToken,
+      );
+
+  /// POST /externalsecrets/refresh-namespace/{namespace} (no trailing path).
+  Future<BulkRefreshSubmitResponse> bulkRefreshNamespace({
+    required String namespace,
+    required List<String> targetUIDs,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) =>
+      _submitBulkRefresh(
+        path: '/api/v1/externalsecrets/refresh-namespace/'
+            '${Uri.encodeComponent(namespace)}',
+        targetUIDs: targetUIDs,
+        clusterIdOverride: clusterIdOverride,
+        cancelToken: cancelToken,
+      );
+
+  /// GET /externalsecrets/bulk-refresh-jobs/{jobId}. Caller polls every
+  /// 2s until `completedAt` is non-null.
+  Future<BulkRefreshJob> getBulkRefreshJob({
+    required String jobId,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) =>
+      _getOne<BulkRefreshJob>(
+        path: '/api/v1/externalsecrets/bulk-refresh-jobs/'
+            '${Uri.encodeComponent(jobId)}',
+        parse: BulkRefreshJob.fromJson,
+        notFoundMessage: 'Bulk refresh job $jobId not found',
+        clusterIdOverride: clusterIdOverride,
+        cancelToken: cancelToken,
+      );
+
+  Future<BulkRefreshSubmitResponse> _submitBulkRefresh({
+    required String path,
+    required List<String> targetUIDs,
+    String? clusterIdOverride,
+    CancelToken? cancelToken,
+  }) async {
+    try {
+      final res = await _dio.post<Map<String, dynamic>>(
+        path,
+        data: {'targetUIDs': targetUIDs},
+        options: _opts(clusterIdOverride),
+        cancelToken: cancelToken,
+      );
+      final data = res.data?['data'];
+      if (data is Map) {
+        return BulkRefreshSubmitResponse.fromJson(
+          Map<String, dynamic>.from(data),
+        );
+      }
+      throw ApiError(
+        statusCode: 500,
+        code: 500,
+        message: 'Empty response from bulk refresh submit',
+      );
+    } on DioException catch (e) {
+      if (CancelToken.isCancel(e)) rethrow;
+      final err = e.error;
+      throw err is ApiError ? err : ApiError.fromDio(e);
+    }
+  }
 
   // -------------------------------------------------------------------------
   // Internals

--- a/mobile/lib/api/resource_actions.dart
+++ b/mobile/lib/api/resource_actions.dart
@@ -6,6 +6,19 @@
 //
 // Action verbs hit `POST /api/v1/resources/:kind/:ns/:name/<verb>` (or
 // `DELETE` for delete) — see `backend/internal/server/routes.go:758-762`.
+//
+// Domain-specific writes intentionally OUTSIDE this map (PR-5e-review #20):
+//   - ESO Force Sync — `lib/features/eso/force_sync_controller.dart`
+//     (web parallel: `frontend/islands/ESOExternalSecretDetail.tsx`)
+//   - ESO Bulk Refresh — `lib/features/eso/bulk_refresh_controller.dart`
+//     (web parallel: `frontend/islands/ESOBulkRefreshDialog.tsx`)
+// These live on their own `AutoDisposeFamilyNotifier`-based controllers
+// mixed with `RefreshableController` and are launched from per-detail
+// surfaces / dashboard buttons rather than the generic kebab menu. The
+// rationale is documented in the CLAUDE.md mobile invariant covering
+// domain-specific write controllers. Do NOT migrate them into
+// `actionsByKind` — the scope-resolve + poll-loop shape doesn't fit
+// the single-shot `executeAction` contract.
 
 import 'package:dio/dio.dart';
 

--- a/mobile/lib/features/eso/bulk_refresh_controller.dart
+++ b/mobile/lib/features/eso/bulk_refresh_controller.dart
@@ -1,0 +1,547 @@
+// BulkRefreshController — walks the 4-phase modal sheet for ESO bulk
+// refresh (Force Sync the entire scope of a SecretStore /
+// ClusterSecretStore / Namespace).
+//
+// Phases (mobile-only adds the first; web's `ESOBulkRefreshDialog.tsx`
+// enters at phase 2 because it's launched per-store/per-namespace):
+//
+//   1. scopePick   — operator picks the variant (store /
+//                    clusterStore / namespace) and the identifier.
+//                    Lives entirely client-side; no wire activity.
+//   2. scopeLoad   — GET the variant's `refresh-scope` endpoint to
+//                    enumerate the visible ExternalSecrets.
+//   3. confirm     — render the count + per-namespace breakdown and
+//                    gate on "type REFRESH to confirm".
+//   4. submitPoll  — POST `refresh-all` (with the pinned targetUIDs),
+//                    receive jobId, poll `bulk-refresh-jobs/{jobId}`
+//                    every 2s until `completedAt` lands.
+//
+// Special cases:
+//   * 409 `active_job_exists` on submit — read `error.extra.jobId` and
+//     skip straight to the poll, attaching to the existing job. No
+//     re-confirm.
+//   * 409 `scope_changed` on submit — drop back to scopeLoad and let
+//     the operator re-confirm. (Backend signals UIDs added/removed via
+//     `error.extra`; the M5 mobile surface treats that as "scope moved
+//     under you" and re-resolves rather than showing the diff inline.)
+//   * Poll error (transient) — keep the poll loop running but surface
+//     "Retrying…" inline. Falls back to error state if the same path
+//     keeps failing.
+//   * 5 min total elapsed without completion — flip a flag so the UI
+//     can surface "Taking longer than expected"; poll continues until
+//     dispose or completion.
+//
+// Cluster pinning: the scope picker captures `clusterId` (the pinned
+// cluster) at construction, and every wire call forwards it. Active-
+// cluster switches mid-flow drop the poll loop and surface a clear
+// failure (the worker continues server-side; dismissing the sheet is
+// non-destructive).
+
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../api/api_error.dart';
+import '../../api/eso_repository.dart';
+import '../../cluster/cluster_provider.dart';
+import '../../widgets/refreshable_controller.dart';
+
+/// Sealed selector of which variant the operator is targeting. Each
+/// variant dispatches to a different pair of (scope, submit) endpoints
+/// and carries a different identifier shape — store needs ns+name,
+/// clusterStore needs name, namespace needs just the namespace.
+sealed class BulkRefreshScope {
+  const BulkRefreshScope();
+
+  /// Human-readable identifier used in the confirm UI ("store/foo",
+  /// "clusterstore/bar", "namespace/prod").
+  String displayId();
+}
+
+class BulkRefreshScopeStore extends BulkRefreshScope {
+  const BulkRefreshScopeStore({required this.namespace, required this.name});
+
+  final String namespace;
+  final String name;
+
+  @override
+  String displayId() => 'store $namespace/$name';
+
+  @override
+  bool operator ==(Object other) =>
+      other is BulkRefreshScopeStore &&
+      other.namespace == namespace &&
+      other.name == name;
+
+  @override
+  int get hashCode => Object.hash(namespace, name);
+}
+
+class BulkRefreshScopeClusterStore extends BulkRefreshScope {
+  const BulkRefreshScopeClusterStore({required this.name});
+
+  final String name;
+
+  @override
+  String displayId() => 'cluster store $name';
+
+  @override
+  bool operator ==(Object other) =>
+      other is BulkRefreshScopeClusterStore && other.name == name;
+
+  @override
+  int get hashCode => name.hashCode;
+}
+
+class BulkRefreshScopeNamespace extends BulkRefreshScope {
+  const BulkRefreshScopeNamespace({required this.namespace});
+
+  final String namespace;
+
+  @override
+  String displayId() => 'namespace $namespace';
+
+  @override
+  bool operator ==(Object other) =>
+      other is BulkRefreshScopeNamespace && other.namespace == namespace;
+
+  @override
+  int get hashCode => namespace.hashCode;
+}
+
+/// Phases of the modal sheet. Drives the UI's body switcher.
+enum BulkRefreshPhase {
+  scopePick,
+  scopeLoad,
+  confirm,
+  submit,
+  poll,
+  done,
+  error,
+}
+
+/// Whole state object held by the controller. Immutable copies are
+/// emitted on every transition so `ref.listen` consumers receive a
+/// clean diff.
+class BulkRefreshSheetState {
+  const BulkRefreshSheetState({
+    required this.phase,
+    this.scope,
+    this.scopeResponse,
+    this.jobId,
+    this.job,
+    this.errorMessage,
+    this.takingLong = false,
+    this.attachedToExistingJob = false,
+    this.pollRetrying = false,
+  });
+
+  final BulkRefreshPhase phase;
+  final BulkRefreshScope? scope;
+  final BulkScopeResponse? scopeResponse;
+  final String? jobId;
+  final BulkRefreshJob? job;
+
+  /// Non-null in [BulkRefreshPhase.error] and as a transient banner in
+  /// [BulkRefreshPhase.poll] when [pollRetrying] is true.
+  final String? errorMessage;
+
+  /// True once the poll loop has been running for 5+ minutes without
+  /// completion; UI surfaces a "Taking longer than expected" caption.
+  final bool takingLong;
+
+  /// True when the submit returned 409 active_job_exists and the
+  /// controller attached to an existing jobId rather than starting a
+  /// fresh one. UI mentions this on the poll surface so the operator
+  /// understands why the count may not match a fresh resolution.
+  final bool attachedToExistingJob;
+
+  /// True during a transient poll error (5xx, network) when we're
+  /// still retrying. UI surfaces "Retrying…" inline.
+  final bool pollRetrying;
+
+  BulkRefreshSheetState copyWith({
+    BulkRefreshPhase? phase,
+    BulkRefreshScope? scope,
+    BulkScopeResponse? scopeResponse,
+    String? jobId,
+    BulkRefreshJob? job,
+    String? errorMessage,
+    bool? takingLong,
+    bool? attachedToExistingJob,
+    bool? pollRetrying,
+    bool clearError = false,
+    bool clearJob = false,
+  }) {
+    return BulkRefreshSheetState(
+      phase: phase ?? this.phase,
+      scope: scope ?? this.scope,
+      scopeResponse: scopeResponse ?? this.scopeResponse,
+      jobId: jobId ?? this.jobId,
+      job: clearJob ? null : (job ?? this.job),
+      errorMessage: clearError ? null : (errorMessage ?? this.errorMessage),
+      takingLong: takingLong ?? this.takingLong,
+      attachedToExistingJob:
+          attachedToExistingJob ?? this.attachedToExistingJob,
+      pollRetrying: pollRetrying ?? this.pollRetrying,
+    );
+  }
+}
+
+const Duration _pollInterval = Duration(seconds: 2);
+const Duration _takingLongThreshold = Duration(minutes: 5);
+
+/// Family-keyed controller. Each open sheet gets its own
+/// `clusterId`-keyed slot; closing the sheet disposes the controller
+/// and tears down the poll loop.
+class BulkRefreshController
+    extends AutoDisposeFamilyNotifier<BulkRefreshSheetState, String>
+    with RefreshableController {
+  late String _clusterId;
+  Timer? _pollTimer;
+  DateTime? _pollStartedAt;
+  int _consecutivePollErrors = 0;
+
+  /// Surfaced as an instance member so tests can override / stub. Bulk
+  /// refresh jobs commonly exceed 30s on large scopes, so we tighten
+  /// the receive timeout on poll to 10s — enough to absorb backend
+  /// scheduling latency without holding the loop hostage to a wedged
+  /// kube-apiserver.
+  Duration get pollReceiveTimeout => const Duration(seconds: 10);
+
+  @override
+  String get pinnedClusterId => _clusterId;
+
+  @override
+  String currentActiveClusterId(Ref ref) => ref.read(activeClusterProvider);
+
+  @override
+  BulkRefreshSheetState build(String clusterId) {
+    _clusterId = clusterId;
+    initRefreshable(ref);
+    ref.onDispose(_cancelPoll);
+    return const BulkRefreshSheetState(phase: BulkRefreshPhase.scopePick);
+  }
+
+  /// Phase 1 → 2. Operator confirmed the scope variant + identifier;
+  /// fire the GET refresh-scope.
+  Future<void> beginScopeLoad(BulkRefreshScope scope) async {
+    if (isDisposed) return;
+    // Cluster-pin pre-check; cluster switch since the sheet opened
+    // means the picker's identifier is for a different cluster's data.
+    if (!clusterStillPinned(ref)) {
+      _emitError(pinnedMismatchMessage(PinPhase.preEmission));
+      return;
+    }
+    supersede('scope load');
+    final captured = captureDispatchId();
+    _setState(
+      state.copyWith(
+        phase: BulkRefreshPhase.scopeLoad,
+        scope: scope,
+        scopeResponse: null,
+        clearError: true,
+      ),
+    );
+
+    try {
+      final repo = ref.read(esoRepositoryProvider);
+      final resp = switch (scope) {
+        BulkRefreshScopeStore(:final namespace, :final name) =>
+          await repo.resolveStoreScope(
+            namespace: namespace,
+            name: name,
+            clusterIdOverride: _clusterId,
+            cancelToken: currentCancelToken,
+          ),
+        BulkRefreshScopeClusterStore(:final name) =>
+          await repo.resolveClusterStoreScope(
+            name: name,
+            clusterIdOverride: _clusterId,
+            cancelToken: currentCancelToken,
+          ),
+        BulkRefreshScopeNamespace(:final namespace) =>
+          await repo.resolveNamespaceScope(
+            namespace: namespace,
+            clusterIdOverride: _clusterId,
+            cancelToken: currentCancelToken,
+          ),
+      };
+      if (!isFresh(captured)) return;
+      if (!clusterStillPinned(ref)) {
+        _emitError(pinnedMismatchMessage(PinPhase.postEmission));
+        return;
+      }
+      _setState(state.copyWith(
+        phase: BulkRefreshPhase.confirm,
+        scopeResponse: resp,
+      ));
+    } on DioException catch (e) {
+      if (RefreshableController.isCancelException(e)) return;
+      if (!isFresh(captured)) return;
+      final err = e.error;
+      final apiErr = err is ApiError ? err : ApiError.fromDio(e);
+      _emitError(apiErr.message);
+    } on ApiError catch (e) {
+      if (!isFresh(captured)) return;
+      _emitError(e.message);
+    } catch (e) {
+      if (!isFresh(captured)) return;
+      _emitError(e.toString());
+    }
+  }
+
+  /// Step back to phase 1 so the operator can re-pick the variant.
+  /// Cancels any in-flight scope-load and clears the previous response.
+  void backToScopePick() {
+    if (isDisposed) return;
+    supersede('back to scope pick');
+    _setState(const BulkRefreshSheetState(phase: BulkRefreshPhase.scopePick));
+  }
+
+  /// Phase 3 → 4. Operator passed the type-to-confirm; fire the POST.
+  Future<void> submit() async {
+    if (isDisposed) return;
+    if (state.phase != BulkRefreshPhase.confirm) return;
+    final scope = state.scope;
+    final scopeResp = state.scopeResponse;
+    if (scope == null || scopeResp == null) {
+      _emitError('Internal error: missing scope on submit');
+      return;
+    }
+    if (!clusterStillPinned(ref)) {
+      _emitError(pinnedMismatchMessage(PinPhase.preEmission));
+      return;
+    }
+    supersede('submit');
+    final captured = captureDispatchId();
+    _setState(state.copyWith(phase: BulkRefreshPhase.submit, clearError: true));
+
+    try {
+      final repo = ref.read(esoRepositoryProvider);
+      final uids =
+          scopeResp.targets.map((t) => t.uid).toList(growable: false);
+      final resp = switch (scope) {
+        BulkRefreshScopeStore(:final namespace, :final name) =>
+          await repo.bulkRefreshStore(
+            namespace: namespace,
+            name: name,
+            targetUIDs: uids,
+            clusterIdOverride: _clusterId,
+            cancelToken: currentCancelToken,
+          ),
+        BulkRefreshScopeClusterStore(:final name) =>
+          await repo.bulkRefreshClusterStore(
+            name: name,
+            targetUIDs: uids,
+            clusterIdOverride: _clusterId,
+            cancelToken: currentCancelToken,
+          ),
+        BulkRefreshScopeNamespace(:final namespace) =>
+          await repo.bulkRefreshNamespace(
+            namespace: namespace,
+            targetUIDs: uids,
+            clusterIdOverride: _clusterId,
+            cancelToken: currentCancelToken,
+          ),
+      };
+      if (!isFresh(captured)) return;
+      if (!clusterStillPinned(ref)) {
+        _emitError(pinnedMismatchMessage(PinPhase.postEmission));
+        return;
+      }
+      _startPoll(jobId: resp.jobId, attached: false);
+    } on DioException catch (e) {
+      if (RefreshableController.isCancelException(e)) return;
+      if (!isFresh(captured)) return;
+      final err = e.error;
+      final apiErr = err is ApiError ? err : ApiError.fromDio(e);
+      _handleSubmitFailure(apiErr);
+    } on ApiError catch (e) {
+      if (!isFresh(captured)) return;
+      _handleSubmitFailure(e);
+    } catch (e) {
+      if (!isFresh(captured)) return;
+      _emitError(e.toString());
+    }
+  }
+
+  /// Caller (typically the sheet's "Run in background" / dismiss
+  /// button) tearing down the poll loop while the worker continues
+  /// server-side. The next bulk-refresh-jobs GET keeps server-side
+  /// accounting honest.
+  void cancelPoll() {
+    if (isDisposed) return;
+    _cancelPoll();
+  }
+
+  void _handleSubmitFailure(ApiError err) {
+    // active_job_exists — attach to the existing job and start polling.
+    if (err.statusCode == 409 && err.reason == 'active_job_exists') {
+      final existingId = err.extraString('jobId');
+      if (existingId != null && existingId.isNotEmpty) {
+        _startPoll(jobId: existingId, attached: true);
+        return;
+      }
+      _emitError(
+        'Another bulk refresh is already in flight for this scope. '
+        'Try opening the existing job from the audit log.',
+      );
+      return;
+    }
+    // scope_changed — drop back to scope-load so the operator can
+    // re-confirm against the freshly-resolved scope.
+    if (err.statusCode == 409 && err.reason == 'scope_changed') {
+      final scope = state.scope;
+      if (scope != null) {
+        _setState(state.copyWith(
+          phase: BulkRefreshPhase.scopeLoad,
+          scopeResponse: null,
+          errorMessage:
+              'Scope changed since you confirmed — re-resolving and re-asking.',
+        ));
+        // Fire-and-forget; same scope, fresh resolve.
+        unawaited(beginScopeLoad(scope));
+        return;
+      }
+    }
+    if (err.statusCode == 501) {
+      _emitError(
+        "Bulk refresh isn't available for this cluster — only the local "
+        'cluster supports ESO writes.',
+      );
+      return;
+    }
+    if (err.statusCode == 503) {
+      _emitError(
+        'ESO is not detected on this cluster. Install ESO before triggering '
+        'a bulk refresh.',
+      );
+      return;
+    }
+    if (err.statusCode == 413) {
+      _emitError(
+        'Scope is too large for a single bulk refresh. Use a per-namespace '
+        'refresh instead.',
+      );
+      return;
+    }
+    if (err.statusCode == 422) {
+      _emitError(
+        'Nothing to refresh — no ExternalSecrets are in scope or you have '
+        'no permission to refresh them.',
+      );
+      return;
+    }
+    _emitError(err.message);
+  }
+
+  void _startPoll({required String jobId, required bool attached}) {
+    _cancelPoll();
+    _pollStartedAt = DateTime.now();
+    _consecutivePollErrors = 0;
+    _setState(state.copyWith(
+      phase: BulkRefreshPhase.poll,
+      jobId: jobId,
+      attachedToExistingJob: attached,
+      clearJob: true,
+      clearError: true,
+      pollRetrying: false,
+      takingLong: false,
+    ));
+    // First poll immediately so the UI gets a count instead of the
+    // 2-second blank wait.
+    unawaited(_poll());
+    _pollTimer = Timer.periodic(_pollInterval, (_) => unawaited(_poll()));
+  }
+
+  Future<void> _poll() async {
+    if (isDisposed) return;
+    final jobId = state.jobId;
+    if (jobId == null) return;
+    try {
+      final job = await ref.read(esoRepositoryProvider).getBulkRefreshJob(
+            jobId: jobId,
+            clusterIdOverride: _clusterId,
+            cancelToken: currentCancelToken,
+          );
+      if (isDisposed) return;
+      _consecutivePollErrors = 0;
+      final long = _pollStartedAt != null &&
+          DateTime.now().difference(_pollStartedAt!) >= _takingLongThreshold;
+      if (job.isDone) {
+        _cancelPoll();
+        _setState(state.copyWith(
+          phase: BulkRefreshPhase.done,
+          job: job,
+          pollRetrying: false,
+          takingLong: long,
+          clearError: true,
+        ));
+        return;
+      }
+      _setState(state.copyWith(
+        job: job,
+        pollRetrying: false,
+        takingLong: long,
+        clearError: true,
+      ));
+    } on DioException catch (e) {
+      if (RefreshableController.isCancelException(e)) return;
+      _consecutivePollErrors++;
+      // Tolerate transient blips — give up after 3 consecutive
+      // failures so the sheet doesn't lie about the job's state
+      // forever.
+      if (_consecutivePollErrors >= 3) {
+        _cancelPoll();
+        final err = e.error;
+        final apiErr = err is ApiError ? err : ApiError.fromDio(e);
+        _emitError(
+          'Lost track of the refresh job: ${apiErr.message}. The job may '
+          'still complete server-side; check the audit log for status.',
+        );
+        return;
+      }
+      _setState(state.copyWith(pollRetrying: true));
+    } catch (_) {
+      // Same fall-through as DioException for non-Dio errors.
+      _consecutivePollErrors++;
+      if (_consecutivePollErrors >= 3) {
+        _cancelPoll();
+        _emitError(
+          'Lost track of the refresh job. It may still complete '
+          'server-side; check the audit log.',
+        );
+        return;
+      }
+      _setState(state.copyWith(pollRetrying: true));
+    }
+  }
+
+  void _cancelPoll() {
+    _pollTimer?.cancel();
+    _pollTimer = null;
+  }
+
+  void _emitError(String message) {
+    _cancelPoll();
+    _setState(state.copyWith(
+      phase: BulkRefreshPhase.error,
+      errorMessage: message,
+    ));
+  }
+
+  void _setState(BulkRefreshSheetState next) {
+    RefreshableController.safeSetIfAlive<BulkRefreshSheetState>(
+      isDisposed,
+      (s) => state = s,
+      next,
+    );
+  }
+}
+
+final bulkRefreshControllerProvider = AutoDisposeNotifierProvider.family<
+    BulkRefreshController, BulkRefreshSheetState, String>(
+  BulkRefreshController.new,
+);

--- a/mobile/lib/features/eso/bulk_refresh_controller.dart
+++ b/mobile/lib/features/eso/bulk_refresh_controller.dart
@@ -1,4 +1,4 @@
-// BulkRefreshController — walks the 4-phase modal sheet for ESO bulk
+// BulkRefreshController — walks the 8-phase modal sheet for ESO bulk
 // refresh (Force Sync the entire scope of a SecretStore /
 // ClusterSecretStore / Namespace).
 //
@@ -10,11 +10,22 @@
 //                    Lives entirely client-side; no wire activity.
 //   2. scopeLoad   — GET the variant's `refresh-scope` endpoint to
 //                    enumerate the visible ExternalSecrets.
-//   3. confirm     — render the count + per-namespace breakdown and
-//                    gate on "type REFRESH to confirm".
-//   4. submitPoll  — POST `refresh-all` (with the pinned targetUIDs),
-//                    receive jobId, poll `bulk-refresh-jobs/{jobId}`
-//                    every 2s until `completedAt` lands.
+//   3. preview     — render the count + per-namespace breakdown +
+//                    RBAC restriction notice. "Continue" advances to
+//                    `confirm` (which triggers the shared
+//                    `showConfirmSheet` type-to-confirm modal).
+//   4. confirm     — type-to-confirm REFRESH via the shared
+//                    `confirm_sheet.dart` modal stacked on top. The
+//                    body keeps rendering the preview content so a
+//                    cancel from the inner sheet drops back cleanly.
+//                    On confirmation the controller fires submit.
+//   5. submit      — POST `refresh-all` (with the pinned targetUIDs).
+//                    Transient; resolves to poll on 202 or error on
+//                    409/501/503/etc.
+//   6. poll        — GET `bulk-refresh-jobs/{jobId}` every 2s until
+//                    `completedAt` lands.
+//   7. done        — terminal success surface; summary + outcome lists.
+//   8. error       — terminal failure surface; error copy + retry.
 //
 // Special cases:
 //   * 409 `active_job_exists` on submit — read `error.extra.jobId` and
@@ -32,14 +43,20 @@
 //     dispose or completion.
 //
 // Cluster pinning: the scope picker captures `clusterId` (the pinned
-// cluster) at construction, and every wire call forwards it. Active-
-// cluster switches mid-flow drop the poll loop and surface a clear
-// failure (the worker continues server-side; dismissing the sheet is
-// non-destructive).
+// cluster) at construction, and every wire call forwards it. The poll
+// loop runs against the cluster that was pinned at controller
+// construction — the active cluster can change without affecting the
+// poll because sheet dismissal (autoDispose) is the teardown signal
+// rather than a per-tick active-cluster re-check. The
+// active-cluster-still-pinned re-check lives on beginScopeLoad and
+// submit, where a mismatch would cause the next request to land on
+// the wrong cluster's data. The worker continues server-side; dismissing
+// the sheet is non-destructive.
 
 import 'dart:async';
 
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../api/api_error.dart';
@@ -110,10 +127,12 @@ class BulkRefreshScopeNamespace extends BulkRefreshScope {
   int get hashCode => namespace.hashCode;
 }
 
-/// Phases of the modal sheet. Drives the UI's body switcher.
+/// Phases of the modal sheet. Drives the UI's body switcher. See the
+/// file-top doc comment for the meaning of each phase.
 enum BulkRefreshPhase {
   scopePick,
   scopeLoad,
+  preview,
   confirm,
   submit,
   poll,
@@ -161,6 +180,12 @@ class BulkRefreshSheetState {
   /// still retrying. UI surfaces "Retrying…" inline.
   final bool pollRetrying;
 
+  /// [copyWith] uses a `?? this.field` fall-through for every nullable
+  /// field by default, which means passing `null` to the named parameter
+  /// is indistinguishable from omitting it — both keep the current value.
+  /// To explicitly clear a nullable field, set the matching `clearXxx`
+  /// sentinel to `true`. The sentinel wins over the value parameter, so
+  /// `copyWith(scope: foo, clearScope: true)` clears `scope` to null.
   BulkRefreshSheetState copyWith({
     BulkRefreshPhase? phase,
     BulkRefreshScope? scope,
@@ -173,12 +198,16 @@ class BulkRefreshSheetState {
     bool? pollRetrying,
     bool clearError = false,
     bool clearJob = false,
+    bool clearScope = false,
+    bool clearScopeResponse = false,
+    bool clearJobId = false,
   }) {
     return BulkRefreshSheetState(
       phase: phase ?? this.phase,
-      scope: scope ?? this.scope,
-      scopeResponse: scopeResponse ?? this.scopeResponse,
-      jobId: jobId ?? this.jobId,
+      scope: clearScope ? null : (scope ?? this.scope),
+      scopeResponse:
+          clearScopeResponse ? null : (scopeResponse ?? this.scopeResponse),
+      jobId: clearJobId ? null : (jobId ?? this.jobId),
       job: clearJob ? null : (job ?? this.job),
       errorMessage: clearError ? null : (errorMessage ?? this.errorMessage),
       takingLong: takingLong ?? this.takingLong,
@@ -203,6 +232,14 @@ class BulkRefreshController
   DateTime? _pollStartedAt;
   int _consecutivePollErrors = 0;
 
+  /// Reentrancy guard for [_poll]. Timer.periodic fires every 2s
+  /// regardless of whether the previous tick's GET has returned. On a
+  /// slow backend this races: tick 2 starts before tick 1 returns, both
+  /// land near-simultaneously, and both try to write to state.
+  /// `_pollInFlight` lets tick 2 (and 3, etc.) early-return until tick 1
+  /// has finished its turn at the state setter.
+  bool _pollInFlight = false;
+
   /// Surfaced as an instance member so tests can override / stub. Bulk
   /// refresh jobs commonly exceed 30s on large scopes, so we tighten
   /// the receive timeout on poll to 10s — enough to absorb backend
@@ -226,7 +263,16 @@ class BulkRefreshController
 
   /// Phase 1 → 2. Operator confirmed the scope variant + identifier;
   /// fire the GET refresh-scope.
-  Future<void> beginScopeLoad(BulkRefreshScope scope) async {
+  ///
+  /// [preserveError] keeps the previous [errorMessage] visible across
+  /// the transition. Used by the 409 `scope_changed` recovery path so
+  /// the "Scope changed since you confirmed" banner survives the
+  /// auto-re-resolve; the default behavior (false) clears any stale
+  /// error so a fresh scope load starts clean.
+  Future<void> beginScopeLoad(
+    BulkRefreshScope scope, {
+    bool preserveError = false,
+  }) async {
     if (isDisposed) return;
     // Cluster-pin pre-check; cluster switch since the sheet opened
     // means the picker's identifier is for a different cluster's data.
@@ -240,8 +286,8 @@ class BulkRefreshController
       state.copyWith(
         phase: BulkRefreshPhase.scopeLoad,
         scope: scope,
-        scopeResponse: null,
-        clearError: true,
+        clearScopeResponse: true,
+        clearError: !preserveError,
       ),
     );
 
@@ -274,7 +320,7 @@ class BulkRefreshController
         return;
       }
       _setState(state.copyWith(
-        phase: BulkRefreshPhase.confirm,
+        phase: BulkRefreshPhase.preview,
         scopeResponse: resp,
       ));
     } on DioException catch (e) {
@@ -300,7 +346,26 @@ class BulkRefreshController
     _setState(const BulkRefreshSheetState(phase: BulkRefreshPhase.scopePick));
   }
 
-  /// Phase 3 → 4. Operator passed the type-to-confirm; fire the POST.
+  /// Phase 3 → 4 (preview → confirm). Operator tapped "Continue" on the
+  /// preview body; the sheet is about to open the shared
+  /// `confirm_sheet.dart` type-to-confirm modal on top. The body keeps
+  /// rendering the preview content so a cancel-from-inner-sheet drops
+  /// back to a fully-rendered preview rather than a blank flash.
+  void confirmPreview() {
+    if (isDisposed) return;
+    if (state.phase != BulkRefreshPhase.preview) return;
+    _setState(state.copyWith(phase: BulkRefreshPhase.confirm));
+  }
+
+  /// Phase 4 → 3 (confirm → preview). Called by the sheet when the
+  /// stacked confirm modal returns false / null (operator cancelled).
+  void backToPreview() {
+    if (isDisposed) return;
+    if (state.phase != BulkRefreshPhase.confirm) return;
+    _setState(state.copyWith(phase: BulkRefreshPhase.preview));
+  }
+
+  /// Phase 4 → 5. Operator passed the type-to-confirm; fire the POST.
   Future<void> submit() async {
     if (isDisposed) return;
     if (state.phase != BulkRefreshPhase.confirm) return;
@@ -367,13 +432,28 @@ class BulkRefreshController
     }
   }
 
-  /// Caller (typically the sheet's "Run in background" / dismiss
-  /// button) tearing down the poll loop while the worker continues
-  /// server-side. The next bulk-refresh-jobs GET keeps server-side
-  /// accounting honest.
+  /// Test seam — production teardown happens via `ref.onDispose(_cancelPoll)`.
+  /// Kept available so controller-level tests can deterministically stop
+  /// the periodic timer without disposing the whole notifier.
+  @visibleForTesting
   void cancelPoll() {
     if (isDisposed) return;
     _cancelPoll();
+  }
+
+  /// One-shot poll fired from the AppLifecycleListener on iOS resume.
+  /// Re-using `_poll()` means the existing `_pollInFlight` reentrancy
+  /// guard naturally drops the resume tick on the floor if the periodic
+  /// timer was already mid-fetch. Safe to call when phase != poll; the
+  /// inner post-await guard early-returns.
+  ///
+  /// iOS suspends the periodic Timer when the app backgrounds; without
+  /// this nudge the progress bar can sit stale for up to 2s after the
+  /// app comes back to the foreground.
+  Future<void> pollNow() async {
+    if (isDisposed) return;
+    if (state.phase != BulkRefreshPhase.poll) return;
+    await _poll();
   }
 
   void _handleSubmitFailure(ApiError err) {
@@ -397,12 +477,15 @@ class BulkRefreshController
       if (scope != null) {
         _setState(state.copyWith(
           phase: BulkRefreshPhase.scopeLoad,
-          scopeResponse: null,
+          clearScopeResponse: true,
           errorMessage:
               'Scope changed since you confirmed — re-resolving and re-asking.',
         ));
-        // Fire-and-forget; same scope, fresh resolve.
-        unawaited(beginScopeLoad(scope));
+        // Fire-and-forget; same scope, fresh resolve. preserveError
+        // keeps the explanation banner visible across the auto-re-
+        // resolve so the operator understands why they're being asked
+        // to confirm again.
+        unawaited(beginScopeLoad(scope, preserveError: true));
         return;
       }
     }
@@ -458,64 +541,85 @@ class BulkRefreshController
 
   Future<void> _poll() async {
     if (isDisposed) return;
-    final jobId = state.jobId;
-    if (jobId == null) return;
+    // Reentrancy guard — if the previous tick is still awaiting its
+    // GET, drop this tick on the floor. The next Timer.periodic fire
+    // (or the in-flight one's _setState landing) keeps the loop alive.
+    if (_pollInFlight) return;
+    _pollInFlight = true;
     try {
-      final job = await ref.read(esoRepositoryProvider).getBulkRefreshJob(
-            jobId: jobId,
-            clusterIdOverride: _clusterId,
-            cancelToken: currentCancelToken,
-          );
-      if (isDisposed) return;
-      _consecutivePollErrors = 0;
-      final long = _pollStartedAt != null &&
-          DateTime.now().difference(_pollStartedAt!) >= _takingLongThreshold;
-      if (job.isDone) {
-        _cancelPoll();
+      final jobId = state.jobId;
+      if (jobId == null) return;
+      try {
+        final job = await ref.read(esoRepositoryProvider).getBulkRefreshJob(
+              jobId: jobId,
+              clusterIdOverride: _clusterId,
+              cancelToken: currentCancelToken,
+              receiveTimeout: pollReceiveTimeout,
+            );
+        if (isDisposed) return;
+        // Post-await phase guard — a late-arriving response must NOT
+        // clobber a terminal Done/Error state that an earlier tick (or
+        // _emitError) has already landed. Without this, a tick-1 slow
+        // "still in progress" response can downgrade a tick-2 Done.
+        if (state.phase != BulkRefreshPhase.poll) return;
+        _consecutivePollErrors = 0;
+        final long = _pollStartedAt != null &&
+            DateTime.now().difference(_pollStartedAt!) >= _takingLongThreshold;
+        if (job.isDone) {
+          _cancelPoll();
+          _setState(state.copyWith(
+            phase: BulkRefreshPhase.done,
+            job: job,
+            pollRetrying: false,
+            takingLong: long,
+            clearError: true,
+          ));
+          return;
+        }
         _setState(state.copyWith(
-          phase: BulkRefreshPhase.done,
           job: job,
           pollRetrying: false,
           takingLong: long,
           clearError: true,
         ));
-        return;
+      } on DioException catch (e) {
+        if (RefreshableController.isCancelException(e)) return;
+        if (isDisposed) return;
+        // Same post-await guard for the error path — if we already
+        // emitted a terminal Done/Error, don't downgrade it to "retrying".
+        if (state.phase != BulkRefreshPhase.poll) return;
+        _consecutivePollErrors++;
+        // Tolerate transient blips — give up after 3 consecutive
+        // failures so the sheet doesn't lie about the job's state
+        // forever.
+        if (_consecutivePollErrors >= 3) {
+          _cancelPoll();
+          final err = e.error;
+          final apiErr = err is ApiError ? err : ApiError.fromDio(e);
+          _emitError(
+            'Lost track of the refresh job: ${apiErr.message}. The job may '
+            'still complete server-side; check the audit log for status.',
+          );
+          return;
+        }
+        _setState(state.copyWith(pollRetrying: true));
+      } catch (_) {
+        if (isDisposed) return;
+        if (state.phase != BulkRefreshPhase.poll) return;
+        // Same fall-through as DioException for non-Dio errors.
+        _consecutivePollErrors++;
+        if (_consecutivePollErrors >= 3) {
+          _cancelPoll();
+          _emitError(
+            'Lost track of the refresh job. It may still complete '
+            'server-side; check the audit log.',
+          );
+          return;
+        }
+        _setState(state.copyWith(pollRetrying: true));
       }
-      _setState(state.copyWith(
-        job: job,
-        pollRetrying: false,
-        takingLong: long,
-        clearError: true,
-      ));
-    } on DioException catch (e) {
-      if (RefreshableController.isCancelException(e)) return;
-      _consecutivePollErrors++;
-      // Tolerate transient blips — give up after 3 consecutive
-      // failures so the sheet doesn't lie about the job's state
-      // forever.
-      if (_consecutivePollErrors >= 3) {
-        _cancelPoll();
-        final err = e.error;
-        final apiErr = err is ApiError ? err : ApiError.fromDio(e);
-        _emitError(
-          'Lost track of the refresh job: ${apiErr.message}. The job may '
-          'still complete server-side; check the audit log for status.',
-        );
-        return;
-      }
-      _setState(state.copyWith(pollRetrying: true));
-    } catch (_) {
-      // Same fall-through as DioException for non-Dio errors.
-      _consecutivePollErrors++;
-      if (_consecutivePollErrors >= 3) {
-        _cancelPoll();
-        _emitError(
-          'Lost track of the refresh job. It may still complete '
-          'server-side; check the audit log.',
-        );
-        return;
-      }
-      _setState(state.copyWith(pollRetrying: true));
+    } finally {
+      _pollInFlight = false;
     }
   }
 

--- a/mobile/lib/features/eso/bulk_refresh_scope_picker.dart
+++ b/mobile/lib/features/eso/bulk_refresh_scope_picker.dart
@@ -239,80 +239,21 @@ class _SecondaryHint extends StatelessWidget {
   }
 }
 
-/// Namespaced SecretStore picker. Reads `storesListProvider`, filters
-/// to the chosen namespace, and renders a dropdown.
-class _StorePicker extends ConsumerWidget {
-  const _StorePicker({
-    required this.clusterId,
-    required this.namespace,
-    required this.selected,
-    required this.onChanged,
-  });
+/// Bordered "labeled box" used by both store pickers. Extracted from
+/// duplicate `_frame` helpers that used to live on `_StorePicker` and
+/// `_ClusterStorePicker` — the cluster-store variant previously
+/// hardcoded its label, which made the two helpers structurally
+/// identical but textually inconsistent. Threading the label through
+/// here removes the duplication and the inconsistency in one move.
+class _LabeledPickerFrame extends StatelessWidget {
+  const _LabeledPickerFrame({required this.label, required this.child});
 
-  final String clusterId;
-  final String namespace;
-  final String selected;
-  final ValueChanged<String> onChanged;
+  final String label;
+  final Widget child;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     final colors = Theme.of(context).extension<KubeColors>()!;
-    final async = ref.watch(storesListProvider(clusterId));
-    return async.when(
-      loading: () => _frame(
-        colors,
-        const LinearProgressIndicator(minHeight: 2),
-        label: 'SecretStore',
-      ),
-      error: (e, _) => _frame(
-        colors,
-        Text(
-          'Failed to load stores: $e',
-          style: TextStyle(color: colors.error, fontSize: 12),
-        ),
-        label: 'SecretStore',
-      ),
-      data: (stores) {
-        final filtered = stores
-            .where((s) => s.namespace == namespace)
-            .map((s) => s.name)
-            .toList()
-          ..sort();
-        if (filtered.isEmpty) {
-          return _frame(
-            colors,
-            Text(
-              'No SecretStores in $namespace',
-              style: TextStyle(color: colors.textMuted, fontSize: 12),
-            ),
-            label: 'SecretStore',
-          );
-        }
-        if (selected.isNotEmpty && !filtered.contains(selected)) {
-          filtered.add(selected);
-          filtered.sort();
-        }
-        return DropdownButtonFormField<String>(
-          initialValue: selected.isEmpty ? null : selected,
-          isExpanded: true,
-          decoration: const InputDecoration(
-            labelText: 'SecretStore',
-            border: OutlineInputBorder(),
-          ),
-          items: [
-            for (final v in filtered)
-              DropdownMenuItem(value: v, child: Text(v)),
-          ],
-          onChanged: (v) {
-            if (v == null) return;
-            onChanged(v);
-          },
-        );
-      },
-    );
-  }
-
-  Widget _frame(KubeColors colors, Widget child, {required String label}) {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
       decoration: BoxDecoration(
@@ -338,6 +279,79 @@ class _StorePicker extends ConsumerWidget {
   }
 }
 
+/// Namespaced SecretStore picker. Reads `storesListProvider` with the
+/// chosen namespace in the family key so the backend filters server-side
+/// via `?namespace=` (no client-side `.where` walk over an unbounded
+/// cluster-wide list — large fleets used to pay the entire payload cost
+/// just to render the dropdown for one namespace).
+class _StorePicker extends ConsumerWidget {
+  const _StorePicker({
+    required this.clusterId,
+    required this.namespace,
+    required this.selected,
+    required this.onChanged,
+  });
+
+  final String clusterId;
+  final String namespace;
+  final String selected;
+  final ValueChanged<String> onChanged;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final async = ref.watch(storesListProvider(
+      StoresListKey(clusterId: clusterId, namespace: namespace),
+    ));
+    return async.when(
+      loading: () => const _LabeledPickerFrame(
+        label: 'SecretStore',
+        child: LinearProgressIndicator(minHeight: 2),
+      ),
+      error: (e, _) => _LabeledPickerFrame(
+        label: 'SecretStore',
+        child: Text(
+          'Failed to load stores: $e',
+          style: TextStyle(color: colors.error, fontSize: 12),
+        ),
+      ),
+      data: (stores) {
+        // Backend already filters by namespace; we just project to names.
+        final filtered = stores.map((s) => s.name).toList()..sort();
+        if (filtered.isEmpty) {
+          return _LabeledPickerFrame(
+            label: 'SecretStore',
+            child: Text(
+              'No SecretStores in $namespace',
+              style: TextStyle(color: colors.textMuted, fontSize: 12),
+            ),
+          );
+        }
+        if (selected.isNotEmpty && !filtered.contains(selected)) {
+          filtered.add(selected);
+          filtered.sort();
+        }
+        return DropdownButtonFormField<String>(
+          initialValue: selected.isEmpty ? null : selected,
+          isExpanded: true,
+          decoration: const InputDecoration(
+            labelText: 'SecretStore',
+            border: OutlineInputBorder(),
+          ),
+          items: [
+            for (final v in filtered)
+              DropdownMenuItem(value: v, child: Text(v)),
+          ],
+          onChanged: (v) {
+            if (v == null) return;
+            onChanged(v);
+          },
+        );
+      },
+    );
+  }
+}
+
 class _ClusterStorePicker extends ConsumerWidget {
   const _ClusterStorePicker({
     required this.clusterId,
@@ -354,13 +368,13 @@ class _ClusterStorePicker extends ConsumerWidget {
     final colors = Theme.of(context).extension<KubeColors>()!;
     final async = ref.watch(clusterStoresListProvider(clusterId));
     return async.when(
-      loading: () => _frame(
-        colors,
-        const LinearProgressIndicator(minHeight: 2),
+      loading: () => const _LabeledPickerFrame(
+        label: 'ClusterSecretStore',
+        child: LinearProgressIndicator(minHeight: 2),
       ),
-      error: (e, _) => _frame(
-        colors,
-        Text(
+      error: (e, _) => _LabeledPickerFrame(
+        label: 'ClusterSecretStore',
+        child: Text(
           'Failed to load cluster stores: $e',
           style: TextStyle(color: colors.error, fontSize: 12),
         ),
@@ -368,9 +382,9 @@ class _ClusterStorePicker extends ConsumerWidget {
       data: (stores) {
         final names = stores.map((s) => s.name).toList()..sort();
         if (names.isEmpty) {
-          return _frame(
-            colors,
-            Text(
+          return _LabeledPickerFrame(
+            label: 'ClusterSecretStore',
+            child: Text(
               'No ClusterSecretStores on this cluster',
               style: TextStyle(color: colors.textMuted, fontSize: 12),
             ),
@@ -396,31 +410,6 @@ class _ClusterStorePicker extends ConsumerWidget {
           },
         );
       },
-    );
-  }
-
-  Widget _frame(KubeColors colors, Widget child) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-      decoration: BoxDecoration(
-        border: Border.all(color: colors.borderSubtle),
-        borderRadius: BorderRadius.circular(6),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            'ClusterSecretStore',
-            style: TextStyle(
-              color: colors.textMuted,
-              fontSize: 11,
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-          const SizedBox(height: 4),
-          child,
-        ],
-      ),
     );
   }
 }

--- a/mobile/lib/features/eso/bulk_refresh_scope_picker.dart
+++ b/mobile/lib/features/eso/bulk_refresh_scope_picker.dart
@@ -1,0 +1,427 @@
+// First-phase widget of the ESO Bulk Refresh modal sheet. Mobile-only —
+// the web `ESOBulkRefreshDialog.tsx` is launched from per-store /
+// per-namespace contexts, so it doesn't need a scope-pick UI. Mobile
+// consolidates the entry point onto a single dashboard button, which
+// forces the operator to choose:
+//
+//   * Store          — refresh every ES backed by ns/storeName
+//   * ClusterStore   — refresh every ES backed by clusterStoreName
+//   * Namespace      — refresh every ES in this namespace
+//
+// Once the operator picks a variant + identifier and taps "Continue",
+// the parent sheet calls `BulkRefreshController.beginScopeLoad(scope)`
+// and advances to the scopeLoad phase.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../api/eso_repository.dart';
+import '../../theme/kube_theme_builder.dart';
+import '../../widgets/named_resource_picker.dart';
+import 'bulk_refresh_controller.dart';
+
+enum _ScopeVariant { store, clusterStore, namespace }
+
+class BulkRefreshScopePicker extends ConsumerStatefulWidget {
+  const BulkRefreshScopePicker({
+    super.key,
+    required this.clusterId,
+    required this.onSubmit,
+    required this.onCancel,
+  });
+
+  /// Pinned cluster id from the parent sheet. Threaded into every
+  /// list provider so the picker can't surface a different cluster's
+  /// stores under this cluster's slot.
+  final String clusterId;
+
+  /// Called when the operator taps "Continue" and a valid scope is
+  /// selected.
+  final ValueChanged<BulkRefreshScope> onSubmit;
+
+  /// Called when the operator taps "Cancel" / dismisses.
+  final VoidCallback onCancel;
+
+  @override
+  ConsumerState<BulkRefreshScopePicker> createState() =>
+      _BulkRefreshScopePickerState();
+}
+
+class _BulkRefreshScopePickerState
+    extends ConsumerState<BulkRefreshScopePicker> {
+  _ScopeVariant _variant = _ScopeVariant.namespace;
+
+  String _namespace = '';
+  String _storeName = '';
+  String _clusterStoreName = '';
+
+  bool get _canContinue {
+    return switch (_variant) {
+      _ScopeVariant.store => _namespace.isNotEmpty && _storeName.isNotEmpty,
+      _ScopeVariant.clusterStore => _clusterStoreName.isNotEmpty,
+      _ScopeVariant.namespace => _namespace.isNotEmpty,
+    };
+  }
+
+  BulkRefreshScope? _buildScope() {
+    return switch (_variant) {
+      _ScopeVariant.store =>
+        BulkRefreshScopeStore(namespace: _namespace, name: _storeName),
+      _ScopeVariant.clusterStore =>
+        BulkRefreshScopeClusterStore(name: _clusterStoreName),
+      _ScopeVariant.namespace =>
+        BulkRefreshScopeNamespace(namespace: _namespace),
+    };
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'What should refresh?',
+          style: TextStyle(
+            color: colors.textPrimary,
+            fontSize: 17,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 12),
+        SegmentedButton<_ScopeVariant>(
+          segments: const [
+            ButtonSegment(
+              value: _ScopeVariant.namespace,
+              label: Text('Namespace'),
+              icon: Icon(Icons.folder_outlined, size: 16),
+            ),
+            ButtonSegment(
+              value: _ScopeVariant.store,
+              label: Text('Store'),
+              icon: Icon(Icons.inventory_2_outlined, size: 16),
+            ),
+            ButtonSegment(
+              value: _ScopeVariant.clusterStore,
+              label: Text('Cluster store'),
+              icon: Icon(Icons.public, size: 16),
+            ),
+          ],
+          selected: {_variant},
+          onSelectionChanged: (s) {
+            if (s.isEmpty) return;
+            setState(() {
+              _variant = s.first;
+            });
+          },
+        ),
+        const SizedBox(height: 16),
+        _variantHelper(colors),
+        const SizedBox(height: 12),
+        ..._variantBody(),
+        const SizedBox(height: 20),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            TextButton(
+              onPressed: widget.onCancel,
+              style: TextButton.styleFrom(
+                foregroundColor: colors.textSecondary,
+              ),
+              child: const Text('Cancel'),
+            ),
+            const SizedBox(width: 8),
+            FilledButton(
+              onPressed: _canContinue
+                  ? () {
+                      final scope = _buildScope();
+                      if (scope != null) widget.onSubmit(scope);
+                    }
+                  : null,
+              style: FilledButton.styleFrom(
+                backgroundColor: colors.accent,
+                foregroundColor: Colors.white,
+              ),
+              child: const Text('Continue'),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _variantHelper(KubeColors colors) {
+    final text = switch (_variant) {
+      _ScopeVariant.store =>
+        'Refreshes every ExternalSecret in the chosen namespace that '
+            'references the chosen SecretStore.',
+      _ScopeVariant.clusterStore =>
+        'Refreshes every ExternalSecret across the cluster that '
+            'references the chosen ClusterSecretStore.',
+      _ScopeVariant.namespace =>
+        'Refreshes every ExternalSecret in the chosen namespace.',
+    };
+    return Text(
+      text,
+      style: TextStyle(color: colors.textSecondary, fontSize: 12, height: 1.4),
+    );
+  }
+
+  List<Widget> _variantBody() {
+    switch (_variant) {
+      case _ScopeVariant.namespace:
+        return [
+          NamedResourcePicker(
+            clusterId: widget.clusterId,
+            kind: 'namespaces',
+            namespace: null,
+            selected: _namespace,
+            onChanged: (v) => setState(() => _namespace = v),
+            label: 'Namespace',
+            hint: 'Pick a namespace',
+          ),
+        ];
+      case _ScopeVariant.store:
+        return [
+          NamedResourcePicker(
+            clusterId: widget.clusterId,
+            kind: 'namespaces',
+            namespace: null,
+            selected: _namespace,
+            onChanged: (v) => setState(() {
+              _namespace = v;
+              // Resetting the store-name selection when the namespace
+              // changes prevents a stale name from a different namespace
+              // bleeding into the submitted scope.
+              _storeName = '';
+            }),
+            label: 'Namespace',
+            hint: 'Pick a namespace',
+          ),
+          const SizedBox(height: 12),
+          if (_namespace.isEmpty)
+            _SecondaryHint(text: 'Pick a namespace first to list its stores.')
+          else
+            _StorePicker(
+              clusterId: widget.clusterId,
+              namespace: _namespace,
+              selected: _storeName,
+              onChanged: (v) => setState(() => _storeName = v),
+            ),
+        ];
+      case _ScopeVariant.clusterStore:
+        return [
+          _ClusterStorePicker(
+            clusterId: widget.clusterId,
+            selected: _clusterStoreName,
+            onChanged: (v) => setState(() => _clusterStoreName = v),
+          ),
+        ];
+    }
+  }
+}
+
+class _SecondaryHint extends StatelessWidget {
+  const _SecondaryHint({required this.text});
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 4),
+      child: Text(
+        text,
+        style: TextStyle(color: colors.textMuted, fontSize: 12),
+      ),
+    );
+  }
+}
+
+/// Namespaced SecretStore picker. Reads `storesListProvider`, filters
+/// to the chosen namespace, and renders a dropdown.
+class _StorePicker extends ConsumerWidget {
+  const _StorePicker({
+    required this.clusterId,
+    required this.namespace,
+    required this.selected,
+    required this.onChanged,
+  });
+
+  final String clusterId;
+  final String namespace;
+  final String selected;
+  final ValueChanged<String> onChanged;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final async = ref.watch(storesListProvider(clusterId));
+    return async.when(
+      loading: () => _frame(
+        colors,
+        const LinearProgressIndicator(minHeight: 2),
+        label: 'SecretStore',
+      ),
+      error: (e, _) => _frame(
+        colors,
+        Text(
+          'Failed to load stores: $e',
+          style: TextStyle(color: colors.error, fontSize: 12),
+        ),
+        label: 'SecretStore',
+      ),
+      data: (stores) {
+        final filtered = stores
+            .where((s) => s.namespace == namespace)
+            .map((s) => s.name)
+            .toList()
+          ..sort();
+        if (filtered.isEmpty) {
+          return _frame(
+            colors,
+            Text(
+              'No SecretStores in $namespace',
+              style: TextStyle(color: colors.textMuted, fontSize: 12),
+            ),
+            label: 'SecretStore',
+          );
+        }
+        if (selected.isNotEmpty && !filtered.contains(selected)) {
+          filtered.add(selected);
+          filtered.sort();
+        }
+        return DropdownButtonFormField<String>(
+          initialValue: selected.isEmpty ? null : selected,
+          isExpanded: true,
+          decoration: const InputDecoration(
+            labelText: 'SecretStore',
+            border: OutlineInputBorder(),
+          ),
+          items: [
+            for (final v in filtered)
+              DropdownMenuItem(value: v, child: Text(v)),
+          ],
+          onChanged: (v) {
+            if (v == null) return;
+            onChanged(v);
+          },
+        );
+      },
+    );
+  }
+
+  Widget _frame(KubeColors colors, Widget child, {required String label}) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        border: Border.all(color: colors.borderSubtle),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: TextStyle(
+              color: colors.textMuted,
+              fontSize: 11,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 4),
+          child,
+        ],
+      ),
+    );
+  }
+}
+
+class _ClusterStorePicker extends ConsumerWidget {
+  const _ClusterStorePicker({
+    required this.clusterId,
+    required this.selected,
+    required this.onChanged,
+  });
+
+  final String clusterId;
+  final String selected;
+  final ValueChanged<String> onChanged;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final async = ref.watch(clusterStoresListProvider(clusterId));
+    return async.when(
+      loading: () => _frame(
+        colors,
+        const LinearProgressIndicator(minHeight: 2),
+      ),
+      error: (e, _) => _frame(
+        colors,
+        Text(
+          'Failed to load cluster stores: $e',
+          style: TextStyle(color: colors.error, fontSize: 12),
+        ),
+      ),
+      data: (stores) {
+        final names = stores.map((s) => s.name).toList()..sort();
+        if (names.isEmpty) {
+          return _frame(
+            colors,
+            Text(
+              'No ClusterSecretStores on this cluster',
+              style: TextStyle(color: colors.textMuted, fontSize: 12),
+            ),
+          );
+        }
+        if (selected.isNotEmpty && !names.contains(selected)) {
+          names.add(selected);
+          names.sort();
+        }
+        return DropdownButtonFormField<String>(
+          initialValue: selected.isEmpty ? null : selected,
+          isExpanded: true,
+          decoration: const InputDecoration(
+            labelText: 'ClusterSecretStore',
+            border: OutlineInputBorder(),
+          ),
+          items: [
+            for (final v in names) DropdownMenuItem(value: v, child: Text(v)),
+          ],
+          onChanged: (v) {
+            if (v == null) return;
+            onChanged(v);
+          },
+        );
+      },
+    );
+  }
+
+  Widget _frame(KubeColors colors, Widget child) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        border: Border.all(color: colors.borderSubtle),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'ClusterSecretStore',
+            style: TextStyle(
+              color: colors.textMuted,
+              fontSize: 11,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 4),
+          child,
+        ],
+      ),
+    );
+  }
+}
+

--- a/mobile/lib/features/eso/bulk_refresh_sheet.dart
+++ b/mobile/lib/features/eso/bulk_refresh_sheet.dart
@@ -1,0 +1,758 @@
+// ESO Bulk Refresh modal bottom sheet. Walks the four phases owned by
+// `BulkRefreshController` and surfaces snackbars + progress UI matching
+// the M4 invariants (drift tri-state coloring, type-to-confirm friction,
+// cluster-pin discipline).
+//
+// Entry point: `showBulkRefreshSheet(context, clusterId)`. The sheet
+// stays open across phases — `isDismissible: true` + a top close button
+// give the operator two escapes (scrim tap, button) without dropping
+// state, since the controller's autoDispose tears the timer down on
+// either path.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../api/eso_repository.dart';
+import '../../theme/kube_theme_builder.dart';
+import 'bulk_refresh_controller.dart';
+import 'bulk_refresh_scope_picker.dart';
+
+const String kBulkRefreshConfirmToken = 'REFRESH';
+
+/// Show the bulk-refresh sheet. Returns when the operator dismisses it
+/// (controller continues poll loop independently when dismissed mid-job).
+Future<void> showBulkRefreshSheet({
+  required BuildContext context,
+  required String clusterId,
+}) {
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    isDismissible: true,
+    builder: (ctx) => _BulkRefreshSheet(clusterId: clusterId),
+  );
+}
+
+class _BulkRefreshSheet extends ConsumerWidget {
+  const _BulkRefreshSheet({required this.clusterId});
+
+  final String clusterId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(bulkRefreshControllerProvider(clusterId));
+    final ctrl = ref.read(bulkRefreshControllerProvider(clusterId).notifier);
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final viewInsets = MediaQuery.of(context).viewInsets;
+
+    return Padding(
+      padding: EdgeInsets.only(bottom: viewInsets.bottom),
+      child: SafeArea(
+        top: false,
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            maxHeight: MediaQuery.of(context).size.height * 0.85,
+          ),
+          child: SingleChildScrollView(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Center(
+                    child: Container(
+                      width: 36,
+                      height: 4,
+                      margin: const EdgeInsets.only(bottom: 12),
+                      decoration: BoxDecoration(
+                        color: colors.borderSubtle,
+                        borderRadius: BorderRadius.circular(2),
+                      ),
+                    ),
+                  ),
+                  _Header(phase: state.phase, colors: colors),
+                  const SizedBox(height: 12),
+                  _Body(state: state, controller: ctrl, clusterId: clusterId),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _Header extends StatelessWidget {
+  const _Header({required this.phase, required this.colors});
+
+  final BulkRefreshPhase phase;
+  final KubeColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    final label = switch (phase) {
+      BulkRefreshPhase.scopePick => 'Refresh ExternalSecrets',
+      BulkRefreshPhase.scopeLoad => 'Resolving scope…',
+      BulkRefreshPhase.confirm => 'Confirm refresh',
+      BulkRefreshPhase.submit => 'Starting refresh…',
+      BulkRefreshPhase.poll => 'Refreshing…',
+      BulkRefreshPhase.done => 'Refresh complete',
+      BulkRefreshPhase.error => 'Refresh failed',
+    };
+    return Text(
+      label,
+      style: TextStyle(
+        color: colors.textPrimary,
+        fontSize: 17,
+        fontWeight: FontWeight.w600,
+      ),
+    );
+  }
+}
+
+class _Body extends ConsumerWidget {
+  const _Body({
+    required this.state,
+    required this.controller,
+    required this.clusterId,
+  });
+
+  final BulkRefreshSheetState state;
+  final BulkRefreshController controller;
+  final String clusterId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    switch (state.phase) {
+      case BulkRefreshPhase.scopePick:
+        return BulkRefreshScopePicker(
+          clusterId: clusterId,
+          onSubmit: controller.beginScopeLoad,
+          onCancel: () => Navigator.of(context).pop(),
+        );
+      case BulkRefreshPhase.scopeLoad:
+        return const _PhaseProgress(
+          message: 'Resolving the refresh scope…',
+        );
+      case BulkRefreshPhase.confirm:
+        return _ConfirmBody(
+          state: state,
+          onConfirm: controller.submit,
+          onBack: controller.backToScopePick,
+          onCancel: () => Navigator.of(context).pop(),
+        );
+      case BulkRefreshPhase.submit:
+        return const _PhaseProgress(message: 'Sending request…');
+      case BulkRefreshPhase.poll:
+        return _PollBody(
+          state: state,
+          onDismiss: () => Navigator.of(context).pop(),
+        );
+      case BulkRefreshPhase.done:
+        return _DoneBody(
+          state: state,
+          onClose: () => Navigator.of(context).pop(),
+        );
+      case BulkRefreshPhase.error:
+        return _ErrorBody(
+          state: state,
+          onClose: () => Navigator.of(context).pop(),
+          onRetry: controller.backToScopePick,
+        );
+    }
+  }
+}
+
+class _PhaseProgress extends StatelessWidget {
+  const _PhaseProgress({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return Row(
+      children: [
+        const SizedBox(
+          width: 16,
+          height: 16,
+          child: CircularProgressIndicator(strokeWidth: 2),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Text(
+            message,
+            style: TextStyle(color: colors.textSecondary),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ConfirmBody extends StatefulWidget {
+  const _ConfirmBody({
+    required this.state,
+    required this.onConfirm,
+    required this.onBack,
+    required this.onCancel,
+  });
+
+  final BulkRefreshSheetState state;
+  final VoidCallback onConfirm;
+  final VoidCallback onBack;
+  final VoidCallback onCancel;
+
+  @override
+  State<_ConfirmBody> createState() => _ConfirmBodyState();
+}
+
+class _ConfirmBodyState extends State<_ConfirmBody> {
+  late final TextEditingController _input = TextEditingController()
+    ..addListener(() => setState(() {}));
+
+  @override
+  void dispose() {
+    _input.dispose();
+    super.dispose();
+  }
+
+  bool get _canConfirm {
+    final scope = widget.state.scopeResponse;
+    if (scope == null || scope.visibleCount == 0) return false;
+    return _input.text.trim() == kBulkRefreshConfirmToken;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final scope = widget.state.scopeResponse;
+    if (scope == null) {
+      return Text(
+        'Scope not loaded — go back and re-pick.',
+        style: TextStyle(color: colors.error, fontSize: 13),
+      );
+    }
+    if (scope.visibleCount == 0) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            "No ExternalSecrets are in scope, or you don't have permission "
+            'to refresh them.',
+            style: TextStyle(color: colors.textSecondary, fontSize: 13),
+          ),
+          const SizedBox(height: 20),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              TextButton(
+                onPressed: widget.onBack,
+                child: const Text('Back'),
+              ),
+              const SizedBox(width: 8),
+              FilledButton(
+                onPressed: widget.onCancel,
+                child: const Text('Close'),
+              ),
+            ],
+          ),
+        ],
+      );
+    }
+
+    final scopeIdentifier =
+        widget.state.scope?.displayId() ?? scope.scopeTarget;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        RichText(
+          text: TextSpan(
+            style: TextStyle(color: colors.textPrimary, fontSize: 14),
+            children: [
+              TextSpan(
+                text: '${scope.visibleCount}',
+                style: const TextStyle(fontWeight: FontWeight.w600),
+              ),
+              TextSpan(
+                text: scope.visibleCount == 1
+                    ? ' ExternalSecret across '
+                    : ' ExternalSecrets across ',
+              ),
+              TextSpan(
+                text: '${scope.byNamespace.length}',
+                style: const TextStyle(fontWeight: FontWeight.w600),
+              ),
+              TextSpan(
+                text: scope.byNamespace.length == 1
+                    ? ' namespace will receive a force-sync from '
+                    : ' namespaces will receive a force-sync from ',
+              ),
+              TextSpan(
+                text: scopeIdentifier,
+                style: const TextStyle(fontWeight: FontWeight.w600),
+              ),
+              const TextSpan(text: '.'),
+            ],
+          ),
+        ),
+        if (scope.restricted) ...[
+          const SizedBox(height: 10),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+            decoration: BoxDecoration(
+              color: colors.bgElevated,
+              borderRadius: BorderRadius.circular(6),
+              border: Border.all(color: colors.borderSubtle),
+            ),
+            child: Text(
+              'Showing only resources you can refresh. '
+              '${scope.totalCount - scope.visibleCount} additional '
+              '${scope.totalCount - scope.visibleCount == 1 ? "is" : "are"} '
+              'out of your visibility.',
+              style: TextStyle(color: colors.textMuted, fontSize: 12),
+            ),
+          ),
+        ],
+        const SizedBox(height: 12),
+        Container(
+          constraints: const BoxConstraints(maxHeight: 180),
+          decoration: BoxDecoration(
+            border: Border.all(color: colors.borderSubtle),
+            borderRadius: BorderRadius.circular(6),
+          ),
+          child: ListView(
+            shrinkWrap: true,
+            children: [
+              for (final row in scope.byNamespace)
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 12, vertical: 6),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          row.namespace,
+                          style: TextStyle(
+                            color: colors.textPrimary,
+                            fontSize: 13,
+                            fontFamily: 'monospace',
+                          ),
+                        ),
+                      ),
+                      Text(
+                        '${row.count}',
+                        style: TextStyle(
+                          color: colors.textMuted,
+                          fontSize: 13,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 16),
+        Text.rich(
+          TextSpan(
+            style: TextStyle(color: colors.textSecondary, fontSize: 13),
+            children: [
+              const TextSpan(text: 'Type '),
+              TextSpan(
+                text: kBulkRefreshConfirmToken,
+                style: const TextStyle(
+                  fontFamily: 'monospace',
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const TextSpan(text: ' to confirm'),
+            ],
+          ),
+        ),
+        const SizedBox(height: 8),
+        TextField(
+          controller: _input,
+          autofocus: true,
+          autocorrect: false,
+          enableSuggestions: false,
+          textCapitalization: TextCapitalization.characters,
+          autofillHints: const <String>[],
+          style: TextStyle(
+            fontFamily: 'monospace',
+            color: colors.textPrimary,
+          ),
+          decoration: InputDecoration(
+            hintText: kBulkRefreshConfirmToken,
+            hintStyle: TextStyle(
+              color: colors.textMuted,
+              fontFamily: 'monospace',
+            ),
+            border: const OutlineInputBorder(),
+          ),
+        ),
+        if (widget.state.errorMessage != null) ...[
+          const SizedBox(height: 10),
+          Text(
+            widget.state.errorMessage!,
+            style: TextStyle(color: colors.warning, fontSize: 12),
+          ),
+        ],
+        const SizedBox(height: 16),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            TextButton(
+              onPressed: widget.onBack,
+              style: TextButton.styleFrom(
+                foregroundColor: colors.textSecondary,
+              ),
+              child: const Text('Back'),
+            ),
+            const SizedBox(width: 8),
+            FilledButton(
+              onPressed: _canConfirm ? widget.onConfirm : null,
+              style: FilledButton.styleFrom(
+                backgroundColor: colors.accent,
+                foregroundColor: Colors.white,
+              ),
+              child: Text('Refresh ${scope.visibleCount}'),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _PollBody extends StatelessWidget {
+  const _PollBody({required this.state, required this.onDismiss});
+
+  final BulkRefreshSheetState state;
+  final VoidCallback onDismiss;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final job = state.job;
+    final targetCount = job?.targetCount ?? 0;
+    final processed = job?.processed ?? 0;
+    final progressValue = (job != null && targetCount > 0)
+        ? (processed / targetCount).clamp(0.0, 1.0)
+        : null;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (state.attachedToExistingJob)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 10),
+            child: Text(
+              'Attached to an existing refresh job — counts come from the '
+              'in-flight job, not a fresh resolution.',
+              style: TextStyle(color: colors.textMuted, fontSize: 12),
+            ),
+          ),
+        LinearProgressIndicator(
+          value: progressValue,
+          minHeight: 6,
+          backgroundColor: colors.bgElevated,
+        ),
+        const SizedBox(height: 8),
+        // Live-region semantics so VoiceOver/TalkBack announce count
+        // updates without the operator needing to re-focus the field.
+        Semantics(
+          liveRegion: true,
+          child: Text(
+            job == null
+                ? 'Tracking job ${state.jobId ?? ""}…'
+                : 'Refreshing $processed of $targetCount',
+            style: TextStyle(color: colors.textSecondary, fontSize: 13),
+          ),
+        ),
+        if (state.pollRetrying) ...[
+          const SizedBox(height: 6),
+          Text(
+            'Retrying…',
+            style: TextStyle(color: colors.warning, fontSize: 12),
+          ),
+        ],
+        if (state.takingLong) ...[
+          const SizedBox(height: 6),
+          Text(
+            'Taking longer than expected — feel free to dismiss; the job '
+            'continues in the background.',
+            style: TextStyle(color: colors.warning, fontSize: 12),
+          ),
+        ],
+        if (job != null) ...[
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              _StatCell(
+                label: 'Succeeded',
+                value: '${job.succeeded.length}',
+                color: colors.success,
+              ),
+              const SizedBox(width: 16),
+              _StatCell(
+                label: 'Failed',
+                value: '${job.failed.length}',
+                color: colors.error,
+              ),
+              const SizedBox(width: 16),
+              _StatCell(
+                label: 'Skipped',
+                value: '${job.skipped.length}',
+                color: colors.warning,
+              ),
+            ],
+          ),
+        ],
+        const SizedBox(height: 20),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            FilledButton.tonal(
+              onPressed: onDismiss,
+              child: const Text('Run in background'),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _DoneBody extends StatelessWidget {
+  const _DoneBody({required this.state, required this.onClose});
+
+  final BulkRefreshSheetState state;
+  final VoidCallback onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final job = state.job;
+    if (job == null) {
+      // Defensive: done with no job should never happen, but render
+      // something rather than throwing.
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          Text(
+            'Refresh complete.',
+            style: TextStyle(color: colors.textSecondary, fontSize: 13),
+          ),
+          const SizedBox(height: 12),
+          FilledButton(onPressed: onClose, child: const Text('Close')),
+        ],
+      );
+    }
+    final hasFailures = job.failed.isNotEmpty;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          hasFailures
+              ? 'Refresh finished with ${job.failed.length} failure'
+                  '${job.failed.length == 1 ? "" : "s"}.'
+              : 'All ${job.succeeded.length} ExternalSecret'
+                  '${job.succeeded.length == 1 ? "" : "s"} were refreshed.',
+          style: TextStyle(
+            color: hasFailures ? colors.warning : colors.success,
+            fontSize: 14,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 10),
+        Row(
+          children: [
+            _StatCell(
+              label: 'Succeeded',
+              value: '${job.succeeded.length}',
+              color: colors.success,
+            ),
+            const SizedBox(width: 16),
+            _StatCell(
+              label: 'Failed',
+              value: '${job.failed.length}',
+              color: colors.error,
+            ),
+            const SizedBox(width: 16),
+            _StatCell(
+              label: 'Skipped',
+              value: '${job.skipped.length}',
+              color: colors.warning,
+            ),
+          ],
+        ),
+        if (hasFailures) ...[
+          const SizedBox(height: 12),
+          _OutcomeList(label: 'Failed', outcomes: job.failed, color: colors.error),
+        ],
+        if (job.skipped.isNotEmpty) ...[
+          const SizedBox(height: 8),
+          _OutcomeList(
+              label: 'Skipped',
+              outcomes: job.skipped,
+              color: colors.warning),
+        ],
+        const SizedBox(height: 20),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            FilledButton(
+              onPressed: onClose,
+              child: const Text('Close'),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _ErrorBody extends StatelessWidget {
+  const _ErrorBody({
+    required this.state,
+    required this.onClose,
+    required this.onRetry,
+  });
+
+  final BulkRefreshSheetState state;
+  final VoidCallback onClose;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          state.errorMessage ?? 'Refresh failed.',
+          style: TextStyle(color: colors.error, fontSize: 13, height: 1.4),
+        ),
+        const SizedBox(height: 20),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            TextButton(
+              onPressed: onClose,
+              style: TextButton.styleFrom(
+                foregroundColor: colors.textSecondary,
+              ),
+              child: const Text('Close'),
+            ),
+            const SizedBox(width: 8),
+            FilledButton(
+              onPressed: onRetry,
+              child: const Text('Try again'),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _StatCell extends StatelessWidget {
+  const _StatCell({
+    required this.label,
+    required this.value,
+    required this.color,
+  });
+
+  final String label;
+  final String value;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: TextStyle(color: colors.textMuted, fontSize: 11),
+        ),
+        const SizedBox(height: 2),
+        Text(
+          value,
+          style: TextStyle(
+            color: color,
+            fontSize: 18,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _OutcomeList extends StatelessWidget {
+  const _OutcomeList({
+    required this.label,
+    required this.outcomes,
+    required this.color,
+  });
+
+  final String label;
+  final List<BulkRefreshOutcome> outcomes;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return ExpansionTile(
+      tilePadding: EdgeInsets.zero,
+      childrenPadding: EdgeInsets.zero,
+      title: Text(
+        '$label (${outcomes.length})',
+        style: TextStyle(color: colors.textSecondary, fontSize: 13),
+      ),
+      children: [
+        Container(
+          decoration: BoxDecoration(
+            border: Border.all(color: colors.borderSubtle),
+            borderRadius: BorderRadius.circular(6),
+          ),
+          child: Column(
+            children: [
+              for (final o in outcomes)
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 10, vertical: 6),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          o.uid,
+                          style: TextStyle(
+                            color: colors.textPrimary,
+                            fontFamily: 'monospace',
+                            fontSize: 11,
+                          ),
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Text(
+                        o.reason,
+                        style: TextStyle(color: color, fontSize: 11),
+                      ),
+                    ],
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/mobile/lib/features/eso/bulk_refresh_sheet.dart
+++ b/mobile/lib/features/eso/bulk_refresh_sheet.dart
@@ -1,4 +1,4 @@
-// ESO Bulk Refresh modal bottom sheet. Walks the four phases owned by
+// ESO Bulk Refresh modal bottom sheet. Walks the eight phases owned by
 // `BulkRefreshController` and surfaces snackbars + progress UI matching
 // the M4 invariants (drift tri-state coloring, type-to-confirm friction,
 // cluster-pin discipline).
@@ -8,12 +8,20 @@
 // give the operator two escapes (scrim tap, button) without dropping
 // state, since the controller's autoDispose tears the timer down on
 // either path.
+//
+// Type-to-confirm friction is delegated to the shared
+// `confirm_sheet.dart` modal (PR-5e-review #3) so this surface stays
+// isomorphic with every other destructive write in the app. The preview
+// phase renders the byNamespace breakdown + RBAC notice; "Continue"
+// transitions preview → confirm and stacks the shared sheet on top.
+// Cancel from the inner sheet drops back to preview cleanly.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../api/eso_repository.dart';
 import '../../theme/kube_theme_builder.dart';
+import '../../widgets/confirm_sheet.dart';
 import 'bulk_refresh_controller.dart';
 import 'bulk_refresh_scope_picker.dart';
 
@@ -33,15 +41,59 @@ Future<void> showBulkRefreshSheet({
   );
 }
 
-class _BulkRefreshSheet extends ConsumerWidget {
+class _BulkRefreshSheet extends ConsumerStatefulWidget {
   const _BulkRefreshSheet({required this.clusterId});
 
   final String clusterId;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final state = ref.watch(bulkRefreshControllerProvider(clusterId));
-    final ctrl = ref.read(bulkRefreshControllerProvider(clusterId).notifier);
+  ConsumerState<_BulkRefreshSheet> createState() => _BulkRefreshSheetState();
+}
+
+class _BulkRefreshSheetState extends ConsumerState<_BulkRefreshSheet> {
+  late final AppLifecycleListener _lifecycle;
+
+  @override
+  void initState() {
+    super.initState();
+    // PR-5e-review #9: iOS suspends our 2s periodic Timer when the app
+    // backgrounds. Without a resume-time nudge the progress bar can
+    // sit stale for up to one full poll interval after the app
+    // foregrounds. Fire a one-shot poll on resume; the controller's
+    // `_pollInFlight` reentrancy guard makes this safe even when the
+    // periodic tick is mid-fetch, and the inner phase guard early-
+    // returns when we're not polling.
+    _lifecycle = AppLifecycleListener(
+      onResume: () {
+        if (!mounted) return;
+        final ctrl = ref.read(
+          bulkRefreshControllerProvider(widget.clusterId).notifier,
+        );
+        // Fire-and-forget; the controller surfaces any error through
+        // its own state machine.
+        ctrl.pollNow();
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _lifecycle.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // PR-5e-review #10: watch ONLY the phase here so the outer scaffold
+    // (drag handle, header, body switcher) doesn't rebuild on every
+    // sub-field tick (e.g., per-poll `job.processed` increments). The
+    // deeper field watches are pushed into per-phase Consumer widgets
+    // so a 2s `processed` tick rebuilds only the few lines that
+    // actually depend on it.
+    final phase = ref.watch(bulkRefreshControllerProvider(widget.clusterId)
+        .select((s) => s.phase));
+    final ctrl =
+        ref.read(bulkRefreshControllerProvider(widget.clusterId).notifier);
     final colors = Theme.of(context).extension<KubeColors>()!;
     final viewInsets = MediaQuery.of(context).viewInsets;
 
@@ -71,9 +123,12 @@ class _BulkRefreshSheet extends ConsumerWidget {
                       ),
                     ),
                   ),
-                  _Header(phase: state.phase, colors: colors),
+                  _Header(phase: phase, colors: colors),
                   const SizedBox(height: 12),
-                  _Body(state: state, controller: ctrl, clusterId: clusterId),
+                  _Body(
+                      phase: phase,
+                      controller: ctrl,
+                      clusterId: widget.clusterId),
                 ],
               ),
             ),
@@ -95,7 +150,8 @@ class _Header extends StatelessWidget {
     final label = switch (phase) {
       BulkRefreshPhase.scopePick => 'Refresh ExternalSecrets',
       BulkRefreshPhase.scopeLoad => 'Resolving scope…',
-      BulkRefreshPhase.confirm => 'Confirm refresh',
+      BulkRefreshPhase.preview => 'Review refresh scope',
+      BulkRefreshPhase.confirm => 'Review refresh scope',
       BulkRefreshPhase.submit => 'Starting refresh…',
       BulkRefreshPhase.poll => 'Refreshing…',
       BulkRefreshPhase.done => 'Refresh complete',
@@ -112,20 +168,24 @@ class _Header extends StatelessWidget {
   }
 }
 
-class _Body extends ConsumerWidget {
+class _Body extends StatelessWidget {
   const _Body({
-    required this.state,
+    required this.phase,
     required this.controller,
     required this.clusterId,
   });
 
-  final BulkRefreshSheetState state;
+  /// Bare phase — the only signal that selects which body widget to
+  /// mount. Per-phase widgets fetch the rest of state via their own
+  /// `Consumer`/`ref.watch(.select)` so a tick on a different slice
+  /// doesn't bubble through the body switcher.
+  final BulkRefreshPhase phase;
   final BulkRefreshController controller;
   final String clusterId;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    switch (state.phase) {
+  Widget build(BuildContext context) {
+    switch (phase) {
       case BulkRefreshPhase.scopePick:
         return BulkRefreshScopePicker(
           clusterId: clusterId,
@@ -136,28 +196,33 @@ class _Body extends ConsumerWidget {
         return const _PhaseProgress(
           message: 'Resolving the refresh scope…',
         );
+      case BulkRefreshPhase.preview:
       case BulkRefreshPhase.confirm:
-        return _ConfirmBody(
-          state: state,
-          onConfirm: controller.submit,
-          onBack: controller.backToScopePick,
-          onCancel: () => Navigator.of(context).pop(),
+        // Preview body stays mounted across both phases. In `confirm`
+        // the shared `confirm_sheet.dart` modal is stacked on top; the
+        // body underneath still renders the breakdown so a cancel from
+        // the inner sheet drops back to a fully-rendered preview rather
+        // than a blank flash.
+        return _PreviewBody(
+          controller: controller,
+          clusterId: clusterId,
+          continueDisabled: phase == BulkRefreshPhase.confirm,
         );
       case BulkRefreshPhase.submit:
         return const _PhaseProgress(message: 'Sending request…');
       case BulkRefreshPhase.poll:
         return _PollBody(
-          state: state,
+          clusterId: clusterId,
           onDismiss: () => Navigator.of(context).pop(),
         );
       case BulkRefreshPhase.done:
         return _DoneBody(
-          state: state,
+          clusterId: clusterId,
           onClose: () => Navigator.of(context).pop(),
         );
       case BulkRefreshPhase.error:
         return _ErrorBody(
-          state: state,
+          clusterId: clusterId,
           onClose: () => Navigator.of(context).pop(),
           onRetry: controller.backToScopePick,
         );
@@ -192,43 +257,68 @@ class _PhaseProgress extends StatelessWidget {
   }
 }
 
-class _ConfirmBody extends StatefulWidget {
-  const _ConfirmBody({
-    required this.state,
-    required this.onConfirm,
-    required this.onBack,
-    required this.onCancel,
+/// Renders the resolved-scope breakdown + RBAC notice. The type-to-
+/// confirm friction (kBulkRefreshConfirmToken == "REFRESH") is delegated
+/// to the shared `showConfirmSheet`; tapping "Continue" advances the
+/// controller to `confirm`, stacks the shared sheet on top, and routes
+/// the operator's answer back into the controller (submit / backToPreview).
+class _PreviewBody extends ConsumerWidget {
+  const _PreviewBody({
+    required this.controller,
+    required this.clusterId,
+    required this.continueDisabled,
   });
 
-  final BulkRefreshSheetState state;
-  final VoidCallback onConfirm;
-  final VoidCallback onBack;
-  final VoidCallback onCancel;
+  final BulkRefreshController controller;
+  final String clusterId;
 
-  @override
-  State<_ConfirmBody> createState() => _ConfirmBodyState();
-}
+  /// True while the shared confirm sheet is layered on top (phase ==
+  /// confirm). Keeps "Continue" disabled so a stray tap on the underlying
+  /// surface doesn't double-fire confirmPreview() while the inner sheet
+  /// is owning the operator's focus.
+  final bool continueDisabled;
 
-class _ConfirmBodyState extends State<_ConfirmBody> {
-  late final TextEditingController _input = TextEditingController()
-    ..addListener(() => setState(() {}));
-
-  @override
-  void dispose() {
-    _input.dispose();
-    super.dispose();
+  Future<void> _onContinue(
+    BuildContext context,
+    BulkScopeResponse scope,
+    BulkRefreshScope? selectedScope,
+  ) async {
+    if (scope.visibleCount == 0) return;
+    controller.confirmPreview();
+    final scopeIdentifier = selectedScope?.displayId() ?? scope.scopeTarget;
+    final visibleCount = scope.visibleCount;
+    final confirmed = await showConfirmSheet(
+      context: context,
+      title: 'Refresh $visibleCount ExternalSecret'
+          '${visibleCount == 1 ? "" : "s"}',
+      message:
+          'This triggers an immediate sync of every ExternalSecret in '
+          '$scopeIdentifier against its store. Existing Secrets are '
+          'overwritten with the upstream value.',
+      confirmLabel: 'Refresh $visibleCount',
+      typeToConfirm: kBulkRefreshConfirmToken,
+      danger: true,
+    );
+    if (confirmed == true) {
+      await controller.submit();
+    } else {
+      // Cancel / scrim dismiss / null — drop back to preview so the
+      // operator can re-review or hit Back.
+      controller.backToPreview();
+    }
   }
 
-  bool get _canConfirm {
-    final scope = widget.state.scopeResponse;
-    if (scope == null || scope.visibleCount == 0) return false;
-    return _input.text.trim() == kBulkRefreshConfirmToken;
-  }
-
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final colors = Theme.of(context).extension<KubeColors>()!;
-    final scope = widget.state.scopeResponse;
+    // Watch only the slice we depend on (scopeResponse, scope,
+    // errorMessage). Phase ticks are owned by the outer sheet.
+    final scope = ref.watch(bulkRefreshControllerProvider(clusterId)
+        .select((s) => s.scopeResponse));
+    final selectedScope = ref.watch(bulkRefreshControllerProvider(clusterId)
+        .select((s) => s.scope));
+    final errorMessage = ref.watch(bulkRefreshControllerProvider(clusterId)
+        .select((s) => s.errorMessage));
     if (scope == null) {
       return Text(
         'Scope not loaded — go back and re-pick.',
@@ -249,12 +339,12 @@ class _ConfirmBodyState extends State<_ConfirmBody> {
             mainAxisAlignment: MainAxisAlignment.end,
             children: [
               TextButton(
-                onPressed: widget.onBack,
+                onPressed: controller.backToScopePick,
                 child: const Text('Back'),
               ),
               const SizedBox(width: 8),
               FilledButton(
-                onPressed: widget.onCancel,
+                onPressed: () => Navigator.of(context).pop(),
                 child: const Text('Close'),
               ),
             ],
@@ -263,8 +353,7 @@ class _ConfirmBodyState extends State<_ConfirmBody> {
       );
     }
 
-    final scopeIdentifier =
-        widget.state.scope?.displayId() ?? scope.scopeTarget;
+    final scopeIdentifier = selectedScope?.displayId() ?? scope.scopeTarget;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -356,48 +445,10 @@ class _ConfirmBodyState extends State<_ConfirmBody> {
             ],
           ),
         ),
-        const SizedBox(height: 16),
-        Text.rich(
-          TextSpan(
-            style: TextStyle(color: colors.textSecondary, fontSize: 13),
-            children: [
-              const TextSpan(text: 'Type '),
-              TextSpan(
-                text: kBulkRefreshConfirmToken,
-                style: const TextStyle(
-                  fontFamily: 'monospace',
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-              const TextSpan(text: ' to confirm'),
-            ],
-          ),
-        ),
-        const SizedBox(height: 8),
-        TextField(
-          controller: _input,
-          autofocus: true,
-          autocorrect: false,
-          enableSuggestions: false,
-          textCapitalization: TextCapitalization.characters,
-          autofillHints: const <String>[],
-          style: TextStyle(
-            fontFamily: 'monospace',
-            color: colors.textPrimary,
-          ),
-          decoration: InputDecoration(
-            hintText: kBulkRefreshConfirmToken,
-            hintStyle: TextStyle(
-              color: colors.textMuted,
-              fontFamily: 'monospace',
-            ),
-            border: const OutlineInputBorder(),
-          ),
-        ),
-        if (widget.state.errorMessage != null) ...[
+        if (errorMessage != null) ...[
           const SizedBox(height: 10),
           Text(
-            widget.state.errorMessage!,
+            errorMessage,
             style: TextStyle(color: colors.warning, fontSize: 12),
           ),
         ],
@@ -406,7 +457,8 @@ class _ConfirmBodyState extends State<_ConfirmBody> {
           mainAxisAlignment: MainAxisAlignment.end,
           children: [
             TextButton(
-              onPressed: widget.onBack,
+              onPressed:
+                  continueDisabled ? null : controller.backToScopePick,
               style: TextButton.styleFrom(
                 foregroundColor: colors.textSecondary,
               ),
@@ -414,12 +466,14 @@ class _ConfirmBodyState extends State<_ConfirmBody> {
             ),
             const SizedBox(width: 8),
             FilledButton(
-              onPressed: _canConfirm ? widget.onConfirm : null,
+              onPressed: continueDisabled
+                  ? null
+                  : () => _onContinue(context, scope, selectedScope),
               style: FilledButton.styleFrom(
                 backgroundColor: colors.accent,
                 foregroundColor: Colors.white,
               ),
-              child: Text('Refresh ${scope.visibleCount}'),
+              child: const Text('Continue'),
             ),
           ],
         ),
@@ -428,16 +482,28 @@ class _ConfirmBodyState extends State<_ConfirmBody> {
   }
 }
 
-class _PollBody extends StatelessWidget {
-  const _PollBody({required this.state, required this.onDismiss});
+class _PollBody extends ConsumerWidget {
+  const _PollBody({required this.clusterId, required this.onDismiss});
 
-  final BulkRefreshSheetState state;
+  final String clusterId;
   final VoidCallback onDismiss;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final colors = Theme.of(context).extension<KubeColors>()!;
-    final job = state.job;
+    // Watch only the fields we render. Per the PR-5e-review #10 rebuild
+    // pattern, the outer sheet's phase-only watch means this widget is
+    // the only thing that re-builds on per-poll job ticks.
+    final job = ref.watch(bulkRefreshControllerProvider(clusterId)
+        .select((s) => s.job));
+    final jobId = ref.watch(bulkRefreshControllerProvider(clusterId)
+        .select((s) => s.jobId));
+    final attached = ref.watch(bulkRefreshControllerProvider(clusterId)
+        .select((s) => s.attachedToExistingJob));
+    final pollRetrying = ref.watch(bulkRefreshControllerProvider(clusterId)
+        .select((s) => s.pollRetrying));
+    final takingLong = ref.watch(bulkRefreshControllerProvider(clusterId)
+        .select((s) => s.takingLong));
     final targetCount = job?.targetCount ?? 0;
     final processed = job?.processed ?? 0;
     final progressValue = (job != null && targetCount > 0)
@@ -447,7 +513,7 @@ class _PollBody extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        if (state.attachedToExistingJob)
+        if (attached)
           Padding(
             padding: const EdgeInsets.only(bottom: 10),
             child: Text(
@@ -468,19 +534,19 @@ class _PollBody extends StatelessWidget {
           liveRegion: true,
           child: Text(
             job == null
-                ? 'Tracking job ${state.jobId ?? ""}…'
+                ? 'Tracking job ${jobId ?? ""}…'
                 : 'Refreshing $processed of $targetCount',
             style: TextStyle(color: colors.textSecondary, fontSize: 13),
           ),
         ),
-        if (state.pollRetrying) ...[
+        if (pollRetrying) ...[
           const SizedBox(height: 6),
           Text(
             'Retrying…',
             style: TextStyle(color: colors.warning, fontSize: 12),
           ),
         ],
-        if (state.takingLong) ...[
+        if (takingLong) ...[
           const SizedBox(height: 6),
           Text(
             'Taking longer than expected — feel free to dismiss; the job '
@@ -527,16 +593,21 @@ class _PollBody extends StatelessWidget {
   }
 }
 
-class _DoneBody extends StatelessWidget {
-  const _DoneBody({required this.state, required this.onClose});
+class _DoneBody extends ConsumerWidget {
+  const _DoneBody({required this.clusterId, required this.onClose});
 
-  final BulkRefreshSheetState state;
+  final String clusterId;
   final VoidCallback onClose;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final colors = Theme.of(context).extension<KubeColors>()!;
-    final job = state.job;
+    // PR-5e-review #10: Done is terminal so this watch normally fires
+    // once on phase transition. The .select keeps things consistent
+    // with the rest of the sheet so a delayed late-arriving poll
+    // tick (race against teardown) doesn't bubble through the wrapper.
+    final job = ref.watch(bulkRefreshControllerProvider(clusterId)
+        .select((s) => s.job));
     if (job == null) {
       // Defensive: done with no job should never happen, but render
       // something rather than throwing.
@@ -553,17 +624,30 @@ class _DoneBody extends StatelessWidget {
       );
     }
     final hasFailures = job.failed.isNotEmpty;
+    // All-skipped (or all-failed) outcomes are NOT success. Surfacing
+    // "All 0 ExternalSecrets were refreshed" in green success copy is
+    // an operator-visible lie — they pressed Refresh, ESO touched
+    // nothing, and the sheet implied success. Treat any run that did
+    // not refresh at least one ES as a warning-tier outcome.
+    final hasSuccesses = job.succeeded.isNotEmpty;
+    final isWarning = hasFailures || !hasSuccesses;
+    final String headline;
+    if (hasFailures) {
+      headline = 'Refresh finished with ${job.failed.length} failure'
+          '${job.failed.length == 1 ? "" : "s"}.';
+    } else if (!hasSuccesses) {
+      headline = 'All targets were skipped — no ExternalSecrets refreshed.';
+    } else {
+      headline = 'All ${job.succeeded.length} ExternalSecret'
+          '${job.succeeded.length == 1 ? "" : "s"} were refreshed.';
+    }
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
-          hasFailures
-              ? 'Refresh finished with ${job.failed.length} failure'
-                  '${job.failed.length == 1 ? "" : "s"}.'
-              : 'All ${job.succeeded.length} ExternalSecret'
-                  '${job.succeeded.length == 1 ? "" : "s"} were refreshed.',
+          headline,
           style: TextStyle(
-            color: hasFailures ? colors.warning : colors.success,
+            color: isWarning ? colors.warning : colors.success,
             fontSize: 14,
             fontWeight: FontWeight.w600,
           ),
@@ -616,25 +700,27 @@ class _DoneBody extends StatelessWidget {
   }
 }
 
-class _ErrorBody extends StatelessWidget {
+class _ErrorBody extends ConsumerWidget {
   const _ErrorBody({
-    required this.state,
+    required this.clusterId,
     required this.onClose,
     required this.onRetry,
   });
 
-  final BulkRefreshSheetState state;
+  final String clusterId;
   final VoidCallback onClose;
   final VoidCallback onRetry;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final colors = Theme.of(context).extension<KubeColors>()!;
+    final errorMessage = ref.watch(bulkRefreshControllerProvider(clusterId)
+        .select((s) => s.errorMessage));
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
-          state.errorMessage ?? 'Refresh failed.',
+          errorMessage ?? 'Refresh failed.',
           style: TextStyle(color: colors.error, fontSize: 13, height: 1.4),
         ),
         const SizedBox(height: 20),
@@ -695,7 +781,14 @@ class _StatCell extends StatelessWidget {
   }
 }
 
-class _OutcomeList extends StatelessWidget {
+/// PR-5e-review #10: large failed/skipped lists (a stuck Vault store
+/// dumping thousands of "auth method failed" rows is the worst case)
+/// used to render every single row eagerly inside a `Column`, which
+/// blew through the sheet's max-height and stalled the scroll. Now caps
+/// at [_initialCap] rows and exposes a "Show all (N)" affordance for the
+/// tail. The visible rows use `ListView.builder` so even an expanded
+/// 10k-row list paints lazily.
+class _OutcomeList extends StatefulWidget {
   const _OutcomeList({
     required this.label,
     required this.outcomes,
@@ -706,14 +799,31 @@ class _OutcomeList extends StatelessWidget {
   final List<BulkRefreshOutcome> outcomes;
   final Color color;
 
+  /// Max rows to render before the operator opts into the full list.
+  /// Picked as 50 because it covers the top end of "looks like a real
+  /// list" without overflowing a 0.85-screen modal even on small phones.
+  static const int _initialCap = 50;
+
+  @override
+  State<_OutcomeList> createState() => _OutcomeListState();
+}
+
+class _OutcomeListState extends State<_OutcomeList> {
+  bool _expanded = false;
+
   @override
   Widget build(BuildContext context) {
     final colors = Theme.of(context).extension<KubeColors>()!;
+    final total = widget.outcomes.length;
+    final capped = total > _OutcomeList._initialCap && !_expanded;
+    final visible = capped
+        ? widget.outcomes.sublist(0, _OutcomeList._initialCap)
+        : widget.outcomes;
     return ExpansionTile(
       tilePadding: EdgeInsets.zero,
       childrenPadding: EdgeInsets.zero,
       title: Text(
-        '$label (${outcomes.length})',
+        '${widget.label} ($total)',
         style: TextStyle(color: colors.textSecondary, fontSize: 13),
       ),
       children: [
@@ -724,27 +834,30 @@ class _OutcomeList extends StatelessWidget {
           ),
           child: Column(
             children: [
-              for (final o in outcomes)
+              // Constrained-height ListView.builder so even the expanded
+              // 10k-row case paints lazily and stays scrollable.
+              ConstrainedBox(
+                constraints: const BoxConstraints(maxHeight: 240),
+                child: ListView.builder(
+                  shrinkWrap: true,
+                  itemCount: visible.length,
+                  itemBuilder: (context, i) => _OutcomeRow(
+                    outcome: visible[i],
+                    color: widget.color,
+                    colors: colors,
+                  ),
+                ),
+              ),
+              if (capped)
                 Padding(
                   padding: const EdgeInsets.symmetric(
-                      horizontal: 10, vertical: 6),
+                      horizontal: 6, vertical: 4),
                   child: Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
                     children: [
-                      Expanded(
-                        child: Text(
-                          o.uid,
-                          style: TextStyle(
-                            color: colors.textPrimary,
-                            fontFamily: 'monospace',
-                            fontSize: 11,
-                          ),
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      ),
-                      const SizedBox(width: 8),
-                      Text(
-                        o.reason,
-                        style: TextStyle(color: color, fontSize: 11),
+                      TextButton(
+                        onPressed: () => setState(() => _expanded = true),
+                        child: Text('Show all ($total)'),
                       ),
                     ],
                   ),
@@ -753,6 +866,47 @@ class _OutcomeList extends StatelessWidget {
           ),
         ),
       ],
+    );
+  }
+}
+
+/// One row in `_OutcomeList`. Extracted so widget-tests can count the
+/// rendered row count via `find.byType(_OutcomeRow)`.
+class _OutcomeRow extends StatelessWidget {
+  const _OutcomeRow({
+    required this.outcome,
+    required this.color,
+    required this.colors,
+  });
+
+  final BulkRefreshOutcome outcome;
+  final Color color;
+  final KubeColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              outcome.uid,
+              style: TextStyle(
+                color: colors.textPrimary,
+                fontFamily: 'monospace',
+                fontSize: 11,
+              ),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          const SizedBox(width: 8),
+          Text(
+            outcome.reason,
+            style: TextStyle(color: color, fontSize: 11),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/mobile/lib/features/eso/dashboard_screen.dart
+++ b/mobile/lib/features/eso/dashboard_screen.dart
@@ -27,7 +27,15 @@ class EsoDashboardScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('External Secrets')),
+      appBar: AppBar(
+        title: const Text('External Secrets'),
+        actions: const [
+          Padding(
+            padding: EdgeInsets.symmetric(horizontal: 8),
+            child: Center(child: BulkRefreshButton()),
+          ),
+        ],
+      ),
       body: EsoStatusGate(
         builder: (clusterId) => _DashboardBody(clusterId: clusterId),
       ),

--- a/mobile/lib/features/eso/dashboard_screen.dart
+++ b/mobile/lib/features/eso/dashboard_screen.dart
@@ -56,6 +56,7 @@ class _DashboardBodyState extends ConsumerState<_DashboardBody>
     with RefreshGuardMixin {
   ExternalSecretListKey get _listKey =>
       ExternalSecretListKey(clusterId: widget.clusterId);
+  StoresListKey get _storesKey => StoresListKey(clusterId: widget.clusterId);
 
   // Refresh entry point shared by the RefreshIndicator pull-down and the
   // ListErrorShell retry. The guard collapses a second concurrent call
@@ -63,7 +64,7 @@ class _DashboardBodyState extends ConsumerState<_DashboardBody>
   // invalidate+fetch cycles against the same provider slot.
   Future<void> _handleRefresh() => guardedRefresh(() async {
         ref.invalidate(externalSecretListProvider(_listKey));
-        ref.invalidate(storesListProvider(widget.clusterId));
+        ref.invalidate(storesListProvider(_storesKey));
         ref.invalidate(clusterStoresListProvider(widget.clusterId));
         try {
           // Wait for all three so the RefreshIndicator stays visible
@@ -71,7 +72,7 @@ class _DashboardBodyState extends ConsumerState<_DashboardBody>
           // one we surface errors for via .when.
           await Future.wait([
             ref.read(externalSecretListProvider(_listKey).future),
-            ref.read(storesListProvider(widget.clusterId).future),
+            ref.read(storesListProvider(_storesKey).future),
             ref.read(clusterStoresListProvider(widget.clusterId).future),
           ]);
         } on Object {

--- a/mobile/lib/features/eso/eso_widgets.dart
+++ b/mobile/lib/features/eso/eso_widgets.dart
@@ -12,8 +12,11 @@ import '../../api/api_error.dart';
 import '../../api/eso_repository.dart';
 import '../../cluster/cluster_provider.dart';
 import '../../theme/kube_theme_builder.dart';
+import '../../widgets/confirm_sheet.dart';
 import '../../widgets/empty_states.dart';
 import '../../widgets/feature_unavailable_state.dart';
+import 'bulk_refresh_sheet.dart';
+import 'force_sync_controller.dart';
 
 /// Wraps a per-cluster ESO surface body in the standard discovery-status
 /// gate. The outer ConsumerWidget watches `esoStatusProvider(clusterId)`,
@@ -352,38 +355,148 @@ class ProviderChip extends StatelessWidget {
   }
 }
 
-/// Disabled "Revert drift" button with a tooltip pointing to desktop.
-/// Per R12: M4 ships read-only; the drift-revert write action is
-/// deferred to M5+. Rendering the button (rather than omitting it)
-/// signals to operators that the capability exists but isn't available
-/// on this surface — same affordance as the web.
-class DisabledRevertDriftButton extends StatelessWidget {
-  const DisabledRevertDriftButton({super.key});
+/// Force Sync button for the ExternalSecret detail screen. Replaces
+/// the M4-era `DisabledRevertDriftButton` — the web/backend canonical
+/// term is "Force Sync" (the M4 mobile label was wrong; there is no
+/// separate "revert drift" action).
+///
+/// Behavior:
+///   * Disabled with explanatory tooltip when the active cluster is
+///     non-local (backend returns 501 for remote-cluster ESO writes;
+///     the UI gate is the first line of defense).
+///   * Enabled-tap shows the existing `confirm_sheet.dart` with
+///     type-to-confirm against the ExternalSecret's name.
+///   * On confirmed tap, drives [ForceSyncController]; success shows
+///     a snackbar (the controller also invalidates
+///     [externalSecretDetailProvider] so the drift chip refreshes).
+class ForceSyncButton extends ConsumerStatefulWidget {
+  const ForceSyncButton({
+    super.key,
+    required this.namespace,
+    required this.name,
+  });
 
-  /// Snackbar copy is exported so tests can assert on the exact wording
-  /// without duplicating the string literal.
-  static const String desktopMessage = 'Use desktop to revert drift';
+  final String namespace;
+  final String name;
+
+  /// Tooltip surfaced on the disabled (non-local-cluster) state.
+  static const String nonLocalTooltip =
+      'Force Sync is local-cluster only — use the desktop UI for '
+      'remote clusters.';
+
+  @override
+  ConsumerState<ForceSyncButton> createState() => _ForceSyncButtonState();
+}
+
+class _ForceSyncButtonState extends ConsumerState<ForceSyncButton> {
+  int _lastHandledGeneration = 0;
 
   @override
   Widget build(BuildContext context) {
+    final clusterId = ref.watch(activeClusterProvider);
+    final isLocal = clusterId == 'local';
+    final key = ForceSyncKey(
+      clusterId: clusterId,
+      namespace: widget.namespace,
+      name: widget.name,
+    );
+    final state = ref.watch(forceSyncControllerProvider(key));
+
+    // Side-effect: snackbar on success/failure. Guarded against
+    // re-firing on rebuild via the controller's monotonically-increasing
+    // generation field. `addPostFrameCallback` defers messaging until
+    // the current build is committed so we don't violate Flutter's
+    // no-`setState`-during-build rule.
+    _handleStateForSnackbar(state, key);
+
+    final inFlight = state is ForceSyncInFlight;
+    final onPressed = !isLocal || inFlight
+        ? null
+        : () => _onTap(context, key);
+
     return Tooltip(
-      message: desktopMessage,
+      message: isLocal ? '' : ForceSyncButton.nonLocalTooltip,
       child: OutlinedButton.icon(
-        // Null onPressed disables the button. Material's disabled style
-        // automatically dims the foreground using onSurface @ 38%, so
-        // operators can see the button exists but it's clearly inert.
-        onPressed: null,
-        icon: const Icon(Icons.undo_outlined, size: 16),
-        label: const Text('Revert drift'),
+        onPressed: onPressed,
+        icon: inFlight
+            ? const SizedBox(
+                width: 14,
+                height: 14,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              )
+            : const Icon(Icons.sync, size: 16),
+        label: const Text('Force Sync'),
       ),
     );
   }
 
-  /// Convenience for screens that want to surface the desktop message
-  /// as a snackbar (e.g., on a long-press hint).
-  static void showDesktopHint(BuildContext context) {
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text(desktopMessage)),
+  void _handleStateForSnackbar(ForceSyncState state, ForceSyncKey key) {
+    final gen = switch (state) {
+      ForceSyncSuccess(:final generation) => generation,
+      ForceSyncFailure(:final generation) => generation,
+      _ => 0,
+    };
+    if (gen == 0 || gen == _lastHandledGeneration) return;
+    _lastHandledGeneration = gen;
+    final messenger = ScaffoldMessenger.of(context);
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      if (state is ForceSyncSuccess) {
+        messenger.showSnackBar(SnackBar(content: Text(state.message)));
+      } else if (state is ForceSyncFailure) {
+        messenger.showSnackBar(SnackBar(
+          content: Text(state.message),
+          backgroundColor:
+              state.alreadyRefreshing ? null : colors.error,
+        ));
+      }
+      // Acknowledge so a follow-up tap can re-fire.
+      ref.read(forceSyncControllerProvider(key).notifier).acknowledge();
+    });
+  }
+
+  Future<void> _onTap(BuildContext context, ForceSyncKey key) async {
+    final confirmed = await showConfirmSheet(
+      context: context,
+      title: 'Force Sync',
+      message: 'This triggers an immediate sync of '
+          '${widget.namespace}/${widget.name} against its store. '
+          'The current Secret is overwritten with the upstream value.',
+      confirmLabel: 'Force Sync',
+      typeToConfirm: widget.name,
+    );
+    if (confirmed != true) return;
+    await ref.read(forceSyncControllerProvider(key).notifier).forceSync();
+  }
+}
+
+/// Dashboard-level entry point for the bulk-refresh modal. Local-cluster
+/// only per R12. Non-local renders disabled with a tooltip matching the
+/// Force Sync button.
+class BulkRefreshButton extends ConsumerWidget {
+  const BulkRefreshButton({super.key});
+
+  static const String nonLocalTooltip =
+      'Bulk refresh is local-cluster only — use the desktop UI for '
+      'remote clusters.';
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final clusterId = ref.watch(activeClusterProvider);
+    final isLocal = clusterId == 'local';
+    return Tooltip(
+      message: isLocal ? '' : nonLocalTooltip,
+      child: OutlinedButton.icon(
+        onPressed: isLocal
+            ? () => showBulkRefreshSheet(
+                  context: context,
+                  clusterId: clusterId,
+                )
+            : null,
+        icon: const Icon(Icons.cyclone, size: 16),
+        label: const Text('Bulk refresh'),
+      ),
     );
   }
 }

--- a/mobile/lib/features/eso/eso_widgets.dart
+++ b/mobile/lib/features/eso/eso_widgets.dart
@@ -474,6 +474,11 @@ class _ForceSyncButtonState extends ConsumerState<ForceSyncButton> {
 /// Dashboard-level entry point for the bulk-refresh modal. Local-cluster
 /// only per R12. Non-local renders disabled with a tooltip matching the
 /// Force Sync button.
+///
+/// Hidden entirely on clusters where ESO is not detected — clicking
+/// "Bulk refresh" against a cluster with no ESO CRDs returns 503 and
+/// confuses the operator. The button lives in the dashboard AppBar
+/// (outside `EsoStatusGate`'s body), so it has to gate itself.
 class BulkRefreshButton extends ConsumerWidget {
   const BulkRefreshButton({super.key});
 
@@ -484,6 +489,16 @@ class BulkRefreshButton extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final clusterId = ref.watch(activeClusterProvider);
+    final statusAsync = ref.watch(esoStatusProvider(clusterId));
+    // Hide the button while ESO status is loading or has resolved to
+    // not-detected. The dashboard's main body renders
+    // FeatureUnavailableState in those cases, so a parallel "Bulk
+    // refresh" button in the AppBar would be misleading.
+    final esoDetected = statusAsync.maybeWhen(
+      data: (s) => s.detected,
+      orElse: () => false,
+    );
+    if (!esoDetected) return const SizedBox.shrink();
     final isLocal = clusterId == 'local';
     return Tooltip(
       message: isLocal ? '' : nonLocalTooltip,

--- a/mobile/lib/features/eso/external_secret_detail_screen.dart
+++ b/mobile/lib/features/eso/external_secret_detail_screen.dart
@@ -1,9 +1,12 @@
 // ExternalSecret detail — fetches the live `driftStatus` (the list
 // endpoint only emits `lastObservedDriftStatus`; this screen is the
 // source of truth for drift). Renders a read-only attribute dump, the
-// store reference (tappable → store detail), and a disabled "Revert
-// drift" button per R12. Drift-Unknown surfaces with the backend's
-// reason tooltip so operators understand WHY drift wasn't resolvable.
+// store reference (tappable → store detail), and the Force Sync button
+// (PR-5e). Drift-Unknown surfaces with the backend's reason tooltip so
+// operators understand WHY drift wasn't resolvable. The Force Sync
+// button is disabled on non-local clusters (backend returns 501 for
+// remote ESO writes); on success it triggers a snackbar and the drift
+// chip refreshes via `externalSecretDetailProvider` invalidation.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -117,9 +120,9 @@ class _HeaderCard extends StatelessWidget {
               if (drift != DriftStatus.notObserved)
                 DriftPill(status: drift, reason: es.driftUnknownReason),
               const Spacer(),
-              // Disabled per R12 — write surface defers to desktop. The
-              // tooltip carries the desktop-redirect copy.
-              const DisabledRevertDriftButton(),
+              // Force Sync (PR-5e). Disabled on non-local clusters; the
+              // tooltip on the disabled state explains why.
+              ForceSyncButton(namespace: es.namespace, name: es.name),
             ],
           ),
           const SizedBox(height: 12),

--- a/mobile/lib/features/eso/force_sync_controller.dart
+++ b/mobile/lib/features/eso/force_sync_controller.dart
@@ -1,0 +1,258 @@
+// ForceSyncController — owns the POST /externalsecrets/{ns}/{name}/force-sync
+// write path for a single ExternalSecret.
+//
+// The controller mirrors the M3 `executeAction` write shape (single-shot
+// trigger, transient `inFlight` → terminal `success | failure`, no auto-
+// invalidate on the same controller) and the M4 `RefreshableController`
+// race-protection invariants (cluster-pin re-check at result arrival,
+// dispose-guarded state writes, cancel-on-disposal CancelToken).
+//
+// State machine: idle → inFlight → success | failure. The UI observes
+// `success` once, surfaces a snackbar, and the controller bumps its
+// state back to `idle` so a follow-up tap can re-fire. On `success`, the
+// controller also invalidates `externalSecretDetailProvider` for the
+// same key — the detail screen's drift chip transitions from Drifted →
+// Unknown (in-flight) → InSync over the next poll cycle without
+// operator-visible inconsistency.
+//
+// Cluster-pin discipline: the family key carries the pinned cluster id;
+// `clusterIdOverride` is forwarded as `X-Cluster-ID` on the wire so the
+// request lands on the pinned cluster even if the operator switches
+// mid-flight. The postEmission check after the await catches the case
+// where the operator switched between submit and response — the response
+// already pinned the request, but a follow-up `invalidate` would target
+// the wrong (newly-active) family slot, so we surface a clear failure
+// message instead.
+
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../api/api_error.dart';
+import '../../api/eso_repository.dart';
+import '../../cluster/cluster_provider.dart';
+import '../../widgets/refreshable_controller.dart';
+
+/// State machine for a Force Sync invocation.
+sealed class ForceSyncState {
+  const ForceSyncState();
+}
+
+class ForceSyncIdle extends ForceSyncState {
+  const ForceSyncIdle();
+}
+
+class ForceSyncInFlight extends ForceSyncState {
+  const ForceSyncInFlight();
+}
+
+/// 202 received from the backend; UI surfaces a snackbar with [message].
+/// Carries a generation id so the UI consumes the success exactly once
+/// rather than re-firing the snackbar on every rebuild.
+class ForceSyncSuccess extends ForceSyncState {
+  const ForceSyncSuccess({required this.message, required this.generation});
+
+  final String message;
+  final int generation;
+}
+
+/// Non-cancel error path. [message] is operator-ready (mapped from
+/// ApiError or a cluster-pin mismatch). [alreadyRefreshing] is true for
+/// the 409 `already_refreshing` case so the UI can soften the surface
+/// to an informational snackbar rather than a destructive failure card.
+class ForceSyncFailure extends ForceSyncState {
+  const ForceSyncFailure({
+    required this.message,
+    required this.generation,
+    this.alreadyRefreshing = false,
+  });
+
+  final String message;
+  final int generation;
+  final bool alreadyRefreshing;
+}
+
+/// Family key for the ForceSync controller. Matches
+/// [ExternalSecretDetailKey] so the controller and the detail provider
+/// share a slot per pinned (cluster, ns, name).
+class ForceSyncKey {
+  const ForceSyncKey({
+    required this.clusterId,
+    required this.namespace,
+    required this.name,
+  });
+
+  final String clusterId;
+  final String namespace;
+  final String name;
+
+  @override
+  bool operator ==(Object other) =>
+      other is ForceSyncKey &&
+      other.clusterId == clusterId &&
+      other.namespace == namespace &&
+      other.name == name;
+
+  @override
+  int get hashCode => Object.hash(clusterId, namespace, name);
+}
+
+class ForceSyncController
+    extends AutoDisposeFamilyNotifier<ForceSyncState, ForceSyncKey>
+    with RefreshableController {
+  late ForceSyncKey _key;
+  int _generation = 0;
+
+  @override
+  String get pinnedClusterId => _key.clusterId;
+
+  @override
+  String currentActiveClusterId(Ref ref) => ref.read(activeClusterProvider);
+
+  @override
+  ForceSyncState build(ForceSyncKey arg) {
+    _key = arg;
+    initRefreshable(ref);
+    return const ForceSyncIdle();
+  }
+
+  /// Triggers the POST. Caller is responsible for showing the confirm
+  /// sheet first; this method assumes confirmation has happened.
+  ///
+  /// No-ops when an in-flight request is already running so a fast
+  /// double-tap on the Force Sync button doesn't enqueue two POSTs.
+  Future<void> forceSync() async {
+    if (isDisposed) return;
+    if (state is ForceSyncInFlight) return;
+    supersede('force-sync triggered');
+    final captured = captureDispatchId();
+    RefreshableController.safeSetIfAlive<ForceSyncState>(
+      isDisposed,
+      (s) => state = s,
+      const ForceSyncInFlight(),
+    );
+
+    try {
+      await ref.read(esoRepositoryProvider).forceSync(
+            namespace: _key.namespace,
+            name: _key.name,
+            clusterIdOverride: _key.clusterId,
+            cancelToken: currentCancelToken,
+          );
+      if (!isFresh(captured)) return;
+      if (!clusterStillPinned(ref)) {
+        _emitFailure(pinnedMismatchMessage(PinPhase.postEmission));
+        return;
+      }
+
+      // Invalidate the detail provider for the same key so the drift
+      // chip re-fetches on the next frame. Per the M4 drift tri-state
+      // invariant the intermediate Unknown state renders as textMuted
+      // (never red); the chip transitions Drifted → Unknown → InSync.
+      ref.invalidate(externalSecretDetailProvider(ExternalSecretDetailKey(
+        clusterId: _key.clusterId,
+        namespace: _key.namespace,
+        name: _key.name,
+      )));
+
+      _generation++;
+      RefreshableController.safeSetIfAlive<ForceSyncState>(
+        isDisposed,
+        (s) => state = s,
+        ForceSyncSuccess(
+          message: 'Force Sync triggered for ${_key.namespace}/${_key.name}',
+          generation: _generation,
+        ),
+      );
+    } on DioException catch (e) {
+      if (RefreshableController.isCancelException(e)) return;
+      if (!isFresh(captured)) return;
+      final err = e.error;
+      final apiErr = err is ApiError ? err : ApiError.fromDio(e);
+      _emitFromApiError(apiErr);
+    } on ApiError catch (e) {
+      if (!isFresh(captured)) return;
+      _emitFromApiError(e);
+    } catch (e) {
+      if (!isFresh(captured)) return;
+      _emitFailure(e.toString());
+    }
+  }
+
+  /// Resets state back to [ForceSyncIdle]. Called from the consuming
+  /// screen's `ref.listen` callback after the success snackbar has been
+  /// shown so a follow-up tap can re-trigger the action.
+  void acknowledge() {
+    if (isDisposed) return;
+    if (state is ForceSyncIdle) return;
+    RefreshableController.safeSetIfAlive<ForceSyncState>(
+      isDisposed,
+      (s) => state = s,
+      const ForceSyncIdle(),
+    );
+  }
+
+  void _emitFromApiError(ApiError err) {
+    if (err.statusCode == 409 && err.reason == 'already_refreshing') {
+      _generation++;
+      RefreshableController.safeSetIfAlive<ForceSyncState>(
+        isDisposed,
+        (s) => state = s,
+        ForceSyncFailure(
+          message: 'A sync is already in progress for '
+              '${_key.namespace}/${_key.name}. Try again in a few seconds.',
+          generation: _generation,
+          alreadyRefreshing: true,
+        ),
+      );
+      return;
+    }
+    if (err.statusCode == 501) {
+      _emitFailure(
+        "Force Sync isn't available for this cluster — only the local "
+        'cluster supports ESO writes.',
+      );
+      return;
+    }
+    if (err.statusCode == 503) {
+      _emitFailure(
+        'ESO is not detected on this cluster. Install ESO before triggering '
+        'a Force Sync.',
+      );
+      return;
+    }
+    if (err.statusCode == 403) {
+      _emitFailure(
+        "You don't have permission to refresh "
+        '${_key.namespace}/${_key.name}.',
+      );
+      return;
+    }
+    if (err.statusCode == 404) {
+      _emitFailure(
+        'ExternalSecret ${_key.namespace}/${_key.name} was not found. '
+        'It may have been deleted.',
+      );
+      return;
+    }
+    _emitFailure(err.message);
+  }
+
+  void _emitFailure(String message) {
+    _generation++;
+    RefreshableController.safeSetIfAlive<ForceSyncState>(
+      isDisposed,
+      (s) => state = s,
+      ForceSyncFailure(
+        message: message,
+        generation: _generation,
+      ),
+    );
+  }
+}
+
+final forceSyncControllerProvider = AutoDisposeNotifierProvider.family<
+    ForceSyncController, ForceSyncState, ForceSyncKey>(
+  ForceSyncController.new,
+);

--- a/mobile/lib/features/eso/force_sync_controller.dart
+++ b/mobile/lib/features/eso/force_sync_controller.dart
@@ -183,9 +183,14 @@ class ForceSyncController
   /// Resets state back to [ForceSyncIdle]. Called from the consuming
   /// screen's `ref.listen` callback after the success snackbar has been
   /// shown so a follow-up tap can re-trigger the action.
+  ///
+  /// Only resets terminal states — if a new forceSync() landed before
+  /// the snackbar's postFrame callback fires, acknowledge() must NOT
+  /// clobber the fresh InFlight back to Idle (that would let a third
+  /// tap fire concurrently with the second's POST).
   void acknowledge() {
     if (isDisposed) return;
-    if (state is ForceSyncIdle) return;
+    if (state is! ForceSyncSuccess && state is! ForceSyncFailure) return;
     RefreshableController.safeSetIfAlive<ForceSyncState>(
       isDisposed,
       (s) => state = s,

--- a/mobile/lib/features/eso/stores_list_screen.dart
+++ b/mobile/lib/features/eso/stores_list_screen.dart
@@ -38,17 +38,19 @@ class _ListBody extends ConsumerStatefulWidget {
 
 class _ListBodyState extends ConsumerState<_ListBody>
     with RefreshGuardMixin {
+  StoresListKey get _key => StoresListKey(clusterId: widget.clusterId);
+
   Future<void> _handleRefresh() => guardedRefresh(() async {
-        ref.invalidate(storesListProvider(widget.clusterId));
+        ref.invalidate(storesListProvider(_key));
         try {
-          await ref.read(storesListProvider(widget.clusterId).future);
+          await ref.read(storesListProvider(_key).future);
         } on Object {/* surfaces via .when */}
       });
 
   @override
   Widget build(BuildContext context) {
     final colors = Theme.of(context).extension<KubeColors>()!;
-    final async = ref.watch(storesListProvider(widget.clusterId));
+    final async = ref.watch(storesListProvider(_key));
 
     return RefreshIndicator(
       onRefresh: _handleRefresh,

--- a/mobile/lib/routing/app_router.dart
+++ b/mobile/lib/routing/app_router.dart
@@ -308,9 +308,10 @@ final appRouterProvider = Provider<GoRouter>((ref) {
       //
       // Status gating is screen-level (each surface checks
       // `esoStatusProvider` and falls back to
-      // `FeatureUnavailableState.eso()`). Drift Revert + bulk-refresh
-      // POSTs are deferred to M5+ per R12 — `DisabledRevertDriftButton`
-      // points operators at desktop.
+      // `FeatureUnavailableState.eso()`). PR-5e wired Force Sync (per-ES
+      // on the detail screen) and Bulk Refresh (dashboard button) over
+      // these surfaces — local-cluster only; non-local renders the
+      // disabled state with a tooltip pointing operators at desktop.
       GoRoute(
         path: '/clusters/:clusterId/eso',
         builder: (context, state) => const eso_dashboard.EsoDashboardScreen(),

--- a/mobile/lib/widgets/named_resource_picker.dart
+++ b/mobile/lib/widgets/named_resource_picker.dart
@@ -1,17 +1,18 @@
 // Named-resource picker. Fetches a list of resources of a given kind
 // (and optional namespace) via [resourceListProvider] and presents
 // them as a tap-to-pick dropdown. Used by HPA's `scaleTargetRef.name`
-// (deployments/statefulsets/replicasets) and RoleBinding's
-// `roleRef.name` (roles/clusterroles).
+// (deployments/statefulsets/replicasets), RoleBinding's
+// `roleRef.name` (roles/clusterroles), and the ESO bulk-refresh
+// scope picker (secretstores/clustersecretstores/namespaces).
 //
-// Cluster pinning: the wizard owns the pinned cluster id and threads
+// Cluster pinning: the caller owns the pinned cluster id and threads
 // it in via [clusterId]. We don't read `activeClusterProvider` here;
 // `resourceListProvider` does (so cluster switches force a refetch),
-// but the wizard's own cluster-pin discipline ensures the picker's
-// fetch and the eventual apply target the same cluster.
+// but the caller's own cluster-pin discipline ensures the picker's
+// fetch and the eventual write target the same cluster.
 //
 // Empty state: "No <kind> in <namespace>" — the operator can switch
-// namespace via their wizard's Namespace input, which causes the
+// namespace via the surrounding form, which causes the
 // FutureProvider's family key to change and re-fetches.
 //
 // Loading/error states: thin progress indicator while loading; an
@@ -22,8 +23,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../api/resource_repository.dart';
-import '../../theme/kube_theme_builder.dart';
+import '../api/resource_repository.dart';
+import '../theme/kube_theme_builder.dart';
 
 class NamedResourcePicker extends ConsumerWidget {
   const NamedResourcePicker({

--- a/mobile/lib/wizards/types/hpa/hpa_wizard_screen.dart
+++ b/mobile/lib/wizards/types/hpa/hpa_wizard_screen.dart
@@ -11,7 +11,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../cluster/cluster_provider.dart';
 import '../../../theme/kube_theme_builder.dart';
 import '../../widgets/kind_picker.dart';
-import '../../widgets/named_resource_picker.dart';
+import '../../../widgets/named_resource_picker.dart';
 import '../../widgets/optional_int_field.dart';
 import '../../widgets/repeating_row_group.dart';
 import '../../widgets/section_header.dart';

--- a/mobile/lib/wizards/types/pvc/pvc_wizard_screen.dart
+++ b/mobile/lib/wizards/types/pvc/pvc_wizard_screen.dart
@@ -6,7 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../cluster/cluster_provider.dart';
 import '../../../theme/kube_theme_builder.dart';
-import '../../widgets/named_resource_picker.dart';
+import '../../../widgets/named_resource_picker.dart';
 import '../../widgets/section_header.dart';
 import '../../widgets/wizard_review_body.dart';
 import '../../widgets/wizard_screen_scaffold.dart';

--- a/mobile/lib/wizards/types/restore_snapshot/restore_snapshot_wizard_screen.dart
+++ b/mobile/lib/wizards/types/restore_snapshot/restore_snapshot_wizard_screen.dart
@@ -7,7 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../cluster/cluster_provider.dart';
 import '../../widgets/list_picker_screen.dart';
-import '../../widgets/named_resource_picker.dart';
+import '../../../widgets/named_resource_picker.dart';
 import '../../widgets/section_header.dart';
 import '../../widgets/wizard_review_body.dart';
 import '../../widgets/wizard_screen_scaffold.dart';

--- a/mobile/lib/wizards/types/rolebinding/rolebinding_wizard_screen.dart
+++ b/mobile/lib/wizards/types/rolebinding/rolebinding_wizard_screen.dart
@@ -9,7 +9,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../cluster/cluster_provider.dart';
 import '../../../theme/kube_theme_builder.dart';
 import '../../widgets/kind_picker.dart';
-import '../../widgets/named_resource_picker.dart';
+import '../../../widgets/named_resource_picker.dart';
 import '../../widgets/repeating_row_group.dart';
 import '../../widgets/section_header.dart';
 import '../../widgets/wizard_review_body.dart';

--- a/mobile/lib/wizards/types/scheduled_snapshot/scheduled_snapshot_wizard_screen.dart
+++ b/mobile/lib/wizards/types/scheduled_snapshot/scheduled_snapshot_wizard_screen.dart
@@ -12,7 +12,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../cluster/cluster_provider.dart';
 import '../../../theme/kube_theme_builder.dart';
-import '../../widgets/named_resource_picker.dart';
+import '../../../widgets/named_resource_picker.dart';
 import '../../widgets/section_header.dart';
 import '../../widgets/wizard_review_body.dart';
 import '../../widgets/wizard_screen_scaffold.dart';

--- a/mobile/lib/wizards/types/snapshot/snapshot_wizard_screen.dart
+++ b/mobile/lib/wizards/types/snapshot/snapshot_wizard_screen.dart
@@ -8,7 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../cluster/cluster_provider.dart';
-import '../../widgets/named_resource_picker.dart';
+import '../../../widgets/named_resource_picker.dart';
 import '../../widgets/wizard_review_body.dart';
 import '../../widgets/wizard_screen_scaffold.dart';
 import '../../widgets/wizard_unrouted_banner.dart';

--- a/mobile/lib/wizards/types/velero_restore/velero_restore_wizard_screen.dart
+++ b/mobile/lib/wizards/types/velero_restore/velero_restore_wizard_screen.dart
@@ -7,7 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../cluster/cluster_provider.dart';
 import '../../widgets/key_value_table.dart';
-import '../../widgets/named_resource_picker.dart';
+import '../../../widgets/named_resource_picker.dart';
 import '../../widgets/section_header.dart';
 import '../../widgets/wizard_review_body.dart';
 import '../../widgets/wizard_screen_scaffold.dart';

--- a/mobile/test/api/eso_repository_test.dart
+++ b/mobile/test/api/eso_repository_test.dart
@@ -609,6 +609,29 @@ void main() {
         throwsA(isA<ApiError>()),
       );
     });
+
+    // PR-5e-review #11: bulk-refresh scope picker now requests a
+    // namespace-scoped store list rather than fetching cluster-wide and
+    // filtering client-side. Confirm the repo passes the `?namespace=`
+    // query param through to the backend.
+    test('listStores threads namespace through as ?namespace= query',
+        () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/stores',
+        body: <String, Object?>{'data': <Object?>[]},
+      );
+
+      await container
+          .read(esoRepositoryProvider)
+          .listStores(namespace: 'prod');
+
+      expect(mock.requests, hasLength(1));
+      expect(mock.requests.first.queryParameters['namespace'], 'prod');
+    });
   });
 
   // PR-4h-review #23: cluster-pinning header was previously tested only
@@ -713,6 +736,49 @@ void main() {
           .read(esoRepositoryProvider)
           .getExternalSecret(namespace: 'app', name: 'edge');
       expect(es.driftStatus, DriftStatus.notObserved);
+    });
+  });
+
+  // PR-5e-review #4: BulkRefreshAction's open-enum parser used to throw
+  // ArgumentError on unknown wire values, propagating as an unhandled
+  // exception (Sentry crash) when the backend introduces a new variant
+  // before mobile catches up. The fallback now returns
+  // BulkRefreshAction.unknown — same pattern as every other open-enum
+  // parser in this file (EsoStatus, DriftStatus, EsoThresholdSource).
+  group('BulkScopeResponse open-enum parsing', () {
+    test('unknown action wire value collapses to BulkRefreshAction.unknown',
+        () {
+      final resp = BulkScopeResponse.fromJson({
+        'action': 'refresh_push_secret', // not a recognized mobile variant
+        'scopeTarget': 'prod/vault',
+        'totalCount': 1,
+        'totalNamespaces': 1,
+        'visibleCount': 1,
+        'restricted': false,
+        'targets': [
+          {'namespace': 'prod', 'name': 'es1', 'uid': 'u1'},
+        ],
+        'byNamespace': [
+          {'namespace': 'prod', 'count': 1},
+        ],
+      });
+      expect(resp.action, BulkRefreshAction.unknown,
+          reason: 'unknown wire enum must collapse to the sentinel — '
+              'throwing here would propagate as a Sentry crash');
+    });
+
+    test('recognized wire values still parse correctly', () {
+      final resp = BulkScopeResponse.fromJson({
+        'action': 'refresh_store',
+        'scopeTarget': 'prod/vault',
+        'totalCount': 0,
+        'totalNamespaces': 0,
+        'visibleCount': 0,
+        'restricted': false,
+        'targets': <Object>[],
+        'byNamespace': <Object>[],
+      });
+      expect(resp.action, BulkRefreshAction.store);
     });
   });
 }

--- a/mobile/test/features/eso/bulk_refresh_controller_test.dart
+++ b/mobile/test/features/eso/bulk_refresh_controller_test.dart
@@ -27,6 +27,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kubecenter/api/dio_client.dart';
+import 'package:kubecenter/api/eso_repository.dart';
 import 'package:kubecenter/auth/secure_storage.dart';
 import 'package:kubecenter/cluster/cluster_provider.dart';
 import 'package:kubecenter/features/eso/bulk_refresh_controller.dart';
@@ -168,8 +169,15 @@ void main() {
         name: 'vault',
       ));
       await _settle();
-      expect(sub.read().phase, BulkRefreshPhase.confirm);
+      // PR-5e-review #3: scope-load now resolves to `preview` (not
+      // `confirm`). Operator taps "Continue" → `confirmPreview()` →
+      // `confirm` phase (shared confirm sheet stacks on top); the type-
+      // to-confirm gate lives in `showConfirmSheet`, not the body.
+      expect(sub.read().phase, BulkRefreshPhase.preview);
       expect(sub.read().scopeResponse?.visibleCount, 2);
+
+      ctrl.confirmPreview();
+      expect(sub.read().phase, BulkRefreshPhase.confirm);
 
       await ctrl.submit();
       await _settle();
@@ -181,7 +189,7 @@ void main() {
       ctrl.cancelPoll();
     });
 
-    test('back-button rewinds from confirm to scopePick', () async {
+    test('back-button rewinds from preview to scopePick', () async {
       final (:container, :mock) = _make();
       addTearDown(container.dispose);
 
@@ -199,7 +207,7 @@ void main() {
         const BulkRefreshScopeStore(namespace: 'prod', name: 'vault'),
       );
       await _settle();
-      expect(sub.read().phase, BulkRefreshPhase.confirm);
+      expect(sub.read().phase, BulkRefreshPhase.preview);
 
       ctrl.backToScopePick();
       expect(sub.read().phase, BulkRefreshPhase.scopePick);
@@ -228,7 +236,7 @@ void main() {
         const BulkRefreshScopeClusterStore(name: 'vault-shared'),
       );
       await _settle();
-      expect(sub.read().phase, BulkRefreshPhase.confirm);
+      expect(sub.read().phase, BulkRefreshPhase.preview);
       expect(
         mock.requests.any((r) =>
             r.path ==
@@ -256,7 +264,7 @@ void main() {
         const BulkRefreshScopeNamespace(namespace: 'prod'),
       );
       await _settle();
-      expect(sub.read().phase, BulkRefreshPhase.confirm);
+      expect(sub.read().phase, BulkRefreshPhase.preview);
     });
   });
 
@@ -297,6 +305,7 @@ void main() {
         const BulkRefreshScopeStore(namespace: 'prod', name: 'vault'),
       );
       await _settle();
+      ctrl.confirmPreview();
       await ctrl.submit();
       await _settle();
 
@@ -306,7 +315,7 @@ void main() {
       ctrl.cancelPoll();
     });
 
-    test('409 scope_changed re-resolves the scope and lands in confirm',
+    test('409 scope_changed re-resolves the scope and lands in preview',
         () async {
       final (:container, :mock) = _make();
       addTearDown(container.dispose);
@@ -349,11 +358,15 @@ void main() {
         const BulkRefreshScopeStore(namespace: 'prod', name: 'vault'),
       );
       await _settle();
+      ctrl.confirmPreview();
 
       await ctrl.submit();
       await _settle();
 
-      expect(sub.read().phase, BulkRefreshPhase.confirm);
+      // PR-5e-review #3: post-recovery the controller drops back to
+      // scopeLoad → preview (operator confirms again from the new
+      // breakdown before re-firing the confirm sheet).
+      expect(sub.read().phase, BulkRefreshPhase.preview);
       expect(sub.read().scopeResponse?.visibleCount, 3);
     });
 
@@ -385,6 +398,7 @@ void main() {
         const BulkRefreshScopeStore(namespace: 'prod', name: 'vault'),
       );
       await _settle();
+      ctrl.confirmPreview();
       await ctrl.submit();
       await _settle();
 
@@ -417,6 +431,7 @@ void main() {
         const BulkRefreshScopeStore(namespace: 'prod', name: 'vault'),
       );
       await _settle();
+      ctrl.confirmPreview();
       await ctrl.submit();
       await _settle();
 
@@ -487,6 +502,7 @@ void main() {
         const BulkRefreshScopeStore(namespace: 'prod', name: 'vault'),
       );
       await _settle();
+      ctrl.confirmPreview();
       await ctrl.submit();
       await _settle();
 
@@ -494,6 +510,468 @@ void main() {
           reason: 'transient poll error must NOT collapse to error');
       expect(sub.read().pollRetrying, isTrue);
       ctrl.cancelPoll();
+    });
+
+    // PR-5e-review #1: 3-consecutive-poll-error → error state branch was
+    // documented as covered in the file header but only the 1× transient
+    // case was actually tested. Three failures back-to-back must flip to
+    // BulkRefreshPhase.error with the explicit "lost track" copy from
+    // _emitError, and the periodic timer must be cancelled so we stop
+    // hammering a wedged backend.
+    test('3 consecutive poll errors flip to error and cancel the timer',
+        () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/stores/prod/vault/refresh-scope',
+        body: _scopeOk(action: 'refresh_store', scopeTarget: 'prod/vault'),
+      );
+      mock.onJson(
+        'POST',
+        '/api/v1/externalsecrets/stores/prod/vault/refresh-all',
+        status: 202,
+        body: {
+          'data': {'jobId': 'job-1', 'targetCount': 2},
+        },
+      );
+      // Three consecutive 503s on poll.
+      ResponseBody fail(RequestOptions _) => _json({
+            'error': {'code': 503, 'message': 'temporarily unavailable'},
+          }, status: 503);
+      for (var i = 0; i < 3; i++) {
+        mock.on('GET', '/api/v1/externalsecrets/bulk-refresh-jobs/job-1', fail);
+      }
+
+      final sub = _subscribe(container);
+      addTearDown(sub.close);
+      final ctrl =
+          container.read(bulkRefreshControllerProvider(_clusterId).notifier);
+      await ctrl.beginScopeLoad(
+        const BulkRefreshScopeStore(namespace: 'prod', name: 'vault'),
+      );
+      await _settle();
+      ctrl.confirmPreview();
+      await ctrl.submit();
+      await _settle();
+      // submit's first-poll-immediate hit #1. The periodic 2s timer
+      // does fire under real-time in non-widget unit tests, so we
+      // wait long enough for the next two ticks to land.
+      await Future<void>.delayed(const Duration(milliseconds: 2100));
+      await _settle();
+      await Future<void>.delayed(const Duration(milliseconds: 2100));
+      await _settle();
+
+      expect(sub.read().phase, BulkRefreshPhase.error,
+          reason: 'three consecutive poll errors must abandon');
+      final msg = sub.read().errorMessage ?? '';
+      expect(msg.toLowerCase(), contains('lost track'),
+          reason: 'abandon message must reference the lost-track copy');
+      expect(msg.toLowerCase(), contains('audit log'),
+          reason: 'abandon message must point operators at the audit log');
+
+      // Confirm the timer is actually cancelled — after the error
+      // emission no further state changes should occur, even after we
+      // wait long enough for the next periodic tick.
+      final phaseBefore = sub.read().phase;
+      final pollCallsBefore = mock.requests
+          .where((r) => r.path.contains('bulk-refresh-jobs'))
+          .length;
+      await Future<void>.delayed(const Duration(milliseconds: 2200));
+      await _settle();
+      expect(sub.read().phase, phaseBefore,
+          reason: 'periodic timer must be cancelled after the abandon');
+      final pollCallsAfter = mock.requests
+          .where((r) => r.path.contains('bulk-refresh-jobs'))
+          .length;
+      expect(pollCallsAfter, pollCallsBefore,
+          reason: 'no further poll requests must fire after abandon');
+    });
+  });
+
+  group('BulkRefreshController.submit postEmission cluster-pin race', () {
+    // PR-5e-review #2: a cluster switch between POST emission and the
+    // POST response landing must NOT slide through into the poll phase.
+    // The submit() postEmission re-check at lines 349-353 must abort
+    // before _startPoll fires, so no setState happens against a now-
+    // misaligned controller.
+    test('cluster switch between POST and response veto the poll transition',
+        () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/stores/prod/vault/refresh-scope',
+        body: _scopeOk(action: 'refresh_store', scopeTarget: 'prod/vault'),
+      );
+      // Delay the POST response so we have time to switch clusters
+      // between submit emission and the response landing.
+      mock.on(
+        'POST',
+        '/api/v1/externalsecrets/stores/prod/vault/refresh-all',
+        (_) {
+          return _json({
+            'data': {'jobId': 'job-1', 'targetCount': 2},
+          }, status: 202);
+        },
+      );
+
+      final sub = _subscribe(container);
+      addTearDown(sub.close);
+      final ctrl =
+          container.read(bulkRefreshControllerProvider(_clusterId).notifier);
+      await ctrl.beginScopeLoad(
+        const BulkRefreshScopeStore(namespace: 'prod', name: 'vault'),
+      );
+      await _settle();
+      ctrl.confirmPreview();
+
+      // Kick off submit but switch the active cluster before awaiting.
+      final fut = ctrl.submit();
+      container
+          .read(activeClusterProvider.notifier)
+          .setCluster('cluster-b');
+      await fut;
+      await _settle();
+
+      // postEmission re-check must veto — controller must NOT have
+      // entered poll phase. Error phase is the only correct outcome.
+      expect(sub.read().phase, BulkRefreshPhase.error,
+          reason: 'postEmission cluster-pin re-check must abort the poll');
+      expect(sub.read().jobId, isNull,
+          reason: 'no jobId should be retained on aborted submit');
+      // And no follow-up GETs to the poll endpoint should have fired.
+      final pollCalls = mock.requests
+          .where((r) => r.path.contains('bulk-refresh-jobs'))
+          .length;
+      expect(pollCalls, 0,
+          reason: 'aborted submit must not start the poll loop');
+    });
+  });
+
+  group('BulkRefreshController.submit error status mapping', () {
+    // PR-5e-review #12: 503 on submit surfaces the install-guidance copy
+    // straight from _handleSubmitFailure's 503 branch.
+    test('503 on submit surfaces install-guidance copy', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/stores/prod/vault/refresh-scope',
+        body: _scopeOk(action: 'refresh_store', scopeTarget: 'prod/vault'),
+      );
+      mock.on(
+        'POST',
+        '/api/v1/externalsecrets/stores/prod/vault/refresh-all',
+        (_) => _json({
+          'error': {'code': 503, 'message': 'ESO not detected'},
+        }, status: 503),
+      );
+
+      final sub = _subscribe(container);
+      addTearDown(sub.close);
+      final ctrl =
+          container.read(bulkRefreshControllerProvider(_clusterId).notifier);
+      await ctrl.beginScopeLoad(
+        const BulkRefreshScopeStore(namespace: 'prod', name: 'vault'),
+      );
+      await _settle();
+      ctrl.confirmPreview();
+      await ctrl.submit();
+      await _settle();
+
+      expect(sub.read().phase, BulkRefreshPhase.error);
+      final msg = sub.read().errorMessage ?? '';
+      expect(msg, contains('ESO is not detected'));
+      expect(msg, contains('Install ESO'));
+    });
+
+    // PR-5e-review #12: 413 on submit surfaces the scope-too-large copy.
+    test('413 on submit surfaces scope-too-large copy', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/stores/prod/vault/refresh-scope',
+        body: _scopeOk(action: 'refresh_store', scopeTarget: 'prod/vault'),
+      );
+      mock.on(
+        'POST',
+        '/api/v1/externalsecrets/stores/prod/vault/refresh-all',
+        (_) => _json({
+          'error': {'code': 413, 'message': 'scope too large'},
+        }, status: 413),
+      );
+
+      final sub = _subscribe(container);
+      addTearDown(sub.close);
+      final ctrl =
+          container.read(bulkRefreshControllerProvider(_clusterId).notifier);
+      await ctrl.beginScopeLoad(
+        const BulkRefreshScopeStore(namespace: 'prod', name: 'vault'),
+      );
+      await _settle();
+      ctrl.confirmPreview();
+      await ctrl.submit();
+      await _settle();
+
+      expect(sub.read().phase, BulkRefreshPhase.error);
+      final msg = sub.read().errorMessage ?? '';
+      expect(msg, contains('too large'));
+      expect(msg, contains('per-namespace'));
+    });
+
+    // PR-5e-review #13: 409 active_job_exists WITHOUT jobId in extra
+    // emits the "audit log" copy rather than attaching to a phantom job.
+    test('409 active_job_exists with missing jobId emits audit-log copy',
+        () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/stores/prod/vault/refresh-scope',
+        body: _scopeOk(action: 'refresh_store', scopeTarget: 'prod/vault'),
+      );
+      mock.on(
+        'POST',
+        '/api/v1/externalsecrets/stores/prod/vault/refresh-all',
+        (_) => _json({
+          'error': {
+            'code': 409,
+            'message': 'another bulk refresh is already in flight',
+            'reason': 'active_job_exists',
+            'extra': <String, Object>{},
+          },
+        }, status: 409),
+      );
+
+      final sub = _subscribe(container);
+      addTearDown(sub.close);
+      final ctrl =
+          container.read(bulkRefreshControllerProvider(_clusterId).notifier);
+      await ctrl.beginScopeLoad(
+        const BulkRefreshScopeStore(namespace: 'prod', name: 'vault'),
+      );
+      await _settle();
+      ctrl.confirmPreview();
+      await ctrl.submit();
+      await _settle();
+
+      expect(sub.read().phase, BulkRefreshPhase.error,
+          reason: 'no jobId → no attach → land in error');
+      final msg = sub.read().errorMessage ?? '';
+      expect(msg.toLowerCase(), contains('audit log'));
+      expect(sub.read().jobId, isNull);
+    });
+  });
+
+  group('BulkRefreshController.scope_changed recovery', () {
+    // PR-5e-review #6: scope_changed handler sets the operator-visible
+    // banner, then re-fires beginScopeLoad. The preserveError flag must
+    // keep the banner alive across the auto-re-resolve so the operator
+    // understands why the confirm phase rendered again.
+    test('scope_changed → confirm preserves the explanation banner',
+        () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/stores/prod/vault/refresh-scope',
+        body: _scopeOk(action: 'refresh_store', scopeTarget: 'prod/vault'),
+      );
+      mock.on(
+        'POST',
+        '/api/v1/externalsecrets/stores/prod/vault/refresh-all',
+        (_) => _json({
+          'error': {
+            'code': 409,
+            'message': 'scope changed since last resolution',
+            'reason': 'scope_changed',
+            'extra': {'added': ['u3'], 'removed': <Object>[]},
+          },
+        }, status: 409),
+      );
+      // Re-resolve returns a fresh (larger) scope.
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/stores/prod/vault/refresh-scope',
+        body: _scopeOk(action: 'refresh_store', scopeTarget: 'prod/vault',
+            targets: [
+              {'namespace': 'prod', 'name': 'db-creds', 'uid': 'u1'},
+              {'namespace': 'prod', 'name': 'api-creds', 'uid': 'u2'},
+              {'namespace': 'prod', 'name': 'new-creds', 'uid': 'u3'},
+            ]),
+      );
+
+      final sub = _subscribe(container);
+      addTearDown(sub.close);
+      final ctrl =
+          container.read(bulkRefreshControllerProvider(_clusterId).notifier);
+      await ctrl.beginScopeLoad(
+        const BulkRefreshScopeStore(namespace: 'prod', name: 'vault'),
+      );
+      await _settle();
+      ctrl.confirmPreview();
+      await ctrl.submit();
+      await _settle();
+
+      // Now in preview phase again with the re-resolved scope (operator
+      // must re-confirm against the freshly-resolved breakdown before
+      // the confirm sheet stacks on top again).
+      expect(sub.read().phase, BulkRefreshPhase.preview);
+      expect(sub.read().scopeResponse?.visibleCount, 3);
+      // CRITICAL: the explanation banner from the scope_changed handler
+      // must still be visible — without it, the operator sees the
+      // preview phase re-render with no context and is confused.
+      final msg = sub.read().errorMessage ?? '';
+      expect(msg, contains('Scope changed'),
+          reason: 'preserveError must keep the scope_changed banner alive '
+              'across the auto-re-resolve');
+    });
+  });
+
+  group('BulkRefreshSheetState.copyWith clear-sentinels', () {
+    // PR-5e-review #22: the previous shape relied on `?? this.field` so a
+    // bare `field: null` was indistinguishable from "leave alone". The
+    // explicit clear sentinels make "set to null" possible. Each sentinel
+    // gets its own assertion below so a future regression where the
+    // sentinel was wired through one field but skipped on another is
+    // caught at unit-test time, not in a debugging session.
+    test('clearScope sets scope to null even when scope param is provided', () {
+      const seeded = BulkRefreshSheetState(
+        phase: BulkRefreshPhase.confirm,
+        scope: BulkRefreshScopeStore(namespace: 'prod', name: 'vault'),
+      );
+      // Bare null does NOT clear (current vs. baseline behavior).
+      final viaNull = seeded.copyWith(scope: null);
+      expect(viaNull.scope, isNotNull,
+          reason: 'omitted param must keep current value');
+      // Sentinel clears.
+      final viaSentinel = seeded.copyWith(clearScope: true);
+      expect(viaSentinel.scope, isNull);
+      // Sentinel wins over a passed value.
+      final viaSentinelWithValue = seeded.copyWith(
+        scope: const BulkRefreshScopeNamespace(namespace: 'staging'),
+        clearScope: true,
+      );
+      expect(viaSentinelWithValue.scope, isNull,
+          reason: 'clearScope sentinel must override scope param');
+    });
+
+    test('clearScopeResponse sets scopeResponse to null', () {
+      final seeded = BulkRefreshSheetState(
+        phase: BulkRefreshPhase.confirm,
+        scopeResponse: BulkScopeResponse.fromJson(const <String, dynamic>{
+          'action': 'refresh_store',
+          'scopeTarget': 'prod/vault',
+          'totalCount': 2,
+          'totalNamespaces': 1,
+          'visibleCount': 2,
+          'restricted': false,
+          'targets': <Object>[],
+          'byNamespace': <Object>[],
+        }),
+      );
+      final viaSentinel = seeded.copyWith(clearScopeResponse: true);
+      expect(viaSentinel.scopeResponse, isNull);
+    });
+
+    test('clearJobId sets jobId to null', () {
+      const seeded = BulkRefreshSheetState(
+        phase: BulkRefreshPhase.poll,
+        jobId: 'job-123',
+      );
+      final viaSentinel = seeded.copyWith(clearJobId: true);
+      expect(viaSentinel.jobId, isNull);
+    });
+  });
+
+  group('BulkRefreshController.pollNow (iOS resume nudge)', () {
+    // PR-5e-review #9: AppLifecycleListener.onResume calls pollNow() on
+    // foreground so the progress bar doesn't sit stale after iOS
+    // suspended our periodic timer in background. The controller-level
+    // contract: pollNow() fires exactly one GET against the job endpoint
+    // (respecting the same reentrancy + post-await guards as the
+    // periodic tick).
+    test('fires a one-shot poll when in poll phase', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/stores/prod/vault/refresh-scope',
+        body: _scopeOk(action: 'refresh_store', scopeTarget: 'prod/vault'),
+      );
+      mock.onJson(
+        'POST',
+        '/api/v1/externalsecrets/stores/prod/vault/refresh-all',
+        status: 202,
+        body: {
+          'data': {'jobId': 'job-1', 'targetCount': 2},
+        },
+      );
+      // Two in-progress poll responses — one from submit's first-poll-
+      // immediate, one from the resume nudge.
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/bulk-refresh-jobs/job-1',
+        body: _jobInProgress(jobId: 'job-1', succeeded: 1),
+      );
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/bulk-refresh-jobs/job-1',
+        body: _jobInProgress(jobId: 'job-1', succeeded: 1),
+      );
+
+      final sub = _subscribe(container);
+      addTearDown(sub.close);
+      final ctrl =
+          container.read(bulkRefreshControllerProvider(_clusterId).notifier);
+      await ctrl.beginScopeLoad(
+        const BulkRefreshScopeStore(namespace: 'prod', name: 'vault'),
+      );
+      await _settle();
+      ctrl.confirmPreview();
+      await ctrl.submit();
+      await _settle();
+
+      expect(sub.read().phase, BulkRefreshPhase.poll);
+      final pollCallsBeforeResume = mock.requests
+          .where((r) => r.path.contains('bulk-refresh-jobs'))
+          .length;
+
+      // Simulate app foreground after suspend — fire one-shot poll.
+      await ctrl.pollNow();
+      await _settle();
+
+      final pollCallsAfterResume = mock.requests
+          .where((r) => r.path.contains('bulk-refresh-jobs'))
+          .length;
+      expect(pollCallsAfterResume, pollCallsBeforeResume + 1,
+          reason: 'pollNow must fire exactly one extra GET on resume');
+      ctrl.cancelPoll();
+    });
+
+    test('no-ops when phase != poll (avoids spurious GETs)', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      final sub = _subscribe(container);
+      addTearDown(sub.close);
+      final ctrl =
+          container.read(bulkRefreshControllerProvider(_clusterId).notifier);
+
+      // Phase is scopePick — pollNow should do nothing.
+      expect(sub.read().phase, BulkRefreshPhase.scopePick);
+      await ctrl.pollNow();
+      await _settle();
+      expect(mock.requests, isEmpty);
     });
   });
 }

--- a/mobile/test/features/eso/bulk_refresh_controller_test.dart
+++ b/mobile/test/features/eso/bulk_refresh_controller_test.dart
@@ -1,0 +1,499 @@
+// Controller-level tests for the ESO Bulk Refresh write path.
+//
+// Coverage:
+//   * Full state-machine walk for the store variant:
+//     scopePick → scopeLoad → confirm → submit → poll → done.
+//   * 409 active_job_exists on submit attaches to the existing jobId
+//     and skips straight to poll, flagging `attachedToExistingJob`.
+//   * 409 scope_changed on submit drops back to scopeLoad and re-runs
+//     scope resolution.
+//   * 501 on submit surfaces local-cluster-only copy.
+//   * Cluster-pin race postEmission on scope-load emits error.
+//   * cancelPoll() tears the timer down (verified via state transition
+//     + absence of follow-up polls after dispose).
+//   * Transient poll error (1×) keeps the loop alive with
+//     `pollRetrying: true`; 3 consecutive errors flip to error state.
+//
+// Polling uses `Timer.periodic`, which `flutter_test` does not advance
+// virtually — we rely on the controller's first-poll-immediate behavior
+// to assert state transitions without time travel. The "3 consecutive
+// errors" test uses the same hook by re-invoking the same first-poll
+// path; we deliberately don't try to simulate the 2-second cadence.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kubecenter/api/dio_client.dart';
+import 'package:kubecenter/auth/secure_storage.dart';
+import 'package:kubecenter/cluster/cluster_provider.dart';
+import 'package:kubecenter/features/eso/bulk_refresh_controller.dart';
+
+import '../../support/mock_dio_adapter.dart';
+
+ResponseBody _json(Object body, {int status = 200}) {
+  return ResponseBody.fromBytes(
+    Uint8List.fromList(utf8.encode(jsonEncode(body))),
+    status,
+    headers: {
+      Headers.contentTypeHeader: ['application/json'],
+    },
+  );
+}
+
+({ProviderContainer container, MockDioAdapter mock}) _make() {
+  final mock = MockDioAdapter();
+  final container = ProviderContainer(
+    overrides: [
+      backendUrlProvider.overrideWithValue('http://test'),
+      secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+    ],
+  );
+  container.read(refreshDioProvider).httpClientAdapter = mock;
+  container.read(dioProvider).httpClientAdapter = mock;
+  return (container: container, mock: mock);
+}
+
+const _clusterId = 'local';
+
+ProviderSubscription<BulkRefreshSheetState> _subscribe(
+  ProviderContainer container,
+) {
+  return container.listen<BulkRefreshSheetState>(
+    bulkRefreshControllerProvider(_clusterId),
+    (_, _) {},
+  );
+}
+
+Future<void> _settle() => pumpEventQueue(times: 30);
+
+Map<String, Object> _scopeOk({
+  required String action,
+  required String scopeTarget,
+  List<Map<String, String>> targets = const [
+    {'namespace': 'prod', 'name': 'db-creds', 'uid': 'u1'},
+    {'namespace': 'prod', 'name': 'api-creds', 'uid': 'u2'},
+  ],
+}) {
+  return {
+    'data': {
+      'action': action,
+      'scopeTarget': scopeTarget,
+      'totalCount': targets.length,
+      'totalNamespaces': 1,
+      'visibleCount': targets.length,
+      'restricted': false,
+      'targets': targets,
+      'byNamespace': [
+        {'namespace': 'prod', 'count': targets.length},
+      ],
+    },
+  };
+}
+
+Map<String, Object> _jobInProgress({
+  required String jobId,
+  int succeeded = 0,
+}) {
+  return {
+    'data': {
+      'jobId': jobId,
+      'clusterId': _clusterId,
+      'requestedBy': 'oncall',
+      'action': 'refresh_store',
+      'scopeTarget': 'prod/vault',
+      'targetCount': 2,
+      'createdAt': '2026-05-17T10:00:00Z',
+      'succeeded': List.generate(succeeded, (i) => 'u${i + 1}'),
+      'failed': <Object>[],
+      'skipped': <Object>[],
+    },
+  };
+}
+
+Map<String, Object> _jobDone({required String jobId}) {
+  return {
+    'data': {
+      'jobId': jobId,
+      'clusterId': _clusterId,
+      'requestedBy': 'oncall',
+      'action': 'refresh_store',
+      'scopeTarget': 'prod/vault',
+      'targetCount': 2,
+      'createdAt': '2026-05-17T10:00:00Z',
+      'completedAt': '2026-05-17T10:00:30Z',
+      'succeeded': ['u1', 'u2'],
+      'failed': <Object>[],
+      'skipped': <Object>[],
+    },
+  };
+}
+
+void main() {
+  group('BulkRefreshController.state machine', () {
+    test('full happy path: store variant walks scopePick → done', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/stores/prod/vault/refresh-scope',
+        body: _scopeOk(action: 'refresh_store', scopeTarget: 'prod/vault'),
+      );
+      mock.onJson(
+        'POST',
+        '/api/v1/externalsecrets/stores/prod/vault/refresh-all',
+        status: 202,
+        body: {
+          'data': {'jobId': 'job-1', 'targetCount': 2},
+        },
+      );
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/bulk-refresh-jobs/job-1',
+        body: _jobDone(jobId: 'job-1'),
+      );
+
+      final sub = _subscribe(container);
+      addTearDown(sub.close);
+      final ctrl =
+          container.read(bulkRefreshControllerProvider(_clusterId).notifier);
+
+      expect(sub.read().phase, BulkRefreshPhase.scopePick);
+
+      await ctrl.beginScopeLoad(const BulkRefreshScopeStore(
+        namespace: 'prod',
+        name: 'vault',
+      ));
+      await _settle();
+      expect(sub.read().phase, BulkRefreshPhase.confirm);
+      expect(sub.read().scopeResponse?.visibleCount, 2);
+
+      await ctrl.submit();
+      await _settle();
+      // First-poll-immediate behavior puts us in `done` since the
+      // first poll already returns `completedAt`.
+      expect(sub.read().phase, BulkRefreshPhase.done);
+      expect(sub.read().job?.succeeded.length, 2);
+      expect(sub.read().attachedToExistingJob, isFalse);
+      ctrl.cancelPoll();
+    });
+
+    test('back-button rewinds from confirm to scopePick', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/stores/prod/vault/refresh-scope',
+        body: _scopeOk(action: 'refresh_store', scopeTarget: 'prod/vault'),
+      );
+
+      final sub = _subscribe(container);
+      addTearDown(sub.close);
+      final ctrl =
+          container.read(bulkRefreshControllerProvider(_clusterId).notifier);
+      await ctrl.beginScopeLoad(
+        const BulkRefreshScopeStore(namespace: 'prod', name: 'vault'),
+      );
+      await _settle();
+      expect(sub.read().phase, BulkRefreshPhase.confirm);
+
+      ctrl.backToScopePick();
+      expect(sub.read().phase, BulkRefreshPhase.scopePick);
+      expect(sub.read().scopeResponse, isNull);
+    });
+
+    test('clusterstore variant dispatches to /clusterstores endpoint',
+        () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/clusterstores/vault-shared/refresh-scope',
+        body: _scopeOk(
+          action: 'refresh_cluster_store',
+          scopeTarget: 'vault-shared',
+        ),
+      );
+
+      final sub = _subscribe(container);
+      addTearDown(sub.close);
+      final ctrl =
+          container.read(bulkRefreshControllerProvider(_clusterId).notifier);
+      await ctrl.beginScopeLoad(
+        const BulkRefreshScopeClusterStore(name: 'vault-shared'),
+      );
+      await _settle();
+      expect(sub.read().phase, BulkRefreshPhase.confirm);
+      expect(
+        mock.requests.any((r) =>
+            r.path ==
+            '/api/v1/externalsecrets/clusterstores/vault-shared/refresh-scope'),
+        isTrue,
+      );
+    });
+
+    test('namespace variant dispatches to /refresh-namespace endpoint',
+        () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/refresh-namespace/prod/refresh-scope',
+        body: _scopeOk(action: 'refresh_namespace', scopeTarget: 'prod'),
+      );
+
+      final sub = _subscribe(container);
+      addTearDown(sub.close);
+      final ctrl =
+          container.read(bulkRefreshControllerProvider(_clusterId).notifier);
+      await ctrl.beginScopeLoad(
+        const BulkRefreshScopeNamespace(namespace: 'prod'),
+      );
+      await _settle();
+      expect(sub.read().phase, BulkRefreshPhase.confirm);
+    });
+  });
+
+  group('BulkRefreshController.submit error handling', () {
+    test('409 active_job_exists attaches to existing jobId and polls',
+        () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/stores/prod/vault/refresh-scope',
+        body: _scopeOk(action: 'refresh_store', scopeTarget: 'prod/vault'),
+      );
+      mock.on(
+        'POST',
+        '/api/v1/externalsecrets/stores/prod/vault/refresh-all',
+        (_) => _json({
+          'error': {
+            'code': 409,
+            'message': 'another bulk refresh is already in flight',
+            'reason': 'active_job_exists',
+            'extra': {'jobId': 'job-existing'},
+          },
+        }, status: 409),
+      );
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/bulk-refresh-jobs/job-existing',
+        body: _jobInProgress(jobId: 'job-existing', succeeded: 1),
+      );
+
+      final sub = _subscribe(container);
+      addTearDown(sub.close);
+      final ctrl =
+          container.read(bulkRefreshControllerProvider(_clusterId).notifier);
+      await ctrl.beginScopeLoad(
+        const BulkRefreshScopeStore(namespace: 'prod', name: 'vault'),
+      );
+      await _settle();
+      await ctrl.submit();
+      await _settle();
+
+      expect(sub.read().phase, BulkRefreshPhase.poll);
+      expect(sub.read().jobId, 'job-existing');
+      expect(sub.read().attachedToExistingJob, isTrue);
+      ctrl.cancelPoll();
+    });
+
+    test('409 scope_changed re-resolves the scope and lands in confirm',
+        () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      // First scope-load returns 2; submit fails with scope_changed; second
+      // scope-load (auto-triggered) returns 3 targets.
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/stores/prod/vault/refresh-scope',
+        body: _scopeOk(action: 'refresh_store', scopeTarget: 'prod/vault'),
+      );
+      mock.on(
+        'POST',
+        '/api/v1/externalsecrets/stores/prod/vault/refresh-all',
+        (_) => _json({
+          'error': {
+            'code': 409,
+            'message': 'scope changed since last resolution',
+            'reason': 'scope_changed',
+            'extra': {'added': ['u3'], 'removed': <Object>[]},
+          },
+        }, status: 409),
+      );
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/stores/prod/vault/refresh-scope',
+        body: _scopeOk(action: 'refresh_store', scopeTarget: 'prod/vault',
+            targets: [
+              {'namespace': 'prod', 'name': 'db-creds', 'uid': 'u1'},
+              {'namespace': 'prod', 'name': 'api-creds', 'uid': 'u2'},
+              {'namespace': 'prod', 'name': 'new-creds', 'uid': 'u3'},
+            ]),
+      );
+
+      final sub = _subscribe(container);
+      addTearDown(sub.close);
+      final ctrl =
+          container.read(bulkRefreshControllerProvider(_clusterId).notifier);
+      await ctrl.beginScopeLoad(
+        const BulkRefreshScopeStore(namespace: 'prod', name: 'vault'),
+      );
+      await _settle();
+
+      await ctrl.submit();
+      await _settle();
+
+      expect(sub.read().phase, BulkRefreshPhase.confirm);
+      expect(sub.read().scopeResponse?.visibleCount, 3);
+    });
+
+    test('501 surfaces local-cluster-only copy', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/stores/prod/vault/refresh-scope',
+        body: _scopeOk(action: 'refresh_store', scopeTarget: 'prod/vault'),
+      );
+      mock.on(
+        'POST',
+        '/api/v1/externalsecrets/stores/prod/vault/refresh-all',
+        (_) => _json({
+          'error': {
+            'code': 501,
+            'message': 'ESO write actions are local-cluster only in v1',
+          },
+        }, status: 501),
+      );
+
+      final sub = _subscribe(container);
+      addTearDown(sub.close);
+      final ctrl =
+          container.read(bulkRefreshControllerProvider(_clusterId).notifier);
+      await ctrl.beginScopeLoad(
+        const BulkRefreshScopeStore(namespace: 'prod', name: 'vault'),
+      );
+      await _settle();
+      await ctrl.submit();
+      await _settle();
+
+      expect(sub.read().phase, BulkRefreshPhase.error);
+      expect(sub.read().errorMessage, contains('local cluster'));
+    });
+
+    test('422 (empty scope) surfaces nothing-to-refresh copy', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/stores/prod/vault/refresh-scope',
+        body: _scopeOk(action: 'refresh_store', scopeTarget: 'prod/vault'),
+      );
+      mock.on(
+        'POST',
+        '/api/v1/externalsecrets/stores/prod/vault/refresh-all',
+        (_) => _json({
+          'error': {'code': 422, 'message': 'scope is empty'},
+        }, status: 422),
+      );
+
+      final sub = _subscribe(container);
+      addTearDown(sub.close);
+      final ctrl =
+          container.read(bulkRefreshControllerProvider(_clusterId).notifier);
+      await ctrl.beginScopeLoad(
+        const BulkRefreshScopeStore(namespace: 'prod', name: 'vault'),
+      );
+      await _settle();
+      await ctrl.submit();
+      await _settle();
+
+      expect(sub.read().errorMessage, contains('Nothing to refresh'));
+    });
+  });
+
+  group('BulkRefreshController.cluster-pin race', () {
+    test('postEmission switch on scope-load surfaces failure', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/stores/prod/vault/refresh-scope',
+        body: _scopeOk(action: 'refresh_store', scopeTarget: 'prod/vault'),
+      );
+
+      final sub = _subscribe(container);
+      addTearDown(sub.close);
+      final ctrl =
+          container.read(bulkRefreshControllerProvider(_clusterId).notifier);
+      final future = ctrl.beginScopeLoad(
+        const BulkRefreshScopeStore(namespace: 'prod', name: 'vault'),
+      );
+      container.read(activeClusterProvider.notifier).setCluster('prod-cluster');
+      await future;
+      await _settle();
+
+      expect(sub.read().phase, BulkRefreshPhase.error);
+      expect(sub.read().errorMessage?.toLowerCase(), contains('cluster'));
+    });
+  });
+
+  group('BulkRefreshController.poll retry handling', () {
+    test('transient 503 on first poll keeps loop alive with retrying flag',
+        () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'GET',
+        '/api/v1/externalsecrets/stores/prod/vault/refresh-scope',
+        body: _scopeOk(action: 'refresh_store', scopeTarget: 'prod/vault'),
+      );
+      mock.onJson(
+        'POST',
+        '/api/v1/externalsecrets/stores/prod/vault/refresh-all',
+        status: 202,
+        body: {
+          'data': {'jobId': 'job-1', 'targetCount': 2},
+        },
+      );
+      // First poll returns 503 — controller should set pollRetrying.
+      mock.on(
+        'GET',
+        '/api/v1/externalsecrets/bulk-refresh-jobs/job-1',
+        (_) => _json({
+          'error': {'code': 503, 'message': 'temporarily unavailable'},
+        }, status: 503),
+      );
+
+      final sub = _subscribe(container);
+      addTearDown(sub.close);
+      final ctrl =
+          container.read(bulkRefreshControllerProvider(_clusterId).notifier);
+      await ctrl.beginScopeLoad(
+        const BulkRefreshScopeStore(namespace: 'prod', name: 'vault'),
+      );
+      await _settle();
+      await ctrl.submit();
+      await _settle();
+
+      expect(sub.read().phase, BulkRefreshPhase.poll,
+          reason: 'transient poll error must NOT collapse to error');
+      expect(sub.read().pollRetrying, isTrue);
+      ctrl.cancelPoll();
+    });
+  });
+}

--- a/mobile/test/features/eso/bulk_refresh_sheet_test.dart
+++ b/mobile/test/features/eso/bulk_refresh_sheet_test.dart
@@ -1,0 +1,312 @@
+// Widget tests for the ESO Bulk Refresh modal bottom sheet.
+//
+// Coverage:
+//   * Phase 1 (scopePick) renders the variant segmented button and gates
+//     "Continue" until an identifier is selected.
+//   * Phase 3 (confirm) gates "Refresh N" until type-to-confirm matches.
+//   * Phase 4 (poll) renders the progress bar + screen-reader live region
+//     copy and the "Run in background" dismiss.
+//   * Phase 5 (done) renders the success summary.
+//   * Error phase renders the message + retry CTA.
+//
+// We drive phase transitions directly by overriding the controller's
+// `build` to seed canned state, rather than walking the full wire path
+// (the controller-level tests cover that).
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kubecenter/api/dio_client.dart';
+import 'package:kubecenter/api/eso_repository.dart';
+import 'package:kubecenter/auth/secure_storage.dart';
+import 'package:kubecenter/features/eso/bulk_refresh_controller.dart';
+import 'package:kubecenter/features/eso/bulk_refresh_sheet.dart';
+import 'package:kubecenter/theme/kube_theme_builder.dart';
+
+import '../../support/mock_dio_adapter.dart';
+
+const _clusterId = 'local';
+
+/// Test-only override that lets the widget pump any phase without
+/// walking the controller's full state machine. The override registers
+/// against the family slot; consumers `ref.read(...notifier).method()`
+/// would still call the real controller methods, so we only stub `build`.
+class _SeedController extends BulkRefreshController {
+  _SeedController(this.seed);
+
+  final BulkRefreshSheetState seed;
+
+  @override
+  BulkRefreshSheetState build(String clusterId) {
+    super.build(clusterId);
+    return seed;
+  }
+}
+
+Widget _wrap({
+  required BulkRefreshSheetState seed,
+  required MockDioAdapter mock,
+}) {
+  return ProviderScope(
+    overrides: [
+      backendUrlProvider.overrideWithValue('http://test'),
+      secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+      bulkRefreshControllerProvider.overrideWith(
+        () => _SeedController(seed),
+      ),
+    ],
+    child: MaterialApp(
+      theme: buildKubeTheme('nexus'),
+      home: Scaffold(
+        body: Builder(
+          builder: (ctx) {
+            return Center(
+              child: ElevatedButton(
+                onPressed: () =>
+                    showBulkRefreshSheet(context: ctx, clusterId: _clusterId),
+                child: const Text('Open'),
+              ),
+            );
+          },
+        ),
+      ),
+    ),
+  );
+}
+
+Future<void> _openSheet(WidgetTester tester) async {
+  await tester.tap(find.text('Open'));
+  await tester.pumpAndSettle();
+}
+
+BulkScopeResponse _scopeOk({int visible = 2}) {
+  final raw = {
+    'action': 'refresh_store',
+    'scopeTarget': 'prod/vault',
+    'totalCount': visible,
+    'totalNamespaces': 1,
+    'visibleCount': visible,
+    'restricted': false,
+    'targets': List.generate(
+      visible,
+      (i) => {'namespace': 'prod', 'name': 'es-$i', 'uid': 'u$i'},
+    ),
+    'byNamespace': [
+      {'namespace': 'prod', 'count': visible},
+    ],
+  };
+  return BulkScopeResponse.fromJson(raw);
+}
+
+BulkRefreshJob _jobInProgress() {
+  return BulkRefreshJob.fromJson({
+    'jobId': 'job-1',
+    'clusterId': _clusterId,
+    'requestedBy': 'oncall',
+    'action': 'refresh_store',
+    'scopeTarget': 'prod/vault',
+    'targetCount': 2,
+    'createdAt': '2026-05-17T10:00:00Z',
+    'succeeded': ['u1'],
+    'failed': <Object>[],
+    'skipped': <Object>[],
+  });
+}
+
+BulkRefreshJob _jobDone() {
+  return BulkRefreshJob.fromJson({
+    'jobId': 'job-1',
+    'clusterId': _clusterId,
+    'requestedBy': 'oncall',
+    'action': 'refresh_store',
+    'scopeTarget': 'prod/vault',
+    'targetCount': 2,
+    'createdAt': '2026-05-17T10:00:00Z',
+    'completedAt': '2026-05-17T10:00:30Z',
+    'succeeded': ['u1', 'u2'],
+    'failed': <Object>[],
+    'skipped': <Object>[],
+  });
+}
+
+void main() {
+  group('BulkRefreshSheet.scopePick phase', () {
+    testWidgets('renders variant picker and disables Continue without input',
+        (tester) async {
+      final mock = MockDioAdapter();
+      await tester.pumpWidget(_wrap(
+        seed: const BulkRefreshSheetState(phase: BulkRefreshPhase.scopePick),
+        mock: mock,
+      ));
+      await _openSheet(tester);
+
+      expect(find.text('Namespace'), findsAtLeastNWidgets(1));
+      expect(find.text('Store'), findsOneWidget);
+      expect(find.text('Cluster store'), findsOneWidget);
+
+      // "Continue" exists but is disabled until an identifier is picked.
+      final continueBtn = find.widgetWithText(FilledButton, 'Continue');
+      expect(continueBtn, findsOneWidget);
+      expect(
+        tester.widget<FilledButton>(continueBtn).onPressed,
+        isNull,
+        reason: 'Continue must be disabled when no namespace is selected',
+      );
+    });
+  });
+
+  group('BulkRefreshSheet.confirm phase', () {
+    testWidgets('gates Refresh button on the REFRESH type-to-confirm token',
+        (tester) async {
+      final mock = MockDioAdapter();
+      await tester.pumpWidget(_wrap(
+        seed: BulkRefreshSheetState(
+          phase: BulkRefreshPhase.confirm,
+          scope: const BulkRefreshScopeStore(namespace: 'prod', name: 'vault'),
+          scopeResponse: _scopeOk(visible: 47),
+        ),
+        mock: mock,
+      ));
+      await _openSheet(tester);
+
+      expect(find.textContaining('47'), findsAtLeastNWidgets(1));
+      // Without typing REFRESH the action button is disabled.
+      final refreshBtn = find.widgetWithText(FilledButton, 'Refresh 47');
+      expect(refreshBtn, findsOneWidget);
+      expect(tester.widget<FilledButton>(refreshBtn).onPressed, isNull);
+
+      // Type the wrong token first.
+      await tester.enterText(find.byType(TextField), 'refresh');
+      await tester.pump();
+      expect(tester.widget<FilledButton>(refreshBtn).onPressed, isNull,
+          reason: 'lowercase must NOT satisfy the gate (case-sensitive)');
+
+      // Type the correct token.
+      await tester.enterText(find.byType(TextField), kBulkRefreshConfirmToken);
+      await tester.pump();
+      expect(tester.widget<FilledButton>(refreshBtn).onPressed, isNotNull);
+    });
+
+    testWidgets('zero-visible scope renders no-permission copy + Close',
+        (tester) async {
+      final mock = MockDioAdapter();
+      await tester.pumpWidget(_wrap(
+        seed: BulkRefreshSheetState(
+          phase: BulkRefreshPhase.confirm,
+          scope: const BulkRefreshScopeStore(namespace: 'prod', name: 'vault'),
+          scopeResponse: _scopeOk(visible: 0),
+        ),
+        mock: mock,
+      ));
+      await _openSheet(tester);
+
+      expect(find.textContaining('permission'), findsOneWidget);
+      expect(find.widgetWithText(FilledButton, 'Close'), findsOneWidget);
+    });
+  });
+
+  group('BulkRefreshSheet.poll phase', () {
+    testWidgets('renders Refreshing N of M in a Semantics liveRegion',
+        (tester) async {
+      final mock = MockDioAdapter();
+      await tester.pumpWidget(_wrap(
+        seed: BulkRefreshSheetState(
+          phase: BulkRefreshPhase.poll,
+          jobId: 'job-1',
+          job: _jobInProgress(),
+        ),
+        mock: mock,
+      ));
+      await _openSheet(tester);
+
+      expect(find.text('Refreshing 1 of 2'), findsOneWidget);
+      expect(find.text('Run in background'), findsOneWidget);
+      // The live region announcement is a Semantics node; locate it by
+      // its child label to confirm wrapping rather than digging
+      // through the semantics tree.
+      final progressLine = find.text('Refreshing 1 of 2');
+      final semantics = find.ancestor(
+        of: progressLine,
+        matching: find.byWidgetPredicate(
+          (w) => w is Semantics && (w.properties.liveRegion ?? false),
+        ),
+      );
+      expect(semantics, findsOneWidget);
+    });
+
+    testWidgets('takingLong flag surfaces the long-running caption',
+        (tester) async {
+      final mock = MockDioAdapter();
+      await tester.pumpWidget(_wrap(
+        seed: BulkRefreshSheetState(
+          phase: BulkRefreshPhase.poll,
+          jobId: 'job-1',
+          job: _jobInProgress(),
+          takingLong: true,
+        ),
+        mock: mock,
+      ));
+      await _openSheet(tester);
+
+      expect(find.textContaining('Taking longer'), findsOneWidget);
+    });
+
+    testWidgets('attachedToExistingJob shows the in-flight banner',
+        (tester) async {
+      final mock = MockDioAdapter();
+      await tester.pumpWidget(_wrap(
+        seed: BulkRefreshSheetState(
+          phase: BulkRefreshPhase.poll,
+          jobId: 'job-existing',
+          job: _jobInProgress(),
+          attachedToExistingJob: true,
+        ),
+        mock: mock,
+      ));
+      await _openSheet(tester);
+
+      expect(
+        find.textContaining('Attached to an existing'),
+        findsOneWidget,
+      );
+    });
+  });
+
+  group('BulkRefreshSheet.done phase', () {
+    testWidgets('renders success summary with succeeded count', (tester) async {
+      final mock = MockDioAdapter();
+      await tester.pumpWidget(_wrap(
+        seed: BulkRefreshSheetState(
+          phase: BulkRefreshPhase.done,
+          jobId: 'job-1',
+          job: _jobDone(),
+        ),
+        mock: mock,
+      ));
+      await _openSheet(tester);
+
+      expect(find.textContaining('All 2 ExternalSecrets'), findsOneWidget);
+      expect(find.widgetWithText(FilledButton, 'Close'), findsOneWidget);
+    });
+  });
+
+  group('BulkRefreshSheet.error phase', () {
+    testWidgets('renders the error message + retry CTA', (tester) async {
+      final mock = MockDioAdapter();
+      await tester.pumpWidget(_wrap(
+        seed: const BulkRefreshSheetState(
+          phase: BulkRefreshPhase.error,
+          errorMessage: 'Scope is too large for a single bulk refresh.',
+        ),
+        mock: mock,
+      ));
+      await _openSheet(tester);
+
+      expect(
+        find.text('Scope is too large for a single bulk refresh.'),
+        findsOneWidget,
+      );
+      expect(find.widgetWithText(FilledButton, 'Try again'), findsOneWidget);
+    });
+  });
+}

--- a/mobile/test/features/eso/bulk_refresh_sheet_test.dart
+++ b/mobile/test/features/eso/bulk_refresh_sheet_test.dart
@@ -155,13 +155,17 @@ void main() {
     });
   });
 
-  group('BulkRefreshSheet.confirm phase', () {
-    testWidgets('gates Refresh button on the REFRESH type-to-confirm token',
+  group('BulkRefreshSheet.preview phase', () {
+    // PR-5e-review #3: type-to-confirm friction moved into the shared
+    // `showConfirmSheet`. The preview body now renders the breakdown +
+    // a "Continue" button; tapping Continue stacks the shared confirm
+    // sheet on top of the bulk sheet.
+    testWidgets('renders byNamespace breakdown + enabled Continue button',
         (tester) async {
       final mock = MockDioAdapter();
       await tester.pumpWidget(_wrap(
         seed: BulkRefreshSheetState(
-          phase: BulkRefreshPhase.confirm,
+          phase: BulkRefreshPhase.preview,
           scope: const BulkRefreshScopeStore(namespace: 'prod', name: 'vault'),
           scopeResponse: _scopeOk(visible: 47),
         ),
@@ -170,21 +174,41 @@ void main() {
       await _openSheet(tester);
 
       expect(find.textContaining('47'), findsAtLeastNWidgets(1));
-      // Without typing REFRESH the action button is disabled.
-      final refreshBtn = find.widgetWithText(FilledButton, 'Refresh 47');
-      expect(refreshBtn, findsOneWidget);
-      expect(tester.widget<FilledButton>(refreshBtn).onPressed, isNull);
+      // Type-to-confirm input is NOT on the preview body — it lives on
+      // the shared confirm sheet that stacks on Continue.
+      expect(find.byType(TextField), findsNothing,
+          reason: 'preview body must NOT render the type-to-confirm input '
+              '— that lives on the shared confirm sheet');
+      final continueBtn = find.widgetWithText(FilledButton, 'Continue');
+      expect(continueBtn, findsOneWidget);
+      expect(tester.widget<FilledButton>(continueBtn).onPressed, isNotNull,
+          reason: 'Continue is enabled while phase == preview');
+    });
 
-      // Type the wrong token first.
-      await tester.enterText(find.byType(TextField), 'refresh');
-      await tester.pump();
-      expect(tester.widget<FilledButton>(refreshBtn).onPressed, isNull,
-          reason: 'lowercase must NOT satisfy the gate (case-sensitive)');
+    testWidgets('Continue stacks the shared confirm sheet on top',
+        (tester) async {
+      final mock = MockDioAdapter();
+      await tester.pumpWidget(_wrap(
+        seed: BulkRefreshSheetState(
+          phase: BulkRefreshPhase.preview,
+          scope: const BulkRefreshScopeStore(namespace: 'prod', name: 'vault'),
+          scopeResponse: _scopeOk(visible: 3),
+        ),
+        mock: mock,
+      ));
+      await _openSheet(tester);
 
-      // Type the correct token.
-      await tester.enterText(find.byType(TextField), kBulkRefreshConfirmToken);
-      await tester.pump();
-      expect(tester.widget<FilledButton>(refreshBtn).onPressed, isNotNull);
+      // Tap Continue and pump until the inner sheet is fully open.
+      await tester.tap(find.widgetWithText(FilledButton, 'Continue'));
+      await tester.pumpAndSettle();
+
+      // Shared confirm sheet uses the title "Refresh <N> ExternalSecret(s)";
+      // type-to-confirm TextField is present and the inner confirm button
+      // is labeled "Refresh 3".
+      expect(find.text('Refresh 3 ExternalSecrets'), findsOneWidget);
+      expect(find.byType(TextField), findsOneWidget,
+          reason: 'shared confirm sheet renders the type-to-confirm input');
+      expect(find.widgetWithText(FilledButton, 'Refresh 3'), findsOneWidget);
     });
 
     testWidgets('zero-visible scope renders no-permission copy + Close',
@@ -192,7 +216,7 @@ void main() {
       final mock = MockDioAdapter();
       await tester.pumpWidget(_wrap(
         seed: BulkRefreshSheetState(
-          phase: BulkRefreshPhase.confirm,
+          phase: BulkRefreshPhase.preview,
           scope: const BulkRefreshScopeStore(namespace: 'prod', name: 'vault'),
           scopeResponse: _scopeOk(visible: 0),
         ),
@@ -270,6 +294,30 @@ void main() {
         findsOneWidget,
       );
     });
+
+    // PR-5e-review #14: pollRetrying surfaces the transient-error banner
+    // inline so the operator knows the loop is alive (vs. wedged).
+    testWidgets('pollRetrying flag renders the Retrying caption in warning',
+        (tester) async {
+      final mock = MockDioAdapter();
+      await tester.pumpWidget(_wrap(
+        seed: BulkRefreshSheetState(
+          phase: BulkRefreshPhase.poll,
+          jobId: 'job-1',
+          job: _jobInProgress(),
+          pollRetrying: true,
+        ),
+        mock: mock,
+      ));
+      await _openSheet(tester);
+
+      expect(find.text('Retrying…'), findsOneWidget);
+      final text = tester.widget<Text>(find.text('Retrying…'));
+      final ctx = tester.element(find.text('Retrying…'));
+      final colors = Theme.of(ctx).extension<KubeColors>()!;
+      expect(text.style?.color, colors.warning,
+          reason: 'Retrying caption must use the warning token, not error');
+    });
   });
 
   group('BulkRefreshSheet.done phase', () {
@@ -286,7 +334,170 @@ void main() {
       await _openSheet(tester);
 
       expect(find.textContaining('All 2 ExternalSecrets'), findsOneWidget);
+      final headline =
+          tester.widget<Text>(find.textContaining('All 2 ExternalSecrets'));
+      final ctx = tester.element(find.textContaining('All 2 ExternalSecrets'));
+      final colors = Theme.of(ctx).extension<KubeColors>()!;
+      expect(headline.style?.color, colors.success,
+          reason: 'pure success run must render success-colored copy');
       expect(find.widgetWithText(FilledButton, 'Close'), findsOneWidget);
+    });
+
+    // PR-5e-review #15: partial-failure Done state must render warning
+    // copy (NOT success) and surface the failed outcome list.
+    testWidgets('partial failures render warning headline + failed list',
+        (tester) async {
+      final mock = MockDioAdapter();
+      final job = BulkRefreshJob.fromJson({
+        'jobId': 'job-1',
+        'clusterId': _clusterId,
+        'requestedBy': 'oncall',
+        'action': 'refresh_store',
+        'scopeTarget': 'prod/vault',
+        'targetCount': 4,
+        'createdAt': '2026-05-17T10:00:00Z',
+        'completedAt': '2026-05-17T10:00:30Z',
+        'succeeded': ['u1', 'u2', 'u3'],
+        'failed': [
+          {'uid': 'u4', 'reason': 'auth method failed'},
+        ],
+        'skipped': <Object>[],
+      });
+      await tester.pumpWidget(_wrap(
+        seed: BulkRefreshSheetState(
+          phase: BulkRefreshPhase.done,
+          jobId: 'job-1',
+          job: job,
+        ),
+        mock: mock,
+      ));
+      await _openSheet(tester);
+
+      expect(find.textContaining('Refresh finished with 1 failure'),
+          findsOneWidget);
+      final headline = tester
+          .widget<Text>(find.textContaining('Refresh finished with 1 failure'));
+      final ctx =
+          tester.element(find.textContaining('Refresh finished with 1 failure'));
+      final colors = Theme.of(ctx).extension<KubeColors>()!;
+      expect(headline.style?.color, colors.warning,
+          reason: 'partial-failure outcomes must NOT use success copy');
+      expect(headline.style?.color, isNot(colors.success));
+      // The ExpansionTile label includes the failed count.
+      expect(find.text('Failed (1)'), findsOneWidget);
+      // Success-style copy must NOT render.
+      expect(find.textContaining('All 3 ExternalSecrets'), findsNothing);
+    });
+
+    // PR-5e-review #8: all-skipped completion must not pretend
+    // everything was refreshed — "All 0 ExternalSecrets were refreshed"
+    // in green would be an operator-visible lie.
+    testWidgets('all-skipped outcomes render warning copy, not success',
+        (tester) async {
+      final mock = MockDioAdapter();
+      final job = BulkRefreshJob.fromJson({
+        'jobId': 'job-1',
+        'clusterId': _clusterId,
+        'requestedBy': 'oncall',
+        'action': 'refresh_store',
+        'scopeTarget': 'prod/vault',
+        'targetCount': 2,
+        'createdAt': '2026-05-17T10:00:00Z',
+        'completedAt': '2026-05-17T10:00:30Z',
+        'succeeded': <Object>[],
+        'failed': <Object>[],
+        'skipped': [
+          {'uid': 'u1', 'reason': 'rate limit'},
+          {'uid': 'u2', 'reason': 'rate limit'},
+        ],
+      });
+      await tester.pumpWidget(_wrap(
+        seed: BulkRefreshSheetState(
+          phase: BulkRefreshPhase.done,
+          jobId: 'job-1',
+          job: job,
+        ),
+        mock: mock,
+      ));
+      await _openSheet(tester);
+
+      // The all-skipped headline copy.
+      expect(
+        find.textContaining('All targets were skipped'),
+        findsOneWidget,
+      );
+      // Green success copy must NOT appear.
+      expect(find.textContaining('All 0 ExternalSecrets were refreshed'),
+          findsNothing);
+
+      final headline = tester
+          .widget<Text>(find.textContaining('All targets were skipped'));
+      final ctx =
+          tester.element(find.textContaining('All targets were skipped'));
+      final colors = Theme.of(ctx).extension<KubeColors>()!;
+      expect(headline.style?.color, colors.warning,
+          reason: 'all-skipped must be warning-tier, not success');
+      expect(headline.style?.color, isNot(colors.success));
+    });
+
+    // PR-5e-review #10: _OutcomeList must NOT render thousands of rows
+    // eagerly inside the sheet — a stuck Vault store can dump 10k
+    // "auth method failed" rows and the sheet used to render every one
+    // into a Column inside an ExpansionTile. Now caps at 50 with a
+    // "Show all (N)" affordance, and the visible rows go through a
+    // ListView.builder so lazy paint kicks in even when expanded.
+    testWidgets(
+        '_OutcomeList caps at 50 rows initially and expands on Show all',
+        (tester) async {
+      final mock = MockDioAdapter();
+      // 200 failed outcomes — well past the cap.
+      final failed = List.generate(
+        200,
+        (i) => {'uid': 'u$i', 'reason': 'auth method failed'},
+      );
+      final job = BulkRefreshJob.fromJson({
+        'jobId': 'job-1',
+        'clusterId': _clusterId,
+        'requestedBy': 'oncall',
+        'action': 'refresh_store',
+        'scopeTarget': 'prod/vault',
+        'targetCount': 200,
+        'createdAt': '2026-05-17T10:00:00Z',
+        'completedAt': '2026-05-17T10:00:30Z',
+        'succeeded': <Object>[],
+        'failed': failed,
+        'skipped': <Object>[],
+      });
+      await tester.pumpWidget(_wrap(
+        seed: BulkRefreshSheetState(
+          phase: BulkRefreshPhase.done,
+          jobId: 'job-1',
+          job: job,
+        ),
+        mock: mock,
+      ));
+      await _openSheet(tester);
+
+      // ExpansionTile starts collapsed in tests; tap to expand the
+      // outcome list so the rows actually paint.
+      await tester.tap(find.text('Failed (200)'));
+      await tester.pumpAndSettle();
+
+      // Locate _OutcomeRow widgets via runtime-type predicate (private
+      // class). With ListView.builder + a 240px height clamp, the
+      // physical rows painted at any one time are LESS than 50, but
+      // the "Show all" button must NOT be present yet because we are
+      // still in capped mode (item count == 50, not 200).
+      expect(find.text('Show all (200)'), findsOneWidget,
+          reason: 'capped mode shows the "Show all" CTA');
+
+      await tester.tap(find.text('Show all (200)'));
+      await tester.pumpAndSettle();
+
+      // After expanding, the CTA disappears (we now show the full list
+      // via ListView.builder over all 200).
+      expect(find.text('Show all (200)'), findsNothing,
+          reason: 'after tapping Show all the CTA must disappear');
     });
   });
 

--- a/mobile/test/features/eso/eso_widgets_test.dart
+++ b/mobile/test/features/eso/eso_widgets_test.dart
@@ -7,8 +7,10 @@
 // drift Unknown onto the error palette, this test fires.
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kubecenter/api/eso_repository.dart';
+import 'package:kubecenter/cluster/cluster_provider.dart';
 import 'package:kubecenter/features/eso/eso_widgets.dart';
 import 'package:kubecenter/theme/kube_theme_builder.dart';
 
@@ -197,18 +199,51 @@ void main() {
     });
   });
 
-  group('DisabledRevertDriftButton', () {
-    testWidgets('renders disabled with desktop tooltip', (tester) async {
-      await _pumpWith(tester, const DisabledRevertDriftButton());
-      // The button is disabled when onPressed is null.
-      final btn = tester.widget<OutlinedButton>(find.byType(OutlinedButton));
-      expect(btn.onPressed, isNull,
-          reason:
-              'Revert is disabled per R12 — write actions defer to desktop.');
+  group('BulkRefreshButton', () {
+    testWidgets('renders enabled on local cluster (default ProviderScope)',
+        (tester) async {
+      await tester.pumpWidget(
+        const ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(body: Center(child: BulkRefreshButton())),
+          ),
+        ),
+      );
+      final btn =
+          tester.widget<OutlinedButton>(find.byType(OutlinedButton));
+      expect(btn.onPressed, isNotNull,
+          reason: 'local cluster (default) enables bulk refresh');
+    });
 
+    testWidgets('disabled with explanatory tooltip on remote cluster',
+        (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            activeClusterProvider.overrideWith(
+              () => _StubActiveCluster('prod-east'),
+            ),
+          ],
+          child: const MaterialApp(
+            home: Scaffold(body: Center(child: BulkRefreshButton())),
+          ),
+        ),
+      );
+      await tester.pump();
+      final btn =
+          tester.widget<OutlinedButton>(find.byType(OutlinedButton));
+      expect(btn.onPressed, isNull,
+          reason: 'non-local cluster disables bulk refresh');
       final tooltip = tester.widget<Tooltip>(find.byType(Tooltip));
-      expect(tooltip.message, DisabledRevertDriftButton.desktopMessage);
-      expect(tooltip.message, contains('desktop'));
+      expect(tooltip.message, BulkRefreshButton.nonLocalTooltip);
+      expect(tooltip.message, contains('local-cluster only'));
     });
   });
+}
+
+class _StubActiveCluster extends ActiveClusterController {
+  _StubActiveCluster(this._id);
+  final String _id;
+  @override
+  String build() => _id;
 }

--- a/mobile/test/features/eso/eso_widgets_test.dart
+++ b/mobile/test/features/eso/eso_widgets_test.dart
@@ -200,19 +200,28 @@ void main() {
   });
 
   group('BulkRefreshButton', () {
-    testWidgets('renders enabled on local cluster (default ProviderScope)',
+    Override esoDetectedOverride(String clusterId) {
+      return esoStatusProvider(clusterId).overrideWith(
+        (ref) async => const EsoDiscoveryStatus(detected: true),
+      );
+    }
+
+    testWidgets('renders enabled on local cluster when ESO is detected',
         (tester) async {
       await tester.pumpWidget(
-        const ProviderScope(
-          child: MaterialApp(
+        ProviderScope(
+          overrides: [esoDetectedOverride('local')],
+          child: const MaterialApp(
             home: Scaffold(body: Center(child: BulkRefreshButton())),
           ),
         ),
       );
+      // Pump once to resolve the FutureProvider override.
+      await tester.pump();
       final btn =
           tester.widget<OutlinedButton>(find.byType(OutlinedButton));
       expect(btn.onPressed, isNotNull,
-          reason: 'local cluster (default) enables bulk refresh');
+          reason: 'local cluster + ESO detected enables bulk refresh');
     });
 
     testWidgets('disabled with explanatory tooltip on remote cluster',
@@ -223,6 +232,7 @@ void main() {
             activeClusterProvider.overrideWith(
               () => _StubActiveCluster('prod-east'),
             ),
+            esoDetectedOverride('prod-east'),
           ],
           child: const MaterialApp(
             home: Scaffold(body: Center(child: BulkRefreshButton())),
@@ -237,6 +247,69 @@ void main() {
       final tooltip = tester.widget<Tooltip>(find.byType(Tooltip));
       expect(tooltip.message, BulkRefreshButton.nonLocalTooltip);
       expect(tooltip.message, contains('local-cluster only'));
+    });
+
+    // PR-5e-review #24: button must hide entirely when ESO is not
+    // detected on the active cluster — otherwise tapping it issues a
+    // request the backend rejects with 503 and the dashboard's main
+    // body already renders FeatureUnavailableState.
+    testWidgets('hidden when ESO is not detected on the active cluster',
+        (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            esoStatusProvider('local').overrideWith(
+              (ref) async => EsoDiscoveryStatus.empty,
+            ),
+          ],
+          child: const MaterialApp(
+            home: Scaffold(body: Center(child: BulkRefreshButton())),
+          ),
+        ),
+      );
+      await tester.pump();
+      expect(find.byType(OutlinedButton), findsNothing);
+    });
+  });
+
+  // PR-5e-review #16: ForceSyncButton had zero widget tests despite
+  // shipping the canonical local-cluster gating + snackbar tone routing.
+  group('ForceSyncButton', () {
+    testWidgets('disabled with explanatory tooltip on remote cluster',
+        (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            activeClusterProvider.overrideWith(
+              () => _StubActiveCluster('prod-east'),
+            ),
+          ],
+          child: const MaterialApp(
+            home: Scaffold(
+              body: Center(
+                child: ForceSyncButton(
+                  namespace: 'production',
+                  name: 'db-credentials',
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      final btn = tester.widget<OutlinedButton>(find.byType(OutlinedButton));
+      expect(btn.onPressed, isNull,
+          reason: 'non-local cluster must disable Force Sync');
+      // The tooltip wraps the button. Locate ours by the non-local copy
+      // (a separate empty-message Tooltip wraps the IconButton on the
+      // local-cluster path, but we're on remote here).
+      final tooltips = tester
+          .widgetList<Tooltip>(find.byType(Tooltip))
+          .map((t) => t.message ?? '')
+          .toList();
+      expect(tooltips, contains(ForceSyncButton.nonLocalTooltip));
+      expect(ForceSyncButton.nonLocalTooltip, contains('local-cluster only'));
+      expect(ForceSyncButton.nonLocalTooltip, contains('desktop UI'));
     });
   });
 }

--- a/mobile/test/features/eso/force_sync_controller_test.dart
+++ b/mobile/test/features/eso/force_sync_controller_test.dart
@@ -1,0 +1,343 @@
+// Controller-level tests for the ESO Force Sync write path.
+//
+// Coverage:
+//   * Happy path — 202 response lands as ForceSyncSuccess and the wire
+//     POST carried the correct X-Cluster-ID header.
+//   * Idempotent fast-tap — a second invoke while inFlight is a no-op,
+//     no duplicate wire POST.
+//   * 409 already_refreshing — emits ForceSyncFailure with
+//     `alreadyRefreshing: true` and informational copy.
+//   * 501 (defensive — UI should have blocked) — emits failure with
+//     local-cluster-only copy.
+//   * 503 ESO not detected — install-guidance copy.
+//   * 403 RBAC denied — permission copy.
+//   * 404 not found — deleted-resource copy.
+//   * Cluster-pin race postEmission — request succeeded but operator
+//     switched cluster mid-flight; emits failure (no invalidate on the
+//     wrong slot).
+//   * acknowledge() rolls success back to idle so a re-trigger works.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kubecenter/api/dio_client.dart';
+import 'package:kubecenter/auth/secure_storage.dart';
+import 'package:kubecenter/cluster/cluster_provider.dart';
+import 'package:kubecenter/features/eso/force_sync_controller.dart';
+
+import '../../support/mock_dio_adapter.dart';
+
+ResponseBody _json(Object body, {int status = 200}) {
+  return ResponseBody.fromBytes(
+    Uint8List.fromList(utf8.encode(jsonEncode(body))),
+    status,
+    headers: {
+      Headers.contentTypeHeader: ['application/json'],
+    },
+  );
+}
+
+({ProviderContainer container, MockDioAdapter mock}) _make() {
+  final mock = MockDioAdapter();
+  final container = ProviderContainer(
+    overrides: [
+      backendUrlProvider.overrideWithValue('http://test'),
+      secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+    ],
+  );
+  container.read(refreshDioProvider).httpClientAdapter = mock;
+  container.read(dioProvider).httpClientAdapter = mock;
+  return (container: container, mock: mock);
+}
+
+const _key = ForceSyncKey(
+  clusterId: 'local',
+  namespace: 'production',
+  name: 'db-credentials',
+);
+
+const _path =
+    '/api/v1/externalsecrets/externalsecrets/production/db-credentials/force-sync';
+
+ProviderSubscription<ForceSyncState> _subscribe(ProviderContainer container) {
+  return container.listen<ForceSyncState>(
+    forceSyncControllerProvider(_key),
+    (_, _) {},
+  );
+}
+
+Future<void> _settle() => pumpEventQueue(times: 30);
+
+void main() {
+  group('ForceSyncController.happy path', () {
+    test('202 lands as ForceSyncSuccess with the namespace/name message',
+        () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'POST',
+        _path,
+        status: 202,
+        body: {
+          'data': {'status': 'force-syncing'},
+        },
+      );
+
+      final sub = _subscribe(container);
+      addTearDown(sub.close);
+
+      final ctrl = container.read(forceSyncControllerProvider(_key).notifier);
+      expect(sub.read(), isA<ForceSyncIdle>());
+
+      await ctrl.forceSync();
+      await _settle();
+
+      final state = sub.read();
+      expect(state, isA<ForceSyncSuccess>());
+      final success = state as ForceSyncSuccess;
+      expect(success.message, contains('production/db-credentials'));
+      expect(success.generation, greaterThan(0));
+    });
+
+    test('forwards X-Cluster-ID header pinned to the family key', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'POST',
+        _path,
+        status: 202,
+        body: {'data': {'status': 'force-syncing'}},
+      );
+
+      final sub = _subscribe(container);
+      addTearDown(sub.close);
+      final ctrl = container.read(forceSyncControllerProvider(_key).notifier);
+      await ctrl.forceSync();
+      await _settle();
+
+      final headers = mock.requests
+          .where((r) => r.path == _path)
+          .map((r) => r.headers['X-Cluster-ID'])
+          .toList();
+      expect(headers, contains('local'));
+    });
+
+    test('fast double-tap while inFlight does NOT fire a second POST',
+        () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'POST',
+        _path,
+        status: 202,
+        body: {'data': {'status': 'force-syncing'}},
+      );
+
+      final sub = _subscribe(container);
+      addTearDown(sub.close);
+      final ctrl = container.read(forceSyncControllerProvider(_key).notifier);
+
+      // Fire two without awaiting between them. The second hits the
+      // `state is ForceSyncInFlight` guard and short-circuits.
+      final first = ctrl.forceSync();
+      final second = ctrl.forceSync();
+      await Future.wait([first, second]);
+      await _settle();
+
+      final postCount =
+          mock.requests.where((r) => r.path == _path).length;
+      expect(postCount, 1,
+          reason: 'second tap during inFlight must short-circuit');
+    });
+
+    test('acknowledge() rolls success back to idle so the action can re-fire',
+        () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'POST',
+        _path,
+        status: 202,
+        body: {'data': {'status': 'force-syncing'}},
+      );
+
+      final sub = _subscribe(container);
+      addTearDown(sub.close);
+      final ctrl = container.read(forceSyncControllerProvider(_key).notifier);
+      await ctrl.forceSync();
+      await _settle();
+      expect(sub.read(), isA<ForceSyncSuccess>());
+
+      ctrl.acknowledge();
+      expect(sub.read(), isA<ForceSyncIdle>());
+    });
+  });
+
+  group('ForceSyncController.error paths', () {
+    test('409 already_refreshing emits informational ForceSyncFailure',
+        () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.on(
+        'POST',
+        _path,
+        (_) => _json({
+          'error': {
+            'code': 409,
+            'message': 'already refreshing',
+            'reason': 'already_refreshing',
+          },
+        }, status: 409),
+      );
+
+      final sub = _subscribe(container);
+      addTearDown(sub.close);
+      final ctrl = container.read(forceSyncControllerProvider(_key).notifier);
+      await ctrl.forceSync();
+      await _settle();
+
+      final state = sub.read();
+      expect(state, isA<ForceSyncFailure>());
+      final failure = state as ForceSyncFailure;
+      expect(failure.alreadyRefreshing, isTrue);
+      expect(failure.message.toLowerCase(), contains('progress'));
+    });
+
+    test('501 surfaces local-cluster-only copy', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.on(
+        'POST',
+        _path,
+        (_) => _json({
+          'error': {
+            'code': 501,
+            'message': 'ESO write actions are local-cluster only in v1',
+          },
+        }, status: 501),
+      );
+
+      final sub = _subscribe(container);
+      addTearDown(sub.close);
+      final ctrl = container.read(forceSyncControllerProvider(_key).notifier);
+      await ctrl.forceSync();
+      await _settle();
+
+      final state = sub.read() as ForceSyncFailure;
+      expect(state.alreadyRefreshing, isFalse);
+      expect(state.message, contains('local cluster'));
+    });
+
+    test('503 surfaces ESO-not-detected copy', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.on(
+        'POST',
+        _path,
+        (_) => _json({
+          'error': {'code': 503, 'message': 'ESO not detected'},
+        }, status: 503),
+      );
+
+      final sub = _subscribe(container);
+      addTearDown(sub.close);
+      final ctrl = container.read(forceSyncControllerProvider(_key).notifier);
+      await ctrl.forceSync();
+      await _settle();
+
+      final state = sub.read() as ForceSyncFailure;
+      expect(state.message, contains('ESO'));
+    });
+
+    test('403 surfaces permission copy with the resource path', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.on(
+        'POST',
+        _path,
+        (_) => _json({
+          'error': {'code': 403, 'message': 'access denied'},
+        }, status: 403),
+      );
+
+      final sub = _subscribe(container);
+      addTearDown(sub.close);
+      final ctrl = container.read(forceSyncControllerProvider(_key).notifier);
+      await ctrl.forceSync();
+      await _settle();
+
+      final state = sub.read() as ForceSyncFailure;
+      expect(state.message, contains('permission'));
+      expect(state.message, contains('production/db-credentials'));
+    });
+
+    test('404 surfaces deleted-resource copy', () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.on(
+        'POST',
+        _path,
+        (_) => _json({
+          'error': {'code': 404, 'message': 'external secret not found'},
+        }, status: 404),
+      );
+
+      final sub = _subscribe(container);
+      addTearDown(sub.close);
+      final ctrl = container.read(forceSyncControllerProvider(_key).notifier);
+      await ctrl.forceSync();
+      await _settle();
+
+      final state = sub.read() as ForceSyncFailure;
+      expect(state.message, contains('not found'));
+    });
+  });
+
+  group('ForceSyncController.cluster-pin race', () {
+    test('postEmission switch emits failure (no invalidate on wrong slot)',
+        () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      mock.onJson(
+        'POST',
+        _path,
+        status: 202,
+        body: {'data': {'status': 'force-syncing'}},
+      );
+
+      final sub = _subscribe(container);
+      addTearDown(sub.close);
+      final ctrl = container.read(forceSyncControllerProvider(_key).notifier);
+
+      // Switch the active cluster mid-flight by mutating the
+      // ActiveClusterController immediately after firing.
+      final future = ctrl.forceSync();
+      container
+          .read(activeClusterProvider.notifier)
+          .setCluster('prod');
+      await future;
+      await _settle();
+
+      final state = sub.read();
+      expect(state, isA<ForceSyncFailure>(),
+          reason: 'postEmission cluster-pin re-check must veto the success '
+              'so the snackbar does not lie about which cluster received '
+              'the sync');
+      final msg = (state as ForceSyncFailure).message;
+      expect(msg.toLowerCase(), contains('cluster'));
+    });
+  });
+}

--- a/mobile/test/features/eso/force_sync_controller_test.dart
+++ b/mobile/test/features/eso/force_sync_controller_test.dart
@@ -24,6 +24,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kubecenter/api/dio_client.dart';
+import 'package:kubecenter/api/eso_repository.dart';
 import 'package:kubecenter/auth/secure_storage.dart';
 import 'package:kubecenter/cluster/cluster_provider.dart';
 import 'package:kubecenter/features/eso/force_sync_controller.dart';
@@ -177,6 +178,73 @@ void main() {
 
       ctrl.acknowledge();
       expect(sub.read(), isA<ForceSyncIdle>());
+    });
+
+    // PR-5e-review #27: on success the controller invalidates the
+    // externalSecretDetailProvider for the same key so the drift chip
+    // re-fetches on the next frame. Without an explicit assertion, a
+    // regression that drops the invalidate would silently leave the
+    // detail screen rendering "Drifted" forever.
+    test('success invalidates externalSecretDetailProvider for the same key',
+        () async {
+      final (:container, :mock) = _make();
+      addTearDown(container.dispose);
+
+      // Mock the detail endpoint so the provider has something to fetch.
+      // We count hits — the controller's success path must invalidate
+      // the externalSecretDetailProvider, triggering a second fetch.
+      var detailHits = 0;
+      mock.on(
+        'GET',
+        '/api/v1/externalsecrets/externalsecrets/production/db-credentials',
+        (_) {
+          detailHits++;
+          return _json({
+            'data': {
+              'name': 'db-credentials',
+              'namespace': 'production',
+              'uid': 'u1',
+              'status': 'Synced',
+              'storeRef': {'name': 's', 'kind': 'SecretStore'},
+            },
+          });
+        },
+      );
+      mock.onJson(
+        'POST',
+        _path,
+        status: 202,
+        body: {'data': {'status': 'force-syncing'}},
+      );
+
+      // Subscribe to the detail provider so it stays alive (autoDispose
+      // would otherwise tear it down between reads).
+      final detailKey = ExternalSecretDetailKey(
+        clusterId: _key.clusterId,
+        namespace: _key.namespace,
+        name: _key.name,
+      );
+      final detailSub = container.listen(
+        externalSecretDetailProvider(detailKey),
+        (_, _) {},
+      );
+      addTearDown(detailSub.close);
+      // Prime the detail provider.
+      await container.read(externalSecretDetailProvider(detailKey).future);
+      final hitsBeforeForceSync = detailHits;
+
+      final sub = _subscribe(container);
+      addTearDown(sub.close);
+      final ctrl = container.read(forceSyncControllerProvider(_key).notifier);
+      await ctrl.forceSync();
+      await _settle();
+      // Re-read the detail provider to force any pending invalidation
+      // to materialise as a fresh fetch.
+      await container.read(externalSecretDetailProvider(detailKey).future);
+
+      expect(detailHits, greaterThan(hitsBeforeForceSync),
+          reason: 'success path must invalidate externalSecretDetailProvider '
+              'so the drift chip re-fetches');
     });
   });
 

--- a/mobile/test/widgets/named_resource_picker_test.dart
+++ b/mobile/test/widgets/named_resource_picker_test.dart
@@ -17,9 +17,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:kubecenter/api/dio_client.dart';
 import 'package:kubecenter/auth/secure_storage.dart';
 import 'package:kubecenter/theme/kube_theme_builder.dart';
-import 'package:kubecenter/wizards/widgets/named_resource_picker.dart';
+import 'package:kubecenter/widgets/named_resource_picker.dart';
 
-import '../../support/mock_dio_adapter.dart';
+import '../support/mock_dio_adapter.dart';
 
 ({ProviderContainer container, MockDioAdapter mock}) _makeContainer() {
   final mock = MockDioAdapter();


### PR DESCRIPTION
## Summary

Closes the **M5 PR-5e** plan unit (R2 + R3 + R11 + R12) — the last mobile write-parity gap between web and Flutter for ESO. Operators on the local cluster can now:

- Tap **Force Sync** on an ExternalSecret detail screen → type-to-confirm → backend POST → drift chip refreshes through the M4 tri-state sequence (Drifted → Unknown (textMuted, never red) → InSync).
- Tap **Bulk refresh** on the ESO dashboard → walk a 4-phase modal sheet (scope-pick → scope-load → confirm "REFRESH" → submit+poll) → all ExternalSecrets in the chosen Store / ClusterStore / Namespace scope refresh.

Both buttons are **gated on `activeClusterProvider == 'local'`** per the backend's 501 contract; non-local renders the disabled state with an explanatory tooltip.

The misnamed M4 `DisabledRevertDriftButton` (the agent research confirmed "Drift Revert" was wrong — the canonical web/backend term is **Force Sync**) is gone.

## What landed

| Commit | Scope |
|---|---|
| `e51694a` | Precondition — move `named_resource_picker.dart` out of `wizards/widgets/` into `widgets/` so feature directories can import without crossing the wizards layer boundary. Updates 7 wizard imports + the test path via `git mv`. |
| `9152424` | Repository layer + state-machine controllers + 20 controller tests. |
| `e711772` | Scope picker + modal bottom sheet + 8 widget tests. |
| `aae2989` | Wire `ForceSyncButton` into the ExternalSecret detail header card; wire `BulkRefreshButton` into the dashboard AppBar; replace stale doc comment in `app_router`. |

### Backend contract (pre-read per CLAUDE.md Rule 10)

Wire shapes confirmed from `backend/internal/externalsecrets/actions.go` + `bulk.go` before any Dart was written:
- `POST /v1/externalsecrets/externalsecrets/{ns}/{name}/force-sync` → 202 with `{data:{status:"force-syncing"}}`; 409 reason `already_refreshing`; 501 non-local; 503 ESO unavailable.
- `GET /v1/externalsecrets/{stores/{ns}/{name}|clusterstores/{name}|refresh-namespace/{ns}}/refresh-scope` → `{data:{action,scopeTarget,totalCount,totalNamespaces,visibleCount,restricted,targets,byNamespace}}`.
- `POST /v1/externalsecrets/{stores/{ns}/{name}|clusterstores/{name}|refresh-namespace/{ns}}/refresh-all` with REQUIRED `{targetUIDs:[...]}` body → 202 `{data:{jobId,targetCount}}`; 400 if UIDs missing; 409 reason `active_job_exists` with `extra.jobId`; 409 reason `scope_changed` with `extra.added/removed`; 413 oversized; 422 empty scope.
- `GET /v1/externalsecrets/bulk-refresh-jobs/{jobId}` → polled every 2s until `completedAt` non-null.

### Mobile invariants honored

- ✅ All writes route through controllers that pin the active cluster at construction and re-check via `RefreshableController._clusterStillPinned(_PinPhase.postEmission)` after every await.
- ✅ Type-to-confirm via the single `confirm_sheet.dart` surface (matches web `ConfirmDialog.tsx`).
- ✅ Web/Dart isomorphism — wire types mirror `frontend/lib/eso-types.ts` and `backend/.../bulk.go` field-for-field; web/Dart action maps stay parallel.
- ✅ Drift tri-state coloring: `Unknown` is `textMuted`, never red; the post-Force-Sync transient state respects this.
- ✅ Cluster-scoped vs namespaced routing isolated to the EsoRepository URL helpers — no new routing branches in widgets.

### Small additive side change

`ApiError` gained a typed `extra: Map<String,dynamic>?` field + `extraString(key)` helper, mirroring web's `errorExtra(err, key)` shape. This was unavoidable — the 409 `active_job_exists` attach branch is required by the plan (R3) and the previous mobile `ApiError` silently dropped the `extra.jobId` payload.

## Test plan

- [x] `cd mobile && flutter analyze` — clean
- [x] `cd mobile && flutter test` — **1029/1029 passing** repo-wide
- [x] `make check-themes` — themes in sync
- [x] **20 new controller-level tests**: full state machine walks (3 variants), happy paths, header pinning, fast-double-tap idempotency, 409 active_job_exists attach, 409 scope_changed re-resolve, 501/503/403/404/422, cluster-pin race postEmission, transient poll error
- [x] **8 new widget tests**: scope-pick gating, confirm REFRESH-token case sensitivity, zero-visible no-permission path, poll Semantics liveRegion, takingLong banner, attachedToExistingJob banner, done summary, error state
- [x] Existing detail-screen test continues to pass (no reference to the removed button)
- [ ] Live smoke against homelab (deferred per the planning conversation — static verification was sufficient to land; will smoke when next on the local cluster)

## Out of scope

- No backend changes (per M5 scope: only PR-5b touches backend, which already shipped)
- No remote-cluster ESO writes (the backend's `rejectNonLocalClusterWrite` is a hard contract; mobile gates the UI as the first line of defense)
- ESO sync history surface (deferred per `mobile-app-m5-pr-sequence.md` "Deferred to Follow-Up Work")
- Drift-only-revert action distinct from Force Sync (deferred; needs a backend feature request first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)