### PR TITLE
feat(audit): #276 — surface rate-limit 429s in audit table

### DIFF
--- a/backend/cmd/kubecenter/main.go
+++ b/backend/cmd/kubecenter/main.go
@@ -241,8 +241,10 @@ func main() {
 		rateLimiter = middleware.NewRateLimiter() // 5 req/min for production
 	}
 	rateLimiter.StartCleanup(ctx)
+	rateLimiter.SetAuditLogger(auditLogger) // issue #276: surface 429s in audit
 	yamlRateLimiter := middleware.NewRateLimiterWithRate(30, time.Minute)
 	yamlRateLimiter.StartCleanup(ctx)
+	yamlRateLimiter.SetAuditLogger(auditLogger)
 
 	// Initialize monitoring discoverer and start background discovery
 	monDiscoverer := monitoring.NewDiscoverer(k8sClient, cfg.Monitoring, logger)
@@ -265,6 +267,7 @@ func main() {
 
 	logQueryLimiter := middleware.NewRateLimiterWithRate(30, time.Minute)
 	logQueryLimiter.StartCleanup(ctx)
+	logQueryLimiter.SetAuditLogger(auditLogger)
 
 	// Service Mesh integration (Istio + Linkerd) — hoisted above topology so
 	// the topology builder's mesh-overlay path has a route provider wired in.
@@ -373,6 +376,7 @@ func main() {
 
 	webhookRateLimiter := middleware.NewRateLimiterWithRate(300, time.Minute)
 	webhookRateLimiter.StartCleanup(ctx)
+	webhookRateLimiter.SetAuditLogger(auditLogger)
 
 	// Multi-cluster routing — always construct (nil store = local-only fallback)
 	dbEncKey := cfg.Database.EncryptionKey

--- a/backend/internal/audit/logger.go
+++ b/backend/internal/audit/logger.go
@@ -48,6 +48,17 @@ const (
 	ActionESOForceSync             Action = "eso_force_sync"
 	ActionESOBulkRefresh           Action = "eso_bulk_refresh"
 	ActionESOBulkRefreshNamespace  Action = "eso_bulk_refresh_namespace"
+
+	// Infrastructure / cross-cutting actions
+	//
+	// ActionRateLimited fires when the rate-limit middleware rejects a
+	// request before the handler runs. Surfaces brute-force probing in
+	// the audit table — previously rate-limited requests left no trace,
+	// which is what issue #276 fixes. Recorded with SourceIP populated;
+	// User is empty (the 429 fires before any auth happens). The Detail
+	// field carries "<METHOD> <path>: rate limited" so investigators can
+	// filter by route.
+	ActionRateLimited Action = "rate_limited"
 )
 
 // Result represents the outcome of an auditable operation.

--- a/backend/internal/server/middleware/ratelimit.go
+++ b/backend/internal/server/middleware/ratelimit.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/kubecenter/kubecenter/internal/audit"
 	"github.com/kubecenter/kubecenter/pkg/api"
 )
 
@@ -24,11 +25,16 @@ type bucket struct {
 }
 
 // RateLimiter tracks request counts per IP using a fixed-window algorithm.
+//
+// Optional [audit.Logger] hook surfaces 429 rejections in the audit table.
+// Set via [RateLimiter.SetAuditLogger] at server construction; nil logger
+// means rate-limit hits are silent (the legacy behavior).
 type RateLimiter struct {
-	mu      sync.Mutex
-	buckets map[string]*bucket
-	rate    int
-	window  time.Duration
+	mu          sync.Mutex
+	buckets     map[string]*bucket
+	rate        int
+	window      time.Duration
+	auditLogger audit.Logger
 }
 
 // NewRateLimiter creates a rate limiter with default settings (5 req/min).
@@ -43,6 +49,16 @@ func NewRateLimiterWithRate(rate int, window time.Duration) *RateLimiter {
 		rate:    rate,
 		window:  window,
 	}
+}
+
+// SetAuditLogger attaches an audit logger so 429 rejections emit
+// [audit.ActionRateLimited] entries. Issue #276 — without this, brute-force
+// probing of rate-limited endpoints leaves no trace in the audit table.
+// Safe to call once at startup; not safe to call concurrently with
+// requests in flight (no lock — kept lock-free because typical wiring is
+// "construct + SetAuditLogger + start serving").
+func (rl *RateLimiter) SetAuditLogger(logger audit.Logger) {
+	rl.auditLogger = logger
 }
 
 // Check tests if the given IP is within rate limits and returns the retry-after
