### PR TITLE
fix(mobile): #302 — native iOS UIView blocker for app-switcher snapshot race

### DIFF
--- a/mobile/docs/OBSERVABILITY.md
+++ b/mobile/docs/OBSERVABILITY.md
@@ -155,14 +155,26 @@ is swallowed and the mixin degrades to Flutter-overlay-only defense.
 
 The following residuals remain:
 - **`AppLifecycleState.inactive` over-broad on iOS.** Notification
-  banners, Control Center peek, Siri activation, and the screenshot
-  gesture all deliver `.inactive` without a true backgrounding. The
-  Flutter-side scrim flashes mid-use on those events — UX nit, not a
-  leak. The native blocker also installs on these events (because
-  `sceneWillResignActive` is the same hook iOS uses to signal
-  potential snapshot capture). Debounce was considered and rejected
-  because the debounce window introduces its own race against a real
-  fast background gesture.
+  banners, Control Center peek, and Siri activation all deliver
+  `.inactive` without a true backgrounding. The Flutter-side scrim
+  flashes mid-use on those events — UX nit, not a leak. The native
+  blocker installs on the subset of these that route through
+  `sceneWillResignActive` (notification banner pull-down, Control
+  Center peek, incoming call, app-switcher swipe). Debounce was
+  considered and rejected because the debounce window introduces
+  its own race against a real fast background gesture.
+- **AssistiveTouch / hardware-button screenshots bypass
+  `sceneWillResignActive`.** The user-initiated screenshot gesture
+  (side + volume-up on modern iPhones, AssistiveTouch's screenshot
+  shortcut, three-finger drag accessibility) is delivered directly to
+  the iOS screenshot service without a scene-resign event. The native
+  blocker does NOT arm for these paths — only the Flutter overlay
+  defends, and only if it is already in the widget tree (which the
+  eager-overlay pattern ensures for the duration of a sensitive
+  session). A screenshot taken mid-sensitive-session is protected by
+  the Flutter overlay alone; if Flutter has not yet painted the scrim
+  flip, the resulting screenshot can include plaintext. Narrower than
+  the app-switcher race but not closed by #302.
 - **No automated real-device snapshot timing test.** Dart-side coverage
   is `flutter_test` in-memory; native-side coverage is the SceneDelegate
   code path (Swift) which has no unit-test harness. Verifying

--- a/mobile/docs/OBSERVABILITY.md
+++ b/mobile/docs/OBSERVABILITY.md
@@ -131,33 +131,45 @@ contract; if you change init behaviour, do not weaken this gate.
   internal-beta TestFlight / Play Internal lanes so a misconfigured
   filter can't burn project quota from production builds.
 
-## SecureScreenMixin — known residuals (#271 follow-ups)
+## SecureScreenMixin — defense layers and residuals
 
