### PR TITLE
test(mobile): #280 — login_screen OIDC visibility widget tests

### DIFF
--- a/mobile/test/features/login/login_screen_test.dart
+++ b/mobile/test/features/login/login_screen_test.dart
@@ -12,7 +12,10 @@ import 'package:kubecenter/api/dio_client.dart';
 import 'package:kubecenter/auth/auth_repository.dart';
 import 'package:kubecenter/auth/auth_state.dart';
 import 'package:kubecenter/auth/secure_storage.dart';
+import 'package:kubecenter/auth/oidc_controller.dart';
+import 'package:kubecenter/auth/oidc_widgets.dart';
 import 'package:kubecenter/features/login/login_screen.dart';
+import 'package:kubecenter/notifications/deep_link_handler.dart';
 import 'package:kubecenter/theme/kube_theme_builder.dart';
 
 import '../../support/mock_dio_adapter.dart';
@@ -27,12 +30,21 @@ ResponseBody _json(Map<String, dynamic> body, {int status = 200}) {
   );
 }
 
-({ProviderContainer container, MockDioAdapter mock}) _makeContainer() {
+({ProviderContainer container, MockDioAdapter mock}) _makeContainer({
+  String? universalLinkHost,
+}) {
   final mock = MockDioAdapter();
   final container = ProviderContainer(
     overrides: [
       backendUrlProvider.overrideWithValue('http://test'),
       secureTokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
+      // Issue #280 — without this override the provider falls back to
+      // `String.fromEnvironment('UNIVERSAL_LINK_HOST')`, which evaluates
+      // to "" in a `flutter test` run because there's no --dart-define.
+      // Empty host → OIDC buttons hidden, so widget tests for the OIDC
+      // branches need a non-empty value here.
+      if (universalLinkHost != null)
+        universalLinkHostProvider.overrideWithValue(universalLinkHost),
     ],
   );
   container.read(refreshDioProvider).httpClientAdapter = mock;
@@ -185,5 +197,112 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byKey(const ValueKey('login-provider')), findsOneWidget);
+  });
+
+  // ---------------------------------------------------------------------
+  // Issue #280 — OIDC visibility gated by universalLinkHostProvider.
+  //
+  // The Riverpod seam was added in PR-5h but no widget tests exercise the
+  // visible / hidden / OIDC-only-deployment branches. Without these
+  // tests, a future regression that breaks the gate (e.g. someone wires
+  // a hardcoded `true` while debugging) ships silently. These three tests
+  // pin the contract.
+  // ---------------------------------------------------------------------
+
+  testWidgets(
+      'OIDC buttons render when universal link host is configured AND '
+      'backend reports OIDC providers (issue #280)', (tester) async {
+    final (:container, :mock) = _makeContainer(
+      universalLinkHost: 'kubecenter.example.com',
+    );
+    addTearDown(container.dispose);
+    mock.onJson(
+      'GET',
+      '/api/v1/auth/providers',
+      body: {
+        'data': [
+          {'id': 'local', 'name': 'Local', 'kind': 'credential'},
+          {'id': 'authelia', 'name': 'Corp Authelia', 'kind': 'oidc'},
+          {'id': 'okta', 'name': 'Corp Okta', 'kind': 'oidc'},
+        ],
+      },
+    );
+
+    await tester.pumpWidget(_harness(container));
+    await tester.pumpAndSettle();
+
+    expect(
+      container.read(oidcControllerProvider),
+      isA<OIDCFlowIdle>(),
+      reason: 'sanity: controller idles by default in tests',
+    );
+    expect(find.byType(OIDCProviderButton), findsNWidgets(2));
+    // Credential form coexists since at least one credential provider
+    // was returned.
+    expect(find.byKey(const ValueKey('login-submit')), findsOneWidget);
+  });
+
+  testWidgets(
+      'OIDC buttons hidden when universal link host is empty even if '
+      'backend reports OIDC providers (issue #280)', (tester) async {
+    // Default _makeContainer() leaves universalLinkHostProvider at its
+    // production-default ("" in tests). This matches a homelab build
+    // shipping without --dart-define=UNIVERSAL_LINK_HOST.
+    final (:container, :mock) = _makeContainer();
+    addTearDown(container.dispose);
+    mock.onJson(
+      'GET',
+      '/api/v1/auth/providers',
+      body: {
+        'data': [
+          {'id': 'local', 'name': 'Local', 'kind': 'credential'},
+          {'id': 'authelia', 'name': 'Corp Authelia', 'kind': 'oidc'},
+        ],
+      },
+    );
+
+    await tester.pumpWidget(_harness(container));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byType(OIDCProviderButton),
+      findsNothing,
+      reason: 'OIDC buttons must not render without a callback host — '
+          'tapping them would short-circuit to universalLinkNotConfigured',
+    );
+    // Credential form still renders.
+    expect(find.byKey(const ValueKey('login-submit')), findsOneWidget);
+  });
+
+  testWidgets(
+      'OIDC-only deployment hides credential form when host configured '
+      'AND backend reports no credential providers (issue #280)',
+      (tester) async {
+    final (:container, :mock) = _makeContainer(
+      universalLinkHost: 'kubecenter.example.com',
+    );
+    addTearDown(container.dispose);
+    mock.onJson(
+      'GET',
+      '/api/v1/auth/providers',
+      body: {
+        'data': [
+          {'id': 'authelia', 'name': 'Corp Authelia', 'kind': 'oidc'},
+        ],
+      },
+    );
+
+    await tester.pumpWidget(_harness(container));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(OIDCProviderButton), findsOneWidget);
+    // Credential form gone — login-submit key is unique to that form.
+    expect(
+      find.byKey(const ValueKey('login-submit')),
+      findsNothing,
+      reason: 'OIDC-only deployment (no credential providers + host '
+          'configured) must hide the credential form per login_screen '
+          '`hideCredentialForm` branch',
+    );
   });
 }


