### PR TITLE
test(mobile): #275 — singleflight regression tests for AuthInterceptor

### DIFF
--- a/mobile/test/api/dio_client_test.dart
+++ b/mobile/test/api/dio_client_test.dart
@@ -157,4 +157,150 @@ void main() {
       isNull,
     );
   });
+
+  // Issue #275 — P1 regression test. N concurrent requests that 401 must
+  // share a single /v1/auth/refresh call, not fire N independent refreshes.
+  // Without singleflight, every concurrent request's 401 handler races to
+  // refresh; the first wins (rotates the refresh token), the rest see
+  // "refresh token not found" and the user is logged out across N-1 tabs.
+  //
+  // PR-5b's 1h OIDC refresh TTL cap turns this from a once-a-week edge
+  // case into an hourly event for OIDC users with multiple open tabs.
+  test(
+      'AuthInterceptor: N concurrent 401s share one /v1/auth/refresh '
+      '(issue #275 singleflight regression)', () async {
+    final (:container, :mock) = _makeContainer();
+    addTearDown(container.dispose);
+
+    container.read(authTokenHolderProvider).set('stale-access');
+    await container
+        .read(secureTokenStoreProvider)
+        .writeRefreshToken('valid-refresh');
+
+    // Protected endpoint mock: 401 with stale, 200 with fresh.
+    mock.on('GET', '/api/v1/protected', (req) {
+      final auth = req.headers['Authorization'] as String?;
+      if (auth == 'Bearer stale-access') {
+        return _json(
+          {
+            'error': {'code': 401, 'message': 'expired'},
+          },
+          status: 401,
+        );
+      }
+      return _json({'data': 'ok'});
+    });
+
+    // Refresh endpoint mock: count calls. MockDioAdapter handlers are
+    // sync, so we can't inject a delay — but the singleflight check in
+    // _attemptRefresh fires before any awaits, so concurrent onError
+    // handlers reliably observe the in-flight Completer.
+    var refreshHits = 0;
+    mock.on('POST', '/api/v1/auth/refresh', (_) {
+      refreshHits++;
+      return _json({
+        'data': {
+          'accessToken': 'fresh-access',
+          'refreshToken': 'fresh-refresh',
+          'expiresIn': 900,
+        },
+      });
+    });
+
+    // Fire 8 concurrent GETs. Each will hit /protected with the stale
+    // token, get 401, kick onError → _attemptRefresh. Singleflight
+    // requires exactly one refresh HTTP call to fire across all 8.
+    const concurrentRequests = 8;
+    final results = await Future.wait(
+      List.generate(
+        concurrentRequests,
+        (_) => container.read(dioProvider).get<dynamic>('/api/v1/protected'),
+      ),
+    );
+
+    for (var i = 0; i < concurrentRequests; i++) {
+      expect(
+        results[i].statusCode,
+        200,
+        reason: 'request $i should have succeeded after singleflight refresh',
+      );
+    }
+    expect(
+      refreshHits,
+      1,
+      reason: '$concurrentRequests concurrent 401s must collapse to ONE '
+          '/v1/auth/refresh call (issue #275). Got $refreshHits refresh '
+          'calls — singleflight is broken.',
+    );
+    expect(
+      container.read(authTokenHolderProvider).accessToken,
+      'fresh-access',
+    );
+  });
+
+  // Issue #275 follow-up: after a refresh completes, the singleflight
+  // slot must reset so a SUBSEQUENT 401 (later in the session, e.g. when
+  // the next access token expires) can trigger a fresh refresh cycle.
+  // Without the finally-clear, the second refresh would deadlock on a
+  // stale completed Completer.
+  test(
+      'AuthInterceptor: singleflight slot resets after refresh completes',
+      () async {
+    final (:container, :mock) = _makeContainer();
+    addTearDown(container.dispose);
+
+    container.read(authTokenHolderProvider).set('access-1');
+    await container
+        .read(secureTokenStoreProvider)
+        .writeRefreshToken('refresh-1');
+
+    // Two distinct refresh windows: first call rotates access-1 →
+    // access-2; second call (later) rotates access-2 → access-3.
+    var refreshHits = 0;
+    mock.on('POST', '/api/v1/auth/refresh', (_) {
+      refreshHits++;
+      return _json({
+        'data': {
+          'accessToken': 'access-${refreshHits + 1}',
+          'refreshToken': 'refresh-${refreshHits + 1}',
+          'expiresIn': 900,
+        },
+      });
+    });
+
+    // /protected accepts access-2 and access-3; rejects access-1.
+    mock.on('GET', '/api/v1/protected', (req) {
+      final auth = req.headers['Authorization'] as String?;
+      if (auth == 'Bearer access-1') {
+        return _json(
+          {
+            'error': {'code': 401, 'message': 'expired'},
+          },
+          status: 401,
+        );
+      }
+      return _json({'data': 'ok'});
+    });
+
+    // First request triggers refresh 1.
+    final r1 = await container.read(dioProvider).get<dynamic>('/api/v1/protected');
+    expect(r1.statusCode, 200);
+    expect(refreshHits, 1);
+    expect(container.read(authTokenHolderProvider).accessToken, 'access-2');
+
+    // Simulate access-2 expiring later in the session by forcing it
+    // back to access-1 (would-be expired token). A new 401 must
+    // trigger a SECOND refresh, not block on a stale completed slot.
+    container.read(authTokenHolderProvider).set('access-1');
+
+    final r2 = await container.read(dioProvider).get<dynamic>('/api/v1/protected');
+    expect(r2.statusCode, 200);
+    expect(
+      refreshHits,
+      2,
+      reason: 'second 401 must trigger a fresh refresh cycle '
+          '(singleflight slot must reset after completion)',
+    );
+    expect(container.read(authTokenHolderProvider).accessToken, 'access-3');
+  });
 }


