### PR TITLE
fix(frontend): bump libssl3t64 pin to deb13u1 (CI Release hotfix)

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -25,16 +25,18 @@ RUN find /app/node_modules -path '*/esbuild/bin/esbuild' -delete 2>/dev/null; \
 
 # Security patch stage: overlay patched OS libraries onto distroless so Trivy
 # clears the open CVEs. Uses target platform so library arch paths match.
-#   libssl3t64 3.5.5-1~deb13u1 → 3.5.5-1~deb13u2
-#     CVE-2026-31790, CVE-2026-2673, CVE-2026-28387, CVE-2026-28388,
-#     CVE-2026-28389, CVE-2026-28390, CVE-2026-31789
+#   libssl3t64 3.5.5-1~deb13u1 → 3.5.6-1~deb13u1
+#     Supersedes deb13u2 (which was pulled from the Packages index when
+#     openssl 3.5.6 landed in trixie-security). The new release rolls up
+#     the deb13u2 fixes (CVE-2026-31790, -2673, -28387..28390, -31789)
+#     plus the upstream 3.5.6 security advisory contents.
 #   libc6 2.41-12+deb13u2 → 2.41-12+deb13u3
 #     CVE-2026-4046, CVE-2026-4437, CVE-2026-4438
 FROM denoland/deno:distroless-2.7.11 AS runtime-base
 FROM debian:trixie-slim AS security-patch
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      libssl3t64=3.5.5-1~deb13u2 \
+      libssl3t64=3.5.6-1~deb13u1 \
       libc6=2.41-12+deb13u3 && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir -p /patch/usr/lib && \
@@ -45,14 +47,14 @@ RUN apt-get update && \
     done
 # Update the distroless dpkg status.d entries so Trivy sees the patched versions.
 # TEMPORARY: remove this entire security-patch stage once the distroless base
-# ships with libssl3t64 >= 3.5.5-1~deb13u2 AND libc6 >= 2.41-12+deb13u3.
+# ships with libssl3t64 >= 3.5.6-1~deb13u1 AND libc6 >= 2.41-12+deb13u3.
 COPY --from=runtime-base /var/lib/dpkg/status.d/libssl3t64 /tmp/libssl3t64-orig
 COPY --from=runtime-base /var/lib/dpkg/status.d/libc6 /tmp/libc6-orig
 RUN grep -q '3\.5\.5-1~deb13u1' /tmp/libssl3t64-orig || \
     (echo "ERROR: base image no longer contains libssl3t64 3.5.5-1~deb13u1 — drop libssl3t64 from the security-patch stage" && exit 1)
 RUN grep -qF '2.41-12+deb13u2' /tmp/libc6-orig || \
     (echo "ERROR: base image no longer contains libc6 2.41-12+deb13u2 — drop libc6 from the security-patch stage" && exit 1)
-RUN sed 's/3\.5\.5-1~deb13u1/3.5.5-1~deb13u2/g' /tmp/libssl3t64-orig > /patch/libssl3t64-status && \
+RUN sed 's/3\.5\.5-1~deb13u1/3.5.6-1~deb13u1/g' /tmp/libssl3t64-orig > /patch/libssl3t64-status && \
     sed 's/2\.41-12+deb13u2/2.41-12+deb13u3/g' /tmp/libc6-orig > /patch/libc6-status
 
 # Stage 2: Production runtime (uses target platform — arm64 or amd64)

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -25,37 +25,87 @@ RUN find /app/node_modules -path '*/esbuild/bin/esbuild' -delete 2>/dev/null; \
 
 # Security patch stage: overlay patched OS libraries onto distroless so Trivy
 # clears the open CVEs. Uses target platform so library arch paths match.
-#   libssl3t64 3.5.5-1~deb13u1 → 3.5.6-1~deb13u1
+#
+#   libssl3t64 3.5.5-1~deb13u1 → 3.5.6-1~deb13u1   [pinned]
 #     Supersedes deb13u2 (which was pulled from the Packages index when
 #     openssl 3.5.6 landed in trixie-security). The new release rolls up
 #     the deb13u2 fixes (CVE-2026-31790, -2673, -28387..28390, -31789)
