### PR TITLE
feat(ci): add Semgrep + OSV-Scanner SAST for mobile (Flutter/Dart)

### DIFF
--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -113,6 +113,18 @@ jobs:
       - name: Install Semgrep
         run: pip install semgrep==1.162.0
 
+      # Rule selection: Semgrep's open registry has no curated Dart
+      # or Flutter pack (the human-facing /p/dart preview page exists
+      # but the CLI's config-fetch endpoint 404s, and semgrep silently
+      # exits 7 — MISSING_CONFIG — when an unfetchable pack is requested).
+      #   p/default — broad multi-language + regex rules; the regex
+      #     rules apply to .dart files (credentials, hardcoded URLs,
+      #     dangerous patterns) even though semgrep ships no Dart-AST
+      #     rule pack.
+      #   p/secrets — credential / API-key leak detection across all
+      #     file types via regex.
+      # OSV-Scanner (separate job below) handles the pub.dev dep-CVE
+      # surface, which IS Dart-specific.
       # `--metrics=off` keeps run telemetry off public CI. SARIF
       # output lets `upload-sarif` ingest the findings under the
       # `dart-semgrep` category so they slot into the same Security
@@ -121,8 +133,7 @@ jobs:
       - name: Run Semgrep
         run: |
           semgrep scan \
-            --config=p/dart \
-            --config=p/flutter \
+            --config=p/default \
             --config=p/secrets \
             --sarif --output=semgrep.sarif \
             --metrics=off \

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -107,8 +107,11 @@ jobs:
       # clears the 7-day supply-chain cooldown documented in global
       # CLAUDE.md. Newer Semgrep releases land roughly weekly; only
       # bump after the new release ages past the cooldown window.
+      # Semgrep's own transitive deps (click, etc.) are installed
+      # normally — transitive deps are explicitly exempt from the
+      # 7-day rule because the solver picks them, not us.
       - name: Install Semgrep
-        run: pip install --no-deps semgrep==1.162.0
+        run: pip install semgrep==1.162.0
 
       # `--metrics=off` keeps run telemetry off public CI. SARIF
       # output lets `upload-sarif` ingest the findings under the

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -79,6 +79,110 @@ jobs:
         run: deno run --allow-read tools/theme-gen/main.ts --check
 
   # ---------------------------------------------------------------------
+  # Security scans — Semgrep SAST + OSV-Scanner dependency check fill
+  # the role CodeQL plays for the Go/JS halves of the project (CodeQL
+  # has no Dart analyzer). Findings upload as SARIF to the Security
+  # tab; neither job is blocking on day 1 so PRs surface issues
+  # without gating the merge. Flip `fail-on-vuln: true` on osv-scan
+  # and add `--error` to the semgrep call to harden once the baseline
+  # is clean.
+  # ---------------------------------------------------------------------
+
+  semgrep:
+    name: Semgrep SAST (Dart/Flutter)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # Pin Semgrep to 1.162.0 — 10 days old at time of write, which
+      # clears the 7-day supply-chain cooldown documented in global
+      # CLAUDE.md. Newer Semgrep releases land roughly weekly; only
+      # bump after the new release ages past the cooldown window.
+      - name: Install Semgrep
+        run: pip install --no-deps semgrep==1.162.0
+
+      # `--metrics=off` keeps run telemetry off public CI. SARIF
+      # output lets `upload-sarif` ingest the findings under the
+      # `dart-semgrep` category so they slot into the same Security
+      # tab CodeQL writes to without colliding with CodeQL's own
+      # categories.
+      - name: Run Semgrep
+        run: |
+          semgrep scan \
+            --config=p/dart \
+            --config=p/flutter \
+            --config=p/secrets \
+            --sarif --output=semgrep.sarif \
+            --metrics=off \
+            --exclude="mobile/build/**" \
+            --exclude="mobile/.dart_tool/**" \
+            --exclude="mobile/ios/Pods/**" \
+            --exclude="mobile/android/.gradle/**" \
+            mobile/
+
+      - name: Upload SARIF to Security tab
+        if: ${{ !cancelled() }}
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: semgrep.sarif
+          category: "/language:dart-semgrep"
+
+  osv-scan:
+    name: OSV-Scanner (pub.dev advisories)
+    # Reusable workflow handles checkout, scan, SARIF generation, and
+    # upload to the Security tab. Pinned to v2.3.5 (52 days old) to
+    # clear the 7-day cooldown. `fail-on-vuln: false` keeps findings
+    # surfaced without blocking PRs until we baseline the existing
+    # advisory set.
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.5
+    with:
+      scan-args: |-
+        --lockfile=mobile/pubspec.lock
+      fail-on-vuln: false
+
+  mobile-security-summary:
+    # Aggregate gate intended as the single required check for branch
+    # protection. Passes when both scans either succeeded or were
+    # skipped by their path filter; fails on any failure or
+    # cancellation. Mirrors the `CodeQL Summary` pattern in
+    # .github/workflows/codeql.yml so branch protection treats both
+    # security gates identically.
+    name: Mobile Security Summary
+    runs-on: ubuntu-latest
+    needs: [semgrep, osv-scan]
+    if: always()
+    permissions: {}
+    steps:
+      - name: Verify all analyses passed or were skipped
+        env:
+          SEMGREP_RESULT: ${{ needs.semgrep.result }}
+          OSV_RESULT: ${{ needs.osv-scan.result }}
+        run: |
+          fail=0
+          for name in SEMGREP OSV; do
+            var="${name}_RESULT"
+            result="${!var}"
+            case "$result" in
+              success|skipped) ;;
+              *) echo "::error::$name analyze result: $result"; fail=1 ;;
+            esac
+          done
+          exit $fail
+
+  # ---------------------------------------------------------------------
   # Release uploads — only run on push-to-main or workflow_dispatch,
   # gated on analyze. Each job auto-skips with a clear status when its
   # required secrets are absent, so operators bring up the pipeline


