### PR TITLE
feat(mobile): M5 PR-5i — DataTable2 virtualization + perf baseline

### DIFF
--- a/mobile/docs/PERFORMANCE.md
+++ b/mobile/docs/PERFORMANCE.md
@@ -1,0 +1,127 @@
+# Mobile performance — baseline + targets
+
+Status: PR-5i foundation. The `DataTable2` eager-row materialization
+fix landed; baseline measurements are captured manually during the
+homelab smoke pass (Flutter cannot run in CI on a real device under
+profile mode, so the numbers in §Measurements are filled in by the
+person running smoke and committed in a follow-up).
+
+## Frame budget targets
+
+| Surface | Target | Reason |
+|---|---|---|
+| Cold start (time to first frame) | ≤ 800ms (iPhone 14 sim), ≤ 1200ms (Pixel 6 emu) | Industry baseline for "responsive feel" on launch. Sentry init is gated behind opt-in (`sentry_init.dart`), so the off path is a single `shared_preferences` read. |
+| Dashboard scroll | ≤ 16ms / frame (60fps) | The default-route surface on every cold start. |
+| 1000-row resource list scroll | ≤ 16ms / frame | Tablet `PaginatedDataTable2` page size is 50; the source materializes only the visible page. |
+| 6000-row vulnerability list scroll | ≤ 16ms / frame | Already `SliverChildBuilderDelegate` — no DataTable involved. |
+| Metrics tab chart render (5 series × 200 points) | ≤ 16ms initial paint, ≤ 16ms / frame on pinch-zoom | `fl_chart` is the renderer; zoom is the heavy path. |
+
+Anything that exceeds the target by more than 50% (`> 24ms` on a frame
+budget, `> 1200ms` on iPhone cold start) is a release blocker. Within
+target is shippable.
+
+## The bug PR-5i fixed
+
+Before PR-5i, `mobile/lib/widgets/resource_table.dart` constructed
+every `DataRow2` up-front:
+
+```dart
+DataTable2(
+  rows: [
+    for (final item in items)
+      DataRow2(cells: [...]),  // built for ALL items, regardless of viewport
+  ],
+)
+```
+
+On a 500-pod cluster, every cell's `Text` widget materialized on the
+first frame — dominant cost before any of them scrolled into view.
+PR-5i switches the tablet branch to `PaginatedDataTable2(source:
+KubeDataTableSource(...))`, which calls `getRow(index)` lazily for
+just the indices the paginator needs (≤ `rowsPerPage`, defaulted to
+50 here). Verified via the `rowCallCount` counter in
+`mobile/test/widgets/kube_data_table_source_test.dart` — pumping a
+6000-row source through `PaginatedDataTable2` materializes < 60 rows.
+
+The phone branch (`< 768px`) was already `ListView.separated`, which
+virtualizes natively. Unchanged.
+
+The scanning vulnerability list
+(`mobile/lib/features/scanning/vulnerabilities_list_screen.dart`) is
+not a `ResourceTable` consumer — it uses `SliverChildBuilderDelegate`
+directly, so its virtualization is independent of PR-5i.
+
+## Capture methodology
+
+1. Build a profile-mode binary:
+   ```bash
+   cd mobile
+   flutter run --profile -d <device>
+   ```
+   (`<device>` is `iPhone 14 Pro Max` simulator on macOS, `Pixel 6 API
+   34` emulator on Android, or a real device by UDID.)
+
+2. Open the Flutter DevTools timeline tab. Connect to the running
+   instance.
+
+3. For each surface in §Measurements:
+   - Navigate to the surface.
+   - Start a recording.
+   - Perform the action under measurement (cold start = full app
+     relaunch; scroll = fast flick + settle, ~10 seconds; chart render
+     = open Metrics tab and pinch-zoom once).
+   - Stop the recording.
+   - Record the worst-case frame ms over the capture (look for the red
+     bars in the frame chart).
+
+4. For cold start specifically:
+   ```bash
+   flutter run --profile --trace-startup
+   ```
+   Then read `time_to_first_frame_microseconds` from
+   `<app>/build/start_up_info.json`.
+
+5. Drop the numbers in §Measurements. Commit on the same PR if
+   captured during the same session as the code change; otherwise as
+   a follow-up commit referencing PR-5i.
+
+## Measurements
+
+Captured by: TBD
+Cluster: TBD (homelab, populated with ~100 pods / ~5 namespaces / ~5
+ExternalSecrets / Trivy report on at least one namespace)
+Date: TBD
+Flutter version: TBD (output of `flutter --version`)
+
+| Surface | Device | Result | Target | Pass? |
+|---|---|---|---|---|
+| Cold start | iPhone 14 Pro Max sim | TBD | ≤ 800ms | TBD |
+| Cold start | Pixel 6 API 34 emu | TBD | ≤ 1200ms | TBD |
+| Dashboard scroll | iPhone 14 Pro Max sim | TBD | ≤ 16ms | TBD |
+| Dashboard scroll | Pixel 6 API 34 emu | TBD | ≤ 16ms | TBD |
+| 1000-row resource list (Pods) scroll | iPhone 14 Pro Max sim | TBD | ≤ 16ms | TBD |
+| 1000-row resource list (Pods) scroll | Pixel 6 API 34 emu | TBD | ≤ 16ms | TBD |
+| 6000-row vulnerability list scroll | iPhone 14 Pro Max sim | TBD | ≤ 16ms | TBD |
+| 6000-row vulnerability list scroll | Pixel 6 API 34 emu | TBD | ≤ 16ms | TBD |
+| Metrics tab chart render (5×200) | iPhone 14 Pro Max sim | TBD | ≤ 16ms | TBD |
+| Metrics tab chart render (5×200) | Pixel 6 API 34 emu | TBD | ≤ 16ms | TBD |
+
+## Follow-up policy
+
+If a row in §Measurements fails its target:
+
+- **Within 50% of target**: file a follow-up issue, document the
+  hotspot in §Known regressions below. Not a release blocker for M5.
+- **Beyond 50% of target**: release blocker. Identify the offending
+  widget via the DevTools timeline's PaintingContext / MeasureContext
+  hotspot, apply the standard mitigations (`const` constructors,
+  `RepaintBoundary` around the heavy subtree, image caching), and
+  re-measure.
+
+PR-5i scope is the `DataTable2` fix + this doc. Optimisations beyond
+the DataTable fix are explicitly out of scope unless §Measurements
+surfaces a release blocker.
+
+## Known regressions
+
+None at PR-5i baseline. Populate as §Measurements is filled in.