@@ -112,6 +128,11 @@ func extractIP(r *http.Request) string {
 }
 
 // RateLimit returns middleware that applies rate limiting per client IP.
+// When the bucket is exhausted, the middleware emits an audit entry
+// (if the limiter has an audit logger attached via [RateLimiter.SetAuditLogger])
+// before returning 429. Audit-log writes do NOT block the response — they
+// fail silently in the same request goroutine; a slow audit backend would
+// only slow down already-rejected requests, never legitimate ones.
 func RateLimit(limiter *RateLimiter) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -129,6 +150,19 @@ func RateLimit(limiter *RateLimiter) func(http.Handler) http.Handler {
 						Detail:  fmt.Sprintf("try again in %d seconds", retryAfter),
 					},
 				})
+				if logger := limiter.auditLogger; logger != nil {
+					// Best-effort audit write. We deliberately ignore the
+					// return value — if the audit backend is down, the
+					// 429 response has already been sent and there's
+					// nothing useful to do about a logging failure.
+					_ = logger.Log(r.Context(), audit.Entry{
+						Timestamp: time.Now(),
+						SourceIP:  ip,
+						Action:    audit.ActionRateLimited,
+						Result:    audit.ResultDenied,
+						Detail:    fmt.Sprintf("%s %s: rate limited (retry %ds)", r.Method, r.URL.Path, retryAfter),
+					})
+				}
 				return
 			}
 

--- a/backend/internal/server/middleware/ratelimit_test.go
+++ b/backend/internal/server/middleware/ratelimit_test.go
@@ -1,9 +1,38 @@
 package middleware
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/kubecenter/kubecenter/internal/audit"
 )
