### PR TITLE
fix(frontend): use debian:trixie (not -slim) so libc6 changelog survives

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -45,7 +45,13 @@ RUN find /app/node_modules -path '*/esbuild/bin/esbuild' -delete 2>/dev/null; \
 #     entry is now dynamic: extracts base + installed versions at
 #     build time.
 FROM denoland/deno:distroless-2.7.11 AS runtime-base
-FROM debian:trixie-slim AS security-patch
+# debian:trixie (NOT -slim) — the slim variant ships
+# /etc/dpkg/dpkg.cfg.d/docker-clean which path-excludes /usr/share/doc/*,
+# stripping changelog.Debian.gz files. The 7-day cooldown gate below
+# reads libc6's changelog to determine its upload date, so we need the
+# changelogs intact. This is an intermediate build stage; the ~30 MB
+# size delta does not affect the final runtime image.
+FROM debian:trixie AS security-patch
 
 # Pull the base's dpkg status entries first so the consolidated RUN
 # below can read them. Single RUN keeps shell variables (version
@@ -79,6 +85,8 @@ RUN set -e && \
     rm -rf /var/lib/apt/lists/* && \
     LIBC6_VER=$(dpkg-query -W -f='${Version}' libc6) && \
     [ -n "$LIBC6_VER" ] || { echo "ERROR: dpkg-query returned empty libc6 version" >&2; exit 1; } && \
+    [ -f /usr/share/doc/libc6/changelog.Debian.gz ] || \
+        { echo "ERROR: /usr/share/doc/libc6/changelog.Debian.gz missing — the patch stage's base image is stripping docs (slim variant?). The 7-day cooldown gate needs the changelog to read the upload date." >&2; exit 1; } && \
     LIBC6_DATE=$(zcat /usr/share/doc/libc6/changelog.Debian.gz | grep -m1 '^ -- ' | sed -E 's/.*>  //') && \
     [ -n "$LIBC6_DATE" ] || { echo "ERROR: failed to extract libc6 upload date from changelog" >&2; exit 1; } && \
     LIBC6_TS=$(date -d "$LIBC6_DATE" +%s) && \


### PR DESCRIPTION
## Summary

**Follow-up hotfix to #298.** The CI Release run on main after #298's merge ([run 26228986841](https://github.com/maulepilot117/k8sCenter/actions/runs/26228986841)) failed at the same security-patch RUN step that the previous hotfix touched. Different error this time:

```
gzip: /usr/share/doc/libc6/changelog.Debian.gz: No such file or directory
ERROR: failed to extract libc6 upload date from changelog
```

The 7-day cooldown gate that PR #298 added needs to read `libc6`'s changelog to determine its upload date. The changelog wasn't there.

## Root cause

`debian:trixie-slim` (the base of the security-patch stage) ships with `/etc/dpkg/dpkg.cfg.d/docker-clean`:

```
path-exclude=/usr/share/doc/*
path-include=/usr/share/doc/*/copyright
```

The slim base comes with `libc6` pre-installed but the path-exclude config has stripped its changelog. `apt-get install libc6` says `"already the newest version"` and does nothing — so the changelog never gets installed.

I asserted in the PR #298 description that "Debian Policy mandates `changelog.Debian.gz` on every binary `.deb`; `--no-install-recommends` does not skip it." That part is correct — `.deb` files DO ship a changelog. But the slim variant's dpkg config strips it on install, and for pre-installed packages that strip is already permanent.

## Fix

`frontend/Dockerfile` — 2 small edits:

1. **`FROM debian:trixie-slim AS security-patch` → `FROM debian:trixie AS security-patch`.** Non-slim image keeps changelogs intact. ~30 MB larger but this is a BUILDKIT intermediate stage — the final runtime image (distroless) is unaffected.
2. **Defensive guard before `zcat`** so a future regression surfaces a clear error instead of a buried gzip trace:
   ```sh
   [ -f /usr/share/doc/libc6/changelog.Debian.gz ] || \
       { echo "ERROR: ...slim variant?..."; exit 1; }
   ```

## Verification

No local Docker on the Windows dev host — **CI Release on this PR is the canonical verification.** Going to watch the workflow that's failing on main.

## Why not just remove the cooldown gate?

I considered it. The gate is what the prior session asked for explicitly, and the threat model (defense in depth against a same-day malicious Debian upload) is sound. The fix is to make the gate actually work — switching base images is a one-line change. Removing the gate would be a policy decision, not a fix.

## Test plan

- [ ] `CI Release` workflow green on this PR's branch (was failing on main)
- [ ] Post-merge: confirm `CI Release` succeeds on main and a new `v0.22.x` tag + GHCR image lands
- [ ] Trivy scan output — sanity-check no new HIGH/CRITICAL CVEs

Generated with Claude Code