### PR DESCRIPTION
## Summary

Closes the test-infra gap that issue #280 was filed against: `login_screen.dart`'s OIDC button visibility logic gates on `universalLinkHostProvider.isNotEmpty`, but no widget tests exercised the visible / hidden / OIDC-only branches. Without those tests, a future regression that breaks the gate ships silently.

Closes #280.

## Status of the original issue

Issue #280's body described `kUniversalLinkHost` as a bare compile-time const blocking test overrides. That described the situation at PR-5c's HEAD. PR-5h added the Riverpod seam (`universalLinkHostProvider` in `mobile/lib/notifications/deep_link_handler.dart:155`) and `login_screen.dart` already reads via `ref.watch(universalLinkHostProvider)` on line 123. So the production seam exists; only the test coverage was missing.

This PR therefore lands as test-only — no production code touched.

## What's in this PR

Three new widget tests in `mobile/test/features/login/login_screen_test.dart`:

1. **Host configured + backend returns OIDC providers** → `OIDCProviderButton` renders for each entry; credential form also renders (mixed deployment).
2. **Host empty + backend returns OIDC providers** → No `OIDCProviderButton` rendered (the gate works); credential form still visible.
3. **Host configured + backend returns OIDC providers only** → OIDC buttons render; credential form hidden via the `hideCredentialForm` branch (OIDC-only deployment).

Helper change: `_makeContainer` gains an optional `universalLinkHost` named parameter. Tests that pass it get a non-empty provider override; existing 5 tests that omit it keep the production-default empty value (no behavior change).

## Verification

- `flutter analyze` — clean.
- `flutter test test/features/login/` — 8 tests pass (5 baseline + 3 new). CI will run the full suite.

## Out of scope

- #270 (SharedPreferences cold-start hang policy) — separate UX decision.
- #271 (iOS app-switcher one-frame race) — separate real-device measurement.

## Test plan

- [ ] CI green on mobile-ci.yml (full flutter test + analyze)
- [ ] CI green on CodeQL Dart path-filter analysis
- [ ] Manual smoke (optional): run `flutter test test/features/login/login_screen_test.dart` locally and confirm 8 pass

Generated with Claude Code