+
+// recordingAuditLogger captures audit entries for assertion in tests.
+// Mirrors the helper in internal/server/handle_oidc_mobile_test.go; kept
+// local to the middleware package to avoid an import cycle.
+type recordingAuditLogger struct {
+	mu      sync.Mutex
+	entries []audit.Entry
+}
+
+func (r *recordingAuditLogger) Log(_ context.Context, e audit.Entry) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.entries = append(r.entries, e)
+	return nil
+}
+
+func (r *recordingAuditLogger) snapshot() []audit.Entry {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]audit.Entry, len(r.entries))
+	copy(out, r.entries)
+	return out
+}
 
 func TestRateLimiter_AllowsWithinLimit(t *testing.T) {
 	rl := NewRateLimiter()
@@ -94,5 +123,109 @@ func TestRateLimiterWithRate_CustomLimit(t *testing.T) {
 	}
 	if retryAfter <= 0 || retryAfter > 61 {
 		t.Errorf("expected retry after between 1 and 61 seconds, got %d", retryAfter)
+	}
+}
+
+// serveDirect invokes the middleware-wrapped handler against a
+// synthetic request without going through a real TCP listener. This is
+// the only way to control r.RemoteAddr — once an http.Client sends to a
+// real net.Listener, the server side sees the actual TCP peer
+// (127.0.0.1 on loopback), and the field is read-only from the server's
+// perspective. Direct invocation against an httptest.ResponseRecorder
+// preserves the manually-set RemoteAddr.
+func serveDirect(handler http.Handler, method, path, remoteAddr string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, path, nil)
+	req.RemoteAddr = remoteAddr
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	return w
+}
+
+// TestRateLimit_AuditLogsOn429 — issue #276 regression. When the bucket
+// is exhausted, the middleware must emit one audit entry per rejected
+// request so brute-force probing is visible in the audit table.
+func TestRateLimit_AuditLogsOn429(t *testing.T) {
+	rec := &recordingAuditLogger{}
+	rl := NewRateLimiterWithRate(2, time.Minute)
+	rl.SetAuditLogger(rec)
+
+	handler := RateLimit(rl)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	const probeAddr = "203.0.113.42:54321"
+	// First two requests pass.
+	for i := 0; i < 2; i++ {
+		w := serveDirect(handler, http.MethodPost, "/auth/login", probeAddr)
+		if w.Code != http.StatusOK {
+			t.Fatalf("request %d: expected 200, got %d", i+1, w.Code)
+		}
+	}
+	// Third + fourth are rate-limited; each should produce one audit entry.
+	for i := 0; i < 2; i++ {
+		w := serveDirect(handler, http.MethodPost, "/auth/login", probeAddr)
+		if w.Code != http.StatusTooManyRequests {
+			t.Fatalf("probe %d: expected 429, got %d", i+1, w.Code)
+		}
+	}
+
+	got := rec.snapshot()
+	if len(got) != 2 {
+		t.Fatalf("expected 2 audit entries (one per 429), got %d: %+v", len(got), got)
+	}
+	for i, e := range got {
+		if e.Action != audit.ActionRateLimited {
+			t.Errorf("entry[%d]: Action = %q, want %q", i, e.Action, audit.ActionRateLimited)
+		}
+		if e.Result != audit.ResultDenied {
+			t.Errorf("entry[%d]: Result = %q, want %q", i, e.Result, audit.ResultDenied)
+		}
+		if e.SourceIP != "203.0.113.42" {
+			t.Errorf("entry[%d]: SourceIP = %q, want %q", i, e.SourceIP, "203.0.113.42")
+		}
+		// Detail carries the route so investigators can filter by path.
+		if e.Detail == "" {
+			t.Errorf("entry[%d]: Detail is empty; expected route + retry info", i)
+		}
+	}
+}
+
+// TestRateLimit_NilAuditLoggerSilent — without SetAuditLogger called,
+// the middleware preserves the pre-#276 silent behavior. Existing
+// callsites that don't wire an audit logger must not crash.
+func TestRateLimit_NilAuditLoggerSilent(t *testing.T) {
+	rl := NewRateLimiterWithRate(1, time.Minute)
+	// No SetAuditLogger — auditLogger is nil.
+
+	handler := RateLimit(rl)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	for i := 0; i < 3; i++ {
+		w := serveDirect(handler, http.MethodGet, "/", "198.51.100.1:1234")
+		_ = w // exit value not asserted; goal is "did not panic"
+	}
+}
+
+// TestRateLimit_AuditLoggerNotInvokedOn200 — audit entries fire ONLY on
+// 429. Successful requests must not pollute the audit table.
+func TestRateLimit_AuditLoggerNotInvokedOn200(t *testing.T) {
+	rec := &recordingAuditLogger{}
+	rl := NewRateLimiterWithRate(5, time.Minute)
+	rl.SetAuditLogger(rec)
+
+	handler := RateLimit(rl)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	for i := 0; i < 5; i++ {
+		w := serveDirect(handler, http.MethodPost, "/auth/login", "192.0.2.1:5555")
+		if w.Code != http.StatusOK {
+			t.Fatalf("request %d: unexpected status %d", i+1, w.Code)
+		}
+	}
+
+	if got := rec.snapshot(); len(got) != 0 {
+		t.Fatalf("expected 0 audit entries for under-limit traffic, got %d: %+v", len(got), got)
 	}
 }


### PR DESCRIPTION
## Summary

