### PR TITLE
fix(auth): #274 — P1 SessionStore.Validate refresh-rotation race

### DIFF
--- a/backend/internal/auth/session.go
+++ b/backend/internal/auth/session.go
@@ -2,10 +2,18 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
 )
+
+// ErrSessionNotFound is returned by [SessionStore.Consume] when the
+// referenced refresh token row no longer exists — either because a
+// concurrent caller already consumed it or because cleanup removed an
+// expired entry between Peek and Consume. Callers should treat this as
+// non-fatal: the rotation has effectively already happened.
+var ErrSessionNotFound = errors.New("session not found")
 
 // RefreshSession holds a refresh token and its associated user/expiry.
 type RefreshSession struct {
@@ -45,6 +53,12 @@ type ValidatedSession struct {
 // Validate checks if a refresh token is valid (exists and not expired).
 // If valid, it deletes the token (rotation — single use).
 // Returns the session data needed for token refresh.
+//
+// Note: this is the legacy single-call API. Callers that can fail
+// between validation and consumption (e.g., the refresh handler, where
+// issueTokenPair may error after Validate succeeds) should use
+// [Peek] + [Consume] instead — see issue #274. Validate remains for
+// flows where the consumption is unconditional.
 func (s *SessionStore) Validate(token string) (*ValidatedSession, error) {
 	val, ok := s.sessions.Load(token)
 	if !ok {
@@ -65,6 +79,59 @@ func (s *SessionStore) Validate(token string) (*ValidatedSession, error) {
 		Provider:   session.Provider,
 		CachedUser: session.CachedUser,
 	}, nil
+}
+
+// Peek validates a refresh token WITHOUT consuming it. Returns the
+// session payload if the token exists and is not expired. Expired
+// tokens ARE deleted (no value in keeping them), but valid tokens
+// remain in the store — callers MUST follow up with [Consume] on
+// success to enforce single-use rotation.
+//
+// Issue #274 — separating Peek from Consume closes the race window
+// where [Validate] would delete a session BEFORE the caller had
+// successfully minted a replacement. If the post-Peek work (user
+// lookup, token minting) fails, the caller skips Consume and the
+// session remains valid for client retry. Without this split, a
+// transient backend failure between Validate and issueTokenPair
+// silently logs the user out.
+//
+// Concurrency: Peek + Consume is NOT atomic. Two callers can Peek the
+// same token simultaneously and both proceed. The first Consume wins;
+// the second returns [ErrSessionNotFound] (informational — the new
+// pair has already been minted in both branches).
+func (s *SessionStore) Peek(token string) (*ValidatedSession, error) {
+	val, ok := s.sessions.Load(token)
+	if !ok {
+		return nil, fmt.Errorf("refresh token not found")
+	}
+
+	session := val.(RefreshSession)
+
+	if time.Now().After(session.ExpiresAt) {
+		// Expired — purge so it doesn't linger until the next cleanup
+		// tick. Mirrors Validate's behavior on expired tokens.
+		s.sessions.Delete(token)
+		return nil, fmt.Errorf("refresh token expired")
+	}
+
+	return &ValidatedSession{
+		UserID:     session.UserID,
+		Provider:   session.Provider,
+		CachedUser: session.CachedUser,
+	}, nil
+}
+
+// Consume atomically deletes a refresh token. Used by callers that have
+// finished the post-[Peek] work and need to enforce single-use
+// rotation. Returns [ErrSessionNotFound] if the row is already gone
+// (concurrent Peek+Consume race, cleanup race, or explicit Revoke);
+// callers should treat that as non-fatal — the rotation has effectively
+// already happened on the other path.
+func (s *SessionStore) Consume(token string) error {
+	if _, ok := s.sessions.LoadAndDelete(token); !ok {
+		return ErrSessionNotFound
+	}
+	return nil
 }
 
 // Revoke deletes a refresh token (e.g., on logout).

--- a/backend/internal/auth/session_test.go
+++ b/backend/internal/auth/session_test.go
@@ -1,6 +1,9 @@
 package auth
 
 import (
+	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -114,5 +117,159 @@ func TestSessionStore_CachedUser(t *testing.T) {
 	}
 	if result.CachedUser.Username != "alice@example.com" {
 		t.Errorf("CachedUser.Username = %q, want %q", result.CachedUser.Username, "alice@example.com")
+	}
+}
+
+// ---------------------------------------------------------------------
+// Issue #274 — Peek / Consume split tests.
+// ---------------------------------------------------------------------
+
+// TestSessionStore_Peek_DoesNotConsume — the core fix. Peek returns the
+// session WITHOUT deleting it, so a subsequent failure (token-mint, user
+// lookup, etc.) doesn't silently destroy the refresh credential.
+func TestSessionStore_Peek_DoesNotConsume(t *testing.T) {
+	store := NewSessionStore()
+	store.Store(RefreshSession{
+		Token:     "token-peek",
+		UserID:    "user-1",
+		ExpiresAt: time.Now().Add(time.Hour),
+	})
+
+	first, err := store.Peek("token-peek")
+	if err != nil {
+		t.Fatalf("first Peek failed: %v", err)
+	}
+	if first.UserID != "user-1" {
+		t.Errorf("first Peek UserID = %q, want %q", first.UserID, "user-1")
+	}
+
+	// Second Peek must still succeed — Peek is idempotent. Without this
+	// property, a transient post-Peek failure followed by a retry would
+	// surface as "refresh token not found" to the client.
+	second, err := store.Peek("token-peek")
+	if err != nil {
+		t.Fatalf("second Peek failed (expected idempotent): %v", err)
+	}
+	if second.UserID != "user-1" {
+		t.Errorf("second Peek UserID = %q, want %q", second.UserID, "user-1")
+	}
+}
+
+// TestSessionStore_Peek_ExpiredPurges — expired tokens get cleaned up
+// immediately, matching Validate's behavior. Surfaces as "token expired"
+// to the caller AND removes the row so it doesn't linger until the
+// background cleanup tick.
+func TestSessionStore_Peek_ExpiredPurges(t *testing.T) {
+	store := NewSessionStore()
+	store.Store(RefreshSession{
+		Token:     "token-expired",
+		UserID:    "user-1",
+		ExpiresAt: time.Now().Add(-time.Minute),
+	})
+
+	if _, err := store.Peek("token-expired"); err == nil {
+		t.Fatal("expected expired-token error from Peek")
+	}
+	// Should also be gone from the store now.
+	if _, err := store.Peek("token-expired"); err == nil {
+		t.Fatal("expired token should have been deleted on first Peek")
+	}
+}
+
+// TestSessionStore_Consume_DeletesOnce — Consume atomically removes the
+// row; a second Consume of the same token returns ErrSessionNotFound.
+func TestSessionStore_Consume_DeletesOnce(t *testing.T) {
+	store := NewSessionStore()
+	store.Store(RefreshSession{
+		Token:     "token-consume",
+		UserID:    "user-1",
+		ExpiresAt: time.Now().Add(time.Hour),
+	})
+
+	if err := store.Consume("token-consume"); err != nil {
+		t.Fatalf("first Consume failed: %v", err)
+	}
+	if err := store.Consume("token-consume"); !errors.Is(err, ErrSessionNotFound) {
+		t.Fatalf("second Consume: expected ErrSessionNotFound, got %v", err)
+	}
+}
+
+// TestSessionStore_Consume_RaceOnlyOneWins — the LoadAndDelete
+// underneath Consume is atomic per sync.Map, so concurrent Consume
+// calls for the same token are mutually exclusive. Pins this property
+// so a future refactor that splits the operation can't silently
+// reintroduce a double-consume bug.
+func TestSessionStore_Consume_RaceOnlyOneWins(t *testing.T) {
+	store := NewSessionStore()
+	store.Store(RefreshSession{
+		Token:     "token-race",
+		UserID:    "user-1",
+		ExpiresAt: time.Now().Add(time.Hour),
+	})
+
+	const N = 32
+	var successes atomic.Int32
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			if err := store.Consume("token-race"); err == nil {
+				successes.Add(1)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if got := successes.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 successful Consume across %d goroutines, got %d", N, got)
+	}
+}
+
+// TestSessionStore_PeekConsume_RefreshFailurePreservesSession — the
+// load-bearing integration test for #274. Simulates the handleRefresh
+// flow when post-Peek work fails: Peek succeeds, work fails, no Consume
+// → original token is still valid for client retry.
+func TestSessionStore_PeekConsume_RefreshFailurePreservesSession(t *testing.T) {
+	store := NewSessionStore()
+	store.Store(RefreshSession{
+		Token:     "token-survive",
+		UserID:    "user-1",
+		ExpiresAt: time.Now().Add(time.Hour),
+	})
+
+	// Pretend handleRefresh: Peek succeeds.
+	session, err := store.Peek("token-survive")
+	if err != nil {
+		t.Fatalf("Peek failed: %v", err)
+	}
+	if session.UserID != "user-1" {
+		t.Fatalf("Peek UserID = %q", session.UserID)
+	}
+
+	// Pretend issueTokenPair errors. handleRefresh returns 500 without
+	// calling Consume. The session must remain valid for retry.
+	// (We do not call Consume here.)
+
+	// Client retries with the same refresh token. Peek must still
+	// succeed against the same row.
+	retry, err := store.Peek("token-survive")
+	if err != nil {
+		t.Fatalf("retry Peek failed (regression of #274): %v", err)
+	}
+	if retry.UserID != "user-1" {
+		t.Fatalf("retry UserID = %q", retry.UserID)
+	}
+
+	// Now the retry succeeds at issueTokenPair time. handleRefresh
+	// calls Consume; the original token is finally removed.
+	if err := store.Consume("token-survive"); err != nil {
+		t.Fatalf("Consume on successful retry failed: %v", err)
+	}
+	if _, err := store.Peek("token-survive"); err == nil {
+		t.Fatal("after Consume, token should be unusable")
 	}
 }

--- a/backend/internal/server/handle_auth.go
+++ b/backend/internal/server/handle_auth.go
@@ -111,7 +111,11 @@ func (s *Server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 		bodyMode = true
 	}
 
-	session, err := s.Sessions.Validate(refreshTokenIn)
+	// Issue #274 — Peek validates the session without deleting it. We
+	// only Consume the session AFTER issueTokenPair succeeds, so a
+	// transient signing or RNG failure no longer silently logs the
+	// user out (their original refresh token remains valid for retry).
+	session, err := s.Sessions.Peek(refreshTokenIn)
 	if err != nil {
 		entry := s.newAuditEntry(r, "", audit.ActionRefresh, audit.ResultFailure)
 		entry.Detail = "invalid or expired refresh token"
@@ -130,6 +134,13 @@ func (s *Server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 	} else {
 		user, err = s.AuthRegistry.GetUserByID(session.Provider, session.UserID)
 		if err != nil {
+			// User no longer exists — the session is stale. Consume
+			// it now so subsequent refreshes with the same token return
+			// 401 (refresh-token-not-found) instead of repeatedly
+			// hitting the same dead user lookup.
+			if cerr := s.Sessions.Consume(refreshTokenIn); cerr != nil && cerr != auth.ErrSessionNotFound {
+				s.Logger.Warn("failed to consume stale session", "error", cerr)
+			}
 			writeJSON(w, http.StatusUnauthorized, api.Response{
 				Error: &api.APIError{Code: 401, Message: "user not found"},
 			})
@@ -142,11 +153,26 @@ func (s *Server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 	// the existing httpOnly cookie behaviour.
 	accessToken, newRefreshToken, err := s.issueTokenPair(w, user, !bodyMode)
 	if err != nil {
+		// Token mint failed; preserve the session by NOT calling Consume.
+		// The client can retry with the same refresh token. Issue #274.
 		s.Logger.Error("failed to issue tokens", "error", err)
 		writeJSON(w, http.StatusInternalServerError, api.Response{
 			Error: &api.APIError{Code: 500, Message: "failed to issue token"},
 		})
 		return
+	}
+
+	// Token pair successfully minted — consume the original session so
+	// it cannot be replayed. ErrSessionNotFound here means a concurrent
+	// refresh consumed it first; both clients have valid new pairs, so
+	// the rotation is effectively complete either way. Log for
+	// diagnostics but don't fail the response.
+	if cerr := s.Sessions.Consume(refreshTokenIn); cerr != nil {
+		if cerr == auth.ErrSessionNotFound {
+			s.Logger.Debug("refresh consume race — session already gone", "user", user.Username)
+		} else {
+			s.Logger.Warn("refresh consume failed", "error", cerr, "user", user.Username)
+		}
 	}
 
 	s.AuditLogger.Log(r.Context(), s.newAuditEntry(r, user.Username, audit.ActionRefresh, audit.ResultSuccess))


### PR DESCRIPTION
## Summary

**P1.** Closes the silent-logout race in `handleRefresh`. The session was being deleted before `issueTokenPair` got a chance to fail; when that signing/RNG step errored, the user was logged out with no recovery path. PR-5b's 1h OIDC refresh TTL cap amplifies the race window ~168x for OIDC users (refresh fires every 15min vs every few hours under the previous cap), making it a daily occurrence.

Closes #274.

## The race

Before this PR:

```
handleRefresh:
  session = Sessions.Validate(token)   # ← loads AND deletes row
  user = lookup(session)
  pair = issueTokenPair(user)          # ← can fail (signing, RNG)
    ↓ on fail
  return 500                            # ← row already gone. Client
                                          retries → 401 → logout.
```

The user is silently logged out with **no error message that suggests retry** — they just bounce to `/login` next time the access token expires.

## The fix

Split `Validate` into two operations:

- **`Peek(token)`** — non-destructive read; returns the session but leaves the row in place. Expired tokens are still purged (no value keeping them).
- **`Consume(token)`** — atomic `sync.Map.LoadAndDelete`; returns `ErrSessionNotFound` if the row is already gone (concurrent Consume race or cleanup race). Caller treats that as informational.

`handleRefresh` now flows:

```
session = Sessions.Peek(token)
  ↓ on fail → 401 + audit failure
user = lookup(session)
  ↓ on fail → Consume (stale row) + 401
pair = issueTokenPair(user)
  ↓ on fail → return 500, NO Consume → original token survives for retry
Sessions.Consume(token)
  ↓ ErrSessionNotFound: log Debug + continue (the new pair was minted
    either way; the race is informational, not a failure)
```

User-lookup failure **does** consume the session because the underlying user is gone — keeping the row would just produce repeated 401s on the same dead path. Token-mint failure **does not** consume because that's a transient backend error.

## Why not just fix Validate's atomicity?

`SessionStore.Validate` does `Load` then `Delete` non-atomically — two concurrent callers can both see the row. Fixing that to `LoadAndDelete` would make Validate properly single-use under concurrency. But that AMPLIFIES the symptom `#275` (frontend per-tab singleflight) addresses, where multiple tabs all fire `/auth/refresh` and only one wins. So this PR intentionally leaves `Validate` alone — `#275` will handle the client-side singleflight that makes the new atomicity property safe to ship. They're a matched pair.

`Validate`'s doc comment now explicitly points new code at `Peek` + `Consume`.

## Tests

5 new tests in `internal/auth/session_test.go`:

| Test | What it pins |
|---|---|
| `Peek_DoesNotConsume` | Peek is idempotent; two Peeks of the same token both succeed |
| `Peek_ExpiredPurges` | Expired tokens get deleted even on Peek (matches Validate) |
| `Consume_DeletesOnce` | First Consume succeeds; second returns `ErrSessionNotFound` |
| `Consume_RaceOnlyOneWins` | 32 concurrent Consumes of the same token — exactly 1 succeeds |
| `PeekConsume_RefreshFailurePreservesSession` | The load-bearing integration test: Peek → failed work → retry Peek → successful Consume |

Existing Validate tests unchanged (6 tests, all passing).

## Verification

- `go vet ./internal/auth ./internal/server` — clean.
- `go test ./internal/auth/...` — 16 tests pass (11 baseline + 5 new).
- `go test ./internal/server` — handle_auth tests pass.

(Full-repo `go vet` failed on Windows dev host with paging-file OOM on unrelated packages — Linux CI will validate the full tree.)

## Pairs with

- **#275** (frontend `/auth/refresh` per-tab singleflight) — the client-side companion. Together they close the multi-tab refresh logout cascade end-to-end.

## Test plan

- [ ] CI green on backend (`go vet ./...` + `go test ./...`)
- [ ] CI green on E2E (auth-refresh smoke)
- [ ] CI green on CodeQL Go path-filter analysis
- [ ] Manual: while logged into homelab, kill the backend process during a `/auth/refresh` in flight (via concurrent SIGTERM); after restart, verify the SAME refresh token still works. (Tests the survives-issueTokenPair-failure path.)

Generated with Claude Code
