### PR TITLE
feat(mobile): M5 PR-5g — first-launch 3-card onboarding tour

### DIFF
--- a/mobile/lib/features/onboarding/onboarding_cards.dart
+++ b/mobile/lib/features/onboarding/onboarding_cards.dart
@@ -1,0 +1,299 @@
+// Three onboarding card widgets, one per page of the tour.
+//
+//   IntroCard         — public-store strangers: "you need a self-hosted
+//                       backend"; primary CTA advances, secondary CTA
+//                       opens the install guide in the system browser.
+//   ClusterPinCard    — orients new users on the cluster pill.
+//   NotificationsCard — fires the OS push-permission prompt, advances
+//                       regardless of the user's choice.
+//
+// Cards are pure widgets; they expose `onAdvance` and `onSkip`
+// callbacks so the screen owns the PageView / completion state and the
+// cards stay testable in isolation.
+
+import 'dart:io' show Platform;
+
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter/foundation.dart' show debugPrint, kIsWeb;
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../theme/kube_theme_builder.dart';
+
+/// Public-marketing landing page for users who installed the app
+/// without a server to point it at. PR-5j may move this to a versioned
+/// URL; for M5 the path is stable.
+const String kInstallGuideUrl = 'https://kubecenter.io/install';
+
+class IntroCard extends StatelessWidget {
+  const IntroCard({
+    super.key,
+    required this.onAdvance,
+    required this.onSkip,
+  });
+
+  final VoidCallback onAdvance;
+  final VoidCallback onSkip;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return OnboardingCardLayout(
+      icon: Icons.dns_outlined,
+      iconSemanticsLabel: 'Self-hosted server icon',
+      headline: 'k8sCenter Mobile needs a home',
+      body: 'This app is an oncall companion for an existing self-hosted '
+          'k8sCenter backend. If you do not have one set up yet, you can '
+          'install one first and come back.',
+      primary: _PrimaryButton(
+        key: const ValueKey('onboarding-intro-have-server'),
+        label: 'I have a server',
+        onPressed: onAdvance,
+      ),
+      secondary: _GhostButton(
+        key: const ValueKey('onboarding-intro-install-guide'),
+        label: 'How to set up your server',
+        colors: colors,
+        onPressed: () => _launchInstallGuide(context),
+      ),
+      onSkip: onSkip,
+    );
+  }
+
+  Future<void> _launchInstallGuide(BuildContext context) async {
+    final uri = Uri.parse(kInstallGuideUrl);
+    final ok = await launchUrl(uri, mode: LaunchMode.externalApplication);
+    if (!ok && context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Could not open $kInstallGuideUrl')),
+      );
+    }
+  }
+}
+
+class ClusterPinCard extends StatelessWidget {
+  const ClusterPinCard({
+    super.key,
+    required this.onAdvance,
+    required this.onSkip,
+  });
+
+  final VoidCallback onAdvance;
+  final VoidCallback onSkip;
+
+  @override
+  Widget build(BuildContext context) {
+    return OnboardingCardLayout(
+      icon: Icons.hub_outlined,
+      iconSemanticsLabel: 'Cluster icon',
+      headline: 'Pick your cluster',
+      body: 'The cluster pill at the top of every screen switches between '
+          'connected clusters. Tap it any time to add another or to view '
+          'a different one.',
+      primary: _PrimaryButton(
+        key: const ValueKey('onboarding-cluster-next'),
+        label: 'Next',
+        onPressed: onAdvance,
+      ),
+      onSkip: onSkip,
+    );
+  }
+}
+
+class NotificationsCard extends StatelessWidget {
+  const NotificationsCard({
+    super.key,
+    required this.onAdvance,
+    required this.onSkip,
+  });
+
+  final VoidCallback onAdvance;
+  final VoidCallback onSkip;
+
+  @override
+  Widget build(BuildContext context) {
+    return OnboardingCardLayout(
+      icon: Icons.notifications_outlined,
+      iconSemanticsLabel: 'Notifications bell icon',
+      headline: 'Stay on top of alerts',
+      body: 'Push notifications let k8sCenter wake your phone when a '
+          'cluster needs attention. You can change this later in Settings.',
+      primary: _PrimaryButton(
+        key: const ValueKey('onboarding-notifications-enable'),
+        label: 'Enable notifications',
+        onPressed: () async {
+          await _requestNotificationPermission();
+          onAdvance();
+        },
+      ),
+      onSkip: onSkip,
+    );
+  }
+
+  /// Surfaces the OS push-permission prompt by initialising Firebase
+  /// and calling `requestPermission`. Any failure (missing
+  /// google-services.json / GoogleService-Info.plist, web or desktop
+  /// build, sandboxed CI) is swallowed — the card still advances so a
+  /// user without a configured FCM build isn't trapped on the last
+  /// page.
+  Future<void> _requestNotificationPermission() async {
+    if (kIsWeb) return;
+    try {
+      if (!Platform.isIOS && !Platform.isAndroid) return;
+    } catch (_) {
+      return;
+    }
+    try {
+      await Firebase.initializeApp();
+      await FirebaseMessaging.instance.requestPermission(
+        alert: true,
+        badge: true,
+        sound: true,
+      );
+    } catch (e) {
+      debugPrint('[onboarding] notifications init skipped: $e');
+    }
+  }
+}
+
+/// Shared visual scaffold for every card. Top-right Skip, centered
+/// icon, headline + body, primary CTA at the bottom, optional ghost
+/// secondary below it. Exposed (non-private) so widget tests can pump
+/// the layout standalone without a Firebase/url_launcher detour.
+@visibleForTesting
+class OnboardingCardLayout extends StatelessWidget {
+  const OnboardingCardLayout({
+    super.key,
+    required this.icon,
+    required this.iconSemanticsLabel,
+    required this.headline,
+    required this.body,
+    required this.primary,
+    this.secondary,
+    required this.onSkip,
+  });
+
+  final IconData icon;
+  final String iconSemanticsLabel;
+  final String headline;
+  final String body;
+  final Widget primary;
+  final Widget? secondary;
+  final VoidCallback onSkip;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Align(
+              alignment: Alignment.topRight,
+              child: TextButton(
+                key: const ValueKey('onboarding-skip'),
+                onPressed: onSkip,
+                child: Text(
+                  'Skip',
+                  style: TextStyle(color: colors.textMuted),
+                ),
+              ),
+            ),
+            Expanded(
+              flex: 4,
+              child: Center(
+                child: Icon(
+                  icon,
+                  size: 120,
+                  color: colors.accent,
+                  semanticLabel: iconSemanticsLabel,
+                ),
+              ),
+            ),
+            Expanded(
+              flex: 6,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Text(
+                    headline,
+                    style: TextStyle(
+                      color: colors.textPrimary,
+                      fontSize: 24,
+                      fontWeight: FontWeight.w600,
+                      height: 1.2,
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  Text(
+                    body,
+                    style: TextStyle(
+                      color: colors.textSecondary,
+                      fontSize: 16,
+                      height: 1.4,
+                    ),
+                  ),
+                  const Spacer(),
+                  primary,
+                  if (secondary != null) ...[
+                    const SizedBox(height: 8),
+                    secondary!,
+                  ],
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PrimaryButton extends StatelessWidget {
+  const _PrimaryButton({
+    super.key,
+    required this.label,
+    required this.onPressed,
+  });
+
+  final String label;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 48,
+      child: FilledButton(
+        onPressed: onPressed,
+        child: Text(label),
+      ),
+    );
+  }
+}
+
+class _GhostButton extends StatelessWidget {
+  const _GhostButton({
+    super.key,
+    required this.label,
+    required this.onPressed,
+    required this.colors,
+  });
+
+  final String label;
+  final VoidCallback onPressed;
+  final KubeColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 48,
+      child: TextButton(
+        onPressed: onPressed,
+        child: Text(label, style: TextStyle(color: colors.accent)),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/onboarding/onboarding_cards.dart
+++ b/mobile/lib/features/onboarding/onboarding_cards.dart
@@ -1,45 +1,167 @@
-// Three onboarding card widgets, one per page of the tour.
+// Onboarding card widget with three static factory methods, one per page of
+// the tour.
 //
-//   IntroCard         — public-store strangers: "you need a self-hosted
-//                       backend"; primary CTA advances, secondary CTA
-//                       opens the install guide in the system browser.
-//   ClusterPinCard    — orients new users on the cluster pill.
-//   NotificationsCard — fires the OS push-permission prompt, advances
-//                       regardless of the user's choice.
+//   OnboardingCard.intro(...)          — public-store strangers: "you need a
+//                                        self-hosted backend"; primary CTA
+//                                        advances, secondary CTA opens the
+//                                        install guide in the system browser.
+//   OnboardingCard.clusterPin(...)     — orients new users on the cluster pill.
+//   OnboardingCard.notifications(...) — fires the OS push-permission prompt via
+//                                        [requestFcmPermission], then advances.
+//                                        Primary CTA label is "Get started" per
+//                                        the plan spec.
 //
-// Cards are pure widgets; they expose `onAdvance` and `onSkip`
-// callbacks so the screen owns the PageView / completion state and the
-// cards stay testable in isolation.
+// Cards are pure widgets; they expose `onAdvance` and `onSkip` callbacks so
+// the screen owns the PageView / completion state and the cards stay testable
+// in isolation.
+//
+// Callback typing: `FutureOr<void> Function()` so async screen callbacks
+// (`_advance`, `_complete`) are accepted without a wrapper. Any exception
+// thrown by the callback is caught at the card boundary and forwarded to
+// [FlutterError.reportError] so it surfaces in crash reports without
+// trapping the user on the current page.
 
-import 'dart:io' show Platform;
+import 'dart:async' show FutureOr;
 
-import 'package:firebase_core/firebase_core.dart';
-import 'package:firebase_messaging/firebase_messaging.dart';
-import 'package:flutter/foundation.dart' show debugPrint, kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../theme/kube_theme_builder.dart';
+import '../settings/settings_screen.dart' show kInstallGuideUrl;
+import '../../notifications/fcm_registration_helpers.dart'
+    show requestFcmPermission;
 
-/// Public-marketing landing page for users who installed the app
-/// without a server to point it at. PR-5j may move this to a versioned
-/// URL; for M5 the path is stable.
-const String kInstallGuideUrl = 'https://kubecenter.io/install';
+/// Namespace for the three onboarding card factory methods.  Each factory
+/// returns the correctly-configured [Widget] for its page of the tour.
+///
+/// ```dart
+/// OnboardingCard.intro(onAdvance: _advance, onSkip: _complete)
+/// OnboardingCard.clusterPin(onAdvance: _advance, onSkip: _complete)
+/// OnboardingCard.notifications(onAdvance: _advance, onSkip: _complete)
+/// ```
+abstract final class OnboardingCard {
+  // ── factory: intro ──────────────────────────────────────────────────────────
 
-class IntroCard extends StatelessWidget {
-  const IntroCard({
+  static Widget intro({
+    Key? key,
+    required FutureOr<void> Function() onAdvance,
+    required FutureOr<void> Function() onSkip,
+  }) =>
+      _IntroCard(key: key, onAdvance: onAdvance, onSkip: onSkip);
+
+  // ── factory: clusterPin ─────────────────────────────────────────────────────
+
+  static Widget clusterPin({
+    Key? key,
+    required FutureOr<void> Function() onAdvance,
+    required FutureOr<void> Function() onSkip,
+  }) =>
+      _SimpleCard(
+        key: key,
+        icon: Icons.hub_outlined,
+        iconSemanticsLabel: 'Cluster icon',
+        headline: 'Pick your cluster',
+        body: 'The cluster pill at the top of every screen switches between '
+            'connected clusters. Tap it any time to add another or to view '
+            'a different one.',
+        primaryKey: const ValueKey('onboarding-cluster-next'),
+        primaryLabel: 'Next',
+        onPrimaryPressed: onAdvance,
+        onSkip: onSkip,
+      );
+
+  // ── factory: notifications ───────────────────────────────────────────────────
+
+  static Widget notifications({
+    Key? key,
+    required FutureOr<void> Function() onAdvance,
+    required FutureOr<void> Function() onSkip,
+  }) =>
+      _SimpleCard(
+        key: key,
+        icon: Icons.notifications_outlined,
+        iconSemanticsLabel: 'Notifications bell icon',
+        headline: 'Stay on top of alerts',
+        body: 'Push notifications let k8sCenter wake your phone when a '
+            'cluster needs attention. Tap "Get started" to allow notifications '
+            '— you can change this later in Settings.',
+        primaryKey: const ValueKey('onboarding-notifications-get-started'),
+        primaryLabel: 'Get started',
+        onPrimaryPressed: () async {
+          // requestFcmPermission is defined in fcm_registration_helpers.dart.
+          // It swallows all errors so a missing Firebase config in CI never
+          // traps the user.
+          await requestFcmPermission();
+          await onAdvance();
+        },
+        onSkip: onSkip,
+      );
+}
+
+// ── _SimpleCard ────────────────────────────────────────────────────────────────
+//
+// Handles the two cards (ClusterPin, Notifications) that have no secondary CTA.
+
+class _SimpleCard extends StatelessWidget {
+  const _SimpleCard({
+    super.key,
+    required this.icon,
+    required this.iconSemanticsLabel,
+    required this.headline,
+    required this.body,
+    required this.primaryKey,
+    required this.primaryLabel,
+    required this.onPrimaryPressed,
+    required this.onSkip,
+  });
+
+  final IconData icon;
+  final String iconSemanticsLabel;
+  final String headline;
+  final String body;
+  final Key primaryKey;
+  final String primaryLabel;
+  final FutureOr<void> Function() onPrimaryPressed;
+  final FutureOr<void> Function() onSkip;
+
+  @override
+  Widget build(BuildContext context) {
+    return _OnboardingCardLayout(
+      icon: icon,
+      iconSemanticsLabel: iconSemanticsLabel,
+      headline: headline,
+      body: body,
+      primary: _PrimaryButton(
+        key: primaryKey,
+        label: primaryLabel,
+        onPressed: onPrimaryPressed,
+      ),
+      onSkip: onSkip,
+    );
+  }
+}
+
+// ── _IntroCard ─────────────────────────────────────────────────────────────────
+//
+// Intro is the only card with a secondary "install guide" CTA and the
+// associated SnackBar fallback. It keeps its own widget class so the
+// `_launchInstallGuide` helper can capture BuildContext without it being passed
+// as a constructor parameter.
+
+class _IntroCard extends StatelessWidget {
+  const _IntroCard({
     super.key,
     required this.onAdvance,
     required this.onSkip,
   });
 
-  final VoidCallback onAdvance;
-  final VoidCallback onSkip;
+  final FutureOr<void> Function() onAdvance;
+  final FutureOr<void> Function() onSkip;
 
   @override
   Widget build(BuildContext context) {
     final colors = Theme.of(context).extension<KubeColors>()!;
-    return OnboardingCardLayout(
+    return _OnboardingCardLayout(
       icon: Icons.dns_outlined,
       iconSemanticsLabel: 'Self-hosted server icon',
       headline: 'k8sCenter Mobile needs a home',
@@ -72,99 +194,14 @@ class IntroCard extends StatelessWidget {
   }
 }
 
-class ClusterPinCard extends StatelessWidget {
-  const ClusterPinCard({
-    super.key,
-    required this.onAdvance,
-    required this.onSkip,
-  });
-
-  final VoidCallback onAdvance;
-  final VoidCallback onSkip;
-
-  @override
-  Widget build(BuildContext context) {
-    return OnboardingCardLayout(
-      icon: Icons.hub_outlined,
-      iconSemanticsLabel: 'Cluster icon',
-      headline: 'Pick your cluster',
-      body: 'The cluster pill at the top of every screen switches between '
-          'connected clusters. Tap it any time to add another or to view '
-          'a different one.',
-      primary: _PrimaryButton(
-        key: const ValueKey('onboarding-cluster-next'),
-        label: 'Next',
-        onPressed: onAdvance,
-      ),
-      onSkip: onSkip,
-    );
-  }
-}
-
-class NotificationsCard extends StatelessWidget {
-  const NotificationsCard({
-    super.key,
-    required this.onAdvance,
-    required this.onSkip,
-  });
-
-  final VoidCallback onAdvance;
-  final VoidCallback onSkip;
-
-  @override
-  Widget build(BuildContext context) {
-    return OnboardingCardLayout(
-      icon: Icons.notifications_outlined,
-      iconSemanticsLabel: 'Notifications bell icon',
-      headline: 'Stay on top of alerts',
-      body: 'Push notifications let k8sCenter wake your phone when a '
-          'cluster needs attention. You can change this later in Settings.',
-      primary: _PrimaryButton(
-        key: const ValueKey('onboarding-notifications-enable'),
-        label: 'Enable notifications',
-        onPressed: () async {
-          await _requestNotificationPermission();
-          onAdvance();
-        },
-      ),
-      onSkip: onSkip,
-    );
-  }
-
-  /// Surfaces the OS push-permission prompt by initialising Firebase
-  /// and calling `requestPermission`. Any failure (missing
-  /// google-services.json / GoogleService-Info.plist, web or desktop
-  /// build, sandboxed CI) is swallowed — the card still advances so a
-  /// user without a configured FCM build isn't trapped on the last
-  /// page.
-  Future<void> _requestNotificationPermission() async {
-    if (kIsWeb) return;
-    try {
-      if (!Platform.isIOS && !Platform.isAndroid) return;
-    } catch (_) {
-      return;
-    }
-    try {
-      await Firebase.initializeApp();
-      await FirebaseMessaging.instance.requestPermission(
-        alert: true,
-        badge: true,
-        sound: true,
-      );
-    } catch (e) {
-      debugPrint('[onboarding] notifications init skipped: $e');
-    }
-  }
-}
-
 /// Shared visual scaffold for every card. Top-right Skip, centered
 /// icon, headline + body, primary CTA at the bottom, optional ghost
-/// secondary below it. Exposed (non-private) so widget tests can pump
-/// the layout standalone without a Firebase/url_launcher detour.
-@visibleForTesting
-class OnboardingCardLayout extends StatelessWidget {
-  const OnboardingCardLayout({
-    super.key,
+/// secondary below it.
+///
+/// Private: external code (including tests) pumps [OnboardingCard] factory
+/// instances rather than this layout directly.
+class _OnboardingCardLayout extends StatelessWidget {
+  const _OnboardingCardLayout({
     required this.icon,
     required this.iconSemanticsLabel,
     required this.headline,
@@ -180,7 +217,7 @@ class OnboardingCardLayout extends StatelessWidget {
   final String body;
   final Widget primary;
   final Widget? secondary;
-  final VoidCallback onSkip;
+  final FutureOr<void> Function() onSkip;
 
   @override
   Widget build(BuildContext context) {
@@ -195,7 +232,17 @@ class OnboardingCardLayout extends StatelessWidget {
               alignment: Alignment.topRight,
               child: TextButton(
                 key: const ValueKey('onboarding-skip'),
-                onPressed: onSkip,
+                onPressed: () async {
+                  try {
+                    await onSkip();
+                  } catch (e, s) {
+                    FlutterError.reportError(FlutterErrorDetails(
+                      exception: e,
+                      stack: s,
+                      library: 'onboarding',
+                    ));
+                  }
+                },
                 child: Text(
                   'Skip',
                   style: TextStyle(color: colors.textMuted),
@@ -260,14 +307,24 @@ class _PrimaryButton extends StatelessWidget {
   });
 
   final String label;
-  final VoidCallback onPressed;
+  final FutureOr<void> Function() onPressed;
 
   @override
   Widget build(BuildContext context) {
     return SizedBox(
       height: 48,
       child: FilledButton(
-        onPressed: onPressed,
+        onPressed: () async {
+          try {
+            await onPressed();
+          } catch (e, s) {
+            FlutterError.reportError(FlutterErrorDetails(
+              exception: e,
+              stack: s,
+              library: 'onboarding',
+            ));
+          }
+        },
         child: Text(label),
       ),
     );

--- a/mobile/lib/features/onboarding/onboarding_controller.dart
+++ b/mobile/lib/features/onboarding/onboarding_controller.dart
@@ -24,6 +24,11 @@ import '../../providers/shared_preferences_provider.dart';
 const String kOnboardedPrefsKey = 'onboarded_v1';
 
 class OnboardingController extends Notifier<bool> {
+  /// Serializes concurrent complete() calls so a rapid double-tap can't
+  /// produce duplicate prefs writes or interleaved state transitions.
+  /// Pattern mirrors [SentryController._inflight].
+  Future<void>? _inflight;
+
   @override
   bool build() {
     final prefs = ref.read(sharedPreferencesProvider);
@@ -31,9 +36,24 @@ class OnboardingController extends Notifier<bool> {
   }
 
   /// Persists completion. Called on Skip / Get-started taps. Idempotent
-  /// when already true.
+  /// when already true. Concurrent calls are serialized via [_inflight].
   Future<void> complete() async {
+    // Drain any prior call before evaluating the no-op fast path to
+    // prevent comparing against stale `state` mid-transition.
+    final prior = _inflight;
+    if (prior != null) await prior;
     if (state) return;
+
+    final pending = _doComplete();
+    _inflight = pending;
+    try {
+      await pending;
+    } finally {
+      if (identical(_inflight, pending)) _inflight = null;
+    }
+  }
+
+  Future<void> _doComplete() async {
     final prefs = ref.read(sharedPreferencesProvider);
     await prefs.setBool(kOnboardedPrefsKey, true);
     state = true;

--- a/mobile/lib/features/onboarding/onboarding_controller.dart
+++ b/mobile/lib/features/onboarding/onboarding_controller.dart
@@ -1,0 +1,66 @@
+// First-launch onboarding completion flag.
+//
+// Backed by the `onboarded_v1` shared_preferences key. Two callers:
+//   1. Router redirect (app_router.dart) — reads the flag synchronously
+//      to decide whether to send a not-yet-authenticated visitor to
+//      `/onboarding` or `/login`.
+//   2. Onboarding screen "Get started" / "Skip" buttons — flip the flag
+//      to true so the next launch routes straight to `/login`.
+//
+// Internal-beta upgrade detection runs once during main() bootstrap:
+// see [migrateOnboardingFlagForUpgrade]. After that resolves, the flag
+// reliably distinguishes "fresh install" from "upgrade from beta", so
+// the router redirect can stay synchronous (no async keychain read on
+// every navigation).
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../auth/secure_storage.dart';
+import '../../providers/shared_preferences_provider.dart';
+
+/// Versioned key — bumping the suffix lets us re-show the tour after a
+/// material refresh (e.g. when a future milestone adds a biometric card).
+const String kOnboardedPrefsKey = 'onboarded_v1';
+
+class OnboardingController extends Notifier<bool> {
+  @override
+  bool build() {
+    final prefs = ref.read(sharedPreferencesProvider);
+    return prefs.getBool(kOnboardedPrefsKey) ?? false;
+  }
+
+  /// Persists completion. Called on Skip / Get-started taps. Idempotent
+  /// when already true.
+  Future<void> complete() async {
+    if (state) return;
+    final prefs = ref.read(sharedPreferencesProvider);
+    await prefs.setBool(kOnboardedPrefsKey, true);
+    state = true;
+  }
+}
+
+final onboardingControllerProvider =
+    NotifierProvider<OnboardingController, bool>(OnboardingController.new);
+
+/// Internal-beta upgrade detection. Run once before runApp so the
+/// router redirect sees a final flag value and doesn't race with an
+/// async refresh-token read.
+///
+/// If [kOnboardedPrefsKey] is absent AND a refresh token survives in
+/// secure storage, the device is an internal-beta upgrade: silently
+/// set the flag. Otherwise (fresh install, no token), leave it absent
+/// so the router sends the user to `/onboarding`.
+///
+/// The plan considered an explicit `app_version_first_run` flag for
+/// this; the refresh-token proxy needs no migration scaffolding and
+/// works regardless of which build first introduced the flag.
+Future<void> migrateOnboardingFlagForUpgrade(
+  SharedPreferences prefs,
+  SecureTokenStore tokenStore,
+) async {
+  if (prefs.containsKey(kOnboardedPrefsKey)) return;
+  final refreshToken = await tokenStore.readRefreshToken();
+  if (refreshToken == null) return;
+  await prefs.setBool(kOnboardedPrefsKey, true);
+}

--- a/mobile/lib/features/onboarding/onboarding_screen.dart
+++ b/mobile/lib/features/onboarding/onboarding_screen.dart
@@ -1,0 +1,131 @@
+// PageView shell that hosts the three onboarding cards and drives
+// completion. The Skip button on every card and the "Enable
+// notifications" / "Get started" CTA on the last card both go through
+// `_complete`, so flag flips are routed through a single path.
+//
+// After `complete()`, the screen navigates explicitly to `/login`. The
+// router redirect re-evaluates and now passes (`onboarded == true`)
+// so there is no flicker back to `/onboarding`. If the user happens
+// to already be authenticated when they complete onboarding (an
+// internal-beta upgrade that somehow slipped past
+// [migrateOnboardingFlagForUpgrade]), the redirect catches it and
+// sends them to `/` instead.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../theme/kube_theme_builder.dart';
+import 'onboarding_cards.dart';
+import 'onboarding_controller.dart';
+
+class OnboardingScreen extends ConsumerStatefulWidget {
+  const OnboardingScreen({super.key});
+
+  @override
+  ConsumerState<OnboardingScreen> createState() => _OnboardingScreenState();
+}
+
+class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
+  static const int _kPageCount = 3;
+
+  final PageController _pageController = PageController();
+  int _page = 0;
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _advance() async {
+    if (_page < _kPageCount - 1) {
+      await _pageController.nextPage(
+        duration: const Duration(milliseconds: 240),
+        curve: Curves.easeOut,
+      );
+    } else {
+      await _complete();
+    }
+  }
+
+  Future<void> _complete() async {
+    await ref.read(onboardingControllerProvider.notifier).complete();
+    if (!mounted) return;
+    context.go('/login');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    final cards = <Widget>[
+      IntroCard(onAdvance: _advance, onSkip: _complete),
+      ClusterPinCard(onAdvance: _advance, onSkip: _complete),
+      NotificationsCard(onAdvance: _advance, onSkip: _complete),
+    ];
+
+    return Scaffold(
+      body: Column(
+        children: [
+          Expanded(
+            child: PageView.builder(
+              controller: _pageController,
+              itemCount: _kPageCount,
+              onPageChanged: (i) => setState(() => _page = i),
+              itemBuilder: (_, i) => cards[i],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(24, 0, 24, 24),
+            child: _PageIndicator(
+              count: _kPageCount,
+              activeIndex: _page,
+              colors: colors,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PageIndicator extends StatelessWidget {
+  const _PageIndicator({
+    required this.count,
+    required this.activeIndex,
+    required this.colors,
+  });
+
+  final int count;
+  final int activeIndex;
+  final KubeColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      key: const ValueKey('onboarding-page-indicator'),
+      label: 'Step ${activeIndex + 1} of $count',
+      container: true,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          for (var i = 0; i < count; i++) ...[
+            if (i > 0) const SizedBox(width: 8),
+            AnimatedContainer(
+              key: ValueKey('onboarding-dot-$i'),
+              duration: const Duration(milliseconds: 200),
+              width: i == activeIndex ? 16 : 8,
+              height: 8,
+              decoration: BoxDecoration(
+                color: i == activeIndex
+                    ? colors.accent
+                    : colors.textMuted.withValues(alpha: 0.4),
+                borderRadius: BorderRadius.circular(4),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/onboarding/onboarding_screen.dart
+++ b/mobile/lib/features/onboarding/onboarding_screen.dart
@@ -1,7 +1,7 @@
 // PageView shell that hosts the three onboarding cards and drives
-// completion. The Skip button on every card and the "Enable
-// notifications" / "Get started" CTA on the last card both go through
-// `_complete`, so flag flips are routed through a single path.
+// completion. The Skip button on every card and the "Get started" CTA
+// on the last card both go through `_complete`, so flag flips are routed
+// through a single path.
 //
 // After `complete()`, the screen navigates explicitly to `/login`. The
 // router redirect re-evaluates and now passes (`onboarded == true`)
@@ -27,8 +27,6 @@ class OnboardingScreen extends ConsumerStatefulWidget {
 }
 
 class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
-  static const int _kPageCount = 3;
-
   final PageController _pageController = PageController();
   int _page = 0;
 
@@ -39,7 +37,10 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
   }
 
   Future<void> _advance() async {
-    if (_page < _kPageCount - 1) {
+    // Build the card list locally so we can derive the page count from
+    // the actual list length rather than a divergable constant.
+    final pageCount = _buildCards().length;
+    if (_page < pageCount - 1) {
       await _pageController.nextPage(
         duration: const Duration(milliseconds: 240),
         curve: Curves.easeOut,
@@ -50,19 +51,41 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
   }
 
   Future<void> _complete() async {
-    await ref.read(onboardingControllerProvider.notifier).complete();
+    try {
+      await ref.read(onboardingControllerProvider.notifier).complete();
+    } catch (e, s) {
+      // Prefs write failed. Navigate to /login in degraded mode so the
+      // user isn't permanently trapped. The tour may reappear on the next
+      // cold-start if the flag wasn't persisted; the SnackBar explains it.
+      FlutterError.reportError(FlutterErrorDetails(
+        exception: e,
+        stack: s,
+        library: 'onboarding/complete',
+      ));
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text(
+            'Could not save onboarding state — please retry from Settings '
+            'if the tour reappears.',
+          ),
+        ),
+      );
+    }
     if (!mounted) return;
     context.go('/login');
   }
 
+  List<Widget> _buildCards() => [
+        OnboardingCard.intro(onAdvance: _advance, onSkip: _complete),
+        OnboardingCard.clusterPin(onAdvance: _advance, onSkip: _complete),
+        OnboardingCard.notifications(onAdvance: _advance, onSkip: _complete),
+      ];
+
   @override
   Widget build(BuildContext context) {
     final colors = Theme.of(context).extension<KubeColors>()!;
-    final cards = <Widget>[
-      IntroCard(onAdvance: _advance, onSkip: _complete),
-      ClusterPinCard(onAdvance: _advance, onSkip: _complete),
-      NotificationsCard(onAdvance: _advance, onSkip: _complete),
-    ];
+    final cards = _buildCards();
 
     return Scaffold(
       body: Column(
@@ -70,7 +93,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
           Expanded(
             child: PageView.builder(
               controller: _pageController,
-              itemCount: _kPageCount,
+              itemCount: cards.length,
               onPageChanged: (i) => setState(() => _page = i),
               itemBuilder: (_, i) => cards[i],
             ),
@@ -78,7 +101,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
           Padding(
             padding: const EdgeInsets.fromLTRB(24, 0, 24, 24),
             child: _PageIndicator(
-              count: _kPageCount,
+              count: cards.length,
               activeIndex: _page,
               colors: colors,
             ),

--- a/mobile/lib/features/settings/settings_screen.dart
+++ b/mobile/lib/features/settings/settings_screen.dart
@@ -23,8 +23,10 @@ import '../../theme/kube_theme_builder.dart';
 import 'sentry_controller.dart';
 import 'theme_picker_sheet.dart';
 
-/// Public so the privacy policy and store-listing URLs can be referenced
-/// elsewhere (PR-5g onboarding intro card, PR-5j App Privacy doc).
+/// Public so these URLs can be referenced elsewhere (PR-5g onboarding
+/// cards, PR-5j App Privacy doc). All external URL constants live here so
+/// there is a single place to update when domains change.
+const String kInstallGuideUrl = 'https://kubecenter.io/install';
 const String kPrivacyPolicyUrl = 'https://kubecenter.io/privacy';
 const String kSupportUrl = 'https://github.com/kubecenter-io/k8scenter/issues';
 const String kAppStoreListingUrl =

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -11,7 +11,9 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'app.dart';
 import 'auth/auth_repository.dart';
 import 'auth/auth_state.dart';
+import 'auth/secure_storage.dart';
 import 'auth/universal_link_listener.dart';
+import 'features/onboarding/onboarding_controller.dart';
 import 'notifications/fcm_registration.dart';
 import 'observability/sentry_init.dart';
 import 'providers/shared_preferences_provider.dart';
@@ -37,6 +39,19 @@ Future<void> main() async {
       sharedPreferencesProvider.overrideWithValue(prefs),
     ],
   );
+
+  // M5 PR-5g: internal-beta upgrade detection. Runs before the first
+  // router redirect so the synchronous `onboarded_v1` check sees a
+  // stable value. Errors are non-fatal — worst case is showing the
+  // tour once to an upgrade user.
+  try {
+    await migrateOnboardingFlagForUpgrade(
+      prefs,
+      container.read(secureTokenStoreProvider),
+    );
+  } catch (error) {
+    debugPrint('migrateOnboardingFlagForUpgrade threw: $error');
+  }
 
   // Register for FCM the first time auth lands on Authenticated.
   // Conditional Firebase init means this is a no-op when the operator

--- a/mobile/lib/notifications/fcm_registration_helpers.dart
+++ b/mobile/lib/notifications/fcm_registration_helpers.dart
@@ -1,0 +1,43 @@
+// Shared FCM helper functions extracted from feature-specific code.
+//
+// [requestFcmPermission] is the canonical one-shot permission request used
+// by the onboarding tour (NotificationsCard). It is separate from
+// [FcmRegistration.ensureRegistered], which runs post-auth and registers
+// the device token with the backend. Both call the same Firebase singleton,
+// so the platform-level permission dialog is shown at most once per install.
+//
+// Any failure (missing google-services.json / GoogleService-Info.plist,
+// web or desktop build, sandboxed CI) is swallowed and logged — the caller
+// always advances regardless of the user's permission choice.
+
+import 'dart:io' show Platform;
+
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter/foundation.dart' show debugPrint, kIsWeb;
+
+/// Surfaces the OS push-permission prompt by initialising Firebase (if not
+/// already done) and calling [FirebaseMessaging.requestPermission].
+///
+/// Silently swallows all errors so the onboarding tour can always advance
+/// regardless of FCM availability. Use [FcmRegistration.ensureRegistered]
+/// for the full post-auth registration flow that also sends the token to
+/// the backend.
+Future<void> requestFcmPermission() async {
+  if (kIsWeb) return;
+  try {
+    if (!Platform.isIOS && !Platform.isAndroid) return;
+  } catch (_) {
+    return;
+  }
+  try {
+    await Firebase.initializeApp();
+    await FirebaseMessaging.instance.requestPermission(
+      alert: true,
+      badge: true,
+      sound: true,
+    );
+  } catch (e) {
+    debugPrint('[onboarding] notifications permission request skipped: $e');
+  }
+}

--- a/mobile/lib/routing/app_router.dart
+++ b/mobile/lib/routing/app_router.dart
@@ -28,6 +28,8 @@ import '../features/eso/store_detail_screen.dart';
 import '../features/eso/stores_list_screen.dart';
 import '../features/login/login_screen.dart';
 import '../features/notifications_center/feed_screen.dart';
+import '../features/onboarding/onboarding_controller.dart';
+import '../features/onboarding/onboarding_screen.dart';
 import '../features/gitops/application_detail_screen.dart';
 import '../features/gitops/applications_list_screen.dart';
 import '../features/gitops/applicationset_detail_screen.dart';
@@ -90,16 +92,36 @@ final appRouterProvider = Provider<GoRouter>((ref) {
       final loggedIn = authState is AuthAuthenticated;
       final initializing = authState is AuthInitializing;
       final atLogin = state.matchedLocation == '/login';
+      final atOnboarding = state.matchedLocation == '/onboarding';
 
       if (initializing) return null; // splash screen handles this state
-      if (!loggedIn && !atLogin) return '/login';
-      if (loggedIn && atLogin) return '/';
+
+      if (!loggedIn) {
+        // M5 PR-5g: fresh installs (no refresh token, no prior tour
+        // completion) see `/onboarding` first. Internal-beta upgrades
+        // skip silently because migrateOnboardingFlagForUpgrade() flips
+        // the flag at boot before the router runs its first redirect.
+        final onboarded = ref.read(onboardingControllerProvider);
+        if (!onboarded) {
+          return atOnboarding ? null : '/onboarding';
+        }
+        return atLogin ? null : '/login';
+      }
+
+      if (atLogin || atOnboarding) return '/';
       return null;
     },
     routes: [
       GoRoute(
         path: '/login',
         builder: (context, state) => const LoginScreen(),
+      ),
+      // M5 PR-5g: first-launch onboarding tour. Guarded by
+      // `onboardingControllerProvider` in the redirect above so
+      // returning users never land here.
+      GoRoute(
+        path: '/onboarding',
+        builder: (context, state) => const OnboardingScreen(),
       ),
       GoRoute(
         path: '/',

--- a/mobile/test/features/onboarding/onboarding_controller_test.dart
+++ b/mobile/test/features/onboarding/onboarding_controller_test.dart
@@ -1,0 +1,136 @@
+// OnboardingController + migrateOnboardingFlagForUpgrade contract.
+//
+// The controller is a thin sync read/write over the `onboarded_v1`
+// prefs key. The migration helper is the only async surface, and only
+// runs once at app boot. Both are covered here without spinning up a
+// widget tree.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kubecenter/auth/secure_storage.dart';
+import 'package:kubecenter/features/onboarding/onboarding_controller.dart';
+import 'package:kubecenter/providers/shared_preferences_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+ProviderContainer _container(SharedPreferences prefs) {
+  return ProviderContainer(
+    overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+  );
+}
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('OnboardingController.build', () {
+    test('defaults to false when prefs has no onboarded_v1 key', () async {
+      final prefs = await SharedPreferences.getInstance();
+      final container = _container(prefs);
+      addTearDown(container.dispose);
+
+      expect(container.read(onboardingControllerProvider), isFalse);
+    });
+
+    test('returns true when prefs has onboarded_v1 == true', () async {
+      SharedPreferences.setMockInitialValues({kOnboardedPrefsKey: true});
+      final prefs = await SharedPreferences.getInstance();
+      final container = _container(prefs);
+      addTearDown(container.dispose);
+
+      expect(container.read(onboardingControllerProvider), isTrue);
+    });
+  });
+
+  group('OnboardingController.complete', () {
+    test('writes the prefs key and transitions state', () async {
+      final prefs = await SharedPreferences.getInstance();
+      final container = _container(prefs);
+      addTearDown(container.dispose);
+
+      await container.read(onboardingControllerProvider.notifier).complete();
+
+      expect(container.read(onboardingControllerProvider), isTrue);
+      expect(prefs.getBool(kOnboardedPrefsKey), isTrue);
+    });
+
+    test('idempotent when already completed', () async {
+      SharedPreferences.setMockInitialValues({kOnboardedPrefsKey: true});
+      final prefs = await SharedPreferences.getInstance();
+      final container = _container(prefs);
+      addTearDown(container.dispose);
+
+      await container.read(onboardingControllerProvider.notifier).complete();
+
+      expect(container.read(onboardingControllerProvider), isTrue);
+      expect(prefs.getBool(kOnboardedPrefsKey), isTrue);
+    });
+  });
+
+  group('migrateOnboardingFlagForUpgrade', () {
+    test('sets flag when refresh token present and flag absent', () async {
+      final prefs = await SharedPreferences.getInstance();
+      final store = InMemoryTokenStore();
+      await store.writeRefreshToken('rt_internal_beta');
+
+      await migrateOnboardingFlagForUpgrade(prefs, store);
+
+      expect(prefs.getBool(kOnboardedPrefsKey), isTrue);
+    });
+
+    test('no-op when refresh token absent (fresh install)', () async {
+      final prefs = await SharedPreferences.getInstance();
+      final store = InMemoryTokenStore();
+
+      await migrateOnboardingFlagForUpgrade(prefs, store);
+
+      expect(prefs.containsKey(kOnboardedPrefsKey), isFalse);
+    });
+
+    test('no-op when flag already true (returning user)', () async {
+      SharedPreferences.setMockInitialValues({kOnboardedPrefsKey: true});
+      final prefs = await SharedPreferences.getInstance();
+      final store = InMemoryTokenStore();
+      await store.writeRefreshToken('rt_user');
+
+      await migrateOnboardingFlagForUpgrade(prefs, store);
+
+      expect(prefs.getBool(kOnboardedPrefsKey), isTrue);
+    });
+
+    test('does not promote when flag explicitly false', () async {
+      // The `containsKey` guard prevents a user who has Skip'd and then
+      // logged in (refresh token now present) from being re-promoted
+      // back to onboarded — they made their choice. Documents the
+      // current invariant; complete() never writes false today.
+      SharedPreferences.setMockInitialValues({kOnboardedPrefsKey: false});
+      final prefs = await SharedPreferences.getInstance();
+      final store = InMemoryTokenStore();
+      await store.writeRefreshToken('rt_user');
+
+      await migrateOnboardingFlagForUpgrade(prefs, store);
+
+      expect(prefs.getBool(kOnboardedPrefsKey), isFalse);
+    });
+
+    test('app killed mid-onboarding restarts with flag still absent',
+        () async {
+      // Plan scenario: user opens app, swipes to card 2, force-quits.
+      // Flag was never set, so the relaunch routes back to /onboarding
+      // and the PageView starts at card 1. We assert the flag is still
+      // absent — restart-from-card-1 behaviour is owned by the screen's
+      // PageController, not the controller.
+      final prefs = await SharedPreferences.getInstance();
+      final store = InMemoryTokenStore();
+      final container = _container(prefs);
+      addTearDown(container.dispose);
+
+      // Simulate cold-start migration with no refresh token yet (the
+      // user never reached login).
+      await migrateOnboardingFlagForUpgrade(prefs, store);
+
+      expect(container.read(onboardingControllerProvider), isFalse);
+      expect(prefs.containsKey(kOnboardedPrefsKey), isFalse);
+    });
+  });
+}

--- a/mobile/test/features/onboarding/onboarding_controller_test.dart
+++ b/mobile/test/features/onboarding/onboarding_controller_test.dart
@@ -65,6 +65,24 @@ void main() {
       expect(container.read(onboardingControllerProvider), isTrue);
       expect(prefs.getBool(kOnboardedPrefsKey), isTrue);
     });
+
+    test('concurrent calls are serialized — state is true exactly once',
+        () async {
+      // Mirror of sentry_controller_test.dart concurrent-setOptIn test.
+      // Two complete() calls fired simultaneously must not interleave or
+      // double-write: both should resolve with state == true and
+      // exactly one prefs write (idempotent after the first completes).
+      final prefs = await SharedPreferences.getInstance();
+      final container = _container(prefs);
+      addTearDown(container.dispose);
+
+      final notifier = container.read(onboardingControllerProvider.notifier);
+      // Fire two concurrent calls.
+      await Future.wait([notifier.complete(), notifier.complete()]);
+
+      expect(container.read(onboardingControllerProvider), isTrue);
+      expect(prefs.getBool(kOnboardedPrefsKey), isTrue);
+    });
   });
 
   group('migrateOnboardingFlagForUpgrade', () {

--- a/mobile/test/features/onboarding/onboarding_screen_test.dart
+++ b/mobile/test/features/onboarding/onboarding_screen_test.dart
@@ -1,0 +1,232 @@
+// OnboardingScreen widget contract:
+//   - 3 cards in the documented order (Intro → ClusterPin → Notifications).
+//   - "Next" advances; the last card's "Enable notifications" completes
+//     even if the FCM permission call throws (it does in tests).
+//   - "Skip" on any card flips `onboarded_v1` and navigates to /login.
+//   - Page indicator semantics announce "Step N of 3".
+//
+// The screen pulls in `Firebase.initializeApp` and `launchUrl` via the
+// notification + intro cards. Both are caught defensively inside the
+// card code, so the widget tree never sees the throw — we just assert
+// the user-visible outcome.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:kubecenter/features/onboarding/onboarding_controller.dart';
+import 'package:kubecenter/features/onboarding/onboarding_screen.dart';
+import 'package:kubecenter/providers/shared_preferences_provider.dart';
+import 'package:kubecenter/theme/kube_theme_builder.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:url_launcher_platform_interface/link.dart';
+import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
+
+class _StubLauncher extends UrlLauncherPlatform
+    with MockPlatformInterfaceMixin {
+  _StubLauncher();
+  final List<String> launched = [];
+
+  @override
+  LinkDelegate? get linkDelegate => null;
+
+  @override
+  Future<bool> canLaunch(String url) async => true;
+
+  @override
+  Future<void> closeWebView() async {}
+
+  @override
+  Future<bool> launch(
+    String url, {
+    required bool useSafariVC,
+    required bool useWebView,
+    required bool enableJavaScript,
+    required bool enableDomStorage,
+    required bool universalLinksOnly,
+    required Map<String, String> headers,
+    String? webOnlyWindowName,
+  }) async {
+    launched.add(url);
+    return true;
+  }
+}
+
+class _LoginPlaceholder extends StatelessWidget {
+  const _LoginPlaceholder();
+  @override
+  Widget build(BuildContext context) => const Scaffold(
+        body: Center(child: Text('LOGIN_PLACEHOLDER')),
+      );
+}
+
+GoRouter _routerFor() => GoRouter(
+      initialLocation: '/onboarding',
+      routes: [
+        GoRoute(
+          path: '/onboarding',
+          builder: (context, state) => const OnboardingScreen(),
+        ),
+        GoRoute(
+          path: '/login',
+          builder: (context, state) => const _LoginPlaceholder(),
+        ),
+      ],
+    );
+
+Future<void> _pump(
+  WidgetTester tester,
+  SharedPreferences prefs, {
+  UrlLauncherPlatform? launcher,
+}) async {
+  if (launcher != null) {
+    UrlLauncherPlatform.instance = launcher;
+  }
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+      ],
+      child: MaterialApp.router(
+        theme: buildKubeTheme('nexus'),
+        routerConfig: _routerFor(),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('renders intro card first', (tester) async {
+    final prefs = await SharedPreferences.getInstance();
+    await _pump(tester, prefs);
+
+    expect(find.text('k8sCenter Mobile needs a home'), findsOneWidget);
+    expect(find.byKey(const ValueKey('onboarding-intro-have-server')),
+        findsOneWidget);
+    expect(find.byKey(const ValueKey('onboarding-skip')), findsOneWidget);
+  });
+
+  testWidgets('"I have a server" advances to cluster card', (tester) async {
+    final prefs = await SharedPreferences.getInstance();
+    await _pump(tester, prefs);
+
+    await tester.tap(find.byKey(const ValueKey('onboarding-intro-have-server')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Pick your cluster'), findsOneWidget);
+  });
+
+  testWidgets('full tour: Intro → Cluster → Notifications → /login',
+      (tester) async {
+    final prefs = await SharedPreferences.getInstance();
+    await _pump(tester, prefs);
+
+    await tester.tap(find.byKey(const ValueKey('onboarding-intro-have-server')));
+    await tester.pumpAndSettle();
+    expect(find.text('Pick your cluster'), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('onboarding-cluster-next')));
+    await tester.pumpAndSettle();
+    expect(find.text('Stay on top of alerts'), findsOneWidget);
+
+    await tester
+        .tap(find.byKey(const ValueKey('onboarding-notifications-enable')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('LOGIN_PLACEHOLDER'), findsOneWidget);
+    expect(prefs.getBool(kOnboardedPrefsKey), isTrue);
+  });
+
+  testWidgets('Skip on card 1 completes and routes to /login', (tester) async {
+    final prefs = await SharedPreferences.getInstance();
+    await _pump(tester, prefs);
+
+    await tester.tap(find.byKey(const ValueKey('onboarding-skip')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('LOGIN_PLACEHOLDER'), findsOneWidget);
+    expect(prefs.getBool(kOnboardedPrefsKey), isTrue);
+  });
+
+  testWidgets('Skip on card 2 completes and routes to /login', (tester) async {
+    final prefs = await SharedPreferences.getInstance();
+    await _pump(tester, prefs);
+
+    await tester.tap(find.byKey(const ValueKey('onboarding-intro-have-server')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('onboarding-skip')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('LOGIN_PLACEHOLDER'), findsOneWidget);
+    expect(prefs.getBool(kOnboardedPrefsKey), isTrue);
+  });
+
+  testWidgets('Notifications "Enable" still completes when FCM throws',
+      (tester) async {
+    // Firebase.initializeApp() throws in widget tests (no platform
+    // channels). The card swallows the error and advances. We assert
+    // the user-visible outcome — flag set, navigated to /login.
+    final prefs = await SharedPreferences.getInstance();
+    await _pump(tester, prefs);
+
+    await tester.tap(find.byKey(const ValueKey('onboarding-intro-have-server')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('onboarding-cluster-next')));
+    await tester.pumpAndSettle();
+    await tester
+        .tap(find.byKey(const ValueKey('onboarding-notifications-enable')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('LOGIN_PLACEHOLDER'), findsOneWidget);
+    expect(prefs.getBool(kOnboardedPrefsKey), isTrue);
+  });
+
+  testWidgets('install-guide CTA routes through url_launcher', (tester) async {
+    final prefs = await SharedPreferences.getInstance();
+    final launcher = _StubLauncher();
+    await _pump(tester, prefs, launcher: launcher);
+
+    await tester
+        .tap(find.byKey(const ValueKey('onboarding-intro-install-guide')));
+    await tester.pump();
+
+    expect(launcher.launched, contains('https://kubecenter.io/install'));
+    // External link does NOT complete onboarding — flag still absent.
+    expect(prefs.containsKey(kOnboardedPrefsKey), isFalse);
+  });
+
+  testWidgets('page indicator announces "Step N of 3"', (tester) async {
+    // `addTearDown(handle.dispose)` fires AFTER
+    // `_verifySemanticsHandlesWereDisposed`, so the handle is disposed
+    // inline before returning.
+    final handle = tester.ensureSemantics();
+
+    final prefs = await SharedPreferences.getInstance();
+    await _pump(tester, prefs);
+
+    expect(find.bySemanticsLabel('Step 1 of 3'), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('onboarding-intro-have-server')));
+    await tester.pumpAndSettle();
+
+    expect(find.bySemanticsLabel('Step 2 of 3'), findsOneWidget);
+
+    handle.dispose();
+  });
+
+  testWidgets('icons carry accessibility labels', (tester) async {
+    final prefs = await SharedPreferences.getInstance();
+    await _pump(tester, prefs);
+
+    // Intro card icon.
+    final introIcon = tester.widget<Icon>(find.byIcon(Icons.dns_outlined));
+    expect(introIcon.semanticLabel, isNotNull);
+    expect(introIcon.semanticLabel, isNotEmpty);
+  });
+}

--- a/mobile/test/features/onboarding/onboarding_screen_test.dart
+++ b/mobile/test/features/onboarding/onboarding_screen_test.dart
@@ -1,7 +1,7 @@
 // OnboardingScreen widget contract:
 //   - 3 cards in the documented order (Intro → ClusterPin → Notifications).
-//   - "Next" advances; the last card's "Enable notifications" completes
-//     even if the FCM permission call throws (it does in tests).
+//   - "Next" advances; the last card's "Get started" completes even if
+//     the FCM permission call throws (it does in tests).
 //   - "Skip" on any card flips `onboarded_v1` and navigates to /login.
 //   - Page indicator semantics announce "Step N of 3".
 //
@@ -25,7 +25,10 @@ import 'package:url_launcher_platform_interface/url_launcher_platform_interface.
 
 class _StubLauncher extends UrlLauncherPlatform
     with MockPlatformInterfaceMixin {
-  _StubLauncher();
+  _StubLauncher({this.launchResult = true});
+
+  /// Control whether [launch] reports success or failure.
+  final bool launchResult;
   final List<String> launched = [];
 
   @override
@@ -49,7 +52,7 @@ class _StubLauncher extends UrlLauncherPlatform
     String? webOnlyWindowName,
   }) async {
     launched.add(url);
-    return true;
+    return launchResult;
   }
 }
 
@@ -80,6 +83,11 @@ Future<void> _pump(
   SharedPreferences prefs, {
   UrlLauncherPlatform? launcher,
 }) async {
+  // Restore the previous launcher instance after the test to prevent
+  // cross-test pollution.
+  final prevLauncher = UrlLauncherPlatform.instance;
+  addTearDown(() => UrlLauncherPlatform.instance = prevLauncher);
+
   if (launcher != null) {
     UrlLauncherPlatform.instance = launcher;
   }
@@ -135,8 +143,8 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('Stay on top of alerts'), findsOneWidget);
 
-    await tester
-        .tap(find.byKey(const ValueKey('onboarding-notifications-enable')));
+    await tester.tap(
+        find.byKey(const ValueKey('onboarding-notifications-get-started')));
     await tester.pumpAndSettle();
 
     expect(find.text('LOGIN_PLACEHOLDER'), findsOneWidget);
@@ -167,7 +175,29 @@ void main() {
     expect(prefs.getBool(kOnboardedPrefsKey), isTrue);
   });
 
-  testWidgets('Notifications "Enable" still completes when FCM throws',
+  testWidgets('Skip on card 3 completes and routes to /login', (tester) async {
+    // Navigate to card 3, then verify Skip works from there.
+    // PageView keeps offscreen pages in the tree; find.byKey finds the
+    // Skip button in the active card because they all share the same key
+    // and tester.tap hits the first-found (rendered) widget.
+    final prefs = await SharedPreferences.getInstance();
+    await _pump(tester, prefs);
+
+    await tester.tap(find.byKey(const ValueKey('onboarding-intro-have-server')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('onboarding-cluster-next')));
+    await tester.pumpAndSettle();
+    expect(find.text('Stay on top of alerts'), findsOneWidget);
+
+    // Tap Skip on card 3 (Notifications).
+    await tester.tap(find.byKey(const ValueKey('onboarding-skip')).last);
+    await tester.pumpAndSettle();
+
+    expect(find.text('LOGIN_PLACEHOLDER'), findsOneWidget);
+    expect(prefs.getBool(kOnboardedPrefsKey), isTrue);
+  });
+
+  testWidgets('Notifications "Get started" still completes when FCM throws',
       (tester) async {
     // Firebase.initializeApp() throws in widget tests (no platform
     // channels). The card swallows the error and advances. We assert
@@ -179,8 +209,8 @@ void main() {
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('onboarding-cluster-next')));
     await tester.pumpAndSettle();
-    await tester
-        .tap(find.byKey(const ValueKey('onboarding-notifications-enable')));
+    await tester.tap(
+        find.byKey(const ValueKey('onboarding-notifications-get-started')));
     await tester.pumpAndSettle();
 
     expect(find.text('LOGIN_PLACEHOLDER'), findsOneWidget);
@@ -199,6 +229,20 @@ void main() {
     expect(launcher.launched, contains('https://kubecenter.io/install'));
     // External link does NOT complete onboarding — flag still absent.
     expect(prefs.containsKey(kOnboardedPrefsKey), isFalse);
+  });
+
+  testWidgets('install-guide CTA shows snackbar on launch failure',
+      (tester) async {
+    final prefs = await SharedPreferences.getInstance();
+    final launcher = _StubLauncher(launchResult: false);
+    await _pump(tester, prefs, launcher: launcher);
+
+    await tester
+        .tap(find.byKey(const ValueKey('onboarding-intro-install-guide')));
+    await tester.pump(); // trigger async
+    await tester.pump(const Duration(milliseconds: 100)); // settle snackbar
+
+    expect(find.textContaining('Could not open'), findsOneWidget);
   });
 
   testWidgets('page indicator announces "Step N of 3"', (tester) async {

--- a/mobile/test/routing/app_router_redirect_test.dart
+++ b/mobile/test/routing/app_router_redirect_test.dart
@@ -1,0 +1,195 @@
+// Redirect guard contract for the onboarding + auth branches added in
+// M5 PR-5g. Three cases:
+//
+//   1. Not authenticated + onboarded=false  → /onboarding
+//   2. Not authenticated + onboarded=true   → /login
+//   3. Authenticated + atOnboarding         → /  (dashboard)
+//
+// Tests pump a minimal widget tree wired with ProviderScope overrides
+// so they exercise the real GoRouter redirect logic without spinning up
+// actual platform channels or network sockets.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:kubecenter/auth/auth_repository.dart';
+import 'package:kubecenter/auth/auth_state.dart';
+import 'package:kubecenter/auth/user.dart';
+import 'package:kubecenter/features/onboarding/onboarding_controller.dart';
+import 'package:kubecenter/providers/shared_preferences_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+// ---------------------------------------------------------------------------
+// Stub screens so the widget tree can render without pulling in real screens.
+// ---------------------------------------------------------------------------
+class _OnboardingStub extends StatelessWidget {
+  const _OnboardingStub();
+  @override
+  Widget build(BuildContext context) =>
+      const Scaffold(body: Center(child: Text('ONBOARDING')));
+}
+
+class _LoginStub extends StatelessWidget {
+  const _LoginStub();
+  @override
+  Widget build(BuildContext context) =>
+      const Scaffold(body: Center(child: Text('LOGIN')));
+}
+
+class _DashboardStub extends StatelessWidget {
+  const _DashboardStub();
+  @override
+  Widget build(BuildContext context) =>
+      const Scaffold(body: Center(child: Text('DASHBOARD')));
+}
+
+// ---------------------------------------------------------------------------
+// Fake AuthRepository that seeds a fixed initial state.
+// ---------------------------------------------------------------------------
+class _FakeAuth extends AuthRepository {
+  _FakeAuth(this._initial);
+  final AuthState _initial;
+  @override
+  AuthState build() => _initial;
+}
+
+// ---------------------------------------------------------------------------
+// Minimal router that mirrors the redirect logic in app_router.dart but
+// uses stub screens so tests don't need platform plugin registrations.
+// ---------------------------------------------------------------------------
+GoRouter _buildRouter(WidgetRef ref) {
+  final authState = ref.watch(authRepositoryProvider);
+  return GoRouter(
+    initialLocation: '/onboarding',
+    refreshListenable: _AuthListenable(ref),
+    redirect: (context, state) {
+      final loggedIn = authState is AuthAuthenticated;
+      final initializing = authState is AuthInitializing;
+      final atLogin = state.matchedLocation == '/login';
+      final atOnboarding = state.matchedLocation == '/onboarding';
+
+      if (initializing) return null;
+
+      if (!loggedIn) {
+        final onboarded = ref.read(onboardingControllerProvider);
+        if (!onboarded) return atOnboarding ? null : '/onboarding';
+        return atLogin ? null : '/login';
+      }
+
+      if (atLogin || atOnboarding) return '/';
+      return null;
+    },
+    routes: [
+      GoRoute(
+        path: '/onboarding',
+        builder: (_, s) => const _OnboardingStub(),
+      ),
+      GoRoute(
+        path: '/login',
+        builder: (_, s) => const _LoginStub(),
+      ),
+      GoRoute(
+        path: '/',
+        builder: (_, s) => const _DashboardStub(),
+      ),
+    ],
+  );
+}
+
+class _AuthListenable extends ChangeNotifier {
+  _AuthListenable(this._ref) {
+    // WidgetRef.listen returns void and auto-disposes with the widget.
+    _ref.listen<AuthState>(
+      authRepositoryProvider,
+      (prev, next) { notifyListeners(); },
+    );
+  }
+  final WidgetRef _ref;
+  // No _sub field: WidgetRef.listen does not return a ProviderSubscription.
+}
+
+// ---------------------------------------------------------------------------
+// Helper: build a ProviderScope + router with overrides and pump it.
+// ---------------------------------------------------------------------------
+Future<void> _pumpRouter(
+  WidgetTester tester, {
+  required AuthState authState,
+  required bool onboarded,
+}) async {
+  SharedPreferences.setMockInitialValues(
+    onboarded ? {kOnboardedPrefsKey: true} : {},
+  );
+  final prefs = await SharedPreferences.getInstance();
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        authRepositoryProvider.overrideWith(() => _FakeAuth(authState)),
+      ],
+      child: Consumer(
+        builder: (context, ref, child) => MaterialApp.router(
+          routerConfig: _buildRouter(ref),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  testWidgets(
+    '1. not authenticated + onboarded=false → redirects to /onboarding',
+    (tester) async {
+      await _pumpRouter(
+        tester,
+        authState: const AuthUnauthenticated(),
+        onboarded: false,
+      );
+      expect(find.text('ONBOARDING'), findsOneWidget);
+      expect(find.text('LOGIN'), findsNothing);
+      expect(find.text('DASHBOARD'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    '2. not authenticated + onboarded=true → redirects to /login',
+    (tester) async {
+      await _pumpRouter(
+        tester,
+        authState: const AuthUnauthenticated(),
+        onboarded: true,
+      );
+      expect(find.text('LOGIN'), findsOneWidget);
+      expect(find.text('ONBOARDING'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    '3. authenticated + atOnboarding → redirects to /',
+    (tester) async {
+      await _pumpRouter(
+        tester,
+        authState: AuthAuthenticated(
+          user: const UserInfo(
+            id: 'u1',
+            username: 'admin',
+            provider: 'local',
+            roles: ['admin'],
+          ),
+          rbac: const RBACSummary(),
+        ),
+        onboarded: false, // flag value doesn't matter when authenticated
+      );
+      expect(find.text('DASHBOARD'), findsOneWidget);
+      expect(find.text('ONBOARDING'), findsNothing);
+      expect(find.text('LOGIN'), findsNothing);
+    },
+  );
+}


### PR DESCRIPTION
## Summary

PR-5g (U7) of `plans/mobile-app-m5-pr-sequence.md`. Ships a 3-card swipeable onboarding tour shown once per device on fresh installs, before `/login`. Internal-beta upgraders skip silently.

- **IntroCard** — explains the self-hosted-backend requirement; "How to set up your server" CTA opens `https://kubecenter.io/install` in the system browser via `url_launcher`.
- **ClusterPinCard** — short orientation on the cluster pill at the top of every screen.
- **NotificationsCard** — "Enable notifications" fires the OS push-permission prompt; card advances regardless of outcome (and even when FCM is unconfigured).

No biometric card — biometric auth is not implemented in M5 (no `local_auth` dependency, no Settings → Security UI). Advertising it without delivery would violate App Store guideline 2.3 (Accurate Metadata). When biometric auth ships in a future milestone, a new onboarding card can be added then.

## Requirements

Closes **R8** (first-launch onboarding tour). No backend changes.

## Implementation notes

- `OnboardingController` is a `Notifier<bool>` over `shared_preferences` key `onboarded_v1`. `complete()` is idempotent.
- `migrateOnboardingFlagForUpgrade()` runs once before `runApp` (sequenced inside `main.dart` after `SharedPreferences.getInstance()`, before container `listen` registers). If the flag is absent AND a secure-storage refresh token survives, it sets the flag silently — keeping the router redirect synchronous (no async keychain read per navigation).
- The `app_router.dart` redirect grew a pre-login onboarding branch:
  ```dart
  if (!loggedIn) {
    final onboarded = ref.read(onboardingControllerProvider);
    if (!onboarded) return atOnboarding ? null : '/onboarding';
    return atLogin ? null : '/login';
  }
  ```
- Cards live in `mobile/lib/features/onboarding/onboarding_cards.dart`. They take pure `onAdvance` / `onSkip` callbacks so the screen owns PageView + completion state. `NotificationsCard._requestNotificationPermission()` defensively wraps `Firebase.initializeApp()` + `requestPermission()` in try/catch so an unconfigured FCM build never traps the user on the last page.
- Page indicator carries `Semantics(label: 'Step N of $count', container: true)`; each card's icon has a `semanticLabel`.

## Resolved deferred question

Plan §"Deferred to Implementation" asked PR-5g to pick between (a) refresh-token-presence check vs (b) explicit `app_version_first_run` flag for upgrade detection. **Picked (a)** — one prefs check + one async keychain read at boot, no migration scaffolding required, works regardless of which build first introduced the flag.

## Testing

- `cd mobile && flutter analyze` — clean.
- `cd mobile && flutter test` — **1,104 tests pass** (18 new tests for PR-5g: 9 controller + 9 screen).
- Controller tests cover: default-false build, true-from-prefs build, complete() persistence + idempotency, migration with refresh token present / absent / flag-already-set, app-killed-mid-onboarding restart.
- Screen tests cover: intro renders first, "I have a server" advance, full Intro→Cluster→Notifications→/login walk, Skip-on-card-1 + Skip-on-card-2, Notifications "Enable" completes even when FCM throws, install-guide CTA routes through `url_launcher` (and does NOT complete onboarding), page-indicator Semantics announces "Step N of 3", icon accessibility labels.

### Manual smoke (developer TODO before merge)

- [ ] Fresh-install on iOS simulator: full 3-card walk → land on login, verify `onboarded_v1=true` persists.
- [ ] Fresh-install on Android emulator: same.
- [ ] Internal-beta upgrade dry-run: install older build, log in, install new build over top, verify NO onboarding shown.
- [ ] Reinstall (delete + reinstall): onboarding shows again.
- [ ] App killed during onboarding (force-stop on card 2): relaunch restarts at card 1.

## Post-Deploy Monitoring & Validation

- **Sentry** (if opted-in): no new error categories expected; watch for any `[onboarding] notifications init skipped:` debug logs surfacing as crash breadcrumbs (would indicate FCM regression, not onboarding).
- **TestFlight / Play Internal**: collect tester feedback specifically on the intro card's "How to set up your server" CTA — confirms the flow makes sense to first-time installers without a backend.
- **Validation window**: 7-day observation post-merge on TestFlight Internal before PR-5j locks public-store metadata.
- **Failure signal**: any uptick in tester reports of "stuck on onboarding screen" or "cannot reach login" → rollback by reverting `app_router.dart` redirect block and removing `/onboarding` route. The controller + cards can stay in-tree (dead code) without harm.
- **Owner**: mobile maintainer reviewing TestFlight crash + feedback dashboards.

## Plan reference

`plans/mobile-app-m5-pr-sequence.md` §U7 (lines 664–706). Plan stays `status: active` — M5 continues with PR-5h → PR-5j.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>