-The eager-overlay mitigation in `lib/widgets/secure_screen_mixin.dart`
-narrows the iOS app-switcher snapshot race to a single Flutter rebuild
-between lifecycle delivery and first paint of the scrim. It does not
-eliminate the race entirely. The following residuals are tracked but
-not closed by PR #300:
+The iOS screen-capture defense is layered. Primary defense is the
+eager `OverlayEntry` insertion in `lib/widgets/secure_screen_mixin.dart`
+(PR #300, issue #271) — keeps an inert `BackdropFilter`-armed overlay
+in the widget tree the entire time a screen is sensitive, so a
+`ValueNotifier` flip on lifecycle is all that's needed for the scrim
+to paint. Defense-in-depth is the native UIView blocker in
+`ios/Runner/SceneDelegate.swift` (PR #303, issue #302) — installed
+synchronously inside `sceneWillResignActive`, which iOS fires before
+capturing the app-switcher snapshot. UIKit lays out and renders the
+blocker before iOS yields to the snapshotter, closing the sub-frame
+race the pure-Flutter path could not guarantee to close.
 
-- **Sub-frame race remains.** Even with eager insertion, the
-  `BackdropFilter`'s subtree builds on the frame after `_blurVisible`
-  flips. iOS can theoretically snapshot during that gap.
-  Definitive closure requires a native `AppDelegate` UIView blocker
-  inserted synchronously in `applicationWillResignActive` (Mitigation 2
-  in #271's issue body). Open as a follow-up before PR-5j ships to
-  public stores if real-device verification reveals the race is
-  exploitable. Filed as a follow-up GitHub issue.
+Both layers arm together via `SecureScreenMixin.setSensitive(true)` —
+the same call adds Android `FLAG_SECURE`, eager-inserts the Flutter
+overlay, and pushes `setSensitive: true` over the
+`kubecenter/secure_screen` `MethodChannel` to the iOS `SceneDelegate`.
+If the iOS channel is not registered (older binary, Android build,
+test environment without the mock), the call's `MissingPluginException`
+is swallowed and the mixin degrades to Flutter-overlay-only defense.
+
+The following residuals remain:
 - **`AppLifecycleState.inactive` over-broad on iOS.** Notification
   banners, Control Center peek, Siri activation, and the screenshot
   gesture all deliver `.inactive` without a true backgrounding. The
-  scrim flashes mid-use on those events — UX nit, not a leak. Debounce
-  was considered and rejected because the debounce window introduces
-  its own race against a real fast background gesture.
-- **No real-device snapshot timing test.** All current coverage is
-  `flutter_test` in-memory. Verifying iOS Simulator + real-device
-  snapshot contents (recent-apps thumbnail shows blur, not plaintext)
-  is a manual smoke step in PR-5d's checklist and a candidate for a
-  Springboard-snapshot XCUITest job before PR-5j.
+  Flutter-side scrim flashes mid-use on those events — UX nit, not a
+  leak. The native blocker also installs on these events (because
+  `sceneWillResignActive` is the same hook iOS uses to signal
+  potential snapshot capture). Debounce was considered and rejected
+  because the debounce window introduces its own race against a real
+  fast background gesture.
+- **No automated real-device snapshot timing test.** Dart-side coverage
+  is `flutter_test` in-memory; native-side coverage is the SceneDelegate
+  code path (Swift) which has no unit-test harness. Verifying
+  recent-apps thumbnail contents (blocker visible, plaintext not) is a
+  manual smoke step in PR-5d's checklist and a candidate for a
+  Springboard-snapshot XCUITest job before PR-5j. The PR #303 smoke
+  checklist documents the steps.
 - **Sigma=30 blur strength.** Empirically chosen during PR-5a/PR-5d
   work — 24 lets character outlines bleed through on small-font Secret
   values. Not formally characterized against image-reconstruction

--- a/mobile/ios/Runner/SceneDelegate.swift
+++ b/mobile/ios/Runner/SceneDelegate.swift
@@ -1,5 +1,6 @@
 import Flutter
 import UIKit
+import os.log
 
 /// Scene delegate hosting the secure-screen blocker for #302.
 ///
@@ -34,14 +35,28 @@ class SceneDelegate: FlutterSceneDelegate {
   /// test in `mobile/test/widgets/secure_screen_mixin_test.dart`).
   private static let channelName = "kubecenter/secure_screen"
 
+  /// Subsystem-tagged logger so registration failures surface in
+  /// Console.app and unified logging on real-device smoke runs. The Dart
+  /// side cannot observe a missing native registration except through
+  /// `MissingPluginException` on every call — which is swallowed by
+  /// design — so this log is the only on-device signal that the native
+  /// defense-in-depth layer is silently off for the whole session.
+  private static let log = OSLog(
+    subsystem: "io.kubecenter.mobile",
+    category: "secure-screen"
+  )
+
   /// Dart-controlled flag. `true` means a sensitive screen is currently
   /// mounted and the blocker must arm on the next scene-resign-active.
   /// Mirrors `_sensitive` on the Dart `SecureScreenMixin`.
   private var sensitive = false
 
-  /// Single instance of the opaque blocker view. Lazy-initialized on
-  /// first arm so we don't pay the allocation cost during cold start.
-  private lazy var secureBlocker: UIView = makeSecureBlocker()
+  /// Single instance of the opaque blocker view. Allocated on first
+  /// arm so we don't pay the allocation cost during cold start when
+  /// the user never visits a sensitive screen. Stored as an optional
+  /// (not `lazy var`) so `disarmBlocker` on `sceneDidBecomeActive`
+  /// does not force allocation on every foreground transition.
+  private var secureBlocker: UIView?
 
   // MARK: - Method Channel
 
@@ -56,7 +71,16 @@ class SceneDelegate: FlutterSceneDelegate {
     else {
       // Flutter engine attach failed; non-fatal — the Dart side's
       // Flutter overlay still defends the screen, just without the
-      // native belt-and-suspenders layer.
+      // native belt-and-suspenders layer. Log loudly so this isn't a
+      // silent regression — if it ever fires, every subsequent
+      // setSensitive on the Dart side hits MissingPluginException (which
+      // is swallowed by design), making this os_log line the only
+      // visible signal that the native defense is off.
+      os_log(
+        "SceneDelegate: FlutterViewController cast failed — native secure-screen channel NOT registered. Defense degraded to Flutter overlay only.",
+        log: SceneDelegate.log,
+        type: .fault
+      )
       return
     }
     let channel = FlutterMethodChannel(
@@ -90,7 +114,7 @@ class SceneDelegate: FlutterSceneDelegate {
           result(FlutterError(
             code: "BAD_ARG",
             message: "setSensitive requires a Bool argument",
-            details: String(describing: call.arguments)
+            details: "argument type \(type(of: call.arguments)) — expected Bool"
           ))
         }
       default:
@@ -115,13 +139,14 @@ class SceneDelegate: FlutterSceneDelegate {
   // MARK: - Blocker management
 
   private func armBlocker(in window: UIWindow) {
-    secureBlocker.frame = window.bounds
-    window.addSubview(secureBlocker)
-    window.bringSubviewToFront(secureBlocker)
+    let blocker = secureBlocker ?? makeSecureBlocker()
+    secureBlocker = blocker
+    blocker.frame = window.bounds
+    window.addSubview(blocker)
   }
 
   private func disarmBlocker() {
-    secureBlocker.removeFromSuperview()
+    secureBlocker?.removeFromSuperview()
   }
 
   private func makeSecureBlocker() -> UIView {
@@ -138,7 +163,6 @@ class SceneDelegate: FlutterSceneDelegate {
     view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
     view.isUserInteractionEnabled = false
     view.accessibilityElementsHidden = true
-    view.isAccessibilityElement = false
     return view
   }
 }

--- a/mobile/ios/Runner/SceneDelegate.swift
+++ b/mobile/ios/Runner/SceneDelegate.swift
@@ -1,6 +1,144 @@
 import Flutter
 import UIKit
 
+/// Scene delegate hosting the secure-screen blocker for #302.
+///
+/// Closes the residual iOS app-switcher snapshot race left after PR #300
+/// (issue #271 / Mitigation 1). When a sensitive Dart screen is mounted,
+/// `SecureScreenMixin.setSensitive(true)` sends a `setSensitive: true`
+/// call over the `kubecenter/secure_screen` `FlutterMethodChannel`,
+/// flipping `sensitive` on this delegate. iOS calls
+/// `sceneWillResignActive` synchronously before snapshotting the
+/// app-switcher thumbnail — the blocker is added as a top-level subview
+/// of the scene's window inside that callback. UIKit lays out and
+/// renders the blocker before iOS captures the snapshot, so the recent-
+/// apps thumbnail shows the opaque cover, not the revealed Secret.
+///
+/// The Flutter-side blur overlay (eager-OverlayEntry pattern from
+/// PR #300) is still the primary defense. This native layer is
+/// defense-in-depth — it catches the sub-frame race that pure Flutter
+/// rendering cannot guarantee to close before snapshot. Both layers
+/// arm together via `SecureScreenMixin.setSensitive`.
+///
+/// Scene-based vs application-based lifecycle: this app declares
+/// `UIApplicationSceneManifest` in `Info.plist` with
+/// `UIApplicationSupportsMultipleScenes = false`, so the legacy
+/// `AppDelegate.applicationWillResignActive` is NOT called by iOS.
+/// `sceneWillResignActive` on the active scene delegate is the only
+/// pre-snapshot hook for scene apps; implementing this on AppDelegate
+/// would not fire on iOS 13+.
 class SceneDelegate: FlutterSceneDelegate {
 
+  /// Channel name shared with `mobile/lib/widgets/secure_screen_mixin.dart`.
+  /// If you rename here, rename there too (and update the channel-call
+  /// test in `mobile/test/widgets/secure_screen_mixin_test.dart`).
+  private static let channelName = "kubecenter/secure_screen"
+
+  /// Dart-controlled flag. `true` means a sensitive screen is currently
+  /// mounted and the blocker must arm on the next scene-resign-active.
+  /// Mirrors `_sensitive` on the Dart `SecureScreenMixin`.
+  private var sensitive = false
+
+  /// Single instance of the opaque blocker view. Lazy-initialized on
+  /// first arm so we don't pay the allocation cost during cold start.
+  private lazy var secureBlocker: UIView = makeSecureBlocker()
+
+  // MARK: - Method Channel
+
+  override func scene(
+    _ scene: UIScene,
+    willConnectTo session: UISceneSession,
+    options connectionOptions: UIScene.ConnectionOptions
+  ) {
+    super.scene(scene, willConnectTo: session, options: connectionOptions)
+    guard
+      let controller = self.window?.rootViewController as? FlutterViewController
+    else {
+      // Flutter engine attach failed; non-fatal — the Dart side's
+      // Flutter overlay still defends the screen, just without the
+      // native belt-and-suspenders layer.
+      return
+    }
+    let channel = FlutterMethodChannel(
+      name: SceneDelegate.channelName,
+      binaryMessenger: controller.binaryMessenger
+    )
+    channel.setMethodCallHandler { [weak self] call, result in
+      guard let self = self else {
+        result(FlutterError(
+          code: "SCENE_GONE",
+          message: "Scene torn down before method call",
+          details: nil
+        ))
+        return
+      }
+      switch call.method {
+      case "setSensitive":
+        if let value = call.arguments as? Bool {
+          self.sensitive = value
+          // If the user revealed a Secret WHILE the app is currently
+          // resigning active (rare but reachable on iPad Stage Manager
+          // focus loss interleaved with reveal), arm the blocker
+          // immediately so the next snapshot sees it.
+          if value, let window = self.window, scene.activationState != .foregroundActive {
+            self.armBlocker(in: window)
+          } else if !value {
+            self.disarmBlocker()
+          }
+          result(nil)
+        } else {
+          result(FlutterError(
+            code: "BAD_ARG",
+            message: "setSensitive requires a Bool argument",
+            details: String(describing: call.arguments)
+          ))
+        }
+      default:
+        result(FlutterMethodNotImplemented)
+      }
+    }
+  }
+
+  // MARK: - Snapshot defense
+
+  override func sceneWillResignActive(_ scene: UIScene) {
+    super.sceneWillResignActive(scene)
+    guard sensitive, let window = self.window else { return }
+    armBlocker(in: window)
+  }
+
+  override func sceneDidBecomeActive(_ scene: UIScene) {
+    super.sceneDidBecomeActive(scene)
+    disarmBlocker()
+  }
+
+  // MARK: - Blocker management
+
+  private func armBlocker(in window: UIWindow) {
+    secureBlocker.frame = window.bounds
+    window.addSubview(secureBlocker)
+    window.bringSubviewToFront(secureBlocker)
+  }
+
+  private func disarmBlocker() {
+    secureBlocker.removeFromSuperview()
+  }
+
+  private func makeSecureBlocker() -> UIView {
+    // Opaque solid view — chosen over `UIVisualEffectView` because the
+    // blur effect's render path can defer to the next frame, which is
+    // the exact race we're trying to close. A solid `backgroundColor`
+    // is applied synchronously during the next layout pass triggered
+    // by `addSubview`, which iOS completes before snapshotting.
+    //
+    // Uses `systemBackground` so the cover adapts to dark/light mode and
+    // visually matches the theme without per-theme branching.
+    let view = UIView(frame: .zero)
+    view.backgroundColor = .systemBackground
+    view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+    view.isUserInteractionEnabled = false
+    view.accessibilityElementsHidden = true
+    view.isAccessibilityElement = false
+    return view
+  }
 }

--- a/mobile/lib/widgets/secure_screen_mixin.dart
+++ b/mobile/lib/widgets/secure_screen_mixin.dart
@@ -39,6 +39,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_windowmanager/flutter_windowmanager.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 
 /// Channel into `mobile/ios/Runner/SceneDelegate.swift` for the native
 /// iOS UIView blocker added in #302. The native side installs the
@@ -158,6 +159,17 @@ mixin SecureScreenMixin<T extends StatefulWidget> on State<T> {
         } catch (error) {
           debugPrint('SecureScreenMixin clearFlags during dispose: $error');
         }
+        // Symmetric iOS native disarm — the SceneDelegate.sensitive flag
+        // lives on the scene singleton and survives widget teardown. Without
+        // this call, navigating away from a sensitive screen while sensitive
+        // is true leaves the native blocker armed for every subsequent
+        // sceneWillResignActive — every backgrounding from any screen shows
+        // an opaque cover until the process is restarted. #302 P1 follow-up.
+        try {
+          await _notifyIOSNativeSensitive(false);
+        } catch (error) {
+          debugPrint('SecureScreenMixin iOS disarm during dispose: $error');
+        }
       });
       unawaited(_inflightPlatformCall!);
     }
@@ -191,13 +203,26 @@ mixin SecureScreenMixin<T extends StatefulWidget> on State<T> {
     // dispatching both inside the same continuation guarantees the
     // native side knows we're sensitive before the next iOS scene-resign
     // can fire (#302).
+    //
+    // The iOS native notification is dispatched concurrently with the
+    // Android FLAG_SECURE call (not sequentially) so the iOS-side flag
+    // is set as early as possible. The Android call short-circuits on
+    // non-Android platforms — on an iOS build it's a synchronous no-op —
+    // but firing them in parallel still cuts the time-to-native-set on
+    // any platform where both channels exist. Both must complete before
+    // the chain resolves so the next setSensitive call's idempotency
+    // guard sees a consistent state. Race-window narrowing only; the
+    // platform-channel round trip is still async so a sub-15ms reveal-
+    // then-background gesture can still beat the native flag. The
+    // Flutter eager-overlay is the primary defense for that window.
     final next = (_inflightPlatformCall ?? Future.value()).then((_) async {
+      final iosCall = _notifyIOSNativeSensitive(sensitive);
       if (sensitive) {
         await _addFlagSecure();
       } else {
         await _clearFlagSecure();
       }
-      await _notifyIOSNativeSensitive(sensitive);
+      await iosCall;
     });
     _inflightPlatformCall = next;
     try {
@@ -252,9 +277,43 @@ mixin SecureScreenMixin<T extends StatefulWidget> on State<T> {
       );
     } on MissingPluginException {
       // Older binaries or test environments without the channel
-      // registered. Degrade to Flutter-overlay-only defense. Silent.
+      // registered. Degrade to Flutter-overlay-only defense.
+      //
+      // On a healthy post-#302 iOS binary this should never fire — if it
+      // does, the native defense-in-depth layer is silently off for the
+      // whole session. Surface as a Sentry breadcrumb so opted-in users
+      // produce a signal we can investigate. Fire-and-forget — if Sentry
+      // isn't initialized (no DSN, opted out) the SDK no-ops and the
+      // try-catch absorbs anything else.
+      try {
+        Sentry.addBreadcrumb(
+          Breadcrumb(
+            level: SentryLevel.warning,
+            category: 'secure-screen',
+            message: 'iOS native channel missing — degraded to Flutter-overlay '
+                'defense only. Expected on Android, web, and pre-#302 iOS '
+                'binaries; unexpected on a healthy post-#302 iOS build.',
+          ),
+        );
+      } catch (_) {
+        // Sentry not initialized; intentionally silent.
+      }
     } on PlatformException catch (error) {
       debugPrint('SecureScreenMixin iOS channel: $error');
+      // Production builds strip debugPrint output. Mirror to Sentry so
+      // BAD_ARG / SCENE_GONE / native-side exceptions are observable.
+      try {
+        Sentry.addBreadcrumb(
+          Breadcrumb(
+            level: SentryLevel.error,
+            category: 'secure-screen',
+            message:
+                'iOS native channel PlatformException: code=${error.code}',
+          ),
+        );
+      } catch (_) {
+        // Sentry not initialized; intentionally silent.
+      }
     }
   }
 

--- a/mobile/lib/widgets/secure_screen_mixin.dart
+++ b/mobile/lib/widgets/secure_screen_mixin.dart
@@ -5,9 +5,17 @@
 // OS hides the screen contents from the recent-apps preview snapshot and
 // blocks screenshots/screen recording.
 //
-// iOS: there is no equivalent system flag. The pattern is to push a blur
-// overlay when the app lifecycle enters inactive/paused (which fires
-// BEFORE iOS captures the app-switcher snapshot) and remove it on resume.
+// iOS: there is no equivalent system flag. The defense is layered.
+// (1) A Flutter-rendered blur OverlayEntry is eagerly inserted at
+// setSensitive(true) time and made visible by a ValueNotifier flip on
+// lifecycle inactive/paused/hidden. (2) A native UIView blocker added in
+// SceneDelegate.sceneWillResignActive (#302) — fires synchronously
+// before iOS captures the app-switcher snapshot, so the recent-apps
+// thumbnail shows the opaque blocker regardless of whether Flutter
+// completes the next pipeline flush in time. The native layer is
+// defense-in-depth; the Flutter overlay is the primary defense for
+// debug builds and any future iOS multitasking modes that change
+// snapshot timing.
 //
 // Eager-overlay race mitigation (#271): the OverlayEntry is inserted at
 // `setSensitive(true)` time, not on the lifecycle event. While the screen
@@ -29,7 +37,22 @@ import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_windowmanager/flutter_windowmanager.dart';
+
+/// Channel into `mobile/ios/Runner/SceneDelegate.swift` for the native
+/// iOS UIView blocker added in #302. The native side installs the
+/// blocker synchronously inside `sceneWillResignActive` — the only
+/// hook iOS guarantees fires before the app-switcher snapshot — which
+/// closes the residual sub-frame race the eager-OverlayEntry Flutter
+/// pattern from PR #300 narrowed but could not fully eliminate.
+///
+/// If the channel is not registered (Android, Flutter test runs, older
+/// iOS builds that predate this PR) the `MissingPluginException` is
+/// swallowed and the mixin degrades to Flutter-overlay-only defense.
+@visibleForTesting
+const MethodChannel kIOSSecureScreenChannel =
+    MethodChannel('kubecenter/secure_screen');
 
 /// Mix into a `State<...>` subclass to opt into screen-capture
 /// suppression. Call [setSensitive] when secure content is revealed
@@ -144,8 +167,10 @@ mixin SecureScreenMixin<T extends StatefulWidget> on State<T> {
   /// Toggles secure-screen behaviour. Idempotent.
   ///
   /// - `true` on Android: adds `FLAG_SECURE` to the window.
-  /// - `true` on iOS: arms the blur overlay so the next inactive/paused
-  ///   lifecycle event covers the screen.
+  /// - `true` on iOS: arms the eager blur overlay AND notifies the
+  ///   native `SceneDelegate` via [kIOSSecureScreenChannel] so its
+  ///   UIView blocker arms inside `sceneWillResignActive` before iOS
+  ///   captures the app-switcher snapshot (#302).
   /// - `false`: clears both and removes any active overlay.
   Future<void> setSensitive(bool sensitive) async {
     if (_isNoOpEnvironment) return;
@@ -161,13 +186,18 @@ mixin SecureScreenMixin<T extends StatefulWidget> on State<T> {
       _insertBlurOverlay();
     }
     // Chain onto any in-flight platform call so two rapid setSensitive
-    // calls don't race the platform side.
-    final next = (_inflightPlatformCall ?? Future.value()).then((_) {
+    // calls don't race the platform side. The chain serializes BOTH the
+    // Android FLAG_SECURE call and the iOS native blocker notification —
+    // dispatching both inside the same continuation guarantees the
+    // native side knows we're sensitive before the next iOS scene-resign
+    // can fire (#302).
+    final next = (_inflightPlatformCall ?? Future.value()).then((_) async {
       if (sensitive) {
-        return _addFlagSecure();
+        await _addFlagSecure();
       } else {
-        return _clearFlagSecure();
+        await _clearFlagSecure();
       }
+      await _notifyIOSNativeSensitive(sensitive);
     });
     _inflightPlatformCall = next;
     try {
@@ -203,6 +233,29 @@ mixin SecureScreenMixin<T extends StatefulWidget> on State<T> {
   Future<void> _clearFlagSecure() async {
     if (kIsWeb || defaultTargetPlatform != TargetPlatform.android) return;
     await FlutterWindowManager.clearFlags(FlutterWindowManager.FLAG_SECURE);
+  }
+
+  /// Notifies the iOS [SceneDelegate] of the sensitive state via the
+  /// [kIOSSecureScreenChannel] so the native UIView blocker can arm
+  /// synchronously in `sceneWillResignActive` before iOS captures the
+  /// app-switcher snapshot. Fails open: a `MissingPluginException`
+  /// (Android build, test environment, or pre-#302 iOS binary) is
+  /// swallowed because the Flutter overlay still provides primary
+  /// defense. `PlatformException` is logged but not rethrown — a
+  /// native-side failure must not regress the Dart-side sensitive flag.
+  Future<void> _notifyIOSNativeSensitive(bool sensitive) async {
+    if (kIsWeb || defaultTargetPlatform != TargetPlatform.iOS) return;
+    try {
+      await kIOSSecureScreenChannel.invokeMethod<void>(
+        'setSensitive',
+        sensitive,
+      );
+    } on MissingPluginException {
+      // Older binaries or test environments without the channel
+      // registered. Degrade to Flutter-overlay-only defense. Silent.
+    } on PlatformException catch (error) {
+      debugPrint('SecureScreenMixin iOS channel: $error');
+    }
   }
 
   void _onLifecycleStateChanged(AppLifecycleState state) {

--- a/mobile/test/widgets/secure_screen_mixin_test.dart
+++ b/mobile/test/widgets/secure_screen_mixin_test.dart
@@ -483,14 +483,22 @@ void main() {
           find.byKey(SecureScreenMixin.blurOverlayKey),
           findsOneWidget,
         );
+        // Fire the lifecycle event the degraded Flutter-only path
+        // depends on and assert the BackdropFilter actually paints —
+        // overlay presence alone does not prove the scrim materializes.
+        _fireLifecycle(AppLifecycleState.inactive);
+        await tester.pump();
+        expect(find.byType(BackdropFilter), findsOneWidget);
       });
     });
 
     testWidgets(
         'PlatformException is swallowed (degrades to Flutter-overlay only)',
         (tester) async {
+      var callCount = 0;
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(kIOSSecureScreenChannel, (_) async {
+        callCount++;
         throw PlatformException(code: 'NATIVE_FAIL');
       });
 
@@ -499,6 +507,78 @@ void main() {
         final state = tester.state<_HostState>(find.byType(_Host));
 
         await expectLater(state.setSensitive(true), completes);
+        // No circuit-breaker: subsequent setSensitive calls must still
+        // attempt the channel even after a throwing call. A future change
+        // adding a "stop trying after first failure" optimization would
+        // silently disable the native defense path forever — pin against
+        // that here.
+        await expectLater(state.setSensitive(false), completes);
+        await expectLater(state.setSensitive(true), completes);
+        expect(callCount, 3,
+            reason: 'channel must be attempted on every setSensitive even '
+                'after a PlatformException — no circuit-breaker on swallow.');
+      });
+    });
+
+    testWidgets(
+        'cold-start: no mock handler installed at all does not throw (#302 cold-start race)',
+        (tester) async {
+      // Simulates the window between Flutter engine start and the
+      // SceneDelegate's `scene(_:willConnectTo:)` running. The Dart side
+      // calls setSensitive before any native handler is registered for
+      // kIOSSecureScreenChannel — the call must complete (the
+      // MissingPluginException swallow keeps the Flutter overlay armed
+      // as primary defense). Distinct from the existing MissingPlugin
+      // test which pre-installs a throwing mock; this one installs no
+      // mock at all to exercise the truly-unregistered path.
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(kIOSSecureScreenChannel, null);
+
+      await withPlatform(TargetPlatform.iOS, () async {
+        await tester.pumpWidget(const MaterialApp(home: _Host()));
+        final state = tester.state<_HostState>(find.byType(_Host));
+
+        await expectLater(state.setSensitive(true), completes);
+        await tester.pump();
+        expect(
+          find.byKey(SecureScreenMixin.blurOverlayKey),
+          findsOneWidget,
+          reason: 'Flutter overlay must be armed even when the native '
+              'channel is entirely unregistered (cold-start race window).',
+        );
+      });
+    });
+
+    testWidgets(
+        'dispose() while sensitive notifies iOS channel with setSensitive(false) (#302 P1)',
+        (tester) async {
+      // Regression guard: SceneDelegate.sensitive is scene-singleton state
+      // that survives Dart widget teardown. Without an iOS disarm on
+      // dispose, navigating away from a sensitive screen leaves the
+      // native blocker armed for every subsequent sceneWillResignActive.
+      // Mirrors the Android `dispose clears FLAG_SECURE if sensitive was
+      // true` test above.
+      await withPlatform(TargetPlatform.iOS, () async {
+        await tester.pumpWidget(const MaterialApp(home: _Host()));
+        final state = tester.state<_HostState>(find.byType(_Host));
+
+        await state.setSensitive(true);
+        nativeCalls.clear();
+
+        await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+        await tester.pump();
+        // The dispose chain is fire-and-forget; pump until idle so its
+        // microtasks land before we assert.
+        await tester.pumpAndSettle();
+
+        final disarms = nativeCalls
+            .where((c) => c.method == 'setSensitive' && c.arguments == false);
+        expect(
+          disarms,
+          hasLength(1),
+          reason: 'dispose() must symmetrically notify the iOS native channel '
+              'so SceneDelegate.sensitive resets when the widget tears down.',
+        );
       });
     });
   });

--- a/mobile/test/widgets/secure_screen_mixin_test.dart
+++ b/mobile/test/widgets/secure_screen_mixin_test.dart
@@ -393,6 +393,116 @@ void main() {
     });
   });
 
+  group('SecureScreenMixin iOS native channel (#302)', () {
+    late List<MethodCall> nativeCalls;
+
+    setUp(() {
+      nativeCalls = <MethodCall>[];
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        kIOSSecureScreenChannel,
+        (call) async {
+          nativeCalls.add(call);
+          return null;
+        },
+      );
+    });
+
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(kIOSSecureScreenChannel, null);
+    });
+
+    testWidgets('setSensitive(true) calls native setSensitive(true)',
+        (tester) async {
+      await withPlatform(TargetPlatform.iOS, () async {
+        await tester.pumpWidget(const MaterialApp(home: _Host()));
+        final state = tester.state<_HostState>(find.byType(_Host));
+
+        await state.setSensitive(true);
+
+        expect(
+          nativeCalls.where((c) => c.method == 'setSensitive'),
+          hasLength(1),
+        );
+        expect(nativeCalls.last.arguments, true);
+      });
+    });
+
+    testWidgets('setSensitive(false) calls native setSensitive(false)',
+        (tester) async {
+      await withPlatform(TargetPlatform.iOS, () async {
+        await tester.pumpWidget(const MaterialApp(home: _Host()));
+        final state = tester.state<_HostState>(find.byType(_Host));
+
+        await state.setSensitive(true);
+        nativeCalls.clear();
+        await state.setSensitive(false);
+
+        expect(nativeCalls.single.method, 'setSensitive');
+        expect(nativeCalls.single.arguments, false);
+      });
+    });
+
+    testWidgets('Android setSensitive does NOT call the iOS channel',
+        (tester) async {
+      // Confirms the iOS-only platform guard inside
+      // `_notifyIOSNativeSensitive` — Android relies on `FLAG_SECURE`
+      // for the equivalent defense and must not invoke the iOS channel.
+      await withPlatform(TargetPlatform.android, () async {
+        await tester.pumpWidget(const MaterialApp(home: _Host()));
+        final state = tester.state<_HostState>(find.byType(_Host));
+
+        await state.setSensitive(true);
+        await state.setSensitive(false);
+
+        expect(nativeCalls, isEmpty);
+      });
+    });
+
+    testWidgets(
+        'MissingPluginException is swallowed (degrades to Flutter-overlay only)',
+        (tester) async {
+      // Simulate a binary that predates #302 — the channel is not
+      // registered on the native side. The mixin must NOT throw; the
+      // Flutter eager overlay continues to defend.
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(kIOSSecureScreenChannel, (_) async {
+        throw MissingPluginException('No implementation');
+      });
+
+      await withPlatform(TargetPlatform.iOS, () async {
+        await tester.pumpWidget(const MaterialApp(home: _Host()));
+        final state = tester.state<_HostState>(find.byType(_Host));
+
+        await expectLater(state.setSensitive(true), completes);
+        // Flutter-side overlay still installed despite the channel
+        // failure — primary defense remains armed.
+        await tester.pump();
+        expect(
+          find.byKey(SecureScreenMixin.blurOverlayKey),
+          findsOneWidget,
+        );
+      });
+    });
+
+    testWidgets(
+        'PlatformException is swallowed (degrades to Flutter-overlay only)',
+        (tester) async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(kIOSSecureScreenChannel, (_) async {
+        throw PlatformException(code: 'NATIVE_FAIL');
+      });
+
+      await withPlatform(TargetPlatform.iOS, () async {
+        await tester.pumpWidget(const MaterialApp(home: _Host()));
+        final state = tester.state<_HostState>(find.byType(_Host));
+
+        await expectLater(state.setSensitive(true), completes);
+      });
+    });
+  });
+
   group('SecureScreenMixin debug-mode gate', () {
     testWidgets(
         'in debug build, setSensitive(true) is a no-op (no platform call)',


### PR DESCRIPTION
## Summary

Closes the residual sub-frame race left after PR #300 (issue #271 / Mitigation 1). The eager-OverlayEntry pattern from PR #300 keeps the Flutter blur armed for the duration of a sensitive session but still requires one Flutter rebuild between `sceneWillResignActive` and first paint of the scrim — iOS doesn't guarantee Flutter completes that rebuild before snapshotting. This PR adds Mitigation 2 from #271: a native UIView blocker installed synchronously inside `sceneWillResignActive`, which iOS calls **before** capturing the app-switcher snapshot. UIKit lays out and renders the blocker before iOS yields to the snapshotter — the recent-apps thumbnail shows the opaque cover regardless of Flutter timing.

## Scene-based correction

#302's body suggested implementing on `AppDelegate.applicationWillResignActive`. This app is **scene-based** (`UIApplicationSceneManifest` in `Info.plist`, iOS 13.0 deployment target) — iOS does **not** call `applicationWillResignActive` for scene apps. `SceneDelegate.sceneWillResignActive` is the correct hook. Implementation lives in `ios/Runner/SceneDelegate.swift`.

## Architecture

- **Native side** (`ios/Runner/SceneDelegate.swift`):
  - `kubecenter/secure_screen` `FlutterMethodChannel` registered in `scene(_:willConnectTo:options:)`
  - `sensitive: Bool` flag flipped by the channel's `setSensitive(bool)` method
  - Lazy `secureBlocker: UIView` — opaque solid `systemBackground` (no `UIVisualEffectView` blur because the blur render path can defer to the next frame, which is the exact race we're closing)
  - Arms in `sceneWillResignActive` if sensitive; disarms in `sceneDidBecomeActive`
  - Also arms immediately on channel call when the scene is not `foregroundActive` (iPad Stage Manager reveal-during-focus-loss edge case)

- **Dart side** (`mobile/lib/widgets/secure_screen_mixin.dart`):
  - `kIOSSecureScreenChannel` const (`@visibleForTesting`)
  - `_notifyIOSNativeSensitive(bool)` helper joins the existing `_inflightPlatformCall` serialized chain so the Android `FLAG_SECURE` call AND the iOS native channel call dispatch inside the same continuation
  - `MissingPluginException` swallowed (degrade to Flutter-overlay-only when the channel isn't registered — older binaries, Android builds, test environments)
  - `PlatformException` logged but not rethrown

- **Tests**: 5 new tests in `iOS native channel (#302)` group covering happy path, false-call, Android-no-invoke, MissingPluginException degrade, PlatformException swallow. Mocking follows the existing Android `FLAG_SECURE` test pattern in the same file.

## Verification limitations (read before merging)

- **CI runs `flutter analyze` + `flutter test` on Ubuntu** — the new Swift in `SceneDelegate.swift` is **not** compiled by CI. The first time the Swift compiles is during `xcodebuild` on operator macOS (e.g., the next TestFlight build via `fastlane beta_ios`).
- **The behavioral correctness — recent-apps thumbnail shows the blocker, not Secret plaintext — can only be verified on a real iPhone or iOS Simulator.** `flutter_test` cannot exercise UIKit-level snapshot capture.
- Local `flutter analyze` is clean; local `flutter test` queued behind orphan `dart`/`flutter_tester` processes from prior session runs — CI will run the suite in a clean environment.

## Manual smoke checklist (operator action, required before promoting to public stores)

1. `cd mobile && flutter build ios --debug` — verify Swift compiles.
2. `flutter run -d <iphone>` — launch on physical device or iOS Simulator.
3. Authenticate, navigate to any Secret detail screen (`SecretDetailScreen` already calls `setSensitive(_revealed.isNotEmpty)`).
4. Reveal at least one Secret key.
5. Swipe to app switcher.
6. Verify the recent-apps thumbnail shows the opaque blocker (or Flutter blur scrim — both layers should be visible), NOT the revealed Secret value.
7. Tap back into the app; verify the blocker is removed and the Secret is still revealed.
8. Conceal the Secret key, swipe to app switcher again; verify the thumbnail now shows the app's normal foreground (no blocker — `sensitive` is false).
9. Optional: enable AssistiveTouch to grab a screenshot of the recent-apps thumbnail and confirm zero plaintext bleed through.

If any step shows plaintext, the residual race is still exploitable on this device + OS combination — file as a follow-up with hardware details.

## Test plan

- [x] `cd mobile && flutter analyze` — clean.
- [ ] `cd mobile && flutter test` — to run in CI (orphan processes blocking local run; new tests follow the same MethodChannel-mock pattern as the existing Android tests in the same file).
- [ ] Manual smoke per the checklist above before next TestFlight promotion.

Closes #302.

🤖 Generated with [Claude Code](https://claude.com/claude-code)