--- a/mobile/lib/widgets/kube_data_table_source.dart
+++ b/mobile/lib/widgets/kube_data_table_source.dart
@@ -31,18 +31,17 @@ class KubeDataTableSource<T> extends DataTableSource {
   /// getRow a context that always reflects the current theme.
   final BuildContext context;
 
-  /// Test-only counter that increments on every non-null `getRow`
-  /// return. Widget tests pump a PaginatedDataTable2 over a synthetic
-  /// 6000-row source and assert this stays bounded by the visible page,
-  /// proving virtualization actually kicks in.
-  @visibleForTesting
-  int rowCallCount = 0;
-
   int get itemCount => _items.length;
 
   /// Swap the backing data + columns + tap callback and notify the
-  /// paginator to rebuild. Called by `_TabletTable.didUpdateWidget`
-  /// when the parent rebuilds with new props.
+  /// paginator to rebuild.
+  ///
+  /// `columns` is expected to be stable across rebuilds (defined as
+  /// compile-time const lists at the caller). It is included in the
+  /// signature for API symmetry, not because it changes frequently.
+  /// The hot field is `items`; `onTap` typically also changes per
+  /// rebuild because consumers pass inline lambdas — see the
+  /// `didUpdateWidget` identity check in `_TabletTableState`.
   void update({
     required List<T> items,
     required List<ResourceColumn<T>> columns,
@@ -51,18 +50,20 @@ class KubeDataTableSource<T> extends DataTableSource {
     _items = items;
     _columns = columns;
     _onTap = onTap;
-    rowCallCount = 0;
     notifyListeners();
   }
 
   @override
   DataRow? getRow(int index) {
     if (index < 0 || index >= _items.length) return null;
-    rowCallCount++;
     final item = _items[index];
-    final colors = Theme.of(context).extension<KubeColors>()!;
+    final onTap = _onTap;
+    final kubeColors = Theme.of(context).extension<KubeColors>();
+    assert(kubeColors != null,
+        'KubeColors ThemeExtension missing — wrap your widget in buildKubeTheme()');
+    final colors = kubeColors!;
     return DataRow2(
-      onTap: () => _onTap(item),
+      onTap: () => onTap(item),
       cells: [
         for (final col in _columns)
           DataCell(

--- a/mobile/lib/widgets/kube_data_table_source.dart
+++ b/mobile/lib/widgets/kube_data_table_source.dart
@@ -1,0 +1,88 @@
+// Lazy DataTableSource backing the tablet ResourceTable layout. The
+// previous `DataTable2(rows: [for ...])` path eagerly materialized
+// every row up-front, so a 500-pod cluster paid 500 DataRow builds on
+// the first frame — the dominant cost long before any of those rows
+// scrolled into view. PaginatedDataTable2 calls `getRow(index)` only
+// for the indices it needs to render, so the cost is bounded by
+// `rowsPerPage` regardless of the underlying list size.
+
+import 'package:data_table_2/data_table_2.dart';
+import 'package:flutter/material.dart';
+
+import '../theme/kube_theme_builder.dart';
+import 'resource_table.dart';
+
+class KubeDataTableSource<T> extends DataTableSource {
+  KubeDataTableSource({
+    required List<T> items,
+    required List<ResourceColumn<T>> columns,
+    required ValueChanged<T> onTap,
+    required this.context,
+  })  : _items = items,
+        _columns = columns,
+        _onTap = onTap;
+
+  List<T> _items;
+  List<ResourceColumn<T>> _columns;
+  ValueChanged<T> _onTap;
+
+  /// State.context of the hosting widget. State.context is stable for
+  /// the lifetime of the State, so a single capture in initState gives
+  /// getRow a context that always reflects the current theme.
+  final BuildContext context;
+
+  /// Test-only counter that increments on every non-null `getRow`
+  /// return. Widget tests pump a PaginatedDataTable2 over a synthetic
+  /// 6000-row source and assert this stays bounded by the visible page,
+  /// proving virtualization actually kicks in.
+  @visibleForTesting
+  int rowCallCount = 0;
+
+  int get itemCount => _items.length;
+
+  /// Swap the backing data + columns + tap callback and notify the
+  /// paginator to rebuild. Called by `_TabletTable.didUpdateWidget`
+  /// when the parent rebuilds with new props.
+  void update({
+    required List<T> items,
+    required List<ResourceColumn<T>> columns,
+    required ValueChanged<T> onTap,
+  }) {
+    _items = items;
+    _columns = columns;
+    _onTap = onTap;
+    rowCallCount = 0;
+    notifyListeners();
+  }
+
+  @override
+  DataRow? getRow(int index) {
+    if (index < 0 || index >= _items.length) return null;
+    rowCallCount++;
+    final item = _items[index];
+    final colors = Theme.of(context).extension<KubeColors>()!;
+    return DataRow2(
+      onTap: () => _onTap(item),
+      cells: [
+        for (final col in _columns)
+          DataCell(
+            Text(
+              col.value(item),
+              style: TextStyle(
+                color: col.color?.call(context, item) ?? colors.textPrimary,
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+
+  @override
+  int get rowCount => _items.length;
+
+  @override
+  bool get isRowCountApproximate => false;
+
+  @override
+  int get selectedRowCount => 0;
+}

--- a/mobile/lib/widgets/resource_table.dart
+++ b/mobile/lib/widgets/resource_table.dart
@@ -7,7 +7,17 @@ import 'package:data_table_2/data_table_2.dart';
 import 'package:flutter/material.dart';
 
 import '../theme/kube_theme_builder.dart';
+import 'adaptive_scaffold.dart';
 import 'kube_data_table_source.dart';
+
+/// Median-density column width for k8s name + numeric status cells.
+/// Wide tables (8+ columns, e.g. PVC) overflow and DataTable2 enables
+/// horizontal scroll automatically.
+const double _kColumnWidth = 96.0;
+
+/// Page size for the tablet paginator. Tracked in PERFORMANCE.md;
+/// changing this requires re-measuring against the frame-budget targets.
+const int _kRowsPerPage = 50;
 
 /// One column in the resource table.
 class ResourceColumn<T> {
@@ -58,7 +68,7 @@ class ResourceTable<T> extends StatelessWidget {
 
     return LayoutBuilder(
       builder: (context, constraints) {
-        if (constraints.maxWidth >= 768) {
+        if (constraints.maxWidth >= tabletBreakpoint) {
           return _TabletTable<T>(
             items: items,
             columns: columns,
@@ -71,7 +81,10 @@ class ResourceTable<T> extends StatelessWidget {
   }
 
   Widget _buildPhoneList(BuildContext context) {
-    final colors = Theme.of(context).extension<KubeColors>()!;
+    final kubeColors = Theme.of(context).extension<KubeColors>();
+    assert(kubeColors != null,
+        'KubeColors ThemeExtension missing — wrap your widget in buildKubeTheme()');
+    final colors = kubeColors!;
     return ListView.separated(
       itemCount: items.length,
       padding: const EdgeInsets.symmetric(vertical: 8),
@@ -137,6 +150,7 @@ class _TabletTable<T> extends StatefulWidget {
 
 class _TabletTableState<T> extends State<_TabletTable<T>> {
   late final KubeDataTableSource<T> _source;
+  final PaginatorController _paginator = PaginatorController();
 
   @override
   void initState() {
@@ -152,9 +166,20 @@ class _TabletTableState<T> extends State<_TabletTable<T>> {
   @override
   void didUpdateWidget(_TabletTable<T> oldWidget) {
     super.didUpdateWidget(oldWidget);
+    // Clamp page before updating source: if the new list is shorter than
+    // the current page start index, reset to page 0 to avoid an empty
+    // "201–250 of 30" view. Guard isAttached because the controller is
+    // wired on the first build, not on construction.
+    if (_paginator.isAttached &&
+        widget.items.length < _paginator.currentRowIndex) {
+      _paginator.goToFirstPage();
+    }
+    // onTap is intentionally excluded: the source's _onTap will pick up
+    // the latest callback on the next genuine data-driven update() call.
+    // Consumers always rebuild items alongside onTap, so staleness window
+    // is bounded by the next items change.
     if (!identical(oldWidget.items, widget.items) ||
-        !identical(oldWidget.columns, widget.columns) ||
-        oldWidget.onTap != widget.onTap) {
+        !identical(oldWidget.columns, widget.columns)) {
       _source.update(
         items: widget.items,
         columns: widget.columns,
@@ -165,6 +190,13 @@ class _TabletTableState<T> extends State<_TabletTable<T>> {
 
   @override
   void dispose() {
+    // PaginatedDataTable2 is a direct child of this State, so Flutter
+    // disposes it (removing its listener on _source) BEFORE this
+    // dispose() runs. Safe to dispose _source and _paginator here. If
+    // _source is ever hoisted to a sibling or a Riverpod provider,
+    // re-evaluate this ordering — a notifier disposed while still has
+    // listeners throws in debug mode.
+    _paginator.dispose();
     _source.dispose();
     super.dispose();
   }
@@ -172,9 +204,11 @@ class _TabletTableState<T> extends State<_TabletTable<T>> {
   @override
   Widget build(BuildContext context) {
     final colors = Theme.of(context).extension<KubeColors>()!;
-    final minWidth = (widget.columns.length * 96).toDouble();
+    final minWidth = widget.columns.length * _kColumnWidth;
     return PaginatedDataTable2(
+      key: PageStorageKey<String>('resource_table_${T.toString()}'),
       source: _source,
+      controller: _paginator,
       columns: [
         for (final col in widget.columns)
           DataColumn2(
@@ -190,9 +224,12 @@ class _TabletTableState<T> extends State<_TabletTable<T>> {
       columnSpacing: 16,
       horizontalMargin: 12,
       minWidth: minWidth,
-      rowsPerPage: 50,
+      rowsPerPage: _kRowsPerPage,
       showCheckboxColumn: false,
       wrapInCard: false,
+      // PR-5i review: avoid 40-blank-row allocation + "1-50 of 10" footer on short lists.
+      renderEmptyRowsInTheEnd: false,
+      hidePaginator: widget.items.length <= _kRowsPerPage,
     );
   }
 }

--- a/mobile/lib/widgets/resource_table.dart
+++ b/mobile/lib/widgets/resource_table.dart
@@ -1,12 +1,13 @@
 // Generic resource list adapter. Phone renders a card list; tablet
-// (>= 768px) renders a DataTable. Column config is per-kind so the
-// shared widget handles layout and the kind-specific screens specify
-// what to show.
+// (>= 768px) renders a paginated DataTable. Column config is per-kind
+// so the shared widget handles layout and the kind-specific screens
+// specify what to show.
 
 import 'package:data_table_2/data_table_2.dart';
 import 'package:flutter/material.dart';
 
 import '../theme/kube_theme_builder.dart';
+import 'kube_data_table_source.dart';
 
 /// One column in the resource table.
 class ResourceColumn<T> {
@@ -58,7 +59,11 @@ class ResourceTable<T> extends StatelessWidget {
     return LayoutBuilder(
       builder: (context, constraints) {
         if (constraints.maxWidth >= 768) {
-          return _buildTabletTable(context);
+          return _TabletTable<T>(
+            items: items,
+            columns: columns,
+            onTap: onTap,
+          );
         }
         return _buildPhoneList(context);
       },
@@ -107,23 +112,71 @@ class ResourceTable<T> extends StatelessWidget {
       },
     );
   }
+}
 
-  Widget _buildTabletTable(BuildContext context) {
+// Tablet layout. Owns a long-lived [KubeDataTableSource] so
+// PaginatedDataTable2 can request rows lazily via `getRow(index)`
+// instead of the previous eager `rows: [for (item in items) ...]`
+// path. 96px per column hits a comfortable median for k8s names +
+// numeric status cells; wide tables (8+ columns like PVC) overflow
+// `minWidth` and DataTable2 enables horizontal scroll automatically.
+class _TabletTable<T> extends StatefulWidget {
+  const _TabletTable({
+    required this.items,
+    required this.columns,
+    required this.onTap,
+  });
+
+  final List<T> items;
+  final List<ResourceColumn<T>> columns;
+  final ValueChanged<T> onTap;
+
+  @override
+  State<_TabletTable<T>> createState() => _TabletTableState<T>();
+}
+
+class _TabletTableState<T> extends State<_TabletTable<T>> {
+  late final KubeDataTableSource<T> _source;
+
+  @override
+  void initState() {
+    super.initState();
+    _source = KubeDataTableSource<T>(
+      items: widget.items,
+      columns: widget.columns,
+      onTap: widget.onTap,
+      context: context,
+    );
+  }
+
+  @override
+  void didUpdateWidget(_TabletTable<T> oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!identical(oldWidget.items, widget.items) ||
+        !identical(oldWidget.columns, widget.columns) ||
+        oldWidget.onTap != widget.onTap) {
+      _source.update(
+        items: widget.items,
+        columns: widget.columns,
+        onTap: widget.onTap,
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    _source.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final colors = Theme.of(context).extension<KubeColors>()!;
-    // DataTable2 lazy-builds rows as they scroll into view, which keeps
-    // memory + first-frame latency flat for 500-row clusters. Stock
-    // DataTable wrapped in nested SingleChildScrollViews materialized
-    // every row eagerly — fine for 20 rows, jank for 200.
-    // 96px per column hits a comfortable median for k8s names + numeric
-    // status cells. Wide tables (8+ columns like PVC) push past viewport
-    // and DataTable2 enables horizontal scroll automatically.
-    final minWidth = (columns.length * 96).toDouble();
-    return DataTable2(
-      columnSpacing: 16,
-      horizontalMargin: 12,
-      minWidth: minWidth,
+    final minWidth = (widget.columns.length * 96).toDouble();
+    return PaginatedDataTable2(
+      source: _source,
       columns: [
-        for (final col in columns)
+        for (final col in widget.columns)
           DataColumn2(
             label: Text(
               col.label,
@@ -134,24 +187,12 @@ class ResourceTable<T> extends StatelessWidget {
             ),
           ),
       ],
-      rows: [
-        for (final item in items)
-          DataRow2(
-            onTap: () => onTap(item),
-            cells: [
-              for (final col in columns)
-                DataCell(
-                  Text(
-                    col.value(item),
-                    style: TextStyle(
-                      color: col.color?.call(context, item) ??
-                          colors.textPrimary,
-                    ),
-                  ),
-                ),
-            ],
-          ),
-      ],
+      columnSpacing: 16,
+      horizontalMargin: 12,
+      minWidth: minWidth,
+      rowsPerPage: 50,
+      showCheckboxColumn: false,
+      wrapInCard: false,
     );
   }
 }

--- a/mobile/test/a11y/tap_target_test.dart
+++ b/mobile/test/a11y/tap_target_test.dart
@@ -16,6 +16,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kubecenter/theme/kube_theme_builder.dart';
 import 'package:kubecenter/theme/themes.g.dart';
+import 'package:kubecenter/widgets/resource_table.dart';
 
 import '../a11y_helpers.dart';
 
@@ -123,4 +124,42 @@ void main() {
       );
     });
   }
+
+  testWidgets('tablet ResourceTable paginator buttons meet a11y guidelines',
+      (tester) async {
+    tester.view.physicalSize = const Size(900 * 2, 700 * 2);
+    tester.view.devicePixelRatio = 2;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(MaterialApp(
+      theme: buildKubeTheme('nexus'),
+      home: MediaQuery(
+        data: const MediaQueryData(size: Size(900, 700)),
+        child: SizedBox(
+          width: 900,
+          height: 700,
+          child: Scaffold(
+            body: ResourceTable<String>(
+              items: List.generate(100, (i) => 'item-$i'),
+              columns: [
+                ResourceColumn(label: 'Name', value: (r) => r),
+              ],
+              onTap: (_) {},
+            ),
+          ),
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    await expectMeetsAllGuidelines(
+      tester,
+      // Contrast is exercised by contrast_test.dart over a richer fixture.
+      textContrast: false,
+      iOSTapTarget: true,
+      androidTapTarget: true,
+      labeledTapTargets: true,
+    );
+  });
 }

--- a/mobile/test/widgets/kube_data_table_source_test.dart
+++ b/mobile/test/widgets/kube_data_table_source_test.dart
@@ -1,0 +1,199 @@
+// KubeDataTableSource tests: lazy row materialization, edge indices,
+// update + notify, and end-to-end virtualization via PaginatedDataTable2.
+
+import 'package:data_table_2/data_table_2.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kubecenter/theme/kube_theme_builder.dart';
+import 'package:kubecenter/widgets/kube_data_table_source.dart';
+import 'package:kubecenter/widgets/resource_table.dart';
+
+class _Row {
+  const _Row(this.name, this.status);
+  final String name;
+  final String status;
+}
+
+Widget _harness({required Widget child, required Size size}) {
+  return MaterialApp(
+    theme: buildKubeTheme('nexus'),
+    home: MediaQuery(
+      data: MediaQueryData(size: size),
+      child: SizedBox.fromSize(size: size, child: child),
+    ),
+  );
+}
+
+/// Pumps a no-op widget tree and returns a BuildContext the source can
+/// look up Theme.of(context) against. The widget itself is a Builder
+/// that exposes the inner element to the test via a callback.
+Future<BuildContext> _pumpContext(WidgetTester tester) async {
+  late BuildContext captured;
+  await tester.pumpWidget(_harness(
+    size: const Size(900, 700),
+    child: Scaffold(
+      body: Builder(
+        builder: (context) {
+          captured = context;
+          return const SizedBox.shrink();
+        },
+      ),
+    ),
+  ));
+  await tester.pumpAndSettle();
+  return captured;
+}
+
+KubeDataTableSource<_Row> _source(BuildContext context, List<_Row> items, {
+  ValueChanged<_Row>? onTap,
+}) {
+  return KubeDataTableSource<_Row>(
+    items: items,
+    columns: [
+      ResourceColumn(label: 'Name', value: (r) => r.name),
+      ResourceColumn(label: 'Status', value: (r) => r.status),
+    ],
+    onTap: onTap ?? (_) {},
+    context: context,
+  );
+}
+
+void main() {
+  testWidgets('getRow(0) returns the first row from a 6000-item source',
+      (tester) async {
+    final context = await _pumpContext(tester);
+    final items = List.generate(6000, (i) => _Row('name-$i', 'status-$i'));
+    final source = _source(context, items);
+
+    final row = source.getRow(0);
+    expect(row, isNotNull);
+    expect(row, isA<DataRow2>());
+    final firstCell = (row!.cells.first.child as Text).data;
+    expect(firstCell, 'name-0');
+  });
+
+  testWidgets('getRow(5999) returns the last row of a 6000-item source',
+      (tester) async {
+    final context = await _pumpContext(tester);
+    final items = List.generate(6000, (i) => _Row('name-$i', 'status-$i'));
+    final source = _source(context, items);
+
+    final row = source.getRow(5999);
+    expect(row, isNotNull);
+    final firstCell = (row!.cells.first.child as Text).data;
+    expect(firstCell, 'name-5999');
+  });
+
+  testWidgets('getRow returns null for out-of-range indices', (tester) async {
+    final context = await _pumpContext(tester);
+    final source = _source(context, const [_Row('only', 'Running')]);
+
+    expect(source.getRow(-1), isNull);
+    expect(source.getRow(1), isNull);
+    expect(source.getRow(0), isNotNull);
+  });
+
+  testWidgets('rowCount mirrors items.length', (tester) async {
+    final context = await _pumpContext(tester);
+    final source = _source(context, [
+      const _Row('a', 'Running'),
+      const _Row('b', 'Pending'),
+      const _Row('c', 'Failed'),
+    ]);
+    expect(source.rowCount, 3);
+  });
+
+  testWidgets('update() replaces items, resets rowCallCount, and notifies',
+      (tester) async {
+    final context = await _pumpContext(tester);
+    final source = _source(context, [const _Row('a', 'Running')]);
+
+    source.getRow(0);
+    expect(source.rowCallCount, 1);
+
+    var notified = 0;
+    source.addListener(() => notified++);
+
+    source.update(
+      items: [const _Row('x', 'Pending'), const _Row('y', 'Failed')],
+      columns: [
+        ResourceColumn(label: 'Name', value: (r) => r.name),
+        ResourceColumn(label: 'Status', value: (r) => r.status),
+      ],
+      onTap: (_) {},
+    );
+
+    expect(notified, 1);
+    expect(source.rowCount, 2);
+    expect(source.rowCallCount, 0);
+
+    final row = source.getRow(0);
+    expect((row!.cells.first.child as Text).data, 'x');
+    expect(source.rowCallCount, 1);
+  });
+
+  testWidgets('row onTap callback fires with the underlying item',
+      (tester) async {
+    final context = await _pumpContext(tester);
+    _Row? tapped;
+    final source = _source(
+      context,
+      const [_Row('alpha', 'Running')],
+      onTap: (r) => tapped = r,
+    );
+
+    final row = source.getRow(0) as DataRow2;
+    row.onTap!.call();
+    expect(tapped?.name, 'alpha');
+  });
+
+  testWidgets(
+      'PaginatedDataTable2 only materializes rows for the visible page',
+      (tester) async {
+    tester.view.physicalSize = const Size(900 * 2, 700 * 2);
+    tester.view.devicePixelRatio = 2;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final items = List.generate(6000, (i) => _Row('name-$i', 'status-$i'));
+    late KubeDataTableSource<_Row> source;
+
+    await tester.pumpWidget(_harness(
+      size: const Size(900, 700),
+      child: Scaffold(
+        body: Builder(
+          builder: (context) {
+            source = KubeDataTableSource<_Row>(
+              items: items,
+              columns: [
+                ResourceColumn(label: 'Name', value: (r) => r.name),
+                ResourceColumn(label: 'Status', value: (r) => r.status),
+              ],
+              onTap: (_) {},
+              context: context,
+            );
+            return PaginatedDataTable2(
+              source: source,
+              columns: const [
+                DataColumn2(label: Text('Name')),
+                DataColumn2(label: Text('Status')),
+              ],
+              rowsPerPage: 50,
+              showCheckboxColumn: false,
+              wrapInCard: false,
+            );
+          },
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    // The visible page is 50 rows. PaginatedDataTable2 may request a
+    // couple extra indices for measurement/empty-row padding, so 60 is
+    // the safe bound that still proves virtualization (vs the 6000 a
+    // non-lazy implementation would request).
+    expect(source.rowCallCount, lessThan(60),
+        reason: 'Source requested ${source.rowCallCount} rows '
+            '(must stay bounded by the visible page, not the 6000-item list)');
+  });
+}

--- a/mobile/test/widgets/kube_data_table_source_test.dart
+++ b/mobile/test/widgets/kube_data_table_source_test.dart
@@ -14,6 +14,37 @@ class _Row {
   final String status;
 }
 
+/// Test-only subclass that counts how many non-null rows `getRow` has
+/// returned. Used to verify that PaginatedDataTable2 only materialises
+/// rows for the visible page (virtualization proof).
+class _CountingKubeDataTableSource<T> extends KubeDataTableSource<T> {
+  _CountingKubeDataTableSource({
+    required super.items,
+    required super.columns,
+    required super.onTap,
+    required super.context,
+  });
+
+  int rowCallCount = 0;
+
+  @override
+  DataRow? getRow(int index) {
+    final row = super.getRow(index);
+    if (row != null) rowCallCount++;
+    return row;
+  }
+
+  @override
+  void update({
+    required List<T> items,
+    required List<ResourceColumn<T>> columns,
+    required ValueChanged<T> onTap,
+  }) {
+    rowCallCount = 0;
+    super.update(items: items, columns: columns, onTap: onTap);
+  }
+}
+
 Widget _harness({required Widget child, required Size size}) {
   return MaterialApp(
     theme: buildKubeTheme('nexus'),
@@ -48,6 +79,21 @@ KubeDataTableSource<_Row> _source(BuildContext context, List<_Row> items, {
   ValueChanged<_Row>? onTap,
 }) {
   return KubeDataTableSource<_Row>(
+    items: items,
+    columns: [
+      ResourceColumn(label: 'Name', value: (r) => r.name),
+      ResourceColumn(label: 'Status', value: (r) => r.status),
+    ],
+    onTap: onTap ?? (_) {},
+    context: context,
+  );
+}
+
+_CountingKubeDataTableSource<_Row> _countingSource(
+    BuildContext context, List<_Row> items, {
+  ValueChanged<_Row>? onTap,
+}) {
+  return _CountingKubeDataTableSource<_Row>(
     items: items,
     columns: [
       ResourceColumn(label: 'Name', value: (r) => r.name),
@@ -106,7 +152,7 @@ void main() {
   testWidgets('update() replaces items, resets rowCallCount, and notifies',
       (tester) async {
     final context = await _pumpContext(tester);
-    final source = _source(context, [const _Row('a', 'Running')]);
+    final source = _countingSource(context, [const _Row('a', 'Running')]);
 
     source.getRow(0);
     expect(source.rowCallCount, 1);
@@ -147,6 +193,29 @@ void main() {
     expect(tapped?.name, 'alpha');
   });
 
+  testWidgets('per-row color callback overrides default text color',
+      (tester) async {
+    final context = await _pumpContext(tester);
+    final source = KubeDataTableSource<_Row>(
+      items: const [_Row('alpha', 'Running')],
+      columns: [
+        ResourceColumn(
+          label: 'Status',
+          value: (r) => r.status,
+          color: (ctx, r) => r.status == 'Running'
+              ? const Color(0xFF00FF00)
+              : null,
+        ),
+      ],
+      onTap: (_) {},
+      context: context,
+    );
+
+    final row = source.getRow(0);
+    final cellText = (row!.cells.first.child as Text);
+    expect(cellText.style?.color, const Color(0xFF00FF00));
+  });
+
   testWidgets(
       'PaginatedDataTable2 only materializes rows for the visible page',
       (tester) async {
@@ -156,14 +225,14 @@ void main() {
     addTearDown(tester.view.resetDevicePixelRatio);
 
     final items = List.generate(6000, (i) => _Row('name-$i', 'status-$i'));
-    late KubeDataTableSource<_Row> source;
+    late _CountingKubeDataTableSource<_Row> source;
 
     await tester.pumpWidget(_harness(
       size: const Size(900, 700),
       child: Scaffold(
         body: Builder(
           builder: (context) {
-            source = KubeDataTableSource<_Row>(
+            source = _CountingKubeDataTableSource<_Row>(
               items: items,
               columns: [
                 ResourceColumn(label: 'Name', value: (r) => r.name),
@@ -178,7 +247,7 @@ void main() {
                 DataColumn2(label: Text('Name')),
                 DataColumn2(label: Text('Status')),
               ],
-              rowsPerPage: 50,
+              rowsPerPage: 50, // keep in sync with _kRowsPerPage in resource_table.dart
               showCheckboxColumn: false,
               wrapInCard: false,
             );
@@ -192,8 +261,23 @@ void main() {
     // couple extra indices for measurement/empty-row padding, so 60 is
     // the safe bound that still proves virtualization (vs the 6000 a
     // non-lazy implementation would request).
-    expect(source.rowCallCount, lessThan(60),
+    expect(source.rowCallCount, lessThanOrEqualTo(52),
         reason: 'Source requested ${source.rowCallCount} rows '
-            '(must stay bounded by the visible page, not the 6000-item list)');
+            '(must stay bounded by the visible page = 50 + at most 2 for '
+            'paginator overhead, not the 6000-item list)');
+
+    // update() must trigger an actual PaginatedDataTable2 rebuild,
+    // not just notify a raw listener. Replace items and confirm new
+    // data appears in the rendered tree.
+    source.update(
+      items: [const _Row('updated-row', 'Updated')],
+      columns: [
+        ResourceColumn(label: 'Name', value: (r) => r.name),
+        ResourceColumn(label: 'Status', value: (r) => r.status),
+      ],
+      onTap: (_) {},
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('updated-row'), findsOneWidget);
   });
 }

--- a/mobile/test/widgets/resource_table_test.dart
+++ b/mobile/test/widgets/resource_table_test.dart
@@ -102,4 +102,65 @@ void main() {
 
     expect(find.text('No resources found'), findsOneWidget);
   });
+
+  testWidgets('tablet empty list still shows "No resources found" '
+      '(empty short-circuit runs before LayoutBuilder)', (tester) async {
+    tester.view.physicalSize = const Size(900 * 2, 700 * 2);
+    tester.view.devicePixelRatio = 2;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(_harness(
+      size: const Size(900, 700),
+      child: Scaffold(
+        body: ResourceTable<_Row>(
+          items: const [],
+          columns: [
+            ResourceColumn(label: 'Name', value: (r) => r.name),
+          ],
+          onTap: (_) {},
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text('No resources found'), findsOneWidget);
+    expect(find.byType(PaginatedDataTable2), findsNothing);
+  });
+
+  testWidgets('tablet table refreshes when items list reference changes via parent rebuild',
+      (tester) async {
+    tester.view.physicalSize = const Size(900 * 2, 700 * 2);
+    tester.view.devicePixelRatio = 2;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    var items = [_Row('alpha', 'Running')];
+
+    Widget buildTable() => _harness(
+          size: const Size(900, 700),
+          child: Scaffold(
+            body: ResourceTable<_Row>(
+              items: items,
+              columns: [
+                ResourceColumn(label: 'Name', value: (r) => r.name),
+                ResourceColumn(label: 'Status', value: (r) => r.status),
+              ],
+              onTap: (_) {},
+            ),
+          ),
+        );
+
+    await tester.pumpWidget(buildTable());
+    await tester.pumpAndSettle();
+    expect(find.text('alpha'), findsOneWidget);
+
+    // New list reference → identical() guard fires → source.update() runs.
+    items = [_Row('beta', 'Pending')];
+    await tester.pumpWidget(buildTable());
+    await tester.pumpAndSettle();
+
+    expect(find.text('beta'), findsOneWidget);
+    expect(find.text('alpha'), findsNothing);
+  });
 }

--- a/mobile/test/widgets/resource_table_test.dart
+++ b/mobile/test/widgets/resource_table_test.dart
@@ -51,14 +51,14 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(ListTile), findsNWidgets(2));
-    expect(find.byType(DataTable2), findsNothing);
+    expect(find.byType(PaginatedDataTable2), findsNothing);
 
     await tester.tap(find.byKey(const ValueKey('resource-row-1')));
     await tester.pumpAndSettle();
     expect(tapped?.name, 'beta');
   });
 
-  testWidgets('tablet layout renders DataTable', (tester) async {
+  testWidgets('tablet layout renders PaginatedDataTable2', (tester) async {
     tester.view.physicalSize = const Size(900 * 2, 700 * 2);
     tester.view.devicePixelRatio = 2;
     addTearDown(tester.view.resetPhysicalSize);
@@ -79,8 +79,10 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    expect(find.byType(DataTable2), findsOneWidget);
+    expect(find.byType(PaginatedDataTable2), findsOneWidget);
     expect(find.byType(ListTile), findsNothing);
+    // The cell text should be rendered through the source's getRow path.
+    expect(find.text('alpha'), findsOneWidget);
   });
 
   testWidgets('empty list shows "No resources found"', (tester) async {


### PR DESCRIPTION
## Summary

- **`mobile/lib/widgets/kube_data_table_source.dart`** — new lazy `DataTableSource<T>` with a test-only `rowCallCount` counter and an `update()` method that resets the counter and notifies listeners.
- **`mobile/lib/widgets/resource_table.dart`** — `_buildTabletTable` becomes a stateful `_TabletTable<T>` that owns a `KubeDataTableSource` and feeds `PaginatedDataTable2(rowsPerPage: 50, wrapInCard: false, showCheckboxColumn: false)`. Phone branch (`< 768px`) keeps `ListView.separated`.
- **`mobile/docs/PERFORMANCE.md`** — frame-budget targets, capture methodology, and a measurement matrix with `TBD` placeholders to populate during the homelab smoke pass.

The eager `DataTable2(rows: [for (item in items) ...])` path built every `DataRow2` up-front — a 500-pod cluster paid 500 builds on the first frame before any of those rows scrolled into view. `PaginatedDataTable2` calls `getRow(index)` lazily for just the indices the paginator needs (≤ `rowsPerPage`), so the cost is bounded regardless of the underlying list size.

The public `ResourceTable<T>` API is preserved — the 12 consumer screens (`pod_screens.dart`, `secret_screens.dart`, `service_screens.dart`, etc.) need no edits. `mobile/lib/features/scanning/vulnerabilities_list_screen.dart` is **not** a `ResourceTable` consumer; it already uses `SliverChildBuilderDelegate` directly, so the 6000-row vulnerability list is out of scope.

## Verification

- `cd mobile && flutter analyze` → `No issues found! (ran in 2.1s)`
- `cd mobile && flutter test` → **1139 passing** (was 1132 post-PR-5h; +7 from `kube_data_table_source_test.dart`)
- End-to-end virtualization assertion: pumping a synthetic 6000-row source through `PaginatedDataTable2` materializes `< 60` rows.

## Test plan

- [ ] CI runs `flutter analyze` + `flutter test` on the branch
- [ ] Smoke against homelab: navigate to Pods on the tablet layout; confirm pagination footer ("1-50 of 200") + prev/next buttons render, rows render without horizontal overflow, row tap routes to detail
- [ ] Confirm phone layout (`< 768px`) still renders `ListTile` cards (visual regression check)
- [ ] Optional: run `flutter run --profile` + DevTools timeline on a populated cluster and drop real numbers into the `PERFORMANCE.md` measurement matrix

## Plan reference

`plans/mobile-app-m5-pr-sequence.md` § U9 PR-5i.

🤖 Generated with [Claude Code](https://claude.com/claude-code)