### PR DESCRIPTION
## Summary

**P1.** The frontend + mobile singleflight implementations for `/v1/auth/refresh` already exist (added by infrastructure that landed after #275 was filed). The remaining gap was no regression tests pinning the property — a future refactor could silently break either implementation. This PR adds the missing mobile tests.

Closes #275.

## Status of the original issue

| Side | Singleflight code | Lives at | Status |
|---|---|---|---|
| Frontend | `let refreshPromise: Promise<boolean> \| null = null` | `frontend/lib/api.ts:27, 165-170` | ✅ Implemented |
| Mobile | `Completer<bool>? _refreshing` | `mobile/lib/api/dio_client.dart:131, 181-205` | ✅ Implemented |

So #275 reduces to **test-only on the mobile side**. The frontend has zero unit tests for `lib/api.ts` today (no `api_test.ts` file exists); adding test infrastructure for that module needs DOM mocks + module-state reset between tests, which is its own follow-up. The frontend singleflight property is covered end-to-end by `e2e/tests/auth.spec.ts` and verifiable by code review.

## Mobile tests added

Two new tests in `mobile/test/api/dio_client_test.dart`:

### 1. `N concurrent 401s share one /v1/auth/refresh`
- Sets stale access token + valid refresh token.
- Fires **8 concurrent GETs** to `/api/v1/protected` via `Future.wait`.
- Each gets 401 with the stale token → `onError` → `_attemptRefresh`.
- **Asserts: exactly 1 `/v1/auth/refresh` call fires** (not 8).
- Asserts: all 8 retries return 200 with the fresh access token.

### 2. `Singleflight slot resets after refresh completes`
- First refresh rotates `access-1 → access-2` (1 hit).
- Then "expires" `access-2` (forces back to `access-1`).
- Second 401 must trigger a **fresh** refresh cycle (2 hits total).
- Without the `finally { _refreshing = null }` in `_attemptRefresh`, the second cycle would block on a stale completed `Completer`.

## Pairs with #274

The backend Peek/Consume split (#274) keeps the refresh token alive across post-`Validate` failures. This PR ensures clients don't fire N concurrent refreshes that would multi-consume the same token. **Together they close the multi-tab logout cascade end-to-end.**

## Verification

- `flutter analyze` (scoped) — clean.
- `flutter test test/api/dio_client_test.dart` — 6 tests pass (4 baseline + 2 new).
- Full mobile suite: **1145 tests pass**.

## Out of scope

- Frontend `lib/api.ts` unit tests — needs new test infra (DOM + module-state). Tracked as separate follow-up.
- The (separate) `Validate` non-atomic Load/Delete in `internal/auth/session.go` — #274's note explains why it's intentionally left as-is.

## Test plan

- [ ] CI green on mobile-ci.yml (full flutter test + analyze)
- [ ] CI green on CodeQL Dart path-filter
- [ ] Manual (post-merge): open k8sCenter in 5+ browser tabs, wait for the access token to expire, switch between tabs rapidly. Confirm only ONE `/v1/auth/refresh` fires (devtools Network tab), no tab gets bounced to `/login`.

Generated with Claude Code