-#     plus the upstream 3.5.6 security advisory contents.
-#   libc6 2.41-12+deb13u2 → 2.41-12+deb13u3
-#     CVE-2026-4046, CVE-2026-4437, CVE-2026-4438
+#     plus the upstream 3.5.6 security advisory contents. Pin is bumped
+#     by hand whenever Debian rolls a new patch (every few weeks).
+#
+#   libc6                       → latest in trixie  [unpinned + 7-day gate]
+#     Pinning libc6 was the recurring failure source — Debian rolls
+#     glibc patches faster than we bump pins, and the missing version
+#     fails apt-get with exit 100. Unpinned install + a build-time gate
+#     that aborts if the installed version was uploaded <7 days ago
+#     (matching the global CLAUDE.md application-layer cooldown, even
+#     though Debian's signed security pocket is technically exempt —
+#     7 days of community catch-time is cheap defense in depth).
+#     The sed substitution that updates the distroless dpkg status.d
+#     entry is now dynamic: extracts base + installed versions at
+#     build time.
 FROM denoland/deno:distroless-2.7.11 AS runtime-base
 FROM debian:trixie-slim AS security-patch
-RUN apt-get update && \
+
+# Pull the base's dpkg status entries first so the consolidated RUN
+# below can read them. Single RUN keeps shell variables (version
+# strings, upload dates) reachable across the install + assertion +
+# sed-substitution steps.
+COPY --from=runtime-base /var/lib/dpkg/status.d/libssl3t64 /tmp/libssl3t64-orig
+COPY --from=runtime-base /var/lib/dpkg/status.d/libc6 /tmp/libc6-orig
+
+# Consolidated RUN — install + cooldown gate + assertion + patch + sed
+# substitution. Single RUN so shell variables (LIBC6_VER, BASE_LIBC6_VER,
+# upload-date math) reach every step. The /tmp/*-orig files were COPYed
+# from runtime-base just above. Step-by-step rationale:
+#   1. apt-get install — libssl3t64 stays pinned (target known); libc6
+#      is unpinned so Debian patch rolls don't break the build.
+#   2. 7-day cooldown — abort if apt grabbed a libc6 release uploaded
+#      <7 days ago. Source: changelog.Debian.gz upload-date line, which
+#      Debian Policy mandates on every binary .deb (--no-install-
+#      recommends does not skip it).
+#   3. libssl3t64 base-version assertion — fires only when the
+#      distroless image catches up to the pinned patch (= cleanup signal).
+#   4. libc6 dynamic-version extraction — no static assertion; if base
+#      already matches the patch target, log a NOTE and continue.
+#   5. Copy patched binaries into /patch/.
+#   6. sed the dpkg status.d entries (libssl3t64 = static substitution;
+#      libc6 = dynamic substitution from extracted versions).
+RUN set -e && \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
       libssl3t64=3.5.6-1~deb13u1 \