The `RateLimit` middleware returned 429 before any handler ran, leaving zero trace in the audit table. Brute-force probes of `/auth/login`, `/auth/refresh`, `/auth/oidc/*/callback`, etc. at the 5/min limit were invisible to compliance investigators querying audit logs. This PR fixes that asymmetry — a single bad nonce is audited, but 100 rate-limited probes from the same IP previously left no trace.

Closes #276.

## Design

Opt-in audit hook on the `RateLimiter` **struct** (not the middleware function signature). Keeps all ~30 existing `middleware.RateLimit(s.RateLimiter)` callsites in `routes.go` untouched.

- New constant `audit.ActionRateLimited` in `internal/audit/logger.go`.
- `RateLimiter` gains an `auditLogger audit.Logger` field + `SetAuditLogger` setter.
- `RateLimit` middleware: on 429, if logger is set, emits an `audit.Entry` with `Action=ActionRateLimited`, `Result=ResultDenied`, `SourceIP` populated from `extractIP(r)`, `Detail "<METHOD> <path>: rate limited (retry <N>s)"`. Audit write is best-effort — the 429 response has already been sent.
- `cmd/kubecenter/main.go` wires the audit logger into all four limiter instances: `rateLimiter` (auth), `yamlRateLimiter`, `logQueryLimiter`, `webhookRateLimiter`. One-line `SetAuditLogger(auditLogger)` per limiter after `StartCleanup(ctx)`.

Generic `ActionRateLimited` (not auth-scoped) chosen because the middleware itself is generic — covers auth, YAML, log queries, and webhook paths. The Detail's route prefix lets investigators filter by path when they want auth-only analysis.

## Why a setter, not a constructor parameter

The middleware function signature stays `func RateLimit(limiter *RateLimiter)`. Changing it to `func RateLimit(limiter *RateLimiter, auditLogger audit.Logger)` would touch ~30 callsites in `internal/server/routes.go` — mechanical churn with no behavioral benefit (the routes file would need updates for every single rate-limited endpoint). The setter is the minimum-blast-radius path; it scales naturally if/when other limiter-wide hooks are needed (metrics, rate-tier observability, etc.).

## Tests

Three new tests in `internal/server/middleware/ratelimit_test.go`:

1. **`TestRateLimit_AuditLogsOn429`** — 2-req limit, 2 over-limit probes, asserts exactly 2 audit entries with correct Action / Result / SourceIP / non-empty Detail.
2. **`TestRateLimit_NilAuditLoggerSilent`** — confirms pre-#276 silent behavior is preserved when `SetAuditLogger` is never called (the case for any limiter constructed in a test that doesn't wire audit explicitly).
3. **`TestRateLimit_AuditLoggerNotInvokedOn200`** — confirms 5 under-limit requests produce 0 audit entries; only 429s log.

Test infra note: tests use `httptest.NewRecorder` + direct `handler.ServeHTTP` (via a local `serveDirect` helper), not `httptest.NewServer` + `http.Client`. Once a request goes through a real TCP listener the server-side `r.RemoteAddr` reflects the TCP peer (127.0.0.1 on loopback), not whatever the client set. Direct invocation preserves the synthetic `RemoteAddr`.

## Verification

- `go vet ./...` — clean (full repo)
- `go test ./...` — full repo green (all 30 packages pass, including 12 middleware tests)

## Out of scope

- Rate-tier observability (track total 429s per IP over rolling window for outlier detection) — separate analytics concern.
- Persistent audit storage — `audit.Logger` interface is implementation-agnostic; PostgreSQL backend in production picks up rate-limit entries the same way it picks up every other audited action.

## Test plan

- [ ] CI green on backend (`go vet` + `go test ./...`)
- [ ] CI green on CodeQL Go path-filter analysis
- [ ] Manual smoke: hammer `/api/v1/auth/login` with curl 10 times in 60s, then query the audit log JSON output. Expect 5 successful entries (or login-failure entries) followed by 5 `rate_limited` entries with the route in Detail.

Generated with Claude Code
