### PR TITLE
fix(mobile): #279 — login() rolls back tokens on hydration failure

### DIFF
--- a/mobile/lib/auth/auth_repository.dart
+++ b/mobile/lib/auth/auth_repository.dart
@@ -107,6 +107,16 @@ class AuthRepository extends Notifier<AuthState> {
         await ref.read(secureTokenStoreProvider).writeRefreshToken(refreshToken);
       }
       await _hydrateUser();
+      // Rollback on hydration failure — mirrors [applyAuthTokens]. Without
+      // this, the refresh token survives in secure_storage and the access
+      // token survives in authTokenHolder when /v1/auth/me errors after
+      // /v1/auth/login succeeds. Next cold-start would silently
+      // re-authenticate via /v1/auth/refresh even though the user was
+      // told "Sign-in failed". Issue #279.
+      if (state is AuthUnauthenticated) {
+        ref.read(authTokenHolderProvider).clear();
+        await ref.read(secureTokenStoreProvider).deleteRefreshToken();
+      }
     } on DioException catch (e) {
       final apiError = ApiError.fromDio(e);
       state = AuthUnauthenticated(errorMessage: apiError.message);

--- a/mobile/test/auth/auth_repository_test.dart
+++ b/mobile/test/auth/auth_repository_test.dart
@@ -113,6 +113,100 @@ void main() {
     expect(container.read(authTokenHolderProvider).accessToken, isNull);
   });
 
+  // Issue #279 — when /v1/auth/login returns 200 but /v1/auth/me errors
+  // (or returns a malformed payload), the credentials path must roll
+  // back the tokens it just wrote. Without rollback, the refresh token
+  // survives in secure_storage and the user gets silently re-auth'd on
+  // next cold-start despite being told "Sign-in failed".
+  test(
+      'login: rolls back tokens when /auth/me fails after /auth/login succeeds',
+      () async {
+    final (:container, :mock) = _makeContainer();
+    addTearDown(container.dispose);
+
+    mock.onJson(
+      'POST',
+      '/api/v1/auth/login',
+      body: {
+        'data': {
+          'accessToken': 'leaked-access',
+          'refreshToken': 'leaked-refresh',
+          'expiresIn': 900,
+        },
+      },
+    );
+    mock.on('GET', '/api/v1/auth/me', (_) {
+      return _json(
+        {
+          'error': {'code': 500, 'message': 'hydrate failed'},
+        },
+        status: 500,
+      );
+    });
+
+    await container.read(authRepositoryProvider.notifier).login(
+          username: 'admin',
+          password: 'password1234',
+        );
+
+    final state = container.read(authRepositoryProvider);
+    expect(state, isA<AuthUnauthenticated>());
+
+    // The critical assertion: no token survives the failed login.
+    expect(
+      container.read(authTokenHolderProvider).accessToken,
+      isNull,
+      reason: 'access token must be cleared after hydration failure',
+    );
+    final stored = await container
+        .read(secureTokenStoreProvider)
+        .readRefreshToken();
+    expect(
+      stored,
+      isNull,
+      reason: 'refresh token must be deleted from secure_storage '
+          'after hydration failure (issue #279)',
+    );
+  });
+
+  test(
+      'login: rolls back when /auth/me returns 200 with malformed payload',
+      () async {
+    final (:container, :mock) = _makeContainer();
+    addTearDown(container.dispose);
+
+    mock.onJson(
+      'POST',
+      '/api/v1/auth/login',
+      body: {
+        'data': {
+          'accessToken': 'leaked-access',
+          'refreshToken': 'leaked-refresh',
+          'expiresIn': 900,
+        },
+      },
+    );
+    // /auth/me returns 200 but the user object is missing — same
+    // AuthUnauthenticated transition as a 500, must also roll back.
+    mock.onJson(
+      'GET',
+      '/api/v1/auth/me',
+      body: {'data': <String, dynamic>{}},
+    );
+
+    await container.read(authRepositoryProvider.notifier).login(
+          username: 'admin',
+          password: 'password1234',
+        );
+
+    expect(container.read(authRepositoryProvider), isA<AuthUnauthenticated>());
+    expect(container.read(authTokenHolderProvider).accessToken, isNull);
+    final stored = await container
+        .read(secureTokenStoreProvider)
+        .readRefreshToken();
+    expect(stored, isNull);
+  });
+
   test('bootstrap: with no stored token transitions to Unauthenticated',
       () async {
     final (:container, :mock) = _makeContainer();


### PR DESCRIPTION
## Summary

Mirrors the rollback pattern PR-5c added to `applyAuthTokens()` into the credentials `login()` path. Without it, when `/v1/auth/me` errors right after `/v1/auth/login` succeeds, the user is told "Sign-in failed" but the refresh token survives in secure_storage — next cold-start silently re-authenticates against `/v1/auth/refresh` and the same hydration runs again with the user "signed in" via a flow they were told had failed.

Closes #279.

## The gap

`mobile/lib/auth/auth_repository.dart::login()` writes the access + refresh tokens before calling `_hydrateUser()`. If hydration sets `state = AuthUnauthenticated(...)` (via 5xx response, network failure, or malformed payload), the tokens stay written. The applyAuthTokens path PR-5c added already handles this; the credentials path was left behind.

## The fix

Add a 4-line rollback block after `_hydrateUser()`:

```dart
if (state is AuthUnauthenticated) {
  ref.read(authTokenHolderProvider).clear();
  await ref.read(secureTokenStoreProvider).deleteRefreshToken();
}
```

Identical shape to `applyAuthTokens()` lines 173-176. The comment explicitly cross-references it so future eyes see the parallel.

## Tests

Two regression tests in `mobile/test/auth/auth_repository_test.dart`:

1. **`/auth/me` returns 500 after `/auth/login` success** — asserts `state is AuthUnauthenticated`, `accessToken == null`, secure_storage refresh token deleted.
2. **`/auth/me` returns 200 with malformed payload** (no `user` field) — same rollback path, same assertions. Catches the non-Dio-exception failure mode (line 187 in `auth_repository.dart` sets `AuthUnauthenticated` for missing user payload).

## Verification

- `flutter analyze` — clean.
- `flutter test` (full suite) — 1145 tests pass (1143 baseline + 2 new).

## Out of scope

- The same shape exists in mobile `bootstrap()` path — `/v1/auth/refresh` succeeds, `_hydrateUser()` fails — but that path's tokens come from secure_storage, not freshly written. The "stale refresh token clears storage" test (line 169 in the existing test file) already covers the bootstrap failure mode separately. No new gap here.

## Test plan

- [ ] CI green on mobile-ci.yml (flutter analyze + flutter test)
- [ ] Manual smoke: kill the backend `/v1/auth/me` handler in dev (return 500 unconditionally), attempt local login, confirm error toast surfaces AND the next cold-start of the app lands on the login screen (no silent re-auth)

Generated with Claude Code