-      libc6=2.41-12+deb13u3 && \
+      libc6 && \
     rm -rf /var/lib/apt/lists/* && \
+    LIBC6_VER=$(dpkg-query -W -f='${Version}' libc6) && \
+    [ -n "$LIBC6_VER" ] || { echo "ERROR: dpkg-query returned empty libc6 version" >&2; exit 1; } && \
+    LIBC6_DATE=$(zcat /usr/share/doc/libc6/changelog.Debian.gz | grep -m1 '^ -- ' | sed -E 's/.*>  //') && \
+    [ -n "$LIBC6_DATE" ] || { echo "ERROR: failed to extract libc6 upload date from changelog" >&2; exit 1; } && \
+    LIBC6_TS=$(date -d "$LIBC6_DATE" +%s) && \
+    [ -n "$LIBC6_TS" ] || { echo "ERROR: 'date -d' failed on '$LIBC6_DATE'" >&2; exit 1; } && \
+    AGE_DAYS=$(( ($(date +%s) - LIBC6_TS) / 86400 )) && \
+    if [ "$AGE_DAYS" -lt 7 ]; then \
+        echo "ERROR: libc6 $LIBC6_VER uploaded $AGE_DAYS days ago (< 7-day supply-chain cooldown)." >&2; \
+        echo "  Wait until $(date -d "@$((LIBC6_TS + 7*86400))" -Iseconds) before rebuilding," >&2; \
+        echo "  or temporarily re-introduce a libc6 pin to the previous release." >&2; \
+        exit 1; \
+    fi && \
+    echo "libc6 $LIBC6_VER uploaded $AGE_DAYS days ago — passes 7-day cooldown" && \
+    grep -q '3\.5\.5-1~deb13u1' /tmp/libssl3t64-orig || \
+        { echo "ERROR: distroless base no longer contains libssl3t64 3.5.5-1~deb13u1 — drop libssl3t64 from the security-patch stage" >&2; exit 1; } && \
+    BASE_LIBC6_VER=$(grep '^Version:' /tmp/libc6-orig | awk '{print $2}') && \
+    [ -n "$BASE_LIBC6_VER" ] || { echo "ERROR: failed to extract libc6 Version from /tmp/libc6-orig" >&2; exit 1; } && \
+    if [ "$BASE_LIBC6_VER" = "$LIBC6_VER" ]; then \
+        echo "NOTE: distroless base already ships libc6 $LIBC6_VER — the security-patch stage is a no-op for libc6 and can be dropped"; \
+    fi && \
     mkdir -p /patch/usr/lib && \
     for pkg in libssl3t64 libc6; do \
       dpkg -L "$pkg" | grep '/usr/lib' | while read f; do \
         [ -f "$f" ] && mkdir -p "/patch$(dirname "$f")" && cp -a "$f" "/patch$f"; \
       done; \
-    done
-# Update the distroless dpkg status.d entries so Trivy sees the patched versions.
-# TEMPORARY: remove this entire security-patch stage once the distroless base
-# ships with libssl3t64 >= 3.5.6-1~deb13u1 AND libc6 >= 2.41-12+deb13u3.
-COPY --from=runtime-base /var/lib/dpkg/status.d/libssl3t64 /tmp/libssl3t64-orig
-COPY --from=runtime-base /var/lib/dpkg/status.d/libc6 /tmp/libc6-orig
-RUN grep -q '3\.5\.5-1~deb13u1' /tmp/libssl3t64-orig || \
-    (echo "ERROR: base image no longer contains libssl3t64 3.5.5-1~deb13u1 — drop libssl3t64 from the security-patch stage" && exit 1)
-RUN grep -qF '2.41-12+deb13u2' /tmp/libc6-orig || \
-    (echo "ERROR: base image no longer contains libc6 2.41-12+deb13u2 — drop libc6 from the security-patch stage" && exit 1)
-RUN sed 's/3\.5\.5-1~deb13u1/3.5.6-1~deb13u1/g' /tmp/libssl3t64-orig > /patch/libssl3t64-status && \
-    sed 's/2\.41-12+deb13u2/2.41-12+deb13u3/g' /tmp/libc6-orig > /patch/libc6-status
+    done && \
+    sed 's/3\.5\.5-1~deb13u1/3.5.6-1~deb13u1/g' /tmp/libssl3t64-orig > /patch/libssl3t64-status && \
+    sed "s|${BASE_LIBC6_VER}|${LIBC6_VER}|g" /tmp/libc6-orig > /patch/libc6-status
 
 # Stage 2: Production runtime (uses target platform — arm64 or amd64)
 # Use distroless variant to minimize OS-level CVEs (no shell, no package manager)


### PR DESCRIPTION
## Summary

**Hotfix + recurrence fix.** `CI Release` failed on the #292 merge to main (run [26224271095](https://github.com/maulepilot117/k8sCenter/actions/runs/26224271095)) because `apt-get install libssl3t64=3.5.5-1~deb13u2` referenced a version that Debian had pulled from the Packages index when openssl 3.5.6 landed in trixie-security. This PR ships in two commits:

1. **`8156923` — bump the libssl3t64 pin** to the current trixie release (`3.5.6-1~deb13u1`). Restores CI Release immediately.
2. **`a7f6cc7` — drop the libc6 pin and add a 7-day cooldown gate.** Same brittle-pin pattern caused the failure; second commit removes the recurrence for libc6.

Both commits to `frontend/Dockerfile` only.

## Root cause (commit `8156923`)

```
ERROR: failed to build: failed to solve: process "/bin/sh -c apt-get update && \
  apt-get install -y --no-install-recommends \
    libssl3t64=3.5.5-1~deb13u2 \
    libc6=2.41-12+deb13u3 \
  && ..." did not complete successfully: exit code: 100
```

Verified the current trixie state via `packages.debian.org`:
- `libssl3t64`: now `3.5.6-1~deb13u1` (was pinning `3.5.5-1~deb13u2` — superseded and removed).
- `libc6`: still `2.41-12+deb13u3`.

Commit `8156923` bumps `libssl3t64=3.5.5-1~deb13u2` → `libssl3t64=3.5.6-1~deb13u1`, updates the matching sed substitution, and refreshes the inline comments. Comments retain the CVE annotations from the previous deb13u2 patch plus a note that deb13u1 of 3.5.6 rolls them up.

Per `CLAUDE.md`, Debian-signed security errata is exempt from the 7-day supply-chain cooldown — that exemption applies here for the libssl3t64 bump.

## Recurrence fix (commit `a7f6cc7`)

Pinning libc6 was the **same brittle pattern** that just failed for libssl3t64: every glibc security patch rolls the version, and the previous one drops out of the Packages index within days. The first commit only kicked the can — the next Debian patch would re-fire the same failure mode.

The second commit drops the pin entirely:

- **`apt-get install libc6`** — no version constraint; apt grabs whatever's current in trixie.
- **Build-time 7-day cooldown gate.** After install, the RUN reads the upload date from `/usr/share/doc/libc6/changelog.Debian.gz` (Debian Policy mandates this file on every binary `.deb`; `--no-install-recommends` does not skip it). If apt grabbed a release uploaded `<7 days ago`, the build aborts with a clear error message and a "wait until" timestamp. Mirrors the global `CLAUDE.md` application-layer cooldown policy.
- **Dynamic sed substitution.** Replaces the previous static `s/2.41-12+deb13u2/2.41-12+deb13u3/g` with `s|${BASE_LIBC6_VER}|${LIBC6_VER}|g`, where `BASE_LIBC6_VER` comes from the distroless image's existing dpkg status.d entry and `LIBC6_VER` from `dpkg-query` against the just-installed package. Survives any future libc6 patch roll without code changes.
- **libssl3t64 stays pinned** (target version known, pin lets us bump it deliberately as a CVE-coverage signal). Same unpin treatment could be applied to libssl3t64 as a follow-up; deferred to keep this PR scoped.

### Robustness notes on the new shell

- The four previously-separate `RUN` steps (install, two assertions, sed) are consolidated into a single `RUN` so shell variables flow across the steps. `COPY --from=runtime-base` is hoisted above the RUN so `/tmp/libssl3t64-orig` and `/tmp/libc6-orig` are present.
- Every `$(command-substitution)` capture is followed by an explicit `[ -n "$X" ] || exit 1` guard. POSIX `sh` assignment exit codes don't reliably propagate pipeline failures, and `dash` (Debian's `/bin/sh`) doesn't enable `pipefail` by default. The guards turn every empty-capture path into a loud `exit 1` rather than silent zero-fallthrough arithmetic.
- All `A && B || { exit 1; } && C` patterns parse as `((A && B) || X) && C` under POSIX precedence and short-circuit correctly on both the success and failure branches.

## Verification

No local Docker on the Windows dev host — **CI Release on this PR is the canonical verification.** The Trivy scan still runs against the rebuilt image and will flag any new CVE that the `deb13u1` openssl or the current trixie glibc don't cover.

If the 7-day cooldown ever blocks a future build, the resolution is documented in the failure message: either wait out the rest of the window, or re-introduce a temporary libc6 pin to the previous known-good release.

## Test plan

- [ ] `CI Release` workflow green on this PR (was failing on the prior run)
- [ ] Trivy scan output on the new image — sanity-check no new HIGH/CRITICAL CVEs surface
- [ ] Post-merge: confirm a new `v0.22.x` tag + GHCR image lands from main
- [ ] (Future) Watch the next Debian glibc patch roll — build should now absorb it automatically (or block via the cooldown gate, never break)

## Out of scope (suggested follow-up)

- Apply the same unpin + cooldown gate to libssl3t64. Same recurrence risk, same fix shape; just deferred to keep this PR's blast radius small.
- Cron job that periodically checks `packages.debian.org/trixie/libssl3t64` for new versions and opens a bump-pin PR automatically.

Generated with Claude Code
