### PR TITLE
feat(mobile): M5 PR-5f — M4 polish carryovers (chart zoom, compliance picker, admin all-NS LogQL, service autoderivation)

### DIFF
--- a/mobile/lib/features/mesh/golden_signals_tab.dart
+++ b/mobile/lib/features/mesh/golden_signals_tab.dart
@@ -41,47 +41,39 @@ class GoldenSignalsTab extends ConsumerStatefulWidget {
   /// Single-service entry point — used by Service detail. Equivalent to
   /// passing `candidates: [service]` but kept distinct so existing
   /// call sites don't need to wrap their service name in a list.
-  const GoldenSignalsTab({
+  GoldenSignalsTab({
     super.key,
     required this.namespace,
     required String service,
     required this.status,
-  })  : candidates = const [],
-        _explicitService = service;
+  }) : effectiveCandidates = <String>[service];
 
   /// Multi-service entry point — used by Pod and Deployment detail.
-  /// When [candidates] has 2+ entries, the tab renders a picker so the
-  /// operator can switch between the candidate Services derived from
-  /// the resource's labels.
-  const GoldenSignalsTab.fromCandidates({
+  /// When [effectiveCandidates] has 2+ entries, the tab renders a
+  /// picker so the operator can switch between candidate Services
+  /// derived from the resource's labels.
+  GoldenSignalsTab.fromCandidates({
     super.key,
     required this.namespace,
-    required this.candidates,
+    required List<String> candidates,
     required this.status,
-  })  : _explicitService = null,
-        assert(candidates.length > 0,
-            'GoldenSignalsTab.fromCandidates requires at least one candidate');
+  })  : assert(candidates.isNotEmpty,
+            'GoldenSignalsTab.fromCandidates requires at least one candidate'),
+        effectiveCandidates = List<String>.unmodifiable(candidates);
 
   final String namespace;
 
-  /// Candidate Service names for the picker. Empty when the tab was
-  /// constructed via the single-service constructor.
-  final List<String> candidates;
-
-  /// Original single-service value, if the tab was built via the
-  /// single-service constructor.
-  final String? _explicitService;
+  /// Non-empty list of Service names this tab can render signals for,
+  /// in display order. Single-service callers get a 1-element list;
+  /// multi-candidate callers pass the list directly. Always at least
+  /// one element — both constructors enforce this without relying on a
+  /// debug-only assert.
+  final List<String> effectiveCandidates;
 
   /// Resolved mesh status; carries `detected` so the tab knows
   /// whether to render the mesh picker (both installed) or auto-
   /// select the single installed mesh.
   final MeshStatus status;
-
-  /// All Service names this tab can render signals for, in display
-  /// order. Single-service callers get a list of length 1; multi-
-  /// candidate callers pass the list directly.
-  List<String> get effectiveCandidates =>
-      candidates.isNotEmpty ? candidates : <String>[_explicitService!];
 
   @override
   ConsumerState<GoldenSignalsTab> createState() => _GoldenSignalsTabState();

--- a/mobile/lib/features/mesh/golden_signals_tab.dart
+++ b/mobile/lib/features/mesh/golden_signals_tab.dart
@@ -29,22 +29,59 @@ import 'mesh_widgets.dart';
 
 /// Body of the Metrics-style tab on Service detail. The host
 /// [Widget.build] is reached only when `meshStatus.isInstalled`
-/// — the Service detail screen gates the tab visibility.
+/// — the parent detail screen gates the tab visibility.
+///
+/// PR-5f: Pod and Deployment detail screens also surface this tab
+/// when [findServicesForResource] returns one or more matching
+/// Services. When multiple Services match a single Pod/Deployment, the
+/// tab shows an in-tab picker so the operator can switch which
+/// Service's signals they're inspecting without leaving the detail
+/// route.
 class GoldenSignalsTab extends ConsumerStatefulWidget {
+  /// Single-service entry point — used by Service detail. Equivalent to
+  /// passing `candidates: [service]` but kept distinct so existing
+  /// call sites don't need to wrap their service name in a list.
   const GoldenSignalsTab({
     super.key,
     required this.namespace,
-    required this.service,
+    required String service,
     required this.status,
-  });
+  })  : candidates = const [],
+        _explicitService = service;
+
+  /// Multi-service entry point — used by Pod and Deployment detail.
+  /// When [candidates] has 2+ entries, the tab renders a picker so the
+  /// operator can switch between the candidate Services derived from
+  /// the resource's labels.
+  const GoldenSignalsTab.fromCandidates({
+    super.key,
+    required this.namespace,
+    required this.candidates,
+    required this.status,
+  })  : _explicitService = null,
+        assert(candidates.length > 0,
+            'GoldenSignalsTab.fromCandidates requires at least one candidate');
 
   final String namespace;
-  final String service;
+
+  /// Candidate Service names for the picker. Empty when the tab was
+  /// constructed via the single-service constructor.
+  final List<String> candidates;
+
+  /// Original single-service value, if the tab was built via the
+  /// single-service constructor.
+  final String? _explicitService;
 
   /// Resolved mesh status; carries `detected` so the tab knows
   /// whether to render the mesh picker (both installed) or auto-
   /// select the single installed mesh.
   final MeshStatus status;
+
+  /// All Service names this tab can render signals for, in display
+  /// order. Single-service callers get a list of length 1; multi-
+  /// candidate callers pass the list directly.
+  List<String> get effectiveCandidates =>
+      candidates.isNotEmpty ? candidates : <String>[_explicitService!];
 
   @override
   ConsumerState<GoldenSignalsTab> createState() => _GoldenSignalsTabState();
