### PR TITLE
fix(frontend): patch libc6 to deb13u3 (3 Trivy CVE alerts)

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -23,34 +23,46 @@ RUN find /app/node_modules -path '*/esbuild/bin/esbuild' -delete 2>/dev/null; \
     find /deno-dir -path '*/@esbuild/*/bin/esbuild' -delete 2>/dev/null; \
     true
 
-# Security patch stage: update OpenSSL to fix CVE-2026-31790, CVE-2026-2673,
-# CVE-2026-28387, CVE-2026-28388, CVE-2026-28389, CVE-2026-28390, CVE-2026-31789
-# (libssl3t64 3.5.5-1~deb13u1 → 3.5.5-1~deb13u2)
-# Uses target platform so library arch paths match the distroless runtime.
+# Security patch stage: overlay patched OS libraries onto distroless so Trivy
+# clears the open CVEs. Uses target platform so library arch paths match.
+#   libssl3t64 3.5.5-1~deb13u1 → 3.5.5-1~deb13u2
+#     CVE-2026-31790, CVE-2026-2673, CVE-2026-28387, CVE-2026-28388,
+#     CVE-2026-28389, CVE-2026-28390, CVE-2026-31789
+#   libc6 2.41-12+deb13u2 → 2.41-12+deb13u3
+#     CVE-2026-4046, CVE-2026-4437, CVE-2026-4438
 FROM denoland/deno:distroless-2.7.11 AS runtime-base
 FROM debian:trixie-slim AS security-patch
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends libssl3t64=3.5.5-1~deb13u2 && \
+    apt-get install -y --no-install-recommends \
+      libssl3t64=3.5.5-1~deb13u2 \
+      libc6=2.41-12+deb13u3 && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir -p /patch/usr/lib && \
-    dpkg -L libssl3t64 | grep '/usr/lib' | while read f; do \
-      [ -f "$f" ] && mkdir -p "/patch$(dirname "$f")" && cp -a "$f" "/patch$f"; \
+    for pkg in libssl3t64 libc6; do \
+      dpkg -L "$pkg" | grep '/usr/lib' | while read f; do \
+        [ -f "$f" ] && mkdir -p "/patch$(dirname "$f")" && cp -a "$f" "/patch$f"; \
+      done; \
     done
-# Update the distroless dpkg status.d entry so Trivy sees the patched version.
+# Update the distroless dpkg status.d entries so Trivy sees the patched versions.
 # TEMPORARY: remove this entire security-patch stage once the distroless base
-# ships with libssl3t64 >= 3.5.5-1~deb13u2.
+# ships with libssl3t64 >= 3.5.5-1~deb13u2 AND libc6 >= 2.41-12+deb13u3.
 COPY --from=runtime-base /var/lib/dpkg/status.d/libssl3t64 /tmp/libssl3t64-orig
+COPY --from=runtime-base /var/lib/dpkg/status.d/libc6 /tmp/libc6-orig
 RUN grep -q '3\.5\.5-1~deb13u1' /tmp/libssl3t64-orig || \
-    (echo "ERROR: base image no longer contains libssl3t64 3.5.5-1~deb13u1 — remove the security-patch stage" && exit 1)
-RUN sed 's/3\.5\.5-1~deb13u1/3.5.5-1~deb13u2/g' /tmp/libssl3t64-orig > /patch/libssl3t64-status
+    (echo "ERROR: base image no longer contains libssl3t64 3.5.5-1~deb13u1 — drop libssl3t64 from the security-patch stage" && exit 1)
+RUN grep -qF '2.41-12+deb13u2' /tmp/libc6-orig || \
+    (echo "ERROR: base image no longer contains libc6 2.41-12+deb13u2 — drop libc6 from the security-patch stage" && exit 1)
+RUN sed 's/3\.5\.5-1~deb13u1/3.5.5-1~deb13u2/g' /tmp/libssl3t64-orig > /patch/libssl3t64-status && \
+    sed 's/2\.41-12+deb13u2/2.41-12+deb13u3/g' /tmp/libc6-orig > /patch/libc6-status
 
 # Stage 2: Production runtime (uses target platform — arm64 or amd64)
 # Use distroless variant to minimize OS-level CVEs (no shell, no package manager)
 FROM denoland/deno:distroless-2.7.11
 
-# Overlay patched OpenSSL libraries and updated package metadata
+# Overlay patched libraries (libssl3t64, libc6) and updated package metadata
 COPY --from=security-patch /patch/usr/lib/ /usr/lib/
 COPY --from=security-patch /patch/libssl3t64-status /var/lib/dpkg/status.d/libssl3t64
+COPY --from=security-patch /patch/libc6-status /var/lib/dpkg/status.d/libc6
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

- Extends the existing `security-patch` Dockerfile stage in `frontend/Dockerfile` to overlay **libc6 2.41-12+deb13u3** alongside the libssl3t64 patch already shipped.
- Closes 3 open Trivy code-scanning alerts (all medium, all against `library/k8scenter-frontend`):
  - #123 — CVE-2026-4046 (libc6)
  - #124 — CVE-2026-4437 (libc6)
  - #125 — CVE-2026-4438 (libc6)
- Same mechanical pattern as the libssl3t64 patch: `apt-get install` the fixed package on `debian:trixie-slim`, copy the resulting `.so` files into a scratch `/patch` dir, overlay them on the distroless runtime, then rewrite the `dpkg status.d` entry so Trivy sees the new version.
- Adds a sentinel check that fails the build if the distroless base ever ships libc6 newer than deb13u2, so the temporary stage is dropped instead of silently double-patching.

Backend image is unaffected: `gcr.io/distroless/static-debian12:nonroot` plus a `CGO_ENABLED=0` static binary means no glibc surface.

## Test plan

- [ ] CI build of the frontend image passes on linux/amd64 and linux/arm64
- [ ] Trivy scan in `ci-release.yml` no longer reports CVE-2026-4046 / CVE-2026-4437 / CVE-2026-4438 against the frontend image
- [ ] libssl3t64 patch still applies (sentinel grep on `3.5.5-1~deb13u1` still matches in the base)
- [ ] Container starts and Deno serves `/_fresh/server.js` (no ABI break from the libc6 swap — should be safe since 2.41-12+deb13uN bumps are guaranteed ABI-compatible by Debian security policy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)