### PR DESCRIPTION
## Summary

CodeQL doesn't ship a Dart analyzer, so the mobile/ Flutter app has been outside the SAST gate that Go and JS/TS get from `.github/workflows/codeql.yml`. This adds:

- **Semgrep** scanning over `mobile/` with two packs that Semgrep's open registry actually resolves:
  - `p/default` — broad multi-language + regex rules. The regex-based rules apply to `.dart` files (credentials, hardcoded URLs, common anti-patterns) even though Semgrep ships no Dart-AST rule pack.
  - `p/secrets` — credential / API-key leak detection across all file types via regex.
- **OSV-Scanner** (reusable workflow) against `mobile/pubspec.lock` — covers the pub.dev advisory database, which Trivy doesn't reach today. **This is the Dart-specific dep-CVE story.**
- **Mobile Security Summary** aggregator that mirrors the `CodeQL Summary` gate, so branch protection can require it as a single check.

Both scan jobs upload SARIF under unique categories (`dart-semgrep`, `osv-scanner-pub.dev`) so findings appear in the same Security tab as CodeQL alerts without category collisions.

### Honest framing

Semgrep's open registry has no curated Dart pack — `p/dart` and `p/flutter` HTML preview pages exist but the CLI's config-fetch endpoint 404s them, and an earlier draft of this PR silently exited 7 (MISSING_CONFIG) because of it. So Semgrep here gives the mobile codebase the same level of generic SAST + secrets coverage it gives any codebase, **not** Dart-AST taint-tracking. Pair it with `flutter analyze` (already in CI) for language-level lints.

OSV-Scanner gives genuine Dart-specific dependency coverage.

### Day-1 policy: surface-only

Neither scan blocks PRs on findings:
- `semgrep scan` is invoked without `--error`, so it exits 0 even when rules match.
- `osv-scan` calls the reusable workflow with `fail-on-vuln: false`.

The `Mobile Security Summary` job only fails on workflow-level failure or cancellation. Once the baseline is clean, flip both flags to harden into a gating check.

### Supply-chain pins

Per the 7-day cooldown rule in global CLAUDE.md, both tools pin to versions ≥ 7 days old:

| Tool | Version | Published | Age |
|------|---------|-----------|-----|
| `semgrep` | `1.162.0` | 2026-05-07 | 10 days |
| `google/osv-scanner-action` reusable workflow | `v2.3.5` | 2026-03-26 | 52 days |

## Test plan

- [ ] CI run on this PR succeeds — `semgrep` job uploads SARIF without error, `osv-scan` reusable workflow completes, `Mobile Security Summary` passes.
- [ ] Security tab shows new findings (if any) under `dart-semgrep` and `osv-scanner-pub.dev` categories, distinct from existing CodeQL Go/JS streams.
- [ ] Path filter on the workflow (`mobile/**`, `shared/themes/**`, `tools/theme-gen/**`, `.github/workflows/mobile-ci.yml`) means PRs that don't touch those paths skip the new jobs.
- [ ] Followup: once baseline is clean, harden via `fail-on-vuln: true` + `--error`, and consider promoting `Mobile Security Summary` to a required check in branch protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)