@@ -52,16 +89,29 @@ class GoldenSignalsTab extends ConsumerStatefulWidget {
 
 class _GoldenSignalsTabState extends ConsumerState<GoldenSignalsTab> {
   String? _mesh;
+  // Active Service when the tab carries multiple candidates. For
+  // single-service callers this stays equal to the only candidate and
+  // the picker UI is hidden.
+  late String _activeService;
 
   @override
   void initState() {
     super.initState();
     _mesh = _deriveMesh(widget.status, null);
+    _activeService = widget.effectiveCandidates.first;
   }
 
   @override
   void didUpdateWidget(GoldenSignalsTab oldWidget) {
     super.didUpdateWidget(oldWidget);
+    // If the parent re-derives candidates (e.g. labels changed under a
+    // running detail screen), preserve the active selection when it's
+    // still in the new candidate list; otherwise fall back to the new
+    // first entry so the tab never points at a vanished Service.
+    final newCandidates = widget.effectiveCandidates;
+    if (!newCandidates.contains(_activeService)) {
+      _activeService = newCandidates.first;
+    }
     if (oldWidget.status.detected == widget.status.detected) return;
     // Re-derive preferred mesh from the new status. If the currently
     // selected mesh is still installed, keep it; otherwise fall back to
@@ -101,8 +151,45 @@ class _GoldenSignalsTabState extends ConsumerState<GoldenSignalsTab> {
       }
     });
 
+    final candidates = widget.effectiveCandidates;
+    final showServicePicker = candidates.length > 1;
+
     return Column(
       children: [
+        if (showServicePicker)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+            child: Row(
+              children: [
+                Text(
+                  'Service',
+                  style: TextStyle(color: colors.textMuted, fontSize: 12),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: DropdownButtonFormField<String>(
+                    key: const ValueKey('goldenSignals-service-picker'),
+                    initialValue: _activeService,
+                    isExpanded: true,
+                    decoration: const InputDecoration(
+                      isDense: true,
+                      border: OutlineInputBorder(),
+                      contentPadding: EdgeInsets.symmetric(
+                          horizontal: 12, vertical: 8),
+                    ),
+                    items: [
+                      for (final s in candidates)
+                        DropdownMenuItem<String>(value: s, child: Text(s)),
+                    ],
+                    onChanged: (v) {
+                      if (v == null) return;
+                      setState(() => _activeService = v);
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
         if (widget.status.hasBoth)
           Padding(
             padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
@@ -136,7 +223,7 @@ class _GoldenSignalsTabState extends ConsumerState<GoldenSignalsTab> {
               : _SignalsBody(
                   clusterId: clusterId,
                   namespace: widget.namespace,
-                  service: widget.service,
+                  service: _activeService,
                   mesh: _mesh,
                 ),
         ),

--- a/mobile/lib/features/mesh/golden_signals_tab.dart
+++ b/mobile/lib/features/mesh/golden_signals_tab.dart
@@ -97,7 +97,7 @@ class _GoldenSignalsTabState extends ConsumerState<GoldenSignalsTab> {
   @override
   void initState() {
     super.initState();
-    _mesh = _deriveMesh(widget.status, null);
+    _mesh = _deriveMesh(widget.status);
     _activeService = widget.effectiveCandidates.first;
   }
 
@@ -116,7 +116,7 @@ class _GoldenSignalsTabState extends ConsumerState<GoldenSignalsTab> {
     // Re-derive preferred mesh from the new status. If the currently
     // selected mesh is still installed, keep it; otherwise fall back to
     // the auto-derived choice (or null when both are still installed).
-    final auto = _deriveMesh(widget.status, null);
+    final auto = _deriveMesh(widget.status);
     if (_mesh != null && !_isMeshInstalled(_mesh!, widget.status)) {
       // Previously selected mesh is no longer detected — clear.
       setState(() => _mesh = auto);
@@ -128,7 +128,7 @@ class _GoldenSignalsTabState extends ConsumerState<GoldenSignalsTab> {
 
   /// Returns the auto-selected mesh when exactly one is installed, or
   /// null when both (or neither) are installed.
-  static String? _deriveMesh(MeshStatus status, String? current) {
+  static String? _deriveMesh(MeshStatus status) {
     if (status.hasIstio && !status.hasLinkerd) return 'istio';
     if (status.hasLinkerd && !status.hasIstio) return 'linkerd';
     return null;
@@ -147,7 +147,7 @@ class _GoldenSignalsTabState extends ConsumerState<GoldenSignalsTab> {
     // carrying over the previous selection.
     ref.listen<String>(activeClusterProvider, (previous, next) {
       if (previous != next) {
-        setState(() => _mesh = _deriveMesh(widget.status, null));
+        setState(() => _mesh = _deriveMesh(widget.status));
       }
     });
 
@@ -396,7 +396,11 @@ class _TileGrid extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = Theme.of(context).extension<KubeColors>()!;
     // Backend's missing-query keys match the JSON tag basenames; we
-    // pre-compute one source-of-truth bag here.
+    // pre-compute one source-of-truth bag here. errorRate is missing
+    // when any of its three contributing series fail to evaluate.
+    final errorMissing = signals.isMetricMissing('errorRate') ||
+        signals.isMetricMissing('errorNum') ||
+        signals.isMetricMissing('errorDen');
     final tiles = <_TileData>[
       _TileData(
         label: 'Requests / s',
@@ -410,20 +414,14 @@ class _TileGrid extends StatelessWidget {
           'errorRate',
           signals.errorRate,
           '%',
-          missing: signals.isMetricMissing('errorRate') ||
-              signals.isMetricMissing('errorNum') ||
-              signals.isMetricMissing('errorDen'),
+          missing: errorMissing,
         ),
-        color: signals.isMetricMissing('errorRate') ||
-                signals.isMetricMissing('errorNum') ||
-                signals.isMetricMissing('errorDen')
+        color: errorMissing
             ? colors.textMuted
             : signals.errorRate > 0.05
                 ? colors.error
                 : colors.success,
-        missing: signals.isMetricMissing('errorRate') ||
-            signals.isMetricMissing('errorNum') ||
-            signals.isMetricMissing('errorDen'),
+        missing: errorMissing,
       ),
       _TileData(
         label: 'p50 latency',

--- a/mobile/lib/features/observability/logs/log_filter_bar.dart
+++ b/mobile/lib/features/observability/logs/log_filter_bar.dart
@@ -289,6 +289,19 @@ class _LogFilterBarState extends ConsumerState<LogFilterBar> {
     if (_mode == LogQueryMode.logql && _rawLogql.trim().isEmpty) {
       return false;
     }
+    // Admin "All namespaces" without any other filter would emit a bare
+    // `{}` selector, which Loki rejects with a parse error and the
+    // backend surfaces as an opaque 502. Require at least one additional
+    // matcher (pod/container/severity/contains) so the operator gets a
+    // disabled-button signal instead of a failed query.
+    if (_mode == LogQueryMode.search &&
+        _allNamespaces &&
+        (_pod == null || _pod!.isEmpty) &&
+        (_container == null || _container!.isEmpty) &&
+        _severity == null &&
+        _freeText.isEmpty) {
+      return false;
+    }
     return true;
   }
 
@@ -334,6 +347,7 @@ class _LogFilterBarState extends ConsumerState<LogFilterBar> {
             if (_isAdmin)
               _AllNamespacesCheckbox(
                 value: _allNamespaces,
+                enabled: !widget.inFlight,
                 onChanged: (v) {
                   setState(() {
                     _allNamespaces = v;
@@ -553,17 +567,22 @@ class _AllNamespacesCheckbox extends StatelessWidget {
   const _AllNamespacesCheckbox({
     required this.value,
     required this.onChanged,
+    this.enabled = true,
   });
 
   final bool value;
   final ValueChanged<bool> onChanged;
+
+  /// Gates user interaction during in-flight log submissions so a tap
+  /// can't silently widen the query scope between submissions.
+  final bool enabled;
 
   @override
   Widget build(BuildContext context) {
     final colors = Theme.of(context).extension<KubeColors>()!;
     return InkWell(
       key: const ValueKey('logFilter-allNamespaces'),
-      onTap: () => onChanged(!value),
+      onTap: enabled ? () => onChanged(!value) : null,
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: 4),
         child: Row(
@@ -573,7 +592,7 @@ class _AllNamespacesCheckbox extends StatelessWidget {
               height: 24,
               child: Checkbox(
                 value: value,
-                onChanged: (v) => onChanged(v ?? false),
+                onChanged: enabled ? (v) => onChanged(v ?? false) : null,
                 visualDensity: VisualDensity.compact,
                 materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
               ),
@@ -583,7 +602,7 @@ class _AllNamespacesCheckbox extends StatelessWidget {
               child: Text(
                 'All namespaces (admin)',
                 style: TextStyle(
-                  color: colors.textPrimary,
+                  color: enabled ? colors.textPrimary : colors.textMuted,
                   fontSize: 14,
                 ),
               ),

--- a/mobile/lib/features/observability/logs/log_filter_bar.dart
+++ b/mobile/lib/features/observability/logs/log_filter_bar.dart
@@ -86,6 +86,10 @@ class _LogFilterBarState extends ConsumerState<LogFilterBar> {
   String? _namespace;
   String? _pod;
   String? _container;
+  // PR-5f: explicit admin-only toggle that emits a query without the
+  // namespace selector. The dropdown's null option still works for
+  // backwards-compat; this checkbox is the discoverable surface.
+  bool _allNamespaces = false;
   LogSeverity? _severity;
   String _freeText = '';
   String _rawLogql = '';
@@ -225,7 +229,13 @@ class _LogFilterBarState extends ConsumerState<LogFilterBar> {
     if (_mode == LogQueryMode.logql) return _rawLogql;
 
     final matchers = <String>[];
-    if (_namespace != null && _namespace!.isNotEmpty) {
+    // The all-namespaces checkbox takes precedence — when on, the
+    // namespace matcher is skipped regardless of what the dropdown
+    // value happens to be (we also force it to null when the checkbox
+    // toggles, but defending against drift is cheap).
+    if (!_allNamespaces &&
+        _namespace != null &&
+        _namespace!.isNotEmpty) {
       matchers.add('namespace="${_namespace!}"');
     }
     if (_pod != null && _pod!.isNotEmpty) {
@@ -321,11 +331,34 @@ class _LogFilterBarState extends ConsumerState<LogFilterBar> {
           ),
           const SizedBox(height: 12),
           if (_mode == LogQueryMode.search) ...[
+            if (_isAdmin)
+              _AllNamespacesCheckbox(
+                value: _allNamespaces,
+                onChanged: (v) {
+                  setState(() {
+                    _allNamespaces = v;
+                    if (v) {
+                      // Clearing namespace and the cascaded selectors
+                      // when switching to all-NS prevents a stale pod
+                      // dropdown from leaking into the next un-toggle
+                      // — the operator's intent is "ignore namespace
+                      // scope", not "remember it under the toggle".
+                      _namespace = null;
+                      _pod = null;
+                      _container = null;
+                      _pods = const [];
+                      _containers = const [];
+                    }
+                  });
+                },
+              ),
+            if (_isAdmin) const SizedBox(height: 4),
             _NamespaceDropdown(
               namespaces: _namespaces,
               value: _namespace,
               loading: _loadingNamespaces,
               isAdmin: _isAdmin,
+              enabled: !_allNamespaces,
               onChanged: (v) {
                 setState(() {
                   _namespace = v;
@@ -469,6 +502,7 @@ class _NamespaceDropdown extends StatelessWidget {
     required this.loading,
     required this.isAdmin,
     required this.onChanged,
+    this.enabled = true,
   });
 
   final List<String> namespaces;
@@ -476,6 +510,7 @@ class _NamespaceDropdown extends StatelessWidget {
   final bool loading;
   final bool isAdmin;
   final ValueChanged<String?> onChanged;
+  final bool enabled;
 
   @override
   Widget build(BuildContext context) {
@@ -493,7 +528,9 @@ class _NamespaceDropdown extends StatelessWidget {
       isExpanded: true,
       decoration: InputDecoration(
         labelText: 'Namespace${isAdmin ? '' : ' *'}',
-        helperText: loading ? 'Loading…' : null,
+        helperText: loading
+            ? 'Loading…'
+            : (!enabled ? 'Disabled — using all namespaces' : null),
         border: const OutlineInputBorder(),
         isDense: true,
       ),
@@ -507,7 +544,53 @@ class _NamespaceDropdown extends StatelessWidget {
         for (final ns in items)
           DropdownMenuItem<String?>(value: ns, child: Text(ns)),
       ],
-      onChanged: onChanged,
+      onChanged: enabled ? onChanged : null,
+    );
+  }
+}
+
+class _AllNamespacesCheckbox extends StatelessWidget {
+  const _AllNamespacesCheckbox({
+    required this.value,
+    required this.onChanged,
+  });
+
+  final bool value;
+  final ValueChanged<bool> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return InkWell(
+      key: const ValueKey('logFilter-allNamespaces'),
+      onTap: () => onChanged(!value),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 4),
+        child: Row(
+          children: [
+            SizedBox(
+              width: 24,
+              height: 24,
+              child: Checkbox(
+                value: value,
+                onChanged: (v) => onChanged(v ?? false),
+                visualDensity: VisualDensity.compact,
+                materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              ),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                'All namespaces (admin)',
+                style: TextStyle(
+                  color: colors.textPrimary,
+                  fontSize: 14,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/mobile/lib/features/observability/logs/log_filter_bar.dart
+++ b/mobile/lib/features/observability/logs/log_filter_bar.dart
@@ -55,6 +55,16 @@ extension on LogSeverity {
 /// Callback invoked when the operator presses Run on the filter bar.
 typedef LogSearchSubmit = void Function(LogSearchParams params);
 
+/// Escapes a literal value for safe embedding inside a double-quoted
+/// LogQL string. Backslash and double-quote are the two characters
+/// that need escaping inside `"..."` matchers — without this, a `"` in
+/// operator-supplied input breaks out of the quoted region and can
+/// inject adjacent matchers into the query. Exported so tests and any
+/// future LogQL-building call site can share the same contract.
+String escapeLogQLLiteral(String input) {
+  return input.replaceAll(r'\', r'\\').replaceAll('"', r'\"');
+}
+
 class LogFilterBar extends ConsumerStatefulWidget {
   const LogFilterBar({
     required this.onSubmit,
@@ -105,6 +115,15 @@ class _LogFilterBarState extends ConsumerState<LogFilterBar> {
   bool _loadingPods = false;
   bool _loadingContainers = false;
 
+  // Last fetch error per cascade level. Surfacing these in dropdown
+  // helper text lets non-admin users distinguish "no namespaces exist
+  // in this cluster" from "the label-values API call failed", and
+  // gives them a tap-to-retry affordance instead of a permanently
+  // disabled Run button with no signal.
+  String? _namespaceFetchError;
+  String? _podFetchError;
+  String? _containerFetchError;
+
   @override
   void initState() {
     super.initState();
@@ -134,7 +153,10 @@ class _LogFilterBarState extends ConsumerState<LogFilterBar> {
 
   Future<void> _fetchNamespaces() async {
     if (!mounted) return;
-    setState(() => _loadingNamespaces = true);
+    setState(() {
+      _loadingNamespaces = true;
+      _namespaceFetchError = null;
+    });
     final clusterId = ref.read(activeClusterProvider);
     try {
       final values = await ref
@@ -144,11 +166,19 @@ class _LogFilterBarState extends ConsumerState<LogFilterBar> {
       setState(() {
         _namespaces = values;
       });
+    } catch (e) {
+      // Surface the failure to the dropdown so the operator can
+      // distinguish "no namespaces" from "fetch failed". The repository
+      // soft-degrades 403/502/503 to empty lists already; this catch
+      // covers the harder failures (timeout, 401, 500).
+      if (mounted) {
+        setState(() => _namespaceFetchError = 'Could not load namespaces');
+      }
     } finally {
-      // Reset the loading flag even on non-graceful errors (401, 500,
-      // network timeout). Without this, the repository's narrow
-      // 403/502/503 soft-degrade leaves the dropdown stuck on
-      // "Loading…" indefinitely for any other failure mode.
+      // Reset the loading flag even on non-graceful errors. Without
+      // this, the repository's narrow 403/502/503 soft-degrade leaves
+      // the dropdown stuck on "Loading…" indefinitely for any other
+      // failure mode.
       if (mounted) {
         setState(() => _loadingNamespaces = false);
       }
@@ -165,7 +195,10 @@ class _LogFilterBarState extends ConsumerState<LogFilterBar> {
       return;
     }
     if (!mounted) return;
-    setState(() => _loadingPods = true);
+    setState(() {
+      _loadingPods = true;
+      _podFetchError = null;
+    });
     final clusterId = ref.read(activeClusterProvider);
     try {
       final values = await ref.read(lokiRepositoryProvider).labelValues(
@@ -184,6 +217,10 @@ class _LogFilterBarState extends ConsumerState<LogFilterBar> {
         _pods = values;
         _containers = const [];
       });
+    } catch (e) {
+      if (mounted && _namespace == ns) {
+        setState(() => _podFetchError = 'Could not load pods');
+      }
     } finally {
       if (mounted && _namespace == ns) {
         setState(() => _loadingPods = false);
@@ -199,7 +236,10 @@ class _LogFilterBarState extends ConsumerState<LogFilterBar> {
       return;
     }
     if (!mounted) return;
-    setState(() => _loadingContainers = true);
+    setState(() {
+      _loadingContainers = true;
+      _containerFetchError = null;
+    });
     final clusterId = ref.read(activeClusterProvider);
     try {
       final values = await ref.read(lokiRepositoryProvider).labelValues(
@@ -216,6 +256,10 @@ class _LogFilterBarState extends ConsumerState<LogFilterBar> {
       setState(() {
         _containers = values;
       });
+    } catch (e) {
+      if (mounted && _namespace == ns && _pod == pod) {
+        setState(() => _containerFetchError = 'Could not load containers');
+      }
     } finally {
       if (mounted && _namespace == ns && _pod == pod) {
         setState(() => _loadingContainers = false);
@@ -239,17 +283,21 @@ class _LogFilterBarState extends ConsumerState<LogFilterBar> {
       matchers.add('namespace="${_namespace!}"');
     }
     if (_pod != null && _pod!.isNotEmpty) {
-      matchers.add('pod=~"${_pod!}.*"');
+      matchers.add('pod=~"${escapeLogQLLiteral(_pod!)}.*"');
     }
     if (_container != null && _container!.isNotEmpty) {
-      matchers.add('container="${_container!}"');
+      matchers.add('container="${escapeLogQLLiteral(_container!)}"');
     }
     var q = '{${matchers.join(',')}}';
     if (_severity != null) {
       q += ' | level=~"(?i)${_severity!.value}"';
     }
     if (_freeText.isNotEmpty) {
-      q += ' |= "$_freeText"';
+      // PR-5f review fix #29: escape free-text Contains. A literal `"`
+      // or `\` in the operator's input would otherwise break the LogQL
+      // string and at minimum return a parse error, at worst inject
+      // adjacent matchers into the query.
+      q += ' |= "${escapeLogQLLiteral(_freeText)}"';
     }
     return q;
   }
@@ -274,6 +322,13 @@ class _LogFilterBarState extends ConsumerState<LogFilterBar> {
     });
   }
 
+  /// Single source of truth for whether the form requires the operator
+  /// to pick a namespace before submitting. Used by both [_runEnabled]
+  /// and the bottom-row UI hint so a future condition can be added in
+  /// one place rather than the two-branches-170-lines-apart layout.
+  bool get _requiresNamespaceSelection =>
+      !_isAdmin && (_namespace == null || _namespace!.isEmpty);
+
   bool get _runEnabled {
     // While a prior submission is still in flight, gate further taps
     // so the operator can't stack concurrent queries with a fast double
@@ -282,7 +337,7 @@ class _LogFilterBarState extends ConsumerState<LogFilterBar> {
     // Non-admin without a namespace can't submit — backend hard-403s
     // and the UX is clearer with a disabled button than a
     // post-submit error card.
-    if (!_isAdmin && (_namespace == null || _namespace!.isEmpty)) {
+    if (_requiresNamespaceSelection) {
       return false;
     }
     // LogQL mode requires non-empty query text.
@@ -373,6 +428,8 @@ class _LogFilterBarState extends ConsumerState<LogFilterBar> {
               loading: _loadingNamespaces,
               isAdmin: _isAdmin,
               enabled: !_allNamespaces,
+              fetchError: _namespaceFetchError,
+              onRetry: _fetchNamespaces,
               onChanged: (v) {
                 setState(() {
                   _namespace = v;
@@ -388,6 +445,8 @@ class _LogFilterBarState extends ConsumerState<LogFilterBar> {
               value: _pod,
               loading: _loadingPods,
               enabled: _namespace != null && _namespace!.isNotEmpty,
+              fetchError: _podFetchError,
+              onRetry: _fetchPods,
               onChanged: (v) {
                 setState(() {
                   _pod = v;
@@ -402,6 +461,8 @@ class _LogFilterBarState extends ConsumerState<LogFilterBar> {
               value: _container,
               loading: _loadingContainers,
               enabled: _pod != null && _pod!.isNotEmpty,
+              fetchError: _containerFetchError,
+              onRetry: _fetchContainers,
               onChanged: (v) => setState(() => _container = v),
             ),
             const SizedBox(height: 12),
@@ -454,8 +515,7 @@ class _LogFilterBarState extends ConsumerState<LogFilterBar> {
           const SizedBox(height: 12),
           Row(
             children: [
-              if (!_isAdmin &&
-                  (_namespace == null || _namespace!.isEmpty)) ...[
+              if (_requiresNamespaceSelection) ...[
                 Icon(Icons.info_outline, size: 14, color: colors.warning),
                 const SizedBox(width: 4),
                 Expanded(
@@ -516,7 +576,9 @@ class _NamespaceDropdown extends StatelessWidget {
     required this.loading,
     required this.isAdmin,
     required this.onChanged,
+    required this.onRetry,
     this.enabled = true,
+    this.fetchError,
   });
 
   final List<String> namespaces;
@@ -524,7 +586,9 @@ class _NamespaceDropdown extends StatelessWidget {
   final bool loading;
   final bool isAdmin;
   final ValueChanged<String?> onChanged;
+  final VoidCallback onRetry;
   final bool enabled;
+  final String? fetchError;
 
   @override
   Widget build(BuildContext context) {
@@ -536,29 +600,76 @@ class _NamespaceDropdown extends StatelessWidget {
       if (value != null && value!.isNotEmpty) value!,
     }.toList()
       ..sort();
-    return DropdownButtonFormField<String?>(
-      key: const ValueKey('logFilter-namespace'),
-      initialValue: value,
-      isExpanded: true,
-      decoration: InputDecoration(
-        labelText: 'Namespace${isAdmin ? '' : ' *'}',
-        helperText: loading
-            ? 'Loading…'
-            : (!enabled ? 'Disabled — using all namespaces' : null),
-        border: const OutlineInputBorder(),
-        isDense: true,
+    return _DropdownWithRetry(
+      fetchError: fetchError,
+      onRetry: onRetry,
+      child: DropdownButtonFormField<String?>(
+        key: const ValueKey('logFilter-namespace'),
+        initialValue: value,
+        isExpanded: true,
+        decoration: InputDecoration(
+          labelText: 'Namespace${isAdmin ? '' : ' *'}',
+          helperText: loading
+              ? 'Loading…'
+              : (!enabled
+                  ? 'Disabled — using all namespaces'
+                  : (fetchError != null ? '$fetchError — tap retry' : null)),
+          border: const OutlineInputBorder(),
+          isDense: true,
+        ),
+        hint: Text(isAdmin ? 'All namespaces' : 'Pick a namespace'),
+        items: [
+          if (isAdmin)
+            const DropdownMenuItem<String?>(
+              value: null,
+              child: Text('All namespaces'),
+            ),
+          for (final ns in items)
+            DropdownMenuItem<String?>(value: ns, child: Text(ns)),
+        ],
+        onChanged: enabled ? onChanged : null,
       ),
-      hint: Text(isAdmin ? 'All namespaces' : 'Pick a namespace'),
-      items: [
-        if (isAdmin)
-          const DropdownMenuItem<String?>(
-            value: null,
-            child: Text('All namespaces'),
+    );
+  }
+}
+
+/// Wraps a fetch-backed dropdown with a small Retry button when the
+/// most recent fetch failed. Keeps the dropdown selectable for any
+/// already-loaded values; the button re-fires the fetch the caller
+/// supplies.
+class _DropdownWithRetry extends StatelessWidget {
+  const _DropdownWithRetry({
+    required this.child,
+    required this.fetchError,
+    required this.onRetry,
+  });
+
+  final Widget child;
+  final String? fetchError;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    if (fetchError == null) return child;
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Expanded(child: child),
+        const SizedBox(width: 4),
+        Padding(
+          padding: const EdgeInsets.only(top: 4),
+          child: TextButton(
+            key: const ValueKey('logFilter-retryFetch'),
+            onPressed: onRetry,
+            style: TextButton.styleFrom(
+              minimumSize: const Size(48, 36),
+              padding: const EdgeInsets.symmetric(horizontal: 8),
+              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            ),
+            child: const Text('Retry'),
           ),
-        for (final ns in items)
-          DropdownMenuItem<String?>(value: ns, child: Text(ns)),
+        ),
       ],
-      onChanged: enabled ? onChanged : null,
     );
   }
 }
@@ -621,6 +732,8 @@ class _PodDropdown extends StatelessWidget {
     required this.loading,
     required this.enabled,
     required this.onChanged,
+    required this.onRetry,
+    this.fetchError,
   });
 
   final List<String> pods;
@@ -628,6 +741,8 @@ class _PodDropdown extends StatelessWidget {
   final bool loading;
   final bool enabled;
   final ValueChanged<String?> onChanged;
+  final VoidCallback onRetry;
+  final String? fetchError;
 
   @override
   Widget build(BuildContext context) {
@@ -636,25 +751,31 @@ class _PodDropdown extends StatelessWidget {
       if (value != null && value!.isNotEmpty) value!,
     }.toList()
       ..sort();
-    return DropdownButtonFormField<String?>(
-      key: const ValueKey('logFilter-pod'),
-      initialValue: value,
-      isExpanded: true,
-      decoration: InputDecoration(
-        labelText: 'Pod (optional)',
-        helperText: loading
-            ? 'Loading…'
-            : (!enabled ? 'Pick a namespace first' : null),
-        border: const OutlineInputBorder(),
-        isDense: true,
+    return _DropdownWithRetry(
+      fetchError: enabled ? fetchError : null,
+      onRetry: onRetry,
+      child: DropdownButtonFormField<String?>(
+        key: const ValueKey('logFilter-pod'),
+        initialValue: value,
+        isExpanded: true,
+        decoration: InputDecoration(
+          labelText: 'Pod (optional)',
+          helperText: loading
+              ? 'Loading…'
+              : (!enabled
+                  ? 'Pick a namespace first'
+                  : (fetchError != null ? '$fetchError — tap retry' : null)),
+          border: const OutlineInputBorder(),
+          isDense: true,
+        ),
+        hint: const Text('All pods'),
+        items: [
+          const DropdownMenuItem<String?>(value: null, child: Text('All pods')),
+          for (final p in items)
+            DropdownMenuItem<String?>(value: p, child: Text(p)),
+        ],
+        onChanged: enabled ? onChanged : null,
       ),
-      hint: const Text('All pods'),
-      items: [
-        const DropdownMenuItem<String?>(value: null, child: Text('All pods')),
-        for (final p in items)
-          DropdownMenuItem<String?>(value: p, child: Text(p)),
-      ],
-      onChanged: enabled ? onChanged : null,
     );
   }
 }
@@ -666,6 +787,8 @@ class _ContainerDropdown extends StatelessWidget {
     required this.loading,
     required this.enabled,
     required this.onChanged,
+    required this.onRetry,
+    this.fetchError,
   });
 
   final List<String> containers;
@@ -673,6 +796,8 @@ class _ContainerDropdown extends StatelessWidget {
   final bool loading;
   final bool enabled;
   final ValueChanged<String?> onChanged;
+  final VoidCallback onRetry;
+  final String? fetchError;
 
   @override
   Widget build(BuildContext context) {
@@ -681,25 +806,32 @@ class _ContainerDropdown extends StatelessWidget {
       if (value != null && value!.isNotEmpty) value!,
     }.toList()
       ..sort();
-    return DropdownButtonFormField<String?>(
-      key: const ValueKey('logFilter-container'),
-      initialValue: value,
-      isExpanded: true,
-      decoration: InputDecoration(
-        labelText: 'Container (optional)',
-        helperText:
-            loading ? 'Loading…' : (!enabled ? 'Pick a pod first' : null),
-        border: const OutlineInputBorder(),
-        isDense: true,
+    return _DropdownWithRetry(
+      fetchError: enabled ? fetchError : null,
+      onRetry: onRetry,
+      child: DropdownButtonFormField<String?>(
+        key: const ValueKey('logFilter-container'),
+        initialValue: value,
+        isExpanded: true,
+        decoration: InputDecoration(
+          labelText: 'Container (optional)',
+          helperText: loading
+              ? 'Loading…'
+              : (!enabled
+                  ? 'Pick a pod first'
+                  : (fetchError != null ? '$fetchError — tap retry' : null)),
+          border: const OutlineInputBorder(),
+          isDense: true,
+        ),
+        hint: const Text('All containers'),
+        items: [
+          const DropdownMenuItem<String?>(
+              value: null, child: Text('All containers')),
+          for (final c in items)
+            DropdownMenuItem<String?>(value: c, child: Text(c)),
+        ],
+        onChanged: enabled ? onChanged : null,
       ),
-      hint: const Text('All containers'),
-      items: [
-        const DropdownMenuItem<String?>(
-            value: null, child: Text('All containers')),
-        for (final c in items)
-          DropdownMenuItem<String?>(value: c, child: Text(c)),
-      ],
-      onChanged: enabled ? onChanged : null,
     );
   }
 }

--- a/mobile/lib/features/policy/compliance_history_screen.dart
+++ b/mobile/lib/features/policy/compliance_history_screen.dart
@@ -122,14 +122,17 @@ class _HistoryBodyState extends ConsumerState<_HistoryBody> {
     return async.when(
       loading: () {
         if (_lastSuccess != null) {
-          return _StaleHistoryView(
+          // Stale-overlay path: keep the previous chart on screen
+          // (faded with a spinner) while the new ?days window loads.
+          return _HistoryChart(
             points: _lastSuccess!,
             colors: colors,
             days: _days,
+            onDaysChanged: _setDays,
+            stale: true,
             isLoading: true,
             errorMessage: null,
             onRetry: null,
-            onDaysChanged: _setDays,
           );
         }
         return _FreshLoadingView(days: _days);
@@ -150,14 +153,17 @@ class _HistoryBodyState extends ConsumerState<_HistoryBody> {
           );
         }
         if (_lastSuccess != null) {
-          return _StaleHistoryView(
+          // Stale-overlay path: keep the previous chart with a
+          // "Couldn't refresh" banner + Retry CTA.
+          return _HistoryChart(
             points: _lastSuccess!,
             colors: colors,
             days: _days,
+            onDaysChanged: _setDays,
+            stale: true,
             isLoading: false,
             errorMessage: e is ApiError ? e.message : e.toString(),
             onRetry: () => ref.invalidate(complianceHistoryProvider(key)),
-            onDaysChanged: _setDays,
           );
         }
         return _FreshErrorView(
@@ -340,40 +346,6 @@ class _LoadedHistoryView extends StatelessWidget {
 /// (fade + spinner overlay) or after a transient error (banner + retry).
 /// Keeping the previous chart visible avoids a flash-of-blank when the
 /// user picks a different `?days` window or pulls to refresh.
-class _StaleHistoryView extends StatelessWidget {
-  const _StaleHistoryView({
-    required this.points,
-    required this.colors,
-    required this.days,
-    required this.isLoading,
-    required this.errorMessage,
-    required this.onRetry,
-    required this.onDaysChanged,
-  });
-
-  final List<ComplianceHistoryPoint> points;
-  final KubeColors colors;
-  final int days;
-  final bool isLoading;
-  final String? errorMessage;
-  final VoidCallback? onRetry;
-  final ValueChanged<int> onDaysChanged;
-
-  @override
-  Widget build(BuildContext context) {
-    return _HistoryChart(
-      points: points,
-      colors: colors,
-      days: days,
-      onDaysChanged: onDaysChanged,
-      stale: true,
-      isLoading: isLoading,
-      errorMessage: errorMessage,
-      onRetry: onRetry,
-    );
-  }
-}
-
 class _HistoryChart extends StatelessWidget {
   const _HistoryChart({
     required this.points,

--- a/mobile/lib/features/policy/compliance_history_screen.dart
+++ b/mobile/lib/features/policy/compliance_history_screen.dart
@@ -1,13 +1,19 @@
 // Compliance history — admin-only line chart over
-// `GET /v1/policies/compliance/history`. Fixed 30-day window in M4 (per
-// Scope Boundaries — custom ranges deferred to M5 polish).
+// `GET /v1/policies/compliance/history`. PR-5f adds a ?days=N preset
+// picker (1 / 7 / 30 / 90) above the chart. The picker is the only
+// time-range surface here; a custom date-range picker is out of scope
+// for M5 because the backend's compliance history endpoint accepts
+// `?days=N` only — adding `?start=`/`?end=` is a separate backend
+// addendum.
 //
 // 503 distinguished-error path: when the backend responds 503 with body
 // "requires a database", that's the ComplianceStore PostgreSQL persistence
 // being unconfigured. Surface as a permanent (non-retry-able) empty state
 // — pointing the operator at desktop setup rather than offering a Retry
 // button that will deterministically fail again. Other 503s (rolling
-// restarts, network blips) stay retry-able.
+// restarts, network blips) stay retry-able. When previous data is
+// already on screen, the picker disables and the chart fades to 50%
+// during a refresh so transient backend hiccups don't blank the view.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -21,6 +27,10 @@ import '../../widgets/empty_states.dart';
 import '../../widgets/feature_unavailable_state.dart';
 import '../../widgets/kube_line_chart.dart';
 import 'policy_widgets.dart';
+
+/// Preset day windows accepted by the backend's compliance history
+/// endpoint (capped at 90 by `complianceHistory(days:)`).
+const List<int> kCompliancePresetDays = [1, 7, 30, 90];
 
 class ComplianceHistoryScreen extends ConsumerWidget {
   const ComplianceHistoryScreen({super.key});
@@ -52,82 +62,317 @@ class ComplianceHistoryScreen extends ConsumerWidget {
   }
 }
 
-class _HistoryBody extends ConsumerWidget {
+class _HistoryBody extends ConsumerStatefulWidget {
   const _HistoryBody({required this.clusterId});
 
   final String clusterId;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<_HistoryBody> createState() => _HistoryBodyState();
+}
+
+class _HistoryBodyState extends ConsumerState<_HistoryBody> {
+  int _days = 30;
+
+  // Last successfully fetched datapoints. Holding the previous values
+  // across a refresh lets the chart stay visible (faded) while the new
+  // ?days=N response loads, and lets us show "Couldn't refresh" with
+  // the last-known chart on transient errors instead of blanking to
+  // an error state.
+  List<ComplianceHistoryPoint>? _lastSuccess;
+
+  void _setDays(int next) {
+    if (next == _days) return;
+    setState(() => _days = next);
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final colors = Theme.of(context).extension<KubeColors>()!;
-    final async = ref.watch(
-      complianceHistoryProvider(ComplianceHistoryKey(clusterId: clusterId)),
+    final key = ComplianceHistoryKey(
+      clusterId: widget.clusterId,
+      days: _days,
     );
+    final async = ref.watch(complianceHistoryProvider(key));
 
     return async.when(
-      loading: () => const Center(child: CircularProgressIndicator()),
-      error: (e, _) => _ErrorOrUnconfigured(
-        error: e,
-        onRetry: () => ref.invalidate(
-          complianceHistoryProvider(ComplianceHistoryKey(clusterId: clusterId)),
-        ),
-      ),
-      data: (points) {
-        if (points.isEmpty) {
-          return const EmptyState(
-            title: 'No compliance snapshots yet',
-            message:
-                'The compliance store is configured but has not recorded any '
-                'snapshots yet. The first datapoint will appear on the next '
-                'daily aggregation.',
-            icon: Icons.timeline_outlined,
+      loading: () {
+        if (_lastSuccess != null) {
+          return _StaleHistoryView(
+            points: _lastSuccess!,
+            colors: colors,
+            days: _days,
+            isLoading: true,
+            errorMessage: null,
+            onRetry: null,
+            onDaysChanged: _setDays,
           );
         }
-        return _HistoryChart(points: points, colors: colors);
+        return _FreshLoadingView(
+          colors: colors,
+          days: _days,
+        );
+      },
+      error: (e, _) {
+        if (isComplianceHistoryNotConfigured(e)) {
+          // Permanent empty state — no Retry button, no picker either.
+          // The backend deterministically returns 503 with the same
+          // message until PostgreSQL is configured server-side, which
+          // the operator cannot fix from the phone.
+          return const FeatureUnavailableState(
+            featureName: 'Compliance history',
+            helpMessage:
+                'Compliance history requires database storage on the k8sCenter '
+                'backend. Configure PostgreSQL persistence in the Helm values '
+                'to enable historical trend tracking.',
+            icon: Icons.storage_outlined,
+          );
+        }
+        if (_lastSuccess != null) {
+          return _StaleHistoryView(
+            points: _lastSuccess!,
+            colors: colors,
+            days: _days,
+            isLoading: false,
+            errorMessage: e is ApiError ? e.message : e.toString(),
+            onRetry: () => ref.invalidate(complianceHistoryProvider(key)),
+            onDaysChanged: _setDays,
+          );
+        }
+        return _FreshErrorView(
+          message: e is ApiError ? e.message : e.toString(),
+          colors: colors,
+          days: _days,
+          onRetry: () => ref.invalidate(complianceHistoryProvider(key)),
+          onDaysChanged: _setDays,
+        );
+      },
+      data: (points) {
+        _lastSuccess = points;
+        return _LoadedHistoryView(
+          points: points,
+          colors: colors,
+          days: _days,
+          onDaysChanged: _setDays,
+        );
       },
     );
   }
 }
 
-/// Routes the error envelope to either the permanent "database not
-/// configured" empty state or the retry-able generic error view. The
-/// discriminator is the substring match exposed by
-/// [isComplianceHistoryNotConfigured] — both forms hit 503 but only one
-/// should be retried.
-class _ErrorOrUnconfigured extends StatelessWidget {
-  const _ErrorOrUnconfigured({required this.error, required this.onRetry});
+/// SegmentedButton row over [kCompliancePresetDays]. Pulls its
+/// visual treatment from the shared time-range picker (also a
+/// `SegmentedButton`) so the picker reads consistently across the
+/// app's observability surfaces.
+class _DaysPicker extends StatelessWidget {
+  const _DaysPicker({
+    required this.days,
+    required this.enabled,
+    required this.onChanged,
+  });
 
-  final Object error;
-  final VoidCallback onRetry;
+  final int days;
+  final bool enabled;
+  final ValueChanged<int> onChanged;
 
   @override
   Widget build(BuildContext context) {
-    if (isComplianceHistoryNotConfigured(error)) {
-      // Permanent empty state — no Retry button. The backend will
-      // deterministically return 503 with the same message until
-      // PostgreSQL is configured server-side, which the operator cannot
-      // fix from the phone.
-      return const FeatureUnavailableState(
-        featureName: 'Compliance history',
-        helpMessage:
-            'Compliance history requires database storage on the k8sCenter '
-            'backend. Configure PostgreSQL persistence in the Helm values '
-            'to enable historical trend tracking.',
-        icon: Icons.storage_outlined,
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: SegmentedButton<int>(
+        segments: const [
+          ButtonSegment(value: 1, label: Text('1d')),
+          ButtonSegment(value: 7, label: Text('7d')),
+          ButtonSegment(value: 30, label: Text('30d')),
+          ButtonSegment(value: 90, label: Text('90d')),
+        ],
+        selected: {days},
+        onSelectionChanged: enabled ? (s) => onChanged(s.first) : null,
+        showSelectedIcon: false,
+        style: const ButtonStyle(
+          visualDensity: VisualDensity.compact,
+          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        ),
+      ),
+    );
+  }
+}
+
+/// First-load loading view — no previous chart to keep visible, so
+/// render a centered spinner with the picker disabled.
+class _FreshLoadingView extends StatelessWidget {
+  const _FreshLoadingView({required this.colors, required this.days});
+
+  final KubeColors colors;
+  final int days;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+          child: _DaysPicker(days: days, enabled: false, onChanged: (_) {}),
+        ),
+        const Expanded(child: Center(child: CircularProgressIndicator())),
+      ],
+    );
+  }
+}
+
+/// First-load error view — no previous chart, so render a full error
+/// surface with Retry. The picker stays enabled so the operator can try
+/// a shorter window if the larger one is too expensive.
+class _FreshErrorView extends StatelessWidget {
+  const _FreshErrorView({
+    required this.message,
+    required this.colors,
+    required this.days,
+    required this.onRetry,
+    required this.onDaysChanged,
+  });
+
+  final String message;
+  final KubeColors colors;
+  final int days;
+  final VoidCallback onRetry;
+  final ValueChanged<int> onDaysChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+          child: _DaysPicker(
+            days: days,
+            enabled: true,
+            onChanged: onDaysChanged,
+          ),
+        ),
+        Expanded(
+          child: ErrorStateView(message: message, onRetry: onRetry),
+        ),
+      ],
+    );
+  }
+}
+
+/// Steady-state view: backend returned a fresh response. The picker is
+/// enabled; the chart renders as the original M4 layout.
+class _LoadedHistoryView extends StatelessWidget {
+  const _LoadedHistoryView({
+    required this.points,
+    required this.colors,
+    required this.days,
+    required this.onDaysChanged,
+  });
+
+  final List<ComplianceHistoryPoint> points;
+  final KubeColors colors;
+  final int days;
+  final ValueChanged<int> onDaysChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    if (points.isEmpty) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+            child: _DaysPicker(
+              days: days,
+              enabled: true,
+              onChanged: onDaysChanged,
+            ),
+          ),
+          const Expanded(
+            child: EmptyState(
+              title: 'No compliance snapshots yet',
+              message:
+                  'The compliance store is configured but has not recorded '
+                  'any snapshots yet. The first datapoint will appear on '
+                  'the next daily aggregation.',
+              icon: Icons.timeline_outlined,
+            ),
+          ),
+        ],
       );
     }
-    return ErrorStateView(
-      message: error is ApiError ? (error as ApiError).message : error.toString(),
+    return _HistoryChart(
+      points: points,
+      colors: colors,
+      days: days,
+      onDaysChanged: onDaysChanged,
+      stale: false,
+      isLoading: false,
+      errorMessage: null,
+      onRetry: null,
+    );
+  }
+}
+
+/// Stale view: a previous response is on screen while a new one loads
+/// (fade + spinner overlay) or after a transient error (banner + retry).
+/// Keeping the previous chart visible avoids a flash-of-blank when the
+/// user picks a different `?days` window or pulls to refresh.
+class _StaleHistoryView extends StatelessWidget {
+  const _StaleHistoryView({
+    required this.points,
+    required this.colors,
+    required this.days,
+    required this.isLoading,
+    required this.errorMessage,
+    required this.onRetry,
+    required this.onDaysChanged,
+  });
+
+  final List<ComplianceHistoryPoint> points;
+  final KubeColors colors;
+  final int days;
+  final bool isLoading;
+  final String? errorMessage;
+  final VoidCallback? onRetry;
+  final ValueChanged<int> onDaysChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return _HistoryChart(
+      points: points,
+      colors: colors,
+      days: days,
+      onDaysChanged: onDaysChanged,
+      stale: true,
+      isLoading: isLoading,
+      errorMessage: errorMessage,
       onRetry: onRetry,
     );
   }
 }
 
 class _HistoryChart extends StatelessWidget {
-  const _HistoryChart({required this.points, required this.colors});
+  const _HistoryChart({
+    required this.points,
+    required this.colors,
+    required this.days,
+    required this.onDaysChanged,
+    required this.stale,
+    required this.isLoading,
+    required this.errorMessage,
+    required this.onRetry,
+  });
 
   final List<ComplianceHistoryPoint> points;
   final KubeColors colors;
+  final int days;
+  final ValueChanged<int> onDaysChanged;
+  final bool stale;
+  final bool isLoading;
+  final String? errorMessage;
+  final VoidCallback? onRetry;
 
   @override
   Widget build(BuildContext context) {
@@ -157,57 +402,112 @@ class _HistoryChart extends StatelessWidget {
               : KubeChartSeverity.error),
     );
 
+    // While loading, the picker is disabled so the operator can't
+    // queue up multiple ?days changes mid-fetch. Errors re-enable
+    // the picker — the operator may want to try a smaller window.
+    final pickerEnabled = !isLoading;
+
+    final chartCard = Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: colors.bgSurface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colors.borderSubtle),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Text(
+                'Last ${points.length} ${points.length == 1 ? 'day' : 'days'}',
+                style: TextStyle(
+                  color: colors.textPrimary,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const Spacer(),
+              Text(
+                'Latest: ${latest.toStringAsFixed(0)}% · ${tier.label}',
+                style: TextStyle(
+                  color: tier.fg,
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          KubeLineChart(series: [scoreSeries], height: 200),
+          if (droppedDates > 0)
+            Padding(
+              padding: const EdgeInsets.only(top: 8),
+              child: Text(
+                droppedDates == 1
+                    ? '1 datapoint dropped from the chart due to an '
+                        'unparseable date.'
+                    : '$droppedDates datapoints dropped from the '
+                        'chart due to unparseable dates.',
+                style: TextStyle(color: colors.warning, fontSize: 11),
+              ),
+            ),
+        ],
+      ),
+    );
+
+    final Widget chartWithOverlay = isLoading
+        ? Stack(
+            children: [
+              Opacity(opacity: 0.5, child: chartCard),
+              const Positioned.fill(
+                child: Center(child: CircularProgressIndicator()),
+              ),
+            ],
+          )
+        : chartCard;
+
     return ListView(
       padding: const EdgeInsets.all(16),
       children: [
-        Container(
-          padding: const EdgeInsets.all(14),
-          decoration: BoxDecoration(
-            color: colors.bgSurface,
-            borderRadius: BorderRadius.circular(8),
-            border: Border.all(color: colors.borderSubtle),
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                children: [
-                  Text(
-                    'Last ${points.length} ${points.length == 1 ? 'day' : 'days'}',
+        _DaysPicker(
+          days: days,
+          enabled: pickerEnabled,
+          onChanged: onDaysChanged,
+        ),
+        const SizedBox(height: 12),
+        if (errorMessage != null && onRetry != null) ...[
+          Container(
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: colors.warning.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(6),
+              border: Border.all(color: colors.warning.withValues(alpha: 0.5)),
+            ),
+            child: Row(
+              children: [
+                Icon(Icons.warning_amber_rounded,
+                    color: colors.warning, size: 18),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    "Couldn't refresh — showing previous data.",
                     style: TextStyle(
                       color: colors.textPrimary,
-                      fontSize: 14,
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                  const Spacer(),
-                  Text(
-                    'Latest: ${latest.toStringAsFixed(0)}% · ${tier.label}',
-                    style: TextStyle(
-                      color: tier.fg,
                       fontSize: 12,
-                      fontWeight: FontWeight.w600,
                     ),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 12),
-              KubeLineChart(series: [scoreSeries], height: 200),
-              if (droppedDates > 0)
-                Padding(
-                  padding: const EdgeInsets.only(top: 8),
-                  child: Text(
-                    droppedDates == 1
-                        ? '1 datapoint dropped from the chart due to an '
-                            'unparseable date.'
-                        : '$droppedDates datapoints dropped from the '
-                            'chart due to unparseable dates.',
-                    style: TextStyle(color: colors.warning, fontSize: 11),
                   ),
                 ),
-            ],
+                TextButton(
+                  onPressed: onRetry,
+                  child: const Text('Retry'),
+                ),
+              ],
+            ),
           ),
-        ),
+          const SizedBox(height: 12),
+        ],
+        chartWithOverlay,
         const SizedBox(height: 12),
         Container(
           padding: const EdgeInsets.all(14),

--- a/mobile/lib/features/policy/compliance_history_screen.dart
+++ b/mobile/lib/features/policy/compliance_history_screen.dart
@@ -78,12 +78,27 @@ class _HistoryBodyState extends ConsumerState<_HistoryBody> {
   // across a refresh lets the chart stay visible (faded) while the new
   // ?days=N response loads, and lets us show "Couldn't refresh" with
   // the last-known chart on transient errors instead of blanking to
-  // an error state.
+  // an error state. Cleared on cluster change so cluster A's data
+  // never bleeds into cluster B's loading view.
   List<ComplianceHistoryPoint>? _lastSuccess;
 
   void _setDays(int next) {
     if (next == _days) return;
     setState(() => _days = next);
+  }
+
+  @override
+  void didUpdateWidget(_HistoryBody oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.clusterId != widget.clusterId) {
+      // The State is preserved across cluster switches (PolicyStatusGate
+      // rebuilds _HistoryBody with a new clusterId, same widget identity
+      // by type position). Without this clear, _lastSuccess would render
+      // cluster A's chart under cluster B's spinner during the new key's
+      // loading phase.
+      _lastSuccess = null;
+      _days = 30;
+    }
   }
 
   @override
@@ -93,6 +108,15 @@ class _HistoryBodyState extends ConsumerState<_HistoryBody> {
       clusterId: widget.clusterId,
       days: _days,
     );
+    // Update _lastSuccess outside build() so the assignment stays out
+    // of Flutter's pure-build contract. ref.listen is idempotent across
+    // rebuilds and fires only on value transitions.
+    ref.listen(complianceHistoryProvider(key), (prev, next) {
+      next.whenData((points) {
+        if (!mounted) return;
+        setState(() => _lastSuccess = points);
+      });
+    });
     final async = ref.watch(complianceHistoryProvider(key));
 
     return async.when(
@@ -108,10 +132,7 @@ class _HistoryBodyState extends ConsumerState<_HistoryBody> {
             onDaysChanged: _setDays,
           );
         }
-        return _FreshLoadingView(
-          colors: colors,
-          days: _days,
-        );
+        return _FreshLoadingView(days: _days);
       },
       error: (e, _) {
         if (isComplianceHistoryNotConfigured(e)) {
@@ -148,7 +169,8 @@ class _HistoryBodyState extends ConsumerState<_HistoryBody> {
         );
       },
       data: (points) {
-        _lastSuccess = points;
+        // _lastSuccess is updated via ref.listen above — no side-effect
+        // assignment inside the build pure-function path.
         return _LoadedHistoryView(
           points: points,
           colors: colors,
@@ -201,9 +223,8 @@ class _DaysPicker extends StatelessWidget {
 /// First-load loading view — no previous chart to keep visible, so
 /// render a centered spinner with the picker disabled.
 class _FreshLoadingView extends StatelessWidget {
-  const _FreshLoadingView({required this.colors, required this.days});
+  const _FreshLoadingView({required this.days});
 
-  final KubeColors colors;
   final int days;
 
   @override

--- a/mobile/lib/features/resources/deployment_screens.dart
+++ b/mobile/lib/features/resources/deployment_screens.dart
@@ -4,15 +4,20 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../api/mesh_repository.dart';
 import '../../api/resource_repository.dart';
 import '../../cluster/cluster_provider.dart';
 import '../../routing/domain_sections.dart';
 import '../../theme/kube_theme_builder.dart';
+import '../../util/service_derivation.dart';
 import '../../widgets/empty_states.dart';
 import '../../widgets/resource_actions_button.dart';
 import '../../widgets/resource_detail_scaffold.dart';
 import '../../widgets/resource_list_scaffold.dart';
 import '../../widgets/resource_table.dart';
+// PR-5f: Deployment detail mirrors the Pod-side Golden Signals tab
+// when a Service targets the Deployment's pod template labels.
+import '../mesh/golden_signals_tab.dart';
 import '../observability/metrics/metrics_tab.dart';
 import 'k8s_helpers.dart';
 
@@ -30,6 +35,20 @@ class _DeploymentRow {
   String get strategy =>
       readPath(raw, 'spec.strategy.type') as String? ?? 'RollingUpdate';
   bool get healthy => desired > 0 && ready == desired;
+
+  /// Labels on the pod template (`spec.template.metadata.labels`).
+  /// These — not the Deployment's own labels — are what Services
+  /// select against, so use this map when deriving the Golden Signals
+  /// tab via [findServicesForResource].
+  Map<String, String> get podTemplateLabels {
+    final raw = readPath(this.raw, 'spec.template.metadata.labels');
+    if (raw is! Map) return const {};
+    final out = <String, String>{};
+    raw.forEach((k, v) {
+      if (k is String && v is String) out[k] = v;
+    });
+    return out;
+  }
 }
 
 class DeploymentListScreen extends ConsumerWidget {
@@ -107,6 +126,14 @@ class DeploymentDetailScreen extends ConsumerWidget {
       name: name,
     );
     final get = ref.watch(resourceGetProvider(getKey));
+    final meshStatus = ref.watch(meshStatusProvider(clusterId)).valueOrNull;
+    final servicesAsync = ref.watch(resourceListProvider(
+      ResourceListKey(
+        clusterId: clusterId,
+        kind: 'services',
+        namespace: namespace,
+      ),
+    ));
     return get.when(
       loading: () => const Scaffold(body: LoadingState()),
       error: (e, _) => Scaffold(
@@ -119,6 +146,18 @@ class DeploymentDetailScreen extends ConsumerWidget {
       data: (raw) {
         final d = _DeploymentRow(raw);
         final colors = Theme.of(context).extension<KubeColors>()!;
+        // Use the pod template's labels (not the Deployment's own
+        // labels) — Services target the pods this Deployment manages,
+        // and those pods carry the template labels.
+        final derivedServices =
+            meshStatus != null && meshStatus.isInstalled
+                ? findServicesForResource(
+                    services: servicesAsync.valueOrNull?.items ??
+                        const <Map<String, dynamic>>[],
+                    namespace: d.meta.namespace,
+                    resourceLabels: d.podTemplateLabels,
+                  )
+                : const <DerivedService>[];
         return ResourceDetailScaffold(
           kindLabel: 'Deployment',
           name: d.meta.name,
@@ -144,6 +183,16 @@ class DeploymentDetailScreen extends ConsumerWidget {
                 name: d.meta.name,
               ),
             ),
+            if (derivedServices.isNotEmpty && meshStatus != null)
+              DetailExtraTab(
+                label: 'Golden signals',
+                body: GoldenSignalsTab.fromCandidates(
+                  namespace: d.meta.namespace,
+                  candidates:
+                      derivedServices.map((s) => s.name).toList(),
+                  status: meshStatus,
+                ),
+              ),
           ],
           overview: Column(
             crossAxisAlignment: CrossAxisAlignment.start,

--- a/mobile/lib/features/resources/deployment_screens.dart
+++ b/mobile/lib/features/resources/deployment_screens.dart
@@ -106,7 +106,7 @@ class DeploymentListScreen extends ConsumerWidget {
   }
 }
 
-class DeploymentDetailScreen extends ConsumerWidget {
+class DeploymentDetailScreen extends ConsumerStatefulWidget {
   const DeploymentDetailScreen({
     super.key,
     required this.namespace,
@@ -117,27 +117,43 @@ class DeploymentDetailScreen extends ConsumerWidget {
   final String name;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<DeploymentDetailScreen> createState() =>
+      _DeploymentDetailScreenState();
+}
+
+class _DeploymentDetailScreenState
+    extends ConsumerState<DeploymentDetailScreen> {
+  // Latch mesh status once detected so a transient autoDispose null
+  // doesn't shrink extraTabs while the user is focused on the Golden
+  // Signals tab. Mirrors PodDetailScreen + ServiceDetailScreen.
+  MeshStatus? _stableMeshStatus;
+
+  @override
+  Widget build(BuildContext context) {
     final clusterId = ref.watch(activeClusterProvider);
     final getKey = ResourceGetKey(
       clusterId: clusterId,
       kind: 'deployments',
-      namespace: namespace,
-      name: name,
+      namespace: widget.namespace,
+      name: widget.name,
     );
     final get = ref.watch(resourceGetProvider(getKey));
-    final meshStatus = ref.watch(meshStatusProvider(clusterId)).valueOrNull;
+    final currentMesh = ref.watch(meshStatusProvider(clusterId)).valueOrNull;
+    if (currentMesh != null && currentMesh.isInstalled) {
+      _stableMeshStatus = currentMesh;
+    }
     final servicesAsync = ref.watch(resourceListProvider(
       ResourceListKey(
         clusterId: clusterId,
         kind: 'services',
-        namespace: namespace,
+        namespace: widget.namespace,
       ),
     ));
+    final stableMesh = _stableMeshStatus;
     return get.when(
       loading: () => const Scaffold(body: LoadingState()),
       error: (e, _) => Scaffold(
-        appBar: AppBar(title: Text(name)),
+        appBar: AppBar(title: Text(widget.name)),
         body: ErrorStateView(
           message: e.toString(),
           onRetry: () => ref.invalidate(resourceGetProvider(getKey)),
@@ -149,15 +165,14 @@ class DeploymentDetailScreen extends ConsumerWidget {
         // Use the pod template's labels (not the Deployment's own
         // labels) — Services target the pods this Deployment manages,
         // and those pods carry the template labels.
-        final derivedServices =
-            meshStatus != null && meshStatus.isInstalled
-                ? findServicesForResource(
-                    services: servicesAsync.valueOrNull?.items ??
-                        const <Map<String, dynamic>>[],
-                    namespace: d.meta.namespace,
-                    resourceLabels: d.podTemplateLabels,
-                  )
-                : const <DerivedService>[];
+        final derivedServices = stableMesh != null
+            ? findServicesForResource(
+                services: servicesAsync.valueOrNull?.items ??
+                    const <Map<String, dynamic>>[],
+                namespace: d.meta.namespace,
+                resourceLabels: d.podTemplateLabels,
+              )
+            : const <DerivedService>[];
         return ResourceDetailScaffold(
           kindLabel: 'Deployment',
           name: d.meta.name,
@@ -183,14 +198,14 @@ class DeploymentDetailScreen extends ConsumerWidget {
                 name: d.meta.name,
               ),
             ),
-            if (derivedServices.isNotEmpty && meshStatus != null)
+            if (derivedServices.isNotEmpty && stableMesh != null)
               DetailExtraTab(
                 label: 'Golden signals',
                 body: GoldenSignalsTab.fromCandidates(
                   namespace: d.meta.namespace,
                   candidates:
                       derivedServices.map((s) => s.name).toList(),
-                  status: meshStatus,
+                  status: stableMesh,
                 ),
               ),
           ],

--- a/mobile/lib/features/resources/deployment_screens.dart
+++ b/mobile/lib/features/resources/deployment_screens.dart
@@ -142,13 +142,6 @@ class _DeploymentDetailScreenState
     if (currentMesh != null && currentMesh.isInstalled) {
       _stableMeshStatus = currentMesh;
     }
-    final servicesAsync = ref.watch(resourceListProvider(
-      ResourceListKey(
-        clusterId: clusterId,
-        kind: 'services',
-        namespace: widget.namespace,
-      ),
-    ));
     final stableMesh = _stableMeshStatus;
     return get.when(
       loading: () => const Scaffold(body: LoadingState()),
@@ -164,14 +157,15 @@ class _DeploymentDetailScreenState
         final colors = Theme.of(context).extension<KubeColors>()!;
         // Use the pod template's labels (not the Deployment's own
         // labels) — Services target the pods this Deployment manages,
-        // and those pods carry the template labels.
+        // and those pods carry the template labels. derivedServices
+        // is computed via the memoized provider so identical-rebuild
+        // calls hit the cache.
         final derivedServices = stableMesh != null
-            ? findServicesForResource(
-                services: servicesAsync.valueOrNull?.items ??
-                    const <Map<String, dynamic>>[],
+            ? ref.watch(derivedServicesProvider(DerivedServicesKey(
+                clusterId: clusterId,
                 namespace: d.meta.namespace,
                 resourceLabels: d.podTemplateLabels,
-              )
+              )))
             : const <DerivedService>[];
         return ResourceDetailScaffold(
           kindLabel: 'Deployment',

--- a/mobile/lib/features/resources/pod_screens.dart
+++ b/mobile/lib/features/resources/pod_screens.dart
@@ -234,13 +234,6 @@ class _PodDetailScreenState extends ConsumerState<PodDetailScreen> {
     if (currentMesh != null && currentMesh.isInstalled) {
       _stableMeshStatus = currentMesh;
     }
-    final servicesAsync = ref.watch(resourceListProvider(
-      ResourceListKey(
-        clusterId: clusterId,
-        kind: 'services',
-        namespace: widget.namespace,
-      ),
-    ));
     final stableMesh = _stableMeshStatus;
 
     return get.when(
@@ -261,18 +254,16 @@ class _PodDetailScreenState extends ConsumerState<PodDetailScreen> {
           'Failed' => colors.error,
           _ => colors.textMuted,
         };
-        // Derive candidate Services from this Pod's labels — the
-        // Service detail's existing per-service Golden Signals tab is
-        // mirrored here for Pods so operators don't have to bounce out
-        // to find the matching Service. Uses the latched mesh status
-        // so tab count stays stable across autoDispose flickers.
+        // Derive candidate Services from this Pod's labels via the
+        // memoized provider — same algorithm as before but cached on
+        // (clusterId, namespace, labels) so detail-screen rebuilds
+        // with identical inputs don't re-walk the Service list.
         final derivedServices = stableMesh != null
-            ? findServicesForResource(
-                services: servicesAsync.valueOrNull?.items ??
-                    const <Map<String, dynamic>>[],
+            ? ref.watch(derivedServicesProvider(DerivedServicesKey(
+                clusterId: clusterId,
                 namespace: pod.meta.namespace,
                 resourceLabels: pod.meta.labels,
-              )
+              )))
             : const <DerivedService>[];
         return ResourceDetailScaffold(
           kindLabel: 'Pod',

--- a/mobile/lib/features/resources/pod_screens.dart
+++ b/mobile/lib/features/resources/pod_screens.dart
@@ -198,7 +198,7 @@ class PodListScreen extends ConsumerWidget {
   }
 }
 
-class PodDetailScreen extends ConsumerWidget {
+class PodDetailScreen extends ConsumerStatefulWidget {
   const PodDetailScreen({
     super.key,
     required this.namespace,
@@ -209,32 +209,44 @@ class PodDetailScreen extends ConsumerWidget {
   final String name;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<PodDetailScreen> createState() => _PodDetailScreenState();
+}
+
+class _PodDetailScreenState extends ConsumerState<PodDetailScreen> {
+  // Latch mesh status once detected so a transient autoDispose null
+  // from `meshStatusProvider` doesn't shrink `extraTabs` while the
+  // user is focused on the Golden Signals tab — the TabController
+  // would otherwise see an out-of-bounds index. Mirrors the latching
+  // pattern in ServiceDetailScreen.
+  MeshStatus? _stableMeshStatus;
+
+  @override
+  Widget build(BuildContext context) {
     final clusterId = ref.watch(activeClusterProvider);
     final getKey = ResourceGetKey(
       clusterId: clusterId,
       kind: 'pods',
-      namespace: namespace,
-      name: name,
+      namespace: widget.namespace,
+      name: widget.name,
     );
     final get = ref.watch(resourceGetProvider(getKey));
-    // Mesh detection + service list drive whether the Golden Signals
-    // tab appears. Both are watched at the top of build so a transition
-    // from "no mesh" → "mesh installed" surfaces the tab without
-    // requiring the operator to reopen the detail route.
-    final meshStatus = ref.watch(meshStatusProvider(clusterId)).valueOrNull;
+    final currentMesh = ref.watch(meshStatusProvider(clusterId)).valueOrNull;
+    if (currentMesh != null && currentMesh.isInstalled) {
+      _stableMeshStatus = currentMesh;
+    }
     final servicesAsync = ref.watch(resourceListProvider(
       ResourceListKey(
         clusterId: clusterId,
         kind: 'services',
-        namespace: namespace,
+        namespace: widget.namespace,
       ),
     ));
+    final stableMesh = _stableMeshStatus;
 
     return get.when(
       loading: () => const Scaffold(body: LoadingState()),
       error: (e, _) => Scaffold(
-        appBar: AppBar(title: Text(name)),
+        appBar: AppBar(title: Text(widget.name)),
         body: ErrorStateView(
           message: e.toString(),
           onRetry: () => ref.invalidate(resourceGetProvider(getKey)),
@@ -252,16 +264,16 @@ class PodDetailScreen extends ConsumerWidget {
         // Derive candidate Services from this Pod's labels — the
         // Service detail's existing per-service Golden Signals tab is
         // mirrored here for Pods so operators don't have to bounce out
-        // to find the matching Service.
-        final derivedServices =
-            meshStatus != null && meshStatus.isInstalled
-                ? findServicesForResource(
-                    services: servicesAsync.valueOrNull?.items ??
-                        const <Map<String, dynamic>>[],
-                    namespace: pod.meta.namespace,
-                    resourceLabels: pod.meta.labels,
-                  )
-                : const <DerivedService>[];
+        // to find the matching Service. Uses the latched mesh status
+        // so tab count stays stable across autoDispose flickers.
+        final derivedServices = stableMesh != null
+            ? findServicesForResource(
+                services: servicesAsync.valueOrNull?.items ??
+                    const <Map<String, dynamic>>[],
+                namespace: pod.meta.namespace,
+                resourceLabels: pod.meta.labels,
+              )
+            : const <DerivedService>[];
         return ResourceDetailScaffold(
           kindLabel: 'Pod',
           name: pod.meta.name,
@@ -287,14 +299,14 @@ class PodDetailScreen extends ConsumerWidget {
                 name: pod.meta.name,
               ),
             ),
-            if (derivedServices.isNotEmpty && meshStatus != null)
+            if (derivedServices.isNotEmpty && stableMesh != null)
               DetailExtraTab(
                 label: 'Golden signals',
                 body: GoldenSignalsTab.fromCandidates(
                   namespace: pod.meta.namespace,
                   candidates:
                       derivedServices.map((s) => s.name).toList(),
-                  status: meshStatus,
+                  status: stableMesh,
                 ),
               ),
           ],

--- a/mobile/lib/features/resources/pod_screens.dart
+++ b/mobile/lib/features/resources/pod_screens.dart
@@ -6,15 +6,22 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../api/mesh_repository.dart';
 import '../../api/resource_repository.dart';
 import '../../cluster/cluster_provider.dart';
 import '../../routing/domain_sections.dart';
 import '../../theme/kube_theme_builder.dart';
+import '../../util/service_derivation.dart';
 import '../../widgets/empty_states.dart';
 import '../../widgets/resource_actions_button.dart';
 import '../../widgets/resource_detail_scaffold.dart';
 import '../../widgets/resource_list_scaffold.dart';
 import '../../widgets/resource_table.dart';
+// Intentional cross-feature import: Pod detail surfaces a Golden
+// Signals tab from the mesh feature when a service mesh is detected
+// and a Service targets this Pod's labels. PR-5f service-name
+// autoderivation.
+import '../mesh/golden_signals_tab.dart';
 import '../observability/metrics/metrics_tab.dart';
 import 'k8s_helpers.dart';
 
@@ -211,6 +218,18 @@ class PodDetailScreen extends ConsumerWidget {
       name: name,
     );
     final get = ref.watch(resourceGetProvider(getKey));
+    // Mesh detection + service list drive whether the Golden Signals
+    // tab appears. Both are watched at the top of build so a transition
+    // from "no mesh" → "mesh installed" surfaces the tab without
+    // requiring the operator to reopen the detail route.
+    final meshStatus = ref.watch(meshStatusProvider(clusterId)).valueOrNull;
+    final servicesAsync = ref.watch(resourceListProvider(
+      ResourceListKey(
+        clusterId: clusterId,
+        kind: 'services',
+        namespace: namespace,
+      ),
+    ));
 
     return get.when(
       loading: () => const Scaffold(body: LoadingState()),
@@ -230,6 +249,19 @@ class PodDetailScreen extends ConsumerWidget {
           'Failed' => colors.error,
           _ => colors.textMuted,
         };
+        // Derive candidate Services from this Pod's labels — the
+        // Service detail's existing per-service Golden Signals tab is
+        // mirrored here for Pods so operators don't have to bounce out
+        // to find the matching Service.
+        final derivedServices =
+            meshStatus != null && meshStatus.isInstalled
+                ? findServicesForResource(
+                    services: servicesAsync.valueOrNull?.items ??
+                        const <Map<String, dynamic>>[],
+                    namespace: pod.meta.namespace,
+                    resourceLabels: pod.meta.labels,
+                  )
+                : const <DerivedService>[];
         return ResourceDetailScaffold(
           kindLabel: 'Pod',
           name: pod.meta.name,
@@ -255,6 +287,16 @@ class PodDetailScreen extends ConsumerWidget {
                 name: pod.meta.name,
               ),
             ),
+            if (derivedServices.isNotEmpty && meshStatus != null)
+              DetailExtraTab(
+                label: 'Golden signals',
+                body: GoldenSignalsTab.fromCandidates(
+                  namespace: pod.meta.namespace,
+                  candidates:
+                      derivedServices.map((s) => s.name).toList(),
+                  status: meshStatus,
+                ),
+              ),
           ],
           overview: Column(
             crossAxisAlignment: CrossAxisAlignment.start,

--- a/mobile/lib/util/service_derivation.dart
+++ b/mobile/lib/util/service_derivation.dart
@@ -7,6 +7,17 @@
 // Used by Pod and Deployment detail screens to decide whether to
 // surface the Golden Signals tab — and, when more than one Service
 // matches, to feed the in-tab picker.
+//
+// Two surface layers:
+//   - The pure function `findServicesForResource` is the algorithm.
+//   - The Riverpod `derivedServicesProvider` family caches the result
+//     keyed on (clusterId, namespace, resourceLabels) so the O(services
+//     × selector_keys) work only re-runs when its inputs actually
+//     change, not on every detail-screen rebuild.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../api/resource_repository.dart';
 
 /// A Service-name match for the Golden Signals derivation. Carries
 /// [selectorSize] so consumers (the tab picker, sort-stability tests)
@@ -114,3 +125,63 @@ List<DerivedService> findServicesForResource({
   });
   return matches;
 }
+
+/// Composite key for [derivedServicesProvider]. The labels map is
+/// hashed by entry — two Pods with the same `{app: web, tier: web}`
+/// share a cache slot regardless of insertion order.
+class DerivedServicesKey {
+  DerivedServicesKey({
+    required this.clusterId,
+    required this.namespace,
+    required Map<String, String> resourceLabels,
+  }) : resourceLabels = Map<String, String>.unmodifiable(resourceLabels);
+
+  final String clusterId;
+  final String namespace;
+  final Map<String, String> resourceLabels;
+
+  @override
+  bool operator ==(Object other) {
+    if (other is! DerivedServicesKey) return false;
+    if (other.clusterId != clusterId) return false;
+    if (other.namespace != namespace) return false;
+    if (other.resourceLabels.length != resourceLabels.length) return false;
+    for (final entry in resourceLabels.entries) {
+      if (other.resourceLabels[entry.key] != entry.value) return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode {
+    var labelHash = 0;
+    for (final entry in resourceLabels.entries) {
+      // XOR per-entry hashes so map ordering doesn't affect the result.
+      labelHash ^= Object.hash(entry.key, entry.value);
+    }
+    return Object.hash(clusterId, namespace, labelHash);
+  }
+}
+
+/// Watches the namespace's Service list and runs [findServicesForResource]
+/// against the current labels. Returns the empty list while the Service
+/// list is loading or errored so consumers can use `.isNotEmpty` as the
+/// gate for "show Golden Signals tab". The provider recomputes only
+/// when the upstream Service list or any key field changes — the same
+/// detail-screen rebuilding repeatedly with identical inputs hits the
+/// Riverpod cache, not the O(services × selector_keys) loop.
+final derivedServicesProvider = Provider.autoDispose
+    .family<List<DerivedService>, DerivedServicesKey>((ref, key) {
+  final servicesAsync = ref.watch(resourceListProvider(ResourceListKey(
+    clusterId: key.clusterId,
+    kind: 'services',
+    namespace: key.namespace,
+  )));
+  final items =
+      servicesAsync.valueOrNull?.items ?? const <Map<String, dynamic>>[];
+  return findServicesForResource(
+    services: items,
+    namespace: key.namespace,
+    resourceLabels: key.resourceLabels,
+  );
+});

--- a/mobile/lib/util/service_derivation.dart
+++ b/mobile/lib/util/service_derivation.dart
@@ -1,0 +1,116 @@
+// PR-5f service-name autoderivation. Given a Pod or Deployment-like
+// resource's labels, finds Services in the same namespace whose
+// `spec.selector` is a non-empty subset of those labels. Returns
+// matches sorted by selector specificity (most-specific first) with
+// alphabetical tie-break.
+//
+// Used by Pod and Deployment detail screens to decide whether to
+// surface the Golden Signals tab — and, when more than one Service
+// matches, to feed the in-tab picker.
+
+/// A Service-name match for the Golden Signals derivation. Carries
+/// [selectorSize] so consumers (the tab picker, sort-stability tests)
+/// can reason about why one match is ranked above another without
+/// re-deriving from raw unstructured maps.
+class DerivedService {
+  const DerivedService({
+    required this.name,
+    required this.namespace,
+    required this.selectorSize,
+  });
+
+  final String name;
+  final String namespace;
+
+  /// Number of label keys in the matching Service's `spec.selector`.
+  /// Larger = more specific (the Service narrows pods more tightly);
+  /// the matches list is sorted by this descending.
+  final int selectorSize;
+
+  @override
+  bool operator ==(Object other) =>
+      other is DerivedService &&
+      other.name == name &&
+      other.namespace == namespace &&
+      other.selectorSize == selectorSize;
+
+  @override
+  int get hashCode => Object.hash(name, namespace, selectorSize);
+
+  @override
+  String toString() =>
+      'DerivedService($namespace/$name, selectorSize=$selectorSize)';
+}
+
+/// Walks [services] (raw unstructured Service resources from the
+/// `resourceListProvider`) and returns every Service in [namespace]
+/// whose `spec.selector` is a non-empty subset of [resourceLabels].
+///
+/// Empty selectors are *not* treated as matches even though they would
+/// technically target every pod — a Service with an empty selector is
+/// almost always a headless endpoint or an externally-fronted ExternalName,
+/// neither of which should pollute the Golden Signals tab.
+///
+/// Sort: most-specific selector first (larger selector = more pods it
+/// excludes from the match), then alphabetical by Service name for a
+/// stable display order in the picker.
+List<DerivedService> findServicesForResource({
+  required List<Map<String, dynamic>> services,
+  required String namespace,
+  required Map<String, String> resourceLabels,
+}) {
+  if (namespace.isEmpty) return const [];
+  // No labels → nothing can target this resource via label selector.
+  // A Service with selector {app: web} requires the Pod to also carry
+  // `app=web`; with empty labels, every selector fails the subset test.
+  if (resourceLabels.isEmpty) return const [];
+
+  final matches = <DerivedService>[];
+  for (final svc in services) {
+    final meta = svc['metadata'];
+    if (meta is! Map) continue;
+    final svcNamespace = meta['namespace'] as String? ?? '';
+    if (svcNamespace != namespace) continue;
+    final name = meta['name'] as String?;
+    if (name == null || name.isEmpty) continue;
+
+    final spec = svc['spec'];
+    if (spec is! Map) continue;
+    final selector = spec['selector'];
+    if (selector is! Map || selector.isEmpty) continue;
+
+    // Coerce selector to String/String; reject non-string values rather
+    // than guessing (Kubernetes label values are strings by spec, but
+    // unstructured JSON parsing can leak nulls or numbers through).
+    final selectorMap = <String, String>{};
+    var malformed = false;
+    selector.forEach((k, v) {
+      if (k is String && v is String) {
+        selectorMap[k] = v;
+      } else {
+        malformed = true;
+      }
+    });
+    if (malformed) continue;
+
+    var isSubset = true;
+    selectorMap.forEach((k, v) {
+      if (resourceLabels[k] != v) isSubset = false;
+    });
+    if (!isSubset) continue;
+
+    matches.add(DerivedService(
+      name: name,
+      namespace: namespace,
+      selectorSize: selectorMap.length,
+    ));
+  }
+
+  matches.sort((a, b) {
+    if (a.selectorSize != b.selectorSize) {
+      return b.selectorSize.compareTo(a.selectorSize);
+    }
+    return a.name.compareTo(b.name);
+  });
+  return matches;
+}

--- a/mobile/lib/widgets/kube_line_chart.dart
+++ b/mobile/lib/widgets/kube_line_chart.dart
@@ -20,6 +20,13 @@ import 'package:intl/intl.dart';
 
 import '../theme/kube_theme_builder.dart';
 
+/// Width reserved by fl_chart on the left for Y-axis tick labels.
+/// Mirrored on both the chart's `leftTitles.sideTitles.reservedSize`
+/// and the pinch focal-fraction math so the gesture pivot stays under
+/// the user's fingers (the focal point lands in the plot region, not
+/// the label gutter).
+const double _kYAxisReservedWidth = 40;
+
 /// Severity → KubeColors mapping that drives line colors. Kept in one
 /// enum so the caller declares intent ("this series is an error metric")
 /// and the chart resolves the token, avoiding per-callsite color
@@ -77,6 +84,17 @@ class KubeLineChartState extends State<KubeLineChart> {
   double? _zoomMinX;
   double? _zoomMaxX;
 
+  // Cached per-build derivation. cleanedSeries is the result of the
+  // NaN/Infinity filter + per-series timestamp sort; the initial X
+  // range comes from min/max across all points. Both are pure
+  // functions of widget.series, so the cache is invalidated only when
+  // widget.series identity changes (see didUpdateWidget). Without the
+  // cache, every pinch-induced setState would re-run the sort + flat
+  // pass at 60-120 Hz.
+  List<MetricsSeries> _cachedCleanedSeries = const [];
+  double? _cachedInitialMinX;
+  double? _cachedInitialMaxX;
+
   // Captured at scale gesture start so each onScaleUpdate computes
   // relative to the fingers-down range. Without this we'd compound
   // multiplicative scale onto whatever we already mutated mid-pinch
@@ -111,6 +129,58 @@ class KubeLineChartState extends State<KubeLineChart> {
 
   @visibleForTesting
   double? get zoomMaxX => _zoomMaxX;
+
+  @override
+  void initState() {
+    super.initState();
+    _recomputeSeriesCache();
+  }
+
+  @override
+  void didUpdateWidget(KubeLineChart oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // Recompute the cleaned series + initial range only when the
+    // upstream series reference changes. Providers return stable
+    // references between polls, so identical-data refreshes are a no-op.
+    if (!identical(oldWidget.series, widget.series)) {
+      _recomputeSeriesCache();
+    }
+  }
+
+  /// Re-derives `_cachedCleanedSeries`, `_cachedInitialMinX/MaxX`. Called
+  /// from initState and didUpdateWidget — never from build, so the
+  /// sort/filter/min-max work doesn't run on pinch-induced setState
+  /// rebuilds.
+  void _recomputeSeriesCache() {
+    final cleaned = widget.series
+        .map((s) => (
+              label: s.label,
+              points: _sortByTime(
+                  s.points.where((p) => p.v.isFinite).toList()),
+              severity: s.severity,
+            ))
+        .toList();
+    _cachedCleanedSeries = cleaned;
+
+    final allPoints = cleaned.expand((s) => s.points).toList();
+    if (allPoints.isEmpty) {
+      _cachedInitialMinX = null;
+      _cachedInitialMaxX = null;
+      return;
+    }
+    final minTs = allPoints
+        .map((p) => p.t)
+        .reduce((a, b) => a.isBefore(b) ? a : b);
+    final maxTs = allPoints
+        .map((p) => p.t)
+        .reduce((a, b) => a.isAfter(b) ? a : b);
+    final rawMinX = minTs.millisecondsSinceEpoch.toDouble();
+    final rawMaxX = maxTs.millisecondsSinceEpoch.toDouble();
+    // Pad zero-range axes (single-point series) — the SideTitlesWidget
+    // OOM guard from the original implementation.
+    _cachedInitialMinX = rawMinX == rawMaxX ? rawMinX - 1 : rawMinX;
+    _cachedInitialMaxX = rawMinX == rawMaxX ? rawMaxX + 1 : rawMaxX;
+  }
 
   void _handleDoubleTap() {
     if (_zoomMinX == null && _zoomMaxX == null) return;
@@ -158,12 +228,18 @@ class KubeLineChartState extends State<KubeLineChart> {
 
     // Translate the focal point into chart-local x so the data value
     // under the user's pinch focus stays fixed while the visible
-    // window narrows or widens around it.
+    // window narrows or widens around it. fl_chart reserves
+    // `_kYAxisReservedWidth` px on the left for the Y-axis label
+    // gutter — subtracting it makes focalFraction correspond to the
+    // plotted data region, not the full widget box, so the pivot
+    // lands where the user's fingers actually are.
     final box = _chartBoxKey.currentContext?.findRenderObject() as RenderBox?;
     double focalFraction = 0.5;
-    if (box != null && box.hasSize && box.size.width > 0) {
+    if (box != null && box.hasSize && box.size.width > _kYAxisReservedWidth) {
       final localFocal = box.globalToLocal(details.focalPoint);
-      focalFraction = (localFocal.dx / box.size.width).clamp(0.0, 1.0);
+      final plotWidth = box.size.width - _kYAxisReservedWidth;
+      final plotDx = (localFocal.dx - _kYAxisReservedWidth).clamp(0.0, plotWidth);
+      focalFraction = (plotDx / plotWidth).clamp(0.0, 1.0);
     }
     final focalDataX = startMin + focalFraction * startSpan;
     double newMin = focalDataX - focalFraction * newSpan;
@@ -216,52 +292,32 @@ class KubeLineChartState extends State<KubeLineChart> {
   Widget build(BuildContext context) {
     final colors = Theme.of(context).extension<KubeColors>()!;
 
-    // Pre-clean the series and compute the data's natural X range here
-    // so the gesture handlers can clamp against a value the same build
-    // pass derived. Doing it in _LineChartBody would force the handlers
-    // to re-walk every point on each onScaleUpdate.
-    final cleanedSeries = widget.series
-        .map((s) => (
-              label: s.label,
-              points: _sortByTime(
-                  s.points.where((p) => p.v.isFinite).toList()),
-              severity: s.severity,
-            ))
-        .toList();
-    final allPoints = cleanedSeries.expand((s) => s.points).toList();
-    final hasData = allPoints.isNotEmpty;
-
-    double? initialMinX;
-    double? initialMaxX;
-    if (hasData) {
-      final minTs = allPoints.map((p) => p.t).reduce(
-            (a, b) => a.isBefore(b) ? a : b,
-          );
-      final maxTs = allPoints.map((p) => p.t).reduce(
-            (a, b) => a.isAfter(b) ? a : b,
-          );
-      // Pad zero-range axes (single-point series) — the SideTitlesWidget
-      // OOM guard from the original implementation.
-      final rawMinX = minTs.millisecondsSinceEpoch.toDouble();
-      final rawMaxX = maxTs.millisecondsSinceEpoch.toDouble();
-      initialMinX = rawMinX == rawMaxX ? rawMinX - 1 : rawMinX;
-      initialMaxX = rawMinX == rawMaxX ? rawMaxX + 1 : rawMaxX;
-    }
+    // Use cached cleanedSeries + initial range from initState /
+    // didUpdateWidget. Pinch-induced setStates land here at 60-120 Hz
+    // during sustained gestures — without the cache, each rebuild
+    // would re-run the sort/filter/min-max pass over every series.
+    final cleanedSeries = _cachedCleanedSeries;
+    final initialMinX = _cachedInitialMinX;
+    final initialMaxX = _cachedInitialMaxX;
+    final hasData = initialMinX != null && initialMaxX != null;
     _lastInitialMinX = initialMinX;
     _lastInitialMaxX = initialMaxX;
 
     // Clamp any held zoom into the current data's bounds so a refresh
     // that shrinks the dataset can't leave us pointing off-chart.
-    final effectiveMinX = hasData
-        ? (_zoomMinX != null
-            ? _zoomMinX!.clamp(initialMinX!, initialMaxX!)
-            : initialMinX!)
-        : null;
-    final effectiveMaxX = hasData
-        ? (_zoomMaxX != null
-            ? _zoomMaxX!.clamp(initialMinX!, initialMaxX!)
-            : initialMaxX!)
-        : null;
+    final double? effectiveMinX;
+    final double? effectiveMaxX;
+    if (initialMinX != null && initialMaxX != null) {
+      effectiveMinX = _zoomMinX != null
+          ? _zoomMinX!.clamp(initialMinX, initialMaxX)
+          : initialMinX;
+      effectiveMaxX = _zoomMaxX != null
+          ? _zoomMaxX!.clamp(initialMinX, initialMaxX)
+          : initialMaxX;
+    } else {
+      effectiveMinX = null;
+      effectiveMaxX = null;
+    }
 
     Widget chartContent = SizedBox(
       height: widget.height,
@@ -405,7 +461,7 @@ class _Legend extends StatelessWidget {
   }
 }
 
-class _LineChartBody extends StatelessWidget {
+class _LineChartBody extends StatefulWidget {
   const _LineChartBody({
     super.key,
     required this.cleanedSeries,
@@ -428,23 +484,71 @@ class _LineChartBody extends StatelessWidget {
   final double maxX;
 
   @override
+  State<_LineChartBody> createState() => _LineChartBodyState();
+}
+
+class _LineChartBodyState extends State<_LineChartBody> {
+  // Flat list of every point across all series. Stable across pinch
+  // events for the same input series, so cached and only rebuilt when
+  // cleanedSeries reference changes.
+  List<MetricsPoint> _cachedAllPoints = const [];
+  // Per-series FlSpot lists — only rebuilt when cleanedSeries changes.
+  List<List<FlSpot>> _cachedSpots = const [];
+
+  @override
+  void initState() {
+    super.initState();
+    _recomputeFromSeries();
+  }
+
+  @override
+  void didUpdateWidget(_LineChartBody oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!identical(oldWidget.cleanedSeries, widget.cleanedSeries)) {
+      _recomputeFromSeries();
+    }
+  }
+
+  void _recomputeFromSeries() {
+    _cachedAllPoints =
+        widget.cleanedSeries.expand((s) => s.points).toList(growable: false);
+    _cachedSpots = widget.cleanedSeries
+        .map((s) => s.points
+            .map((p) => FlSpot(
+                  p.t.millisecondsSinceEpoch.toDouble(),
+                  p.v,
+                ))
+            .toList(growable: false))
+        .toList(growable: false);
+  }
+
+  @override
   Widget build(BuildContext context) {
     // Re-derive an effective Y range from points inside the visible
     // window so a zoom-in re-fits Y to the local extrema. If the window
     // contains no points (zoomed into a gap between samples) fall back
     // to the full-dataset Y so the chart doesn't collapse to a line.
-    final allPoints = cleanedSeries.expand((s) => s.points).toList();
+    final allPoints = _cachedAllPoints;
+    final minX = widget.minX;
+    final maxX = widget.maxX;
+    final colors = widget.colors;
+    final showGrid = widget.showGrid;
+    final cleanedSeries = widget.cleanedSeries;
+    // The visible-window filter still runs per build because it depends
+    // on minX/maxX which change with every pinch event. Allocation cost
+    // is small (no inner sorts, just a filter pass).
     final visiblePoints = allPoints.where((p) {
       final tx = p.t.millisecondsSinceEpoch.toDouble();
       return tx >= minX && tx <= maxX;
-    }).toList();
+    }).toList(growable: false);
     final yPoints = visiblePoints.isEmpty ? allPoints : visiblePoints;
 
     final maxTs = DateTime.fromMillisecondsSinceEpoch(maxX.toInt());
     final minTs = DateTime.fromMillisecondsSinceEpoch(minX.toInt());
     final rangeHours = maxTs.difference(minTs).inHours;
     // Short ranges: show HH:mm; longer ranges: include date.
-    final labelFmt = rangeHours <= 24 ? _fmtShort : _fmtLong;
+    final labelFmt =
+        rangeHours <= 24 ? _LineChartBody._fmtShort : _LineChartBody._fmtLong;
 
     final yValues = yPoints.map((p) => p.v);
     final rawMinY = yValues.reduce((a, b) => a < b ? a : b);
@@ -452,14 +556,13 @@ class _LineChartBody extends StatelessWidget {
     final minY = rawMinY == rawMaxY ? rawMinY - 1 : rawMinY;
     final maxY = rawMinY == rawMaxY ? rawMaxY + 1 : rawMaxY;
 
-    final barData = cleanedSeries.map((s) {
+    final cachedSpots = _cachedSpots;
+    final barData = List<LineChartBarData>.generate(cleanedSeries.length, (i) {
+      final s = cleanedSeries[i];
       final color = kubeChartSeverityColor(s.severity, colors);
-      final spots = s.points
-          .map((p) => FlSpot(
-                p.t.millisecondsSinceEpoch.toDouble(),
-                p.v,
-              ))
-          .toList();
+      // Reuse cached FlSpot lists — they only change when cleanedSeries
+      // changes identity, not on every pinch event.
+      final spots = cachedSpots[i];
       return LineChartBarData(
         spots: spots,
         color: color,
@@ -470,7 +573,7 @@ class _LineChartBody extends StatelessWidget {
           color: color.withValues(alpha: 0.08),
         ),
       );
-    }).toList();
+    });
 
     return LineChart(
       LineChartData(
@@ -526,7 +629,7 @@ class _LineChartBody extends StatelessWidget {
           leftTitles: AxisTitles(
             sideTitles: SideTitles(
               showTitles: true,
-              reservedSize: 40,
+              reservedSize: _kYAxisReservedWidth,
               interval: (maxY - minY) / 4,
               getTitlesWidget: (value, meta) => SideTitleWidget(
                 axisSide: meta.axisSide,

--- a/mobile/lib/widgets/kube_line_chart.dart
+++ b/mobile/lib/widgets/kube_line_chart.dart
@@ -84,6 +84,15 @@ class KubeLineChartState extends State<KubeLineChart> {
   double? _scaleStartMinX;
   double? _scaleStartMaxX;
 
+  // Gesture-local snapshot of the data's initial X range, frozen at
+  // _handleScaleStart and consumed by _handleScaleUpdate. Without this
+  // a Riverpod-driven build pass mid-pinch would write fresh values
+  // into _lastInitialMinX/MaxX while startSpan was captured from the
+  // old range — clamping math would be internally inconsistent for
+  // that gesture frame. Cleared in _handleScaleEnd.
+  double? _gestureInitialMinX;
+  double? _gestureInitialMaxX;
+
   // Cached during the most recent build so gesture handlers can clamp
   // without recomputing point-min/max on every onScaleUpdate.
   double? _lastInitialMinX;
@@ -112,15 +121,26 @@ class KubeLineChartState extends State<KubeLineChart> {
   }
 
   void _handleScaleStart(ScaleStartDetails details) {
-    _scaleStartMinX = _zoomMinX ?? _lastInitialMinX;
-    _scaleStartMaxX = _zoomMaxX ?? _lastInitialMaxX;
+    final initMin = _lastInitialMinX;
+    final initMax = _lastInitialMaxX;
+    if (initMin == null || initMax == null) return;
+    // Clamp the held zoom into current data bounds so a data refresh
+    // that shrunk the X range doesn't make startSpan disagree with the
+    // rendered chart. The build()-time clamp ensures the display is
+    // correct; this clamp keeps the gesture math correct too.
+    _scaleStartMinX = (_zoomMinX ?? initMin).clamp(initMin, initMax);
+    _scaleStartMaxX = (_zoomMaxX ?? initMax).clamp(initMin, initMax);
+    _gestureInitialMinX = initMin;
+    _gestureInitialMaxX = initMax;
   }
 
   void _handleScaleUpdate(ScaleUpdateDetails details) {
     final startMin = _scaleStartMinX;
     final startMax = _scaleStartMaxX;
-    final initialMin = _lastInitialMinX;
-    final initialMax = _lastInitialMaxX;
+    // Read the gesture-local snapshot, not the live build cache, so a
+    // mid-pinch rebuild can't shift initialMin/Max out from under us.
+    final initialMin = _gestureInitialMinX;
+    final initialMax = _gestureInitialMaxX;
     if (startMin == null ||
         startMax == null ||
         initialMin == null ||
@@ -188,6 +208,8 @@ class KubeLineChartState extends State<KubeLineChart> {
   void _handleScaleEnd(ScaleEndDetails details) {
     _scaleStartMinX = null;
     _scaleStartMaxX = null;
+    _gestureInitialMinX = null;
+    _gestureInitialMaxX = null;
   }
 
   @override
@@ -393,6 +415,12 @@ class _LineChartBody extends StatelessWidget {
     required this.maxX,
   });
 
+  // Hoisted DateFormat instances. Constructing them inside build() at
+  // 60-120 Hz during a sustained pinch gesture is wasted allocation;
+  // these are immutable and isolate-safe so the static cache is sound.
+  static final DateFormat _fmtShort = DateFormat('HH:mm');
+  static final DateFormat _fmtLong = DateFormat('MM/dd HH:mm');
+
   final List<MetricsSeries> cleanedSeries;
   final KubeColors colors;
   final bool showGrid;
@@ -416,9 +444,7 @@ class _LineChartBody extends StatelessWidget {
     final minTs = DateTime.fromMillisecondsSinceEpoch(minX.toInt());
     final rangeHours = maxTs.difference(minTs).inHours;
     // Short ranges: show HH:mm; longer ranges: include date.
-    final labelFmt = rangeHours <= 24
-        ? DateFormat('HH:mm')
-        : DateFormat('MM/dd HH:mm');
+    final labelFmt = rangeHours <= 24 ? _fmtShort : _fmtLong;
 
     final yValues = yPoints.map((p) => p.v);
     final rawMinY = yValues.reduce((a, b) => a < b ? a : b);

--- a/mobile/lib/widgets/kube_line_chart.dart
+++ b/mobile/lib/widgets/kube_line_chart.dart
@@ -6,8 +6,15 @@
 // X-axis label strategy mirrors the web frontend: ranges ≤ 24 h show
 // HH:mm; longer ranges show MM/dd HH:mm. This keeps the axis readable
 // on a 360dp phone screen without truncation.
+//
+// PR-5f adds pinch-to-zoom on the X axis. A custom recognizer waits for
+// 2+ pointers before claiming the gesture so a single-finger horizontal
+// drag still propagates to the parent TabBarView and switches tabs
+// cleanly. Double-tap resets the zoom to the data's natural range.
+// Vertical pinch is rejected — charts do not zoom on Y in M5.
 
 import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
@@ -33,13 +40,14 @@ typedef MetricsSeries = ({
 /// Multi-series line chart backed by `fl_chart`. Intended for
 /// CPU/memory/network/latency time-series from
 /// `GET /v1/monitoring/query_range`.
-class KubeLineChart extends StatelessWidget {
+class KubeLineChart extends StatefulWidget {
   const KubeLineChart({
     required this.series,
     this.title,
     this.showGrid = true,
     this.showLegend = true,
     this.height = 200,
+    this.enableZoom = true,
     super.key,
   });
 
@@ -49,29 +57,248 @@ class KubeLineChart extends StatelessWidget {
   final bool showLegend;
   final double height;
 
+  /// Opt-out for surfaces that don't want pinch-zoom (e.g. dashboard
+  /// thumbnails). Default is on; non-data-bearing chart bodies skip
+  /// the gesture wrapper entirely so the gesture arena stays empty.
+  final bool enableZoom;
+
+  @override
+  State<KubeLineChart> createState() => KubeLineChartState();
+}
+
+/// Public for `@visibleForTesting` access to zoom state from widget
+/// tests. Consumers should treat this as an opaque implementation
+/// detail.
+class KubeLineChartState extends State<KubeLineChart> {
+  // Effective zoom window. Null pair = no zoom; the chart renders the
+  // data's natural range. A non-null pair is the user's pinched window,
+  // always clamped inside the current data's min/max so we never paint
+  // an off-chart axis if data shrinks under a held zoom.
+  double? _zoomMinX;
+  double? _zoomMaxX;
+
+  // Captured at scale gesture start so each onScaleUpdate computes
+  // relative to the fingers-down range. Without this we'd compound
+  // multiplicative scale onto whatever we already mutated mid-pinch
+  // and the chart would runaway-zoom on any sustained gesture.
+  double? _scaleStartMinX;
+  double? _scaleStartMaxX;
+
+  // Cached during the most recent build so gesture handlers can clamp
+  // without recomputing point-min/max on every onScaleUpdate.
+  double? _lastInitialMinX;
+  double? _lastInitialMaxX;
+
+  final GlobalKey _chartBoxKey = GlobalKey();
+
+  /// Whether the user currently has a non-default zoom window applied.
+  /// Test-only — production code reads the effective range through the
+  /// chart's own rendering, not this flag.
+  @visibleForTesting
+  bool get isZoomed => _zoomMinX != null || _zoomMaxX != null;
+
+  @visibleForTesting
+  double? get zoomMinX => _zoomMinX;
+
+  @visibleForTesting
+  double? get zoomMaxX => _zoomMaxX;
+
+  void _handleDoubleTap() {
+    if (_zoomMinX == null && _zoomMaxX == null) return;
+    setState(() {
+      _zoomMinX = null;
+      _zoomMaxX = null;
+    });
+  }
+
+  void _handleScaleStart(ScaleStartDetails details) {
+    _scaleStartMinX = _zoomMinX ?? _lastInitialMinX;
+    _scaleStartMaxX = _zoomMaxX ?? _lastInitialMaxX;
+  }
+
+  void _handleScaleUpdate(ScaleUpdateDetails details) {
+    final startMin = _scaleStartMinX;
+    final startMax = _scaleStartMaxX;
+    final initialMin = _lastInitialMinX;
+    final initialMax = _lastInitialMaxX;
+    if (startMin == null ||
+        startMax == null ||
+        initialMin == null ||
+        initialMax == null) {
+      return;
+    }
+    final startSpan = startMax - startMin;
+    if (startSpan <= 0) return;
+
+    // Horizontal axis only — vertical scaling is ignored per plan.
+    // details.scale > 1 = pinch-out (zoom in → narrower span);
+    // details.scale < 1 = pinch-in (zoom out → wider span).
+    final scale = details.scale.clamp(0.1, 10.0);
+    final newSpan = startSpan / scale;
+
+    // Translate the focal point into chart-local x so the data value
+    // under the user's pinch focus stays fixed while the visible
+    // window narrows or widens around it.
+    final box = _chartBoxKey.currentContext?.findRenderObject() as RenderBox?;
+    double focalFraction = 0.5;
+    if (box != null && box.hasSize && box.size.width > 0) {
+      final localFocal = box.globalToLocal(details.focalPoint);
+      focalFraction = (localFocal.dx / box.size.width).clamp(0.0, 1.0);
+    }
+    final focalDataX = startMin + focalFraction * startSpan;
+    double newMin = focalDataX - focalFraction * newSpan;
+    double newMax = focalDataX + (1 - focalFraction) * newSpan;
+
+    // Slide the window if either edge is outside the initial range,
+    // then clamp. This preserves the requested span when the user
+    // zooms near a data boundary; clamping the edges alone would
+    // silently change the zoom factor.
+    if (newMin < initialMin) {
+      final delta = initialMin - newMin;
+      newMin += delta;
+      newMax += delta;
+    }
+    if (newMax > initialMax) {
+      final delta = newMax - initialMax;
+      newMin -= delta;
+      newMax -= delta;
+    }
+    newMin = newMin.clamp(initialMin, initialMax);
+    newMax = newMax.clamp(initialMin, initialMax);
+    if (newMax - newMin <= 0) return;
+
+    // Snap to "fully zoomed out" when the user has effectively undone
+    // the zoom — this lets the chart shed the null sentinels and
+    // matches double-tap-reset semantics without a second explicit tap.
+    final atInitialRange =
+        (newMin - initialMin).abs() < 1e-6 &&
+            (newMax - initialMax).abs() < 1e-6;
+
+    setState(() {
+      if (atInitialRange) {
+        _zoomMinX = null;
+        _zoomMaxX = null;
+      } else {
+        _zoomMinX = newMin;
+        _zoomMaxX = newMax;
+      }
+    });
+  }
+
+  void _handleScaleEnd(ScaleEndDetails details) {
+    _scaleStartMinX = null;
+    _scaleStartMaxX = null;
+  }
+
   @override
   Widget build(BuildContext context) {
     final colors = Theme.of(context).extension<KubeColors>()!;
-    final hasData = series.any((s) => s.points.isNotEmpty);
+
+    // Pre-clean the series and compute the data's natural X range here
+    // so the gesture handlers can clamp against a value the same build
+    // pass derived. Doing it in _LineChartBody would force the handlers
+    // to re-walk every point on each onScaleUpdate.
+    final cleanedSeries = widget.series
+        .map((s) => (
+              label: s.label,
+              points: _sortByTime(
+                  s.points.where((p) => p.v.isFinite).toList()),
+              severity: s.severity,
+            ))
+        .toList();
+    final allPoints = cleanedSeries.expand((s) => s.points).toList();
+    final hasData = allPoints.isNotEmpty;
+
+    double? initialMinX;
+    double? initialMaxX;
+    if (hasData) {
+      final minTs = allPoints.map((p) => p.t).reduce(
+            (a, b) => a.isBefore(b) ? a : b,
+          );
+      final maxTs = allPoints.map((p) => p.t).reduce(
+            (a, b) => a.isAfter(b) ? a : b,
+          );
+      // Pad zero-range axes (single-point series) — the SideTitlesWidget
+      // OOM guard from the original implementation.
+      final rawMinX = minTs.millisecondsSinceEpoch.toDouble();
+      final rawMaxX = maxTs.millisecondsSinceEpoch.toDouble();
+      initialMinX = rawMinX == rawMaxX ? rawMinX - 1 : rawMinX;
+      initialMaxX = rawMinX == rawMaxX ? rawMaxX + 1 : rawMaxX;
+    }
+    _lastInitialMinX = initialMinX;
+    _lastInitialMaxX = initialMaxX;
+
+    // Clamp any held zoom into the current data's bounds so a refresh
+    // that shrinks the dataset can't leave us pointing off-chart.
+    final effectiveMinX = hasData
+        ? (_zoomMinX != null
+            ? _zoomMinX!.clamp(initialMinX!, initialMaxX!)
+            : initialMinX!)
+        : null;
+    final effectiveMaxX = hasData
+        ? (_zoomMaxX != null
+            ? _zoomMaxX!.clamp(initialMinX!, initialMaxX!)
+            : initialMaxX!)
+        : null;
+
+    Widget chartContent = SizedBox(
+      height: widget.height,
+      child: hasData
+          ? _LineChartBody(
+              key: _chartBoxKey,
+              cleanedSeries: cleanedSeries,
+              colors: colors,
+              showGrid: widget.showGrid,
+              minX: effectiveMinX!,
+              maxX: effectiveMaxX!,
+            )
+          : _NoDataPlaceholder(colors: colors),
+    );
+
+    if (widget.enableZoom && hasData) {
+      chartContent = RawGestureDetector(
+        behavior: HitTestBehavior.opaque,
+        gestures: <Type, GestureRecognizerFactory>{
+          _TwoFingerScaleRecognizer:
+              GestureRecognizerFactoryWithHandlers<_TwoFingerScaleRecognizer>(
+            () => _TwoFingerScaleRecognizer(debugOwner: this),
+            (recognizer) {
+              recognizer
+                ..onStart = _handleScaleStart
+                ..onUpdate = _handleScaleUpdate
+                ..onEnd = _handleScaleEnd;
+            },
+          ),
+          DoubleTapGestureRecognizer:
+              GestureRecognizerFactoryWithHandlers<DoubleTapGestureRecognizer>(
+            () => DoubleTapGestureRecognizer(debugOwner: this),
+            (recognizer) {
+              recognizer.onDoubleTap = _handleDoubleTap;
+            },
+          ),
+        },
+        child: chartContent,
+      );
+    }
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        if (title != null) _ChartTitle(title: title!, colors: colors),
-        SizedBox(
-          height: height,
-          child: hasData
-              ? _LineChartBody(
-                  series: series,
-                  colors: colors,
-                  showGrid: showGrid,
-                )
-              : _NoDataPlaceholder(colors: colors),
-        ),
-        if (showLegend && hasData)
-          _Legend(series: series, colors: colors),
+        if (widget.title != null) _ChartTitle(title: widget.title!, colors: colors),
+        chartContent,
+        if (widget.showLegend && hasData)
+          _Legend(series: widget.series, colors: colors),
       ],
     );
+  }
+
+  /// Sorts points by timestamp ascending. fl_chart connects spots in
+  /// array order — out-of-order timestamps (Prometheus federated merge,
+  /// Loki shard interleave) render as visible "backwards" segments.
+  List<MetricsPoint> _sortByTime(List<MetricsPoint> points) {
+    if (points.length <= 1) return points;
+    final sorted = [...points]..sort((a, b) => a.t.compareTo(b.t));
+    return sorted;
   }
 }
 
@@ -158,55 +385,42 @@ class _Legend extends StatelessWidget {
 
 class _LineChartBody extends StatelessWidget {
   const _LineChartBody({
-    required this.series,
+    super.key,
+    required this.cleanedSeries,
     required this.colors,
     required this.showGrid,
+    required this.minX,
+    required this.maxX,
   });
 
-  final List<MetricsSeries> series;
+  final List<MetricsSeries> cleanedSeries;
   final KubeColors colors;
   final bool showGrid;
+  final double minX;
+  final double maxX;
 
   @override
   Widget build(BuildContext context) {
-    // Filter out NaN/Infinity points up front. Prometheus emits NaN
-    // for division-by-zero rate windows and stale-for-N samples; a
-    // single NaN poisons fl_chart's reduce(min/max) axis computation
-    // and blanks the entire chart with no operator hint.
-    final cleanedSeries = series
-        .map((s) => (
-              label: s.label,
-              points: _sortByTime(
-                  s.points.where((p) => p.v.isFinite).toList()),
-              severity: s.severity,
-            ))
-        .toList();
+    // Re-derive an effective Y range from points inside the visible
+    // window so a zoom-in re-fits Y to the local extrema. If the window
+    // contains no points (zoomed into a gap between samples) fall back
+    // to the full-dataset Y so the chart doesn't collapse to a line.
     final allPoints = cleanedSeries.expand((s) => s.points).toList();
-    if (allPoints.isEmpty) {
-      return _NoDataPlaceholder(colors: colors);
-    }
-    final minTs = allPoints.map((p) => p.t).reduce(
-      (a, b) => a.isBefore(b) ? a : b,
-    );
-    final maxTs = allPoints.map((p) => p.t).reduce(
-      (a, b) => a.isAfter(b) ? a : b,
-    );
+    final visiblePoints = allPoints.where((p) {
+      final tx = p.t.millisecondsSinceEpoch.toDouble();
+      return tx >= minX && tx <= maxX;
+    }).toList();
+    final yPoints = visiblePoints.isEmpty ? allPoints : visiblePoints;
+
+    final maxTs = DateTime.fromMillisecondsSinceEpoch(maxX.toInt());
+    final minTs = DateTime.fromMillisecondsSinceEpoch(minX.toInt());
     final rangeHours = maxTs.difference(minTs).inHours;
     // Short ranges: show HH:mm; longer ranges: include date.
     final labelFmt = rangeHours <= 24
         ? DateFormat('HH:mm')
         : DateFormat('MM/dd HH:mm');
 
-    // Pad zero-range axes (single-point series). Without explicit
-    // min/max, fl_chart's default interval for a zero range collapses
-    // toward zero and SideTitlesWidget tries to emit millions of axis
-    // labels, OOMing the UI thread. The pad values are arbitrary —
-    // fl_chart only needs a non-zero range to compute a sane interval.
-    final rawMinX = minTs.millisecondsSinceEpoch.toDouble();
-    final rawMaxX = maxTs.millisecondsSinceEpoch.toDouble();
-    final minX = rawMinX == rawMaxX ? rawMinX - 1 : rawMinX;
-    final maxX = rawMinX == rawMaxX ? rawMaxX + 1 : rawMaxX;
-    final yValues = allPoints.map((p) => p.v);
+    final yValues = yPoints.map((p) => p.v);
     final rawMinY = yValues.reduce((a, b) => a < b ? a : b);
     final rawMaxY = yValues.reduce((a, b) => a > b ? a : b);
     final minY = rawMinY == rawMaxY ? rawMinY - 1 : rawMinY;
@@ -238,6 +452,15 @@ class _LineChartBody extends StatelessWidget {
         maxX: maxX,
         minY: minY,
         maxY: maxY,
+        clipData: const FlClipData.all(),
+        // fl_chart's default touch handlers attach a PanGestureRecognizer
+        // for tooltip dragging — that recognizer competes with our
+        // two-finger scale recognizer over single-pointer events and
+        // wins because fl_chart's child gesture detector resolves first.
+        // Disabling internal touch lets the parent gesture-arena gate
+        // single-finger drags through to TabBarView and two-finger
+        // pinches into our scale handlers without contention.
+        lineTouchData: const LineTouchData(enabled: false),
         lineBarsData: barData,
         gridData: FlGridData(
           show: showGrid,
@@ -296,20 +519,29 @@ class _LineChartBody extends StatelessWidget {
     );
   }
 
-  /// Sorts points by timestamp ascending. fl_chart connects spots in
-  /// array order — out-of-order timestamps (Prometheus federated merge,
-  /// Loki shard interleave) render as visible "backwards" segments.
-  List<MetricsPoint> _sortByTime(List<MetricsPoint> points) {
-    if (points.length <= 1) return points;
-    final sorted = [...points]..sort((a, b) => a.t.compareTo(b.t));
-    return sorted;
-  }
-
   String _formatY(double v) {
     if (v >= 1e9) return '${(v / 1e9).toStringAsFixed(1)}G';
     if (v >= 1e6) return '${(v / 1e6).toStringAsFixed(1)}M';
     if (v >= 1e3) return '${(v / 1e3).toStringAsFixed(1)}k';
     return v.toStringAsFixed(v.truncate() == v ? 0 : 1);
+  }
+}
+
+/// Two-finger scale recognizer. Rejects the gesture while only one
+/// pointer is down so the parent `TabBarView`'s horizontal-drag
+/// recognizer can win single-finger swipes cleanly. Without this gate
+/// fl_chart's chart area would swallow every drag and tab swipes would
+/// stop working anywhere a chart was visible.
+class _TwoFingerScaleRecognizer extends ScaleGestureRecognizer {
+  _TwoFingerScaleRecognizer({super.debugOwner});
+
+  @override
+  void acceptGesture(int pointer) {
+    if (pointerCount >= 2) {
+      super.acceptGesture(pointer);
+    } else {
+      rejectGesture(pointer);
+    }
   }
 }
 

--- a/mobile/test/features/mesh/golden_signals_tab_test.dart
+++ b/mobile/test/features/mesh/golden_signals_tab_test.dart
@@ -46,6 +46,37 @@ Future<void> _pump(
   await tester.pumpAndSettle(const Duration(milliseconds: 200));
 }
 
+/// Pump helper for the multi-candidate `fromCandidates` constructor —
+/// exercises the in-tab Service picker added in PR-5f.
+Future<void> _pumpFromCandidates(
+  WidgetTester tester,
+  MockDioAdapter mock, {
+  required MeshStatus status,
+  required List<String> candidates,
+}) async {
+  await tester.pumpWidget(ProviderScope(
+    overrides: [
+      backendUrlProvider.overrideWithValue('http://test'),
+      secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+    ],
+    child: _DioInstaller(
+      mock: mock,
+      child: MaterialApp(
+        theme: buildKubeTheme('nexus'),
+        home: Scaffold(
+          body: GoldenSignalsTab.fromCandidates(
+            namespace: 'app',
+            candidates: candidates,
+            status: status,
+          ),
+        ),
+      ),
+    ),
+  ));
+  await tester.pump();
+  await tester.pumpAndSettle(const Duration(milliseconds: 200));
+}
+
 class _DioInstaller extends ConsumerWidget {
   const _DioInstaller({required this.mock, required this.child});
 
@@ -194,5 +225,137 @@ void main() {
 
     expect(find.textContaining('Both meshes are installed'), findsOneWidget);
     expect(find.text('Requests / s'), findsNothing);
+  });
+
+  testWidgets(
+      'fromCandidates: single candidate hides the picker but still fetches',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/mesh/golden-signals', body: {
+        'data': {
+          'status': {'detected': 'istio'},
+          'signals': {
+            'mesh': 'istio',
+            'namespace': 'app',
+            'service': 'web',
+            'available': true,
+            'rps': 4.2,
+            'errorRate': 0.0,
+            'p50Ms': 12.0,
+            'p95Ms': 28.0,
+            'p99Ms': 45.0,
+            'missingQueries': <String>[],
+          },
+        },
+      });
+
+    await _pumpFromCandidates(
+      tester,
+      mock,
+      status: _istioStatus,
+      candidates: const ['web'],
+    );
+
+    expect(
+      find.byKey(const ValueKey('goldenSignals-service-picker')),
+      findsNothing,
+      reason: 'Single-candidate fromCandidates must not render the picker',
+    );
+    expect(find.text('Requests / s'), findsOneWidget);
+  });
+
+  testWidgets(
+      'fromCandidates: multiple candidates render the picker and fetch the '
+      'first by default', (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/mesh/golden-signals', body: {
+        'data': {
+          'status': {'detected': 'istio'},
+          'signals': {
+            'mesh': 'istio',
+            'namespace': 'app',
+            'service': 'web',
+            'available': true,
+            'rps': 1.0,
+            'errorRate': 0.0,
+            'p50Ms': 10.0,
+            'p95Ms': 20.0,
+            'p99Ms': 30.0,
+            'missingQueries': <String>[],
+          },
+        },
+      });
+
+    await _pumpFromCandidates(
+      tester,
+      mock,
+      status: _istioStatus,
+      candidates: const ['web', 'api'],
+    );
+
+    expect(
+      find.byKey(const ValueKey('goldenSignals-service-picker')),
+      findsOneWidget,
+    );
+    // The first candidate is selected by default — its service name
+    // appears in the picker's selected dropdown text AND in the
+    // bottom-of-tile metadata line.
+    expect(find.textContaining('service=web'), findsOneWidget);
+    // Initial fetch went to the first candidate.
+    final initialReq = mock.requests.firstWhere(
+      (r) => r.path == '/api/v1/mesh/golden-signals',
+    );
+    expect(initialReq.queryParameters['service'], 'web');
+  });
+
+  testWidgets(
+      'fromCandidates: tapping a different candidate re-fires the request',
+      (tester) async {
+    final mock = MockDioAdapter();
+    // Two responses so each service fetch returns a distinct payload.
+    Map<String, Object?> signalsBody(String service, double rps) => {
+          'data': {
+            'status': {'detected': 'istio'},
+            'signals': {
+              'mesh': 'istio',
+              'namespace': 'app',
+              'service': service,
+              'available': true,
+              'rps': rps,
+              'errorRate': 0.0,
+              'p50Ms': 10.0,
+              'p95Ms': 20.0,
+              'p99Ms': 30.0,
+              'missingQueries': <String>[],
+            },
+          },
+        };
+    mock
+      ..onJson('GET', '/api/v1/mesh/golden-signals',
+          body: signalsBody('web', 1.0))
+      ..onJson('GET', '/api/v1/mesh/golden-signals',
+          body: signalsBody('api', 9.9));
+
+    await _pumpFromCandidates(
+      tester,
+      mock,
+      status: _istioStatus,
+      candidates: const ['web', 'api'],
+    );
+
+    // Open the dropdown by tapping the picker, then tap 'api'.
+    await tester.tap(
+      find.byKey(const ValueKey('goldenSignals-service-picker')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('api').last);
+    await tester.pumpAndSettle(const Duration(milliseconds: 250));
+
+    final reqs = mock.requests
+        .where((r) => r.path == '/api/v1/mesh/golden-signals')
+        .toList();
+    expect(reqs.length, greaterThanOrEqualTo(2),
+        reason: 'Picker change must re-fire the golden-signals request');
+    expect(reqs.last.queryParameters['service'], 'api');
   });
 }

--- a/mobile/test/features/observability/logs/log_filter_bar_all_ns_test.dart
+++ b/mobile/test/features/observability/logs/log_filter_bar_all_ns_test.dart
@@ -161,6 +161,78 @@ void main() {
   });
 
   testWidgets(
+      'Run button disabled when all-NS checked AND no other filter set',
+      (tester) async {
+    // The fix for the `{}` LogQL emission: admin all-NS without any
+    // other matcher must keep Run disabled instead of submitting a
+    // query Loki will reject.
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/logs/labels/namespace/values',
+          body: {'data': <String>[]});
+    await _pump(tester, mock: mock, admin: true);
+
+    // Enable all-namespaces.
+    await tester.tap(find.byKey(const ValueKey('logFilter-allNamespaces')));
+    await tester.pumpAndSettle();
+
+    final runBtn = find.byKey(const ValueKey('logFilter-runButton'));
+    final pressedFn = (tester.widget(runBtn) as FilledButton).onPressed;
+    expect(pressedFn, isNull,
+        reason: 'Run must stay disabled to prevent emitting `{}` LogQL');
+  });
+
+  testWidgets(
+      'Run button enabled once all-NS + a Contains filter are set',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/logs/labels/namespace/values',
+          body: {'data': <String>[]});
+    await _pump(tester, mock: mock, admin: true);
+
+    await tester.tap(find.byKey(const ValueKey('logFilter-allNamespaces')));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const ValueKey('logFilter-freeText')),
+      'timeout',
+    );
+    await tester.pumpAndSettle();
+
+    final pressedFn = (tester.widget(
+            find.byKey(const ValueKey('logFilter-runButton'))) as FilledButton)
+        .onPressed;
+    expect(pressedFn, isNotNull,
+        reason: 'A free-text filter is sufficient to unblock submission');
+  });
+
+  testWidgets(
+      'LogQL escapes double-quote and backslash in free-text Contains',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/logs/labels/namespace/values',
+          body: {'data': const ['app']})
+      ..onJson('GET', '/api/v1/logs/labels/pod/values',
+          body: {'data': <String>[]});
+    final submitted = await _pump(tester, mock: mock, admin: false);
+
+    await tester.tap(find.byKey(const ValueKey('logFilter-namespace')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('app').last);
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const ValueKey('logFilter-freeText')),
+      r'a"b\c',
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('logFilter-runButton')));
+    await tester.pumpAndSettle();
+
+    expect(submitted, hasLength(1));
+    // Backslash escaped first, then double-quote, matching the
+    // escapeLogQLLiteral implementation order.
+    expect(submitted.single.query, r'{namespace="app"} |= "a\"b\\c"');
+  });
+
+  testWidgets(
       'unchecking the box re-enables the namespace dropdown',
       (tester) async {
     final mock = MockDioAdapter()

--- a/mobile/test/features/observability/logs/log_filter_bar_all_ns_test.dart
+++ b/mobile/test/features/observability/logs/log_filter_bar_all_ns_test.dart
@@ -1,0 +1,183 @@
+// PR-5f admin "All namespaces" checkbox tests.
+//
+// The checkbox is admin-only. When checked, the namespace dropdown is
+// disabled and the generated LogQL has no namespace label selector.
+// Non-admin users must not see the checkbox at all.
+
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kubecenter/api/dio_client.dart';
+import 'package:kubecenter/auth/auth_repository.dart';
+import 'package:kubecenter/auth/auth_state.dart';
+import 'package:kubecenter/auth/secure_storage.dart';
+import 'package:kubecenter/auth/user.dart';
+import 'package:kubecenter/features/observability/logs/log_filter_bar.dart';
+import 'package:kubecenter/features/observability/logs/log_search_controller.dart';
+import 'package:kubecenter/theme/kube_theme_builder.dart' show buildKubeTheme;
+
+import '../../../support/mock_dio_adapter.dart';
+
+class _StubAuthController extends AuthRepository {
+  _StubAuthController(this._initial);
+  final AuthState _initial;
+  @override
+  AuthState build() => _initial;
+}
+
+AuthState _stubAuth({required bool admin}) {
+  return AuthAuthenticated(
+    user: UserInfo(
+      id: 'u-1',
+      username: admin ? 'root' : 'alice',
+      provider: 'local',
+      roles: admin ? const ['admin'] : const ['operator'],
+    ),
+    rbac: const RBACSummary(),
+  );
+}
+
+Future<List<LogSearchParams>> _pump(
+  WidgetTester tester, {
+  required MockDioAdapter mock,
+  required bool admin,
+}) async {
+  final submitted = <LogSearchParams>[];
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        backendUrlProvider.overrideWithValue('http://test'),
+        secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+        dioProvider.overrideWith((ref) {
+          final dio = Dio(BaseOptions(baseUrl: 'http://test'));
+          dio.httpClientAdapter = mock;
+          return dio;
+        }),
+        refreshDioProvider.overrideWith((ref) {
+          final dio = Dio(BaseOptions(baseUrl: 'http://test'));
+          dio.httpClientAdapter = mock;
+          return dio;
+        }),
+        authRepositoryProvider.overrideWith(
+          () => _StubAuthController(_stubAuth(admin: admin)),
+        ),
+      ],
+      child: MaterialApp(
+        theme: buildKubeTheme('nexus'),
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: LogFilterBar(onSubmit: submitted.add),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 50));
+  return submitted;
+}
+
+void main() {
+  testWidgets('non-admin user sees no checkbox', (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/logs/labels/namespace/values',
+          body: {'data': <String>[]});
+    await _pump(tester, mock: mock, admin: false);
+    expect(
+      find.byKey(const ValueKey('logFilter-allNamespaces')),
+      findsNothing,
+      reason:
+          'Non-admin users must not see the all-namespaces toggle — '
+          'backend would 403 the cluster-wide query anyway.',
+    );
+  });
+
+  testWidgets('admin sees the checkbox above the namespace dropdown',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/logs/labels/namespace/values',
+          body: {'data': <String>['app', 'kube-system']});
+    await _pump(tester, mock: mock, admin: true);
+    expect(
+      find.byKey(const ValueKey('logFilter-allNamespaces')),
+      findsOneWidget,
+    );
+    expect(find.text('All namespaces (admin)'), findsOneWidget);
+  });
+
+  testWidgets(
+      'checking the box disables the namespace dropdown',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/logs/labels/namespace/values',
+          body: {'data': <String>['app']});
+    await _pump(tester, mock: mock, admin: true);
+
+    // Tap to enable all-namespaces.
+    await tester.tap(find.byKey(const ValueKey('logFilter-allNamespaces')));
+    await tester.pumpAndSettle();
+
+    final dropdown = tester.widget<DropdownButtonFormField<String?>>(
+      find.byKey(const ValueKey('logFilter-namespace')),
+    );
+    expect(dropdown.onChanged, isNull,
+        reason: 'Namespace dropdown must be disabled when checkbox is on');
+  });
+
+  testWidgets(
+      'checked checkbox → query has no namespace label selector',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/logs/labels/namespace/values',
+          body: {'data': <String>['app']})
+      ..onJson('GET', '/api/v1/logs/labels/pod/values',
+          body: {'data': <String>[]});
+
+    final submitted = await _pump(tester, mock: mock, admin: true);
+
+    // Enable all-namespaces.
+    await tester.tap(find.byKey(const ValueKey('logFilter-allNamespaces')));
+    await tester.pumpAndSettle();
+    // Pick a severity to put SOMETHING in the query so it's distinct
+    // from the no-filter case.
+    await tester
+        .tap(find.byKey(const ValueKey('logFilter-severity-error')));
+    await tester.pumpAndSettle();
+    // Submit.
+    await tester.tap(find.byKey(const ValueKey('logFilter-runButton')));
+    await tester.pumpAndSettle();
+
+    expect(submitted, hasLength(1));
+    expect(submitted.single.namespace, isNull,
+        reason: 'Submission must carry namespace=null on all-NS path');
+    expect(
+      submitted.single.query.contains('namespace='),
+      isFalse,
+      reason: 'LogQL must not include a namespace label selector when '
+          'the all-namespaces checkbox is on',
+    );
+    expect(submitted.single.query, '{} | level=~"(?i)error"');
+  });
+
+  testWidgets(
+      'unchecking the box re-enables the namespace dropdown',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/logs/labels/namespace/values',
+          body: {'data': <String>['app']});
+    await _pump(tester, mock: mock, admin: true);
+
+    // Check then uncheck.
+    await tester.tap(find.byKey(const ValueKey('logFilter-allNamespaces')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('logFilter-allNamespaces')));
+    await tester.pumpAndSettle();
+
+    final dropdown = tester.widget<DropdownButtonFormField<String?>>(
+      find.byKey(const ValueKey('logFilter-namespace')),
+    );
+    expect(dropdown.onChanged, isNotNull,
+        reason: 'Namespace dropdown must re-enable when checkbox is off');
+  });
+}

--- a/mobile/test/features/policy/compliance_time_range_test.dart
+++ b/mobile/test/features/policy/compliance_time_range_test.dart
@@ -165,6 +165,58 @@ void main() {
   });
 
   testWidgets(
+      'empty datapoints renders the "No compliance snapshots yet" EmptyState',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/policies/status', body: _statusBody())
+      ..onJson('GET', '/api/v1/policies/compliance/history',
+          body: {'data': <Object>[]});
+    await _pump(tester, mock);
+
+    expect(find.text('No compliance snapshots yet'), findsOneWidget);
+  });
+
+  testWidgets(
+      'stale-error banner: previous chart stays visible with "Couldn\'t '
+      'refresh" + Retry when the second fetch errors',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/policies/status', body: _statusBody())
+      ..onJson('GET', '/api/v1/policies/compliance/history',
+          body: _historyBody(30))
+      ..onJson('GET', '/api/v1/policies/compliance/history',
+          status: 500,
+          body: {'error': {'code': 500, 'message': 'transient backend error'}});
+    await _pump(tester, mock);
+
+    // First load succeeds. Switching to 7d fires the queued 500 response.
+    await tester.tap(find.text('7d'));
+    await tester.pumpAndSettle(const Duration(milliseconds: 200));
+
+    // Stale-overlay path: previous chart is still on screen + banner
+    // appears with a Retry button. We can't assert Opacity-around-the-
+    // card directly across the whole subtree, so check the user-visible
+    // signals: banner text + Retry CTA + chart title from the previous
+    // (5-point) response.
+    expect(find.textContaining("Couldn't refresh"), findsOneWidget);
+    expect(find.widgetWithText(TextButton, 'Retry'), findsOneWidget);
+    expect(find.textContaining('Last 5 days'), findsOneWidget);
+
+    // Tapping Retry re-fires the request (the mock's queue is exhausted,
+    // so this surfaces the same 500 — but the request count must rise).
+    final before = mock.requests
+        .where((r) => r.path == '/api/v1/policies/compliance/history')
+        .length;
+    await tester.tap(find.widgetWithText(TextButton, 'Retry'));
+    await tester.pumpAndSettle(const Duration(milliseconds: 200));
+    final after = mock.requests
+        .where((r) => r.path == '/api/v1/policies/compliance/history')
+        .length;
+    expect(after, greaterThan(before),
+        reason: 'Retry button must re-fire the history request');
+  });
+
+  testWidgets(
       'custom date-range picker is intentionally absent in M5',
       (tester) async {
     final mock = MockDioAdapter()

--- a/mobile/test/features/policy/compliance_time_range_test.dart
+++ b/mobile/test/features/policy/compliance_time_range_test.dart
@@ -1,0 +1,184 @@
+// PR-5f compliance time-range picker tests.
+//
+// The picker is a SegmentedButton with values 1/7/30/90 mapped to
+// `?days=N`. Selecting a value must re-fire the backend call with the
+// new days parameter and keep the prior chart visible (faded) during
+// the refresh. Custom date-range picker is intentionally absent in M5.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:kubecenter/api/dio_client.dart';
+import 'package:kubecenter/auth/auth_repository.dart';
+import 'package:kubecenter/auth/auth_state.dart';
+import 'package:kubecenter/auth/secure_storage.dart';
+import 'package:kubecenter/auth/user.dart';
+import 'package:kubecenter/features/policy/compliance_history_screen.dart';
+import 'package:kubecenter/theme/kube_theme_builder.dart';
+
+import '../../support/mock_dio_adapter.dart';
+
+class _FakeAuth extends AuthRepository {
+  _FakeAuth(this._initial);
+  final AuthState _initial;
+  @override
+  AuthState build() => _initial;
+}
+
+Map<String, Object?> _statusBody() => {
+      'data': {
+        'detected': 'both',
+        'kyverno': {'available': true, 'webhooks': 1},
+        'gatekeeper': {'available': true, 'webhooks': 1},
+      },
+    };
+
+Map<String, Object?> _historyBody(int days) => {
+      'data': List.generate(
+        days.clamp(1, 5),
+        (i) => {
+          'date': '2026-05-0${i + 1}',
+          'score': 80.0 + i,
+          'pass': 8,
+          'fail': 2,
+          'warn': 0,
+          'total': 10,
+        },
+      ),
+    };
+
+Future<void> _pump(WidgetTester tester, MockDioAdapter mock) async {
+  await tester.binding.setSurfaceSize(const Size(800, 1600));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+
+  final user = UserInfo(
+    id: 'u1',
+    username: 'admin',
+    provider: 'local',
+    roles: const ['admin'],
+  );
+
+  final router = GoRouter(
+    initialLocation: '/',
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (context, state) => const ComplianceHistoryScreen(),
+      ),
+    ],
+  );
+
+  await tester.pumpWidget(ProviderScope(
+    overrides: [
+      backendUrlProvider.overrideWithValue('http://test'),
+      secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+      authRepositoryProvider.overrideWith(
+        () => _FakeAuth(
+          AuthAuthenticated(user: user, rbac: const RBACSummary()),
+        ),
+      ),
+    ],
+    child: _DioInstaller(
+      mock: mock,
+      child: MaterialApp.router(
+        theme: buildKubeTheme('nexus'),
+        routerConfig: router,
+      ),
+    ),
+  ));
+  await tester.pump();
+  await tester.pumpAndSettle(const Duration(milliseconds: 200));
+}
+
+class _DioInstaller extends ConsumerWidget {
+  const _DioInstaller({required this.mock, required this.child});
+
+  final MockDioAdapter mock;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.read(dioProvider).httpClientAdapter = mock;
+    return child;
+  }
+}
+
+void main() {
+  testWidgets('default selection is 30d', (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/policies/status', body: _statusBody())
+      ..onJson('GET', '/api/v1/policies/compliance/history',
+          body: _historyBody(30));
+    await _pump(tester, mock);
+
+    // SegmentedButton renders each label as a Text widget; verify all 4
+    // chips are present and 30d is the selected initial.
+    expect(find.text('1d'), findsOneWidget);
+    expect(find.text('7d'), findsOneWidget);
+    expect(find.text('30d'), findsOneWidget);
+    expect(find.text('90d'), findsOneWidget);
+  });
+
+  testWidgets('selecting 7d re-fires the request with ?days=7',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/policies/status', body: _statusBody())
+      ..onJson('GET', '/api/v1/policies/compliance/history',
+          body: _historyBody(30));
+    await _pump(tester, mock);
+
+    // Confirm the initial request used days=30. The adapter records
+    // every captured request — locate the compliance history call.
+    final initialReq = mock.requests.firstWhere(
+      (r) => r.path == '/api/v1/policies/compliance/history',
+    );
+    expect(initialReq.queryParameters['days'], '30');
+
+    // Tap the 7d chip; the new request must use days=7.
+    await tester.tap(find.text('7d'));
+    await tester.pumpAndSettle(const Duration(milliseconds: 200));
+
+    final reloads = mock.requests
+        .where((r) => r.path == '/api/v1/policies/compliance/history')
+        .toList();
+    expect(reloads.length, greaterThanOrEqualTo(2),
+        reason: 'Picker change must re-fire the history request');
+    expect(reloads.last.queryParameters['days'], '7');
+  });
+
+  testWidgets('selecting 90d re-fires the request with ?days=90',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/policies/status', body: _statusBody())
+      ..onJson('GET', '/api/v1/policies/compliance/history',
+          body: _historyBody(30));
+    await _pump(tester, mock);
+
+    await tester.tap(find.text('90d'));
+    await tester.pumpAndSettle(const Duration(milliseconds: 200));
+
+    final reloads = mock.requests
+        .where((r) => r.path == '/api/v1/policies/compliance/history')
+        .toList();
+    expect(reloads.last.queryParameters['days'], '90');
+  });
+
+  testWidgets(
+      'custom date-range picker is intentionally absent in M5',
+      (tester) async {
+    final mock = MockDioAdapter()
+      ..onJson('GET', '/api/v1/policies/status', body: _statusBody())
+      ..onJson('GET', '/api/v1/policies/compliance/history',
+          body: _historyBody(30));
+    await _pump(tester, mock);
+
+    // The shared TimeRangePicker uses 'Custom' for date-range entry —
+    // the compliance picker deliberately does NOT include it because the
+    // backend endpoint doesn't accept arbitrary ?start=/?end= ranges.
+    expect(find.text('Custom'), findsNothing,
+        reason:
+            'Compliance picker must not surface a Custom date-range '
+            'option in M5 — that path is a deferred backend addendum.');
+  });
+}

--- a/mobile/test/util/service_derivation_test.dart
+++ b/mobile/test/util/service_derivation_test.dart
@@ -142,6 +142,49 @@ void main() {
               'a stringified compare would mask backend bugs.');
     });
 
+    test('skips services with no metadata key (defensive guard)', () {
+      final result = findServicesForResource(
+        services: [
+          {
+            'spec': {'selector': {'app': 'web'}},
+          },
+        ],
+        namespace: 'web',
+        resourceLabels: const {'app': 'web'},
+      );
+      expect(result, isEmpty,
+          reason: 'Service with missing metadata must not match');
+    });
+
+    test('skips services with no spec key (defensive guard)', () {
+      final result = findServicesForResource(
+        services: [
+          {
+            'metadata': {'namespace': 'web', 'name': 'svc'},
+          },
+        ],
+        namespace: 'web',
+        resourceLabels: const {'app': 'web'},
+      );
+      expect(result, isEmpty,
+          reason: 'Service with missing spec must not match');
+    });
+
+    test('skips services with empty name (defensive guard)', () {
+      final result = findServicesForResource(
+        services: [
+          {
+            'metadata': {'namespace': 'web', 'name': ''},
+            'spec': {'selector': {'app': 'web'}},
+          },
+        ],
+        namespace: 'web',
+        resourceLabels: const {'app': 'web'},
+      );
+      expect(result, isEmpty,
+          reason: 'Service with empty name must not match');
+    });
+
     test('requires every selector key/value to be present on the resource',
         () {
       final result = findServicesForResource(

--- a/mobile/test/util/service_derivation_test.dart
+++ b/mobile/test/util/service_derivation_test.dart
@@ -1,0 +1,164 @@
+// Unit tests for findServicesForResource — the PR-5f service-name
+// derivation that powers the Golden Signals tab on Pod and Deployment
+// detail screens.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kubecenter/util/service_derivation.dart';
+
+Map<String, dynamic> _service({
+  required String namespace,
+  required String name,
+  Map<String, String>? selector,
+}) {
+  return {
+    'metadata': {'namespace': namespace, 'name': name},
+    if (selector != null) 'spec': {'selector': selector},
+    if (selector == null) 'spec': <String, dynamic>{},
+  };
+}
+
+void main() {
+  group('findServicesForResource', () {
+    test('returns empty list when resource has no labels', () {
+      final result = findServicesForResource(
+        services: [
+          _service(namespace: 'web', name: 'svc', selector: {'app': 'web'}),
+        ],
+        namespace: 'web',
+        resourceLabels: const {},
+      );
+      expect(result, isEmpty,
+          reason: 'No labels means no selector can match');
+    });
+
+    test('returns empty list when namespace is empty', () {
+      final result = findServicesForResource(
+        services: const [],
+        namespace: '',
+        resourceLabels: const {'app': 'web'},
+      );
+      expect(result, isEmpty);
+    });
+
+    test('matches a single Service whose selector is a subset', () {
+      final result = findServicesForResource(
+        services: [
+          _service(namespace: 'web', name: 'web-svc', selector: {'app': 'web'}),
+          _service(
+              namespace: 'web', name: 'db-svc', selector: {'app': 'db'}),
+        ],
+        namespace: 'web',
+        resourceLabels: const {'app': 'web', 'tier': 'frontend'},
+      );
+      expect(result, hasLength(1));
+      expect(result.first.name, 'web-svc');
+    });
+
+    test('skips Services in other namespaces', () {
+      final result = findServicesForResource(
+        services: [
+          _service(namespace: 'web', name: 'svc-a', selector: {'app': 'web'}),
+          _service(
+              namespace: 'staging', name: 'svc-b', selector: {'app': 'web'}),
+        ],
+        namespace: 'web',
+        resourceLabels: const {'app': 'web'},
+      );
+      expect(result.map((s) => s.name), ['svc-a']);
+    });
+
+    test('skips Services with empty selectors', () {
+      final result = findServicesForResource(
+        services: [
+          _service(namespace: 'web', name: 'headless', selector: const {}),
+          _service(
+              namespace: 'web', name: 'externalname-svc', selector: null),
+        ],
+        namespace: 'web',
+        resourceLabels: const {'app': 'web'},
+      );
+      expect(result, isEmpty,
+          reason: 'Empty/missing selectors must never flood the picker');
+    });
+
+    test('ranks more-specific selectors first', () {
+      final result = findServicesForResource(
+        services: [
+          _service(
+              namespace: 'web',
+              name: 'broad',
+              selector: {'app': 'web'}),
+          _service(
+              namespace: 'web',
+              name: 'narrow',
+              selector: {'app': 'web', 'tier': 'frontend'}),
+        ],
+        namespace: 'web',
+        resourceLabels: const {'app': 'web', 'tier': 'frontend'},
+      );
+      expect(result.map((s) => s.name), ['narrow', 'broad']);
+    });
+
+    test(
+        'breaks specificity ties alphabetically so the picker order is '
+        'deterministic across builds', () {
+      final result = findServicesForResource(
+        services: [
+          _service(
+              namespace: 'web',
+              name: 'zeta',
+              selector: {'app': 'web'}),
+          _service(
+              namespace: 'web',
+              name: 'alpha',
+              selector: {'app': 'web'}),
+          _service(
+              namespace: 'web',
+              name: 'beta',
+              selector: {'app': 'web'}),
+        ],
+        namespace: 'web',
+        resourceLabels: const {'app': 'web'},
+      );
+      expect(result.map((s) => s.name), ['alpha', 'beta', 'zeta']);
+    });
+
+    test('rejects malformed selectors with non-string values', () {
+      final result = findServicesForResource(
+        services: [
+          {
+            'metadata': {'namespace': 'web', 'name': 'malformed'},
+            'spec': {
+              'selector': {'app': 42},
+            },
+          },
+        ],
+        namespace: 'web',
+        resourceLabels: const {'app': 'web'},
+      );
+      expect(result, isEmpty,
+          reason:
+              'Malformed selectors must not produce a match — guessing '
+              'a stringified compare would mask backend bugs.');
+    });
+
+    test('requires every selector key/value to be present on the resource',
+        () {
+      final result = findServicesForResource(
+        services: [
+          _service(
+            namespace: 'web',
+            name: 'wants-version',
+            selector: {'app': 'web', 'version': 'v2'},
+          ),
+        ],
+        namespace: 'web',
+        resourceLabels: const {'app': 'web', 'version': 'v1'},
+      );
+      expect(result, isEmpty,
+          reason:
+              'A Service whose selector references a missing or '
+              'differently-valued label must not match.');
+    });
+  });
+}

--- a/mobile/test/widgets/kube_line_chart_zoom_test.dart
+++ b/mobile/test/widgets/kube_line_chart_zoom_test.dart
@@ -128,6 +128,32 @@ void main() {
     await tester.pump(const Duration(milliseconds: 500));
   });
 
+  testWidgets('enableZoom: false skips the gesture wrapper', (tester) async {
+    await tester.pumpWidget(_wrap(SizedBox(
+      width: 400,
+      height: 240,
+      child: KubeLineChart(series: sampleSeries, enableZoom: false),
+    )));
+    final state = tester.state<KubeLineChartState>(find.byType(KubeLineChart));
+
+    final chartCenter = tester.getCenter(find.byType(KubeLineChart));
+    final gesture1 = await tester.createGesture();
+    final gesture2 = await tester.createGesture();
+    await gesture1.down(chartCenter + const Offset(-40, 0));
+    await gesture2.down(chartCenter + const Offset(40, 0));
+    await tester.pump();
+    await gesture1.moveTo(chartCenter + const Offset(-160, 0));
+    await gesture2.moveTo(chartCenter + const Offset(160, 0));
+    await tester.pump();
+    await gesture1.up();
+    await gesture2.up();
+    await tester.pump();
+
+    expect(state.isZoomed, isFalse,
+        reason: 'enableZoom: false must not produce any zoom state');
+    await tester.pump(const Duration(milliseconds: 500));
+  });
+
   testWidgets('pinch-in past the initial range stays clamped',
       (tester) async {
     await tester.pumpWidget(_wrap(SizedBox(

--- a/mobile/test/widgets/kube_line_chart_zoom_test.dart
+++ b/mobile/test/widgets/kube_line_chart_zoom_test.dart
@@ -1,0 +1,176 @@
+// Tests for PR-5f chart zoom on KubeLineChart.
+//
+// The recognizer-level gate must reject single-finger horizontal
+// drags so a parent TabBarView can still swipe between tabs from the
+// chart area. Pinching with 2 pointers narrows or widens the X
+// window. Double-tap returns to the data's natural range.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kubecenter/theme/kube_theme_builder.dart';
+import 'package:kubecenter/widgets/kube_line_chart.dart';
+
+void main() {
+  final t0 = DateTime(2026, 5, 9, 12);
+  final samplePoints = List.generate(
+    20,
+    (i) => (t: t0.add(Duration(minutes: i)), v: (i + 1).toDouble()),
+  );
+  final sampleSeries = [
+    (
+      label: 'cpu',
+      points: samplePoints,
+      severity: KubeChartSeverity.success,
+    ),
+  ];
+
+  testWidgets('initial state has no zoom applied', (tester) async {
+    await tester.pumpWidget(_wrap(KubeLineChart(series: sampleSeries)));
+    final state = tester.state<KubeLineChartState>(find.byType(KubeLineChart));
+    expect(state.isZoomed, isFalse);
+    expect(state.zoomMinX, isNull);
+    expect(state.zoomMaxX, isNull);
+  });
+
+  testWidgets('two-finger pinch-out narrows the X range', (tester) async {
+    await tester.pumpWidget(_wrap(SizedBox(
+      width: 400,
+      height: 240,
+      child: KubeLineChart(series: sampleSeries),
+    )));
+    final state = tester.state<KubeLineChartState>(find.byType(KubeLineChart));
+    expect(state.isZoomed, isFalse);
+
+    final chartCenter = tester.getCenter(find.byType(KubeLineChart));
+    final left = chartCenter + const Offset(-40, 0);
+    final right = chartCenter + const Offset(40, 0);
+    final gesture1 = await tester.createGesture();
+    final gesture2 = await tester.createGesture();
+    await gesture1.down(left);
+    await gesture2.down(right);
+    await tester.pump();
+    // Pull fingers further apart → pinch-out → zoom in (narrower span).
+    await gesture1.moveTo(chartCenter + const Offset(-160, 0));
+    await gesture2.moveTo(chartCenter + const Offset(160, 0));
+    await tester.pump();
+    await gesture1.up();
+    await gesture2.up();
+    await tester.pump();
+
+    expect(state.isZoomed, isTrue,
+        reason: 'Pinch-out should establish a non-null zoom window');
+    expect(state.zoomMaxX! - state.zoomMinX!, lessThan(
+        samplePoints.last.t.millisecondsSinceEpoch.toDouble() -
+            samplePoints.first.t.millisecondsSinceEpoch.toDouble()),
+        reason: 'Zoomed span must be tighter than the data\'s initial span');
+    // Flush the DoubleTapGestureRecognizer's settle timer before
+    // teardown — every pointer-down registers a candidate tap and the
+    // recognizer holds it for kDoubleTapTimeout looking for a second
+    // tap that will never arrive.
+    await tester.pump(const Duration(milliseconds: 500));
+  });
+
+  testWidgets('double-tap resets a held zoom', (tester) async {
+    await tester.pumpWidget(_wrap(SizedBox(
+      width: 400,
+      height: 240,
+      child: KubeLineChart(series: sampleSeries),
+    )));
+    final state = tester.state<KubeLineChartState>(find.byType(KubeLineChart));
+
+    // Apply a zoom first.
+    final chartCenter = tester.getCenter(find.byType(KubeLineChart));
+    final gesture1 = await tester.createGesture();
+    final gesture2 = await tester.createGesture();
+    await gesture1.down(chartCenter + const Offset(-40, 0));
+    await gesture2.down(chartCenter + const Offset(40, 0));
+    await tester.pump();
+    await gesture1.moveTo(chartCenter + const Offset(-150, 0));
+    await gesture2.moveTo(chartCenter + const Offset(150, 0));
+    await tester.pump();
+    await gesture1.up();
+    await gesture2.up();
+    await tester.pump();
+    expect(state.isZoomed, isTrue);
+
+    // Now double-tap to reset.
+    await tester.tap(find.byType(KubeLineChart));
+    await tester.pump(const Duration(milliseconds: 50));
+    await tester.tap(find.byType(KubeLineChart));
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(state.isZoomed, isFalse,
+        reason: 'Double-tap should clear the zoom window');
+    expect(state.zoomMinX, isNull);
+    expect(state.zoomMaxX, isNull);
+  });
+
+  testWidgets(
+      'single-finger horizontal drag does NOT zoom (recognizer gate)',
+      (tester) async {
+    await tester.pumpWidget(_wrap(SizedBox(
+      width: 400,
+      height: 240,
+      child: KubeLineChart(series: sampleSeries),
+    )));
+    final state = tester.state<KubeLineChartState>(find.byType(KubeLineChart));
+
+    final chartCenter = tester.getCenter(find.byType(KubeLineChart));
+    final gesture = await tester.startGesture(chartCenter);
+    await gesture.moveBy(const Offset(120, 0));
+    await tester.pump();
+    await gesture.up();
+    await tester.pump();
+
+    expect(state.isZoomed, isFalse,
+        reason:
+            'Single-finger drag must not be claimed by the scale recognizer');
+    await tester.pump(const Duration(milliseconds: 500));
+  });
+
+  testWidgets('pinch-in past the initial range stays clamped',
+      (tester) async {
+    await tester.pumpWidget(_wrap(SizedBox(
+      width: 400,
+      height: 240,
+      child: KubeLineChart(series: sampleSeries),
+    )));
+    final state = tester.state<KubeLineChartState>(find.byType(KubeLineChart));
+
+    final chartCenter = tester.getCenter(find.byType(KubeLineChart));
+    final gesture1 = await tester.createGesture();
+    final gesture2 = await tester.createGesture();
+    await gesture1.down(chartCenter + const Offset(-160, 0));
+    await gesture2.down(chartCenter + const Offset(160, 0));
+    await tester.pump();
+    // Pinch fingers together aggressively past the initial range —
+    // the clamp should snap _zoomMinX/_zoomMaxX back to null rather
+    // than holding a window wider than the data.
+    await gesture1.moveTo(chartCenter + const Offset(-2, 0));
+    await gesture2.moveTo(chartCenter + const Offset(2, 0));
+    await tester.pump();
+    await gesture1.up();
+    await gesture2.up();
+    await tester.pump();
+
+    final initialMin =
+        samplePoints.first.t.millisecondsSinceEpoch.toDouble();
+    final initialMax =
+        samplePoints.last.t.millisecondsSinceEpoch.toDouble();
+    if (state.isZoomed) {
+      expect(state.zoomMinX, greaterThanOrEqualTo(initialMin));
+      expect(state.zoomMaxX, lessThanOrEqualTo(initialMax));
+    }
+    // Either we snapped back to "not zoomed" (preferred) or we're
+    // clamped strictly inside the data range — both satisfy the
+    // invariant "never paint axis off the data".
+    await tester.pump(const Duration(milliseconds: 500));
+  });
+}
+
+Widget _wrap(Widget child) {
+  return MaterialApp(
+    theme: buildKubeTheme('nexus'),
+    home: Scaffold(body: Center(child: child)),
+  );
+}


### PR DESCRIPTION
## Summary

PR-5f bundles four M4 polish carryovers from the M5 plan (`plans/mobile-app-m5-pr-sequence.md` § U6) into one PR. Each is a surgical addition to an existing M4 surface.

### 1. Chart zoom on `KubeLineChart`
- Stateless → Stateful, public `KubeLineChartState` with `@visibleForTesting` accessors.
- Two-finger pinch adjusts the X-axis range around the gesture focal point; double-tap resets to the data's natural span.
- Custom `_TwoFingerScaleRecognizer` rejects single-finger gestures so the parent `TabBarView` still wins single-finger horizontal swipes between tabs.
- `LineTouchData(enabled: false)` disables fl_chart's internal pan recognizer (it would otherwise race-win the gesture arena and swallow our scale gestures inside the chart hit area). The tooltip-on-tap UX is sacrificed in trade.

### 2. Compliance history `?days=N` preset picker
- New SegmentedButton above the compliance history chart with values `1d / 7d / 30d / 90d` — mapped directly to the existing `complianceHistory(days:)` repository call.
- Refresh UX: previous chart stays visible at 50% opacity with a spinner overlay while a new window loads; transient errors keep the last-known chart with a "Couldn't refresh" banner + Retry CTA and re-enable the picker.
- The non-retryable "compliance history requires a database" 503 path is unchanged (still surfaces `FeatureUnavailableState`, no picker).
- Custom date-range picker is intentionally absent — the backend endpoint only accepts `?days=N`.

### 3. Admin all-namespaces LogQL checkbox
- New explicit "All namespaces (admin)" checkbox above the namespace dropdown in `LogFilterBar`.
- Checked → dropdown disabled (with helper text), cascaded pod/container clear, LogQL builder skips the namespace label selector.
- Non-admin users do not see the checkbox; their existing dropdown-required gate is unchanged.

### 4. Service-name autoderivation for the Golden Signals tab
- New `mobile/lib/util/service_derivation.dart` — pure `findServicesForResource()` that filters Services by `spec.selector ⊆ resource labels` and ranks by selector specificity with alphabetical tie-break.
- Pod and Deployment detail screens watch the namespace's Service list and add the Golden Signals tab only when ≥1 Service matches. Pod uses `metadata.labels`; Deployment uses `spec.template.metadata.labels` (the labels its managed Pods carry).
- New `GoldenSignalsTab.fromCandidates(candidates: ...)` constructor + in-tab dropdown when ≥2 Services match, so the operator can switch which Service's signals they're inspecting without leaving the detail route.
- Single-service Service detail keeps the original `GoldenSignalsTab(service: ...)` API untouched.

## Test plan

- [x] `flutter analyze` clean repo-wide (no issues).
- [x] `flutter test` clean repo-wide (1074 tests pass).
- [x] New tests:
  - `test/widgets/kube_line_chart_zoom_test.dart` — initial state, pinch-out narrows, double-tap resets, single-finger gate, pinch past initial clamps.
  - `test/features/policy/compliance_time_range_test.dart` — default 30d, selecting 7d / 90d re-fires with correct `?days=`, custom picker absent.
  - `test/features/observability/logs/log_filter_bar_all_ns_test.dart` — non-admin hidden, admin sees checkbox, check disables dropdown, query has no namespace selector, uncheck re-enables.
  - `test/util/service_derivation_test.dart` — empty labels/namespace, single subset match, cross-namespace skip, empty/null selector skip, specificity ranking, alphabetical tie-break, malformed selector rejection, missing-label exclusion.
- [ ] Smoke against homelab: pinch a metrics chart, switch between compliance day windows, toggle admin all-NS on a real cluster, open a Pod detail screen and verify the Golden Signals tab appears when a Service targets it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)