### PR TITLE
feat(security): Phase 3 — auth primitives (P2-1/P2-2/P2-3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,105 @@ correlate findings back to the audit reports under `docs/security/`.
 
 ---
 
+## Phase 3 — Auth primitives hardening (2026-05 audit)
+
+Phase 3 closes audit findings P2-1 (trusted-proxy CIDR boundary +
+per-account/login-name throttle), P2-2 (atomic refresh-token rotation),
+and P2-3 (LDAP revalidation on refresh + 1h LDAP refresh-token cap).
+The audit report is `plans/security-audit-2026-05-22.md` (same source
+as Phase 2; Phase 3 closes the remaining auth-primitive findings).
+
+### Breaking changes (operator action required)
+
+- **LDAP refresh-token TTL: 7 days → 1 hour** (audit P2-3). LDAP-sourced
+  sessions now cap refresh-token lifetime at 1 hour, mirroring the OIDC
+  cap added in Phase 2. Combined with the new per-refresh revalidation
+  against the directory, this bounds the worst-case revoked-LDAP-user
+  access window to one access-token lifetime (~15 minutes) plus the
+  5-minute transient-outage grace window. Operators relying on long-
+  lived LDAP refresh sessions must adjust client retry / re-login
+  behaviour. See `backend/internal/auth/jwt.go` `LDAPRefreshTokenLifetime`.
+
+- **LDAP revalidation on every refresh** (audit P2-3). The refresh
+  handler now binds to the configured LDAP directory and re-fetches
+  group membership on every refresh attempt for LDAP-sourced sessions.
+  This means: (a) the LDAP server sees one bind+search per active
+  user's refresh interval (~15 minutes); (b) a directory-side LDAP
+  outage longer than 5 minutes evicts all LDAP users until the
+  directory recovers. The 5-minute bounded grace window preserves
+  last-known identity during brief outages. Operators with high LDAP
+  client counts should size the directory accordingly.
+
+- **`KUBECENTER_SERVER_TRUSTEDPROXYCIDRS` config** (audit P2-1). The
+  global middleware no longer trusts X-Forwarded-For / X-Real-IP from
+  every peer (the chi-RealIP default). Operators behind a load
+  balancer or ingress controller MUST configure this CIDR allowlist
+  or rate-limit buckets and audit `SourceIP` fields will key on the
+  proxy's address rather than the client's. Default empty =
+  fail-closed (no proxies trusted). Narrow the trust set to the
+  exact ingress-controller pod or service CIDR — broad ranges (e.g.
+  the full Kubernetes pod CIDR) let any in-cluster workload spoof the
+  header. The middleware emits a startup WARN on `/0` catch-all
+  entries that reinstate the pre-Phase-3 blanket-trust behaviour.
+
+### Non-breaking changes
+
+- **Atomic refresh-token rotation** (audit P2-2). The Peek+Consume
+  split that allowed two concurrent refreshers to each mint a
+  successor pair from one stolen refresh token has been replaced by
+  an atomic `SessionStore.Rotate` (sync.Map.LoadAndDelete-backed).
+  Concurrent refresh attempts on the same token can no longer both
+  succeed; the loser receives 401. Transient post-rotate failures
+  (issueTokenPair signing error, LDAP transient-outside-grace) call
+  `SessionStore.Restore` so the client can retry rather than being
+  silently logged out. No operator action.
+
+- **Per-account login + setup throttle** (audit P2-1 part 2). New
+  per-username rate-limit bucket layered on top of the existing
+  per-IP throttle. An attacker rotating source IPs against a single
+  username (or iterating likely admin names against `/setup/init`)
+  now hits the account bucket regardless of source IP. No operator
+  action; budget shares the global 5/min default.
+
+- **Audit-emit coverage**. handleRefresh body-mode missing-token,
+  user-not-found, and issueTokenPair-failure paths now emit audit
+  entries; handleSetupInit setup-token mismatch now audits the 403.
+  Earlier branches were silent, hiding brute-force probing from the
+  audit table.
+
+### Known follow-ups (filed during Phase 3 ce-code-review)
+
+These are documented review findings deferred to follow-up PRs to
+keep Phase 3 focused. None are blockers for shipping Phase 3.
+
+- Credential-login (`/auth/login`) body-mode is missing — agents using
+  local/LDAP credentials cannot retrieve the refresh token at login
+  time. (agent-native AN-C1, P1, conf 100)
+- `/auth/refresh` 401 responses lack a stable `error.Reason`
+  discriminator across five semantically distinct failure modes.
+  (agent-native AN-W1, P1)
+- Audit query API has no detail-text filter — monitoring agents
+  detecting LDAP-grace-window thrashing must client-side-filter.
+  (agent-native AN-W2, P2)
+- handleLogout revokes only the inbound token; a concurrent refresh
+  can leave an orphaned rotated successor session that survives until
+  ExpiresAt. (adversarial adv-2, P2)
+- Per-account throttle key is case-folded but not Unicode-normalised;
+  trailing whitespace + zero-width characters dilute the throttle.
+  (security sec-2 + adversarial adv-3, P3)
+- `ldapGracePeriod` is a hardcoded 5-minute constant — not
+  config-tunable. (maintainability MAINT-003, P2)
+- LDAP `Revalidate` context cancellation does not propagate to the
+  in-flight LDAP ops (10s wall-clock bound only). (reliability
+  REL-02, P2)
+- No singleflight coalescing on `Revalidate` for the same userDN;
+  mass-refresh after backend restart hits the directory N times per
+  user. NOTE: the learnings researcher flagged this as advisory only
+  — the Phase 2 singleflight pattern in cluster_router does NOT
+  transfer cleanly to per-session LDAP. (reliability REL-03, advisory)
+
+---
+
 ## Phase 2 — Multi-cluster RBAC & TLS hardening (2026-05 audit)
 
 The Phase 2 security audit produced three review rounds (2026-05-13,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,7 @@ k8scenter/
 - **Tailwind CSS utility-only.** No custom CSS class names. Theme via CSS custom properties (`var(--accent)`, `var(--success)`, etc.) — no hardcoded color classes.
 
 ### Security
-- **JWT: 15 min access. Refresh: 7 day (local/LDAP) or 1 hour (OIDC).** The shorter OIDC window propagates IdP revocation (account disabled, group removed) within the hour rather than waiting for the standard 7-day rotation cycle. See `backend/internal/auth/jwt.go` `OIDCRefreshTokenLifetime`. Refresh tokens stored server-side (httpOnly cookie for web, body-mode for mobile).
+- **JWT: 15 min access. Refresh: 7 day (local) or 1 hour (LDAP/OIDC).** The shorter LDAP/OIDC window propagates external-identity-store revocation (account disabled, group removed) within the hour rather than waiting for the standard 7-day rotation cycle. LDAP sessions additionally revalidate against the directory on every refresh with a 5-minute bounded grace window for transient outages. See `backend/internal/auth/jwt.go` `OIDCRefreshTokenLifetime` + `LDAPRefreshTokenLifetime`, and `backend/internal/server/handle_auth.go` `revalidateLDAPSession`. Refresh tokens stored server-side (httpOnly cookie for web, body-mode for mobile).
 - **Secrets masked in API responses.** Reveal requires explicit action + audit log.
 - **CSP headers, NetworkPolicy, Pod Security Standards (restricted profile).**
 - **Audit logging for all write operations.** PostgreSQL-backed, 90-day retention.

--- a/backend/internal/auth/jwt.go
+++ b/backend/internal/auth/jwt.go
@@ -26,18 +26,31 @@ const (
 	// the IdP's. The 1h cap is a pragmatic middle ground: documented as the
 	// session-lifetime guarantee for OIDC users.
 	OIDCRefreshTokenLifetime = 1 * time.Hour
+	// LDAPRefreshTokenLifetime caps refresh tokens issued for LDAP-sourced
+	// sessions. Mirrors the OIDC cap for the same reason: bounds the window
+	// where a revoked LDAP identity (disabled account, removed group
+	// membership) keeps minting valid access tokens. Combined with the
+	// per-refresh LDAPProvider.Revalidate call in the refresh handler, the
+	// worst-case revoked-user access drops from ~7 days to one access-token
+	// lifetime (15min). Closes audit finding P2-3 (2026-05-22).
+	LDAPRefreshTokenLifetime = 1 * time.Hour
 	// RefreshTokenBytes is the length of random refresh tokens.
 	RefreshTokenBytes = 32
 )
 
 // RefreshLifetimeFor returns the refresh token TTL for a given auth
-// provider. OIDC sessions get the shorter cap; everything else gets the
-// standard window.
+// provider. OIDC and LDAP sessions get a 1h cap to bound revocation
+// propagation against external identity stores; local sessions get the
+// standard 7-day window.
 func RefreshLifetimeFor(provider string) time.Duration {
-	if provider == "oidc" {
+	switch provider {
+	case "oidc":
 		return OIDCRefreshTokenLifetime
+	case "ldap":
+		return LDAPRefreshTokenLifetime
+	default:
+		return RefreshTokenLifetime
 	}
-	return RefreshTokenLifetime
 }
 
 // TokenClaims are the JWT claims for access tokens.

--- a/backend/internal/auth/jwt_test.go
+++ b/backend/internal/auth/jwt_test.go
@@ -124,19 +124,21 @@ func TestRefreshTokenLifetime(t *testing.T) {
 	}
 }
 
-// TestRefreshLifetimeFor asserts the provider-aware refresh TTL switch:
-// OIDC sessions are capped at the shorter [OIDCRefreshTokenLifetime] so
-// IdP-side revocation propagates within the hour; everything else (local,
-// LDAP, future credential providers via the default branch) keeps the
-// standard [RefreshTokenLifetime] window.
+// TestRefreshLifetimeFor asserts the provider-aware refresh TTL switch.
+// OIDC and LDAP sessions get the shorter 1h cap so external-identity-store
+// revocation propagates within the hour rather than the 7-day standard
+// rotation window. Local sessions and any unknown provider fall through
+// to [RefreshTokenLifetime]. Audit finding P2-3 (2026-05-22) added LDAP
+// to the capped set; the OIDC cap pre-dates Phase 3.
 func TestRefreshLifetimeFor(t *testing.T) {
 	cases := []struct {
 		provider string
 		want     time.Duration
 	}{
 		{"oidc", OIDCRefreshTokenLifetime},
+		{"ldap", LDAPRefreshTokenLifetime},
 		{"local", RefreshTokenLifetime},
-		{"ldap", RefreshTokenLifetime},
+		{"unknown", RefreshTokenLifetime}, // default branch
 	}
 	for _, tc := range cases {
 		t.Run(tc.provider, func(t *testing.T) {

--- a/backend/internal/auth/ldap.go
+++ b/backend/internal/auth/ldap.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -15,6 +16,15 @@ import (
 	"github.com/go-ldap/ldap/v3"
 	"github.com/kubecenter/kubecenter/internal/config"
 )
+
+// ErrLDAPTransient wraps connection / timeout / unexpected server failures
+// during LDAP revalidation. Callers can branch on it to apply a bounded
+// grace window (reuse last-known identity) rather than logging every LDAP
+// user out the moment the directory has a brief hiccup. Definitive
+// rejections — user not found, account disabled, bad service-account
+// credentials — are NOT wrapped in this sentinel; they return
+// [ErrInvalidCredentials] and the caller must fail closed.
+var ErrLDAPTransient = errors.New("ldap transient failure")
 
 const (
 	ldapDialTimeout      = 5 * time.Second
@@ -298,6 +308,108 @@ func (p *LDAPProvider) mapToUser(entry *ldap.Entry, groups []string) *User {
 		KubernetesGroups:   k8sGroups,
 		Roles:              []string{"user"},
 	}
+}
+
+// ID returns the configured provider ID (e.g. "ldap-corp"). Used by the
+// refresh handler to look up the same provider instance the user
+// authenticated against when revalidating their identity.
+func (p *LDAPProvider) ID() string { return p.config.ID }
+
+// Revalidate re-authorizes a previously authenticated LDAP user without
+// re-prompting for their password. It binds as the service account,
+// searches for the user by DN, and returns a freshly mapped [*User] with
+// the directory's current group membership. The refresh handler calls
+// this on every refresh so that revoked identity (account disabled,
+// group removed) propagates within the LDAP refresh-token cap rather
+// than waiting for the cached session to expire — closes audit finding
+// P2-3 (2026-05-22).
+//
+// Error contract:
+//   - Returns [ErrInvalidCredentials] when the user is no longer present
+//     (search returned zero entries), the DN is malformed, or the entry
+//     set is ambiguous. The caller MUST fail closed on these — the user
+//     is genuinely gone from the directory.
+//   - Returns an error wrapping [ErrLDAPTransient] for connection,
+//     timeout, and unexpected-server errors. The caller MAY fall back to
+//     last-known identity within a bounded grace window to avoid
+//     evicting every active LDAP user during a brief directory outage.
+//
+// Inputs:
+//   - ctx: cancellation propagates to the LDAP operations via SetTimeout.
+//   - userDN: the user's distinguished name as captured at login time
+//     (the second-colon-separated segment of the session UserID).
+func (p *LDAPProvider) Revalidate(ctx context.Context, userDN string) (*User, error) {
+	if userDN == "" {
+		return nil, ErrInvalidCredentials
+	}
+
+	conn, err := p.connect()
+	if err != nil {
+		return nil, fmt.Errorf("%w: connect: %w", ErrLDAPTransient, err)
+	}
+	defer conn.Close()
+
+	// honor caller cancellation if it's already expired before any IO.
+	if cerr := ctx.Err(); cerr != nil {
+		return nil, fmt.Errorf("%w: %w", ErrLDAPTransient, cerr)
+	}
+
+	if berr := conn.Bind(p.config.BindDN, p.config.BindPassword); berr != nil {
+		// Service-account credentials breaking is a configuration problem,
+		// not a per-user signal. Classify as transient so an in-flight
+		// admin rotation doesn't take down every LDAP session at once;
+		// the operator still sees the failure in logs and the audit table.
+		return nil, fmt.Errorf("%w: service bind: %w", ErrLDAPTransient, berr)
+	}
+
+	searchReq := ldap.NewSearchRequest(
+		userDN,
+		ldap.ScopeBaseObject,
+		ldap.NeverDerefAliases,
+		2, // SizeLimit: expect exactly 1 entry; 2 surfaces ambiguity.
+		int(ldapOperationTimeout.Seconds()),
+		false,
+		"(objectClass=*)",
+		p.config.UserAttributes,
+		nil,
+	)
+
+	result, err := conn.Search(searchReq)
+	if err != nil {
+		return nil, classifyLDAPError(err)
+	}
+
+	switch len(result.Entries) {
+	case 0:
+		// Entry no longer exists — definitive rejection.
+		return nil, ErrInvalidCredentials
+	case 1:
+		// happy path; fall through.
+	default:
+		// Ambiguous identity — refuse to choose. Logged for the operator.
+		p.logger.Warn("LDAP revalidation found multiple entries", "dn", userDN, "count", len(result.Entries))
+		return nil, ErrInvalidCredentials
+	}
+
+	entry := result.Entries[0]
+	groups := p.getGroups(conn, entry, userDN)
+	return p.mapToUser(entry, groups), nil
+}
+
+// classifyLDAPError translates a go-ldap error into the public sentinel
+// the refresh handler branches on. NoSuchObject is the only LDAP result
+// code that means "user is gone from the directory"; everything else is
+// a connectivity or server-side hiccup that the caller should treat as
+// transient. This helper is unit-tested in isolation because the rest of
+// the LDAP code path requires a live directory.
+func classifyLDAPError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if ldap.IsErrorWithCode(err, ldap.LDAPResultNoSuchObject) {
+		return ErrInvalidCredentials
+	}
+	return fmt.Errorf("%w: %w", ErrLDAPTransient, err)
 }
 
 // extractCNFromDN extracts the CN value from a Distinguished Name.

--- a/backend/internal/auth/ldap.go
+++ b/backend/internal/auth/ldap.go
@@ -310,11 +310,6 @@ func (p *LDAPProvider) mapToUser(entry *ldap.Entry, groups []string) *User {
 	}
 }
 
-// ID returns the configured provider ID (e.g. "ldap-corp"). Used by the
-// refresh handler to look up the same provider instance the user
-// authenticated against when revalidating their identity.
-func (p *LDAPProvider) ID() string { return p.config.ID }
-
 // Revalidate re-authorizes a previously authenticated LDAP user without
 // re-prompting for their password. It binds as the service account,
 // searches for the user by DN, and returns a freshly mapped [*User] with
@@ -335,7 +330,13 @@ func (p *LDAPProvider) ID() string { return p.config.ID }
 //     evicting every active LDAP user during a brief directory outage.
 //
 // Inputs:
-//   - ctx: cancellation propagates to the LDAP operations via SetTimeout.
+//   - ctx: only checked once, after connect() and before Bind. The
+//     underlying ldap.Conn operations are bounded by
+//     [ldapOperationTimeout] (10s wall-clock deadline set via SetTimeout)
+//     but do NOT propagate ctx cancellation mid-call — a context canceled
+//     while Bind / Search is in flight is observed only after the LDAP
+//     op returns or the 10s deadline expires. Filed as a Phase 3
+//     follow-up; the current bound is acceptable for refresh latency.
 //   - userDN: the user's distinguished name as captured at login time
 //     (the second-colon-separated segment of the session UserID).
 func (p *LDAPProvider) Revalidate(ctx context.Context, userDN string) (*User, error) {

--- a/backend/internal/auth/ldap_test.go
+++ b/backend/internal/auth/ldap_test.go
@@ -76,16 +76,6 @@ func TestClassifyLDAPError(t *testing.T) {
 	}
 }
 
-// TestLDAPProvider_ID asserts the public accessor matches the config —
-// the refresh handler uses this to look up the right provider instance
-// from the registry when revalidating an LDAP user.
-func TestLDAPProvider_ID(t *testing.T) {
-	p := &LDAPProvider{config: LDAPProviderConfig{ID: "ldap-corp"}}
-	if got := p.ID(); got != "ldap-corp" {
-		t.Fatalf("ID() = %q, want %q", got, "ldap-corp")
-	}
-}
-
 // TestLDAPProvider_Revalidate_EmptyDN exercises the only Revalidate
 // branch that doesn't require a live LDAP server: an empty DN must
 // short-circuit to ErrInvalidCredentials before any IO. Anything else

--- a/backend/internal/auth/ldap_test.go
+++ b/backend/internal/auth/ldap_test.go
@@ -1,0 +1,98 @@
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/go-ldap/ldap/v3"
+)
+
+// TestClassifyLDAPError pins the error classification contract that
+// drives the refresh handler's fail-closed vs fail-open-with-grace
+// decision. The full LDAPProvider.Revalidate path requires a live
+// directory and is exercised in the homelab soak; the classifier itself
+// is pure logic and worth a regression test in isolation. Audit finding
+// P2-3 (2026-05-22) — see ldap.go for the security context.
+func TestClassifyLDAPError(t *testing.T) {
+	cases := []struct {
+		name    string
+		err     error
+		wantIs  error // sentinel the result should match via errors.Is
+		wantNil bool
+	}{
+		{
+			name:    "nil input maps to nil",
+			err:     nil,
+			wantNil: true,
+		},
+		{
+			name:   "NoSuchObject is a definitive rejection",
+			err:    ldap.NewError(ldap.LDAPResultNoSuchObject, errors.New("entry missing")),
+			wantIs: ErrInvalidCredentials,
+		},
+		{
+			name:   "InvalidCredentials from the directory is transient (service-account problem, not per-user)",
+			err:    ldap.NewError(ldap.LDAPResultInvalidCredentials, errors.New("bad bind")),
+			wantIs: ErrLDAPTransient,
+		},
+		{
+			name:   "ServerDown is transient",
+			err:    ldap.NewError(ldap.ErrorNetwork, errors.New("connection refused")),
+			wantIs: ErrLDAPTransient,
+		},
+		{
+			name:   "Operations error from the directory is transient",
+			err:    ldap.NewError(ldap.LDAPResultOperationsError, errors.New("internal")),
+			wantIs: ErrLDAPTransient,
+		},
+		{
+			name:   "Arbitrary non-ldap error is transient",
+			err:    errors.New("dial tcp: i/o timeout"),
+			wantIs: ErrLDAPTransient,
+		},
+		{
+			name:   "Wrapped LDAP NoSuchObject is still definitive",
+			err:    fmt.Errorf("search failed: %w", ldap.NewError(ldap.LDAPResultNoSuchObject, errors.New("gone"))),
+			wantIs: ErrInvalidCredentials,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyLDAPError(tc.err)
+			if tc.wantNil {
+				if got != nil {
+					t.Fatalf("expected nil, got %v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected error matching %v, got nil", tc.wantIs)
+			}
+			if !errors.Is(got, tc.wantIs) {
+				t.Fatalf("expected errors.Is(%v, %v) to be true", got, tc.wantIs)
+			}
+		})
+	}
+}
+
+// TestLDAPProvider_ID asserts the public accessor matches the config —
+// the refresh handler uses this to look up the right provider instance
+// from the registry when revalidating an LDAP user.
+func TestLDAPProvider_ID(t *testing.T) {
+	p := &LDAPProvider{config: LDAPProviderConfig{ID: "ldap-corp"}}
+	if got := p.ID(); got != "ldap-corp" {
+		t.Fatalf("ID() = %q, want %q", got, "ldap-corp")
+	}
+}
+
+// TestLDAPProvider_Revalidate_EmptyDN exercises the only Revalidate
+// branch that doesn't require a live LDAP server: an empty DN must
+// short-circuit to ErrInvalidCredentials before any IO. Anything else
+// would either depend on the directory or on a mock we don't have.
+func TestLDAPProvider_Revalidate_EmptyDN(t *testing.T) {
+	p := &LDAPProvider{config: LDAPProviderConfig{ID: "ldap-corp"}, logger: testLogger()}
+	if _, err := p.Revalidate(t.Context(), ""); !errors.Is(err, ErrInvalidCredentials) {
+		t.Fatalf("expected ErrInvalidCredentials for empty DN, got %v", err)
+	}
+}

--- a/backend/internal/auth/session.go
+++ b/backend/internal/auth/session.go
@@ -24,9 +24,20 @@ type RefreshSession struct {
 	UserID    string
 	Provider  string // auth provider that created this session
 	ExpiresAt time.Time
-	// CachedUser stores the full user for providers without a local store (OIDC).
-	// For local and LDAP providers, this is nil and the user is looked up by ID.
+	// CachedUser stores the full user for providers without a local store
+	// (OIDC, LDAP). For local users this is nil and lookups go through the
+	// provider registry. For LDAP users this is the last-known identity; on
+	// refresh the LDAPProvider.Revalidate path overwrites it with fresh
+	// group data unless LDAP is transiently unreachable.
 	CachedUser *User
+	// LastRevalidated is the timestamp of the most recent successful
+	// authorisation refresh against the external identity store. Set to
+	// login time at issuance; updated on each successful LDAP Revalidate.
+	// Used by the refresh handler to bound the LDAP-transient-outage
+	// grace window so a sustained LDAP outage cannot indefinitely extend
+	// access for a user whose identity was revoked while LDAP was down.
+	// Unused for local and OIDC providers (audit finding P2-3, 2026-05-22).
+	LastRevalidated time.Time
 }
 
 // SessionStore manages server-side refresh token storage.

--- a/backend/internal/auth/session.go
+++ b/backend/internal/auth/session.go
@@ -3,17 +3,20 @@ package auth
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 	"time"
 )
 
-// ErrSessionNotFound is returned by [SessionStore.Consume] when the
+// ErrSessionNotFound is returned by [SessionStore.Rotate] when the
 // referenced refresh token row no longer exists — either because a
-// concurrent caller already consumed it or because cleanup removed an
-// expired entry between Peek and Consume. Callers should treat this as
-// non-fatal: the rotation has effectively already happened.
+// concurrent caller already rotated it or because cleanup removed an
+// expired entry before this call landed.
 var ErrSessionNotFound = errors.New("session not found")
+
+// ErrSessionExpired is returned by [SessionStore.Rotate] when the
+// referenced token's ExpiresAt is in the past. The row is removed by
+// Rotate regardless (an expired token has no value going forward).
+var ErrSessionExpired = errors.New("session expired")
 
 // RefreshSession holds a refresh token and its associated user/expiry.
 type RefreshSession struct {
@@ -43,95 +46,55 @@ func (s *SessionStore) Store(session RefreshSession) {
 	s.sessions.Store(session.Token, session)
 }
 
-// ValidatedSession is the result of a successful refresh token validation.
-type ValidatedSession struct {
-	UserID     string
-	Provider   string
-	CachedUser *User // non-nil for OIDC users
-}
-
-// Validate checks if a refresh token is valid (exists and not expired).
-// If valid, it deletes the token (rotation — single use).
-// Returns the session data needed for token refresh.
+// Rotate atomically removes a refresh token from the store and returns its
+// session payload. This is the single-step primitive that backs refresh-
+// token rotation: callers receive the session and may then mint a successor
+// pair. Returns [ErrSessionNotFound] when the row is missing (concurrent
+// rotation winner, explicit Revoke, or cleanup eviction) and
+// [ErrSessionExpired] when the row existed but had expired (the row is
+// removed in both cases so it can't be replayed).
 //
-// Note: this is the legacy single-call API. Callers that can fail
-// between validation and consumption (e.g., the refresh handler, where
-// issueTokenPair may error after Validate succeeds) should use
-// [Peek] + [Consume] instead — see issue #274. Validate remains for
-// flows where the consumption is unconditional.
-func (s *SessionStore) Validate(token string) (*ValidatedSession, error) {
-	val, ok := s.sessions.Load(token)
+// Concurrency contract: Rotate uses sync.Map.LoadAndDelete, which is
+// atomic. Two concurrent Rotate calls for the same token therefore can
+// never both succeed — exactly one returns the session, every other
+// caller observes ErrSessionNotFound. This closes the race documented in
+// audit finding P2-2 (2026-05-22), where the legacy Peek+Consume split
+// allowed two callers to each mint a valid successor pair from a single
+// stolen refresh token.
+//
+// Failure handling: if the caller's post-rotate work (issueTokenPair,
+// LDAP revalidation, etc.) fails, call [Restore] with the returned
+// session to put it back so the client can retry. The returned
+// *RefreshSession is opaque metadata for that purpose; do not mutate it
+// between Rotate and Restore.
+func (s *SessionStore) Rotate(token string) (*RefreshSession, error) {
+	val, ok := s.sessions.LoadAndDelete(token)
 	if !ok {
-		return nil, fmt.Errorf("refresh token not found")
+		return nil, ErrSessionNotFound
 	}
-
 	session := val.(RefreshSession)
-
-	// Always delete — token is single-use regardless of validity
-	s.sessions.Delete(token)
-
 	if time.Now().After(session.ExpiresAt) {
-		return nil, fmt.Errorf("refresh token expired")
+		return nil, ErrSessionExpired
 	}
-
-	return &ValidatedSession{
-		UserID:     session.UserID,
-		Provider:   session.Provider,
-		CachedUser: session.CachedUser,
-	}, nil
+	return &session, nil
 }
 
-// Peek validates a refresh token WITHOUT consuming it. Returns the
-// session payload if the token exists and is not expired. Expired
-// tokens ARE deleted (no value in keeping them), but valid tokens
-// remain in the store — callers MUST follow up with [Consume] on
-// success to enforce single-use rotation.
+// Restore re-stores a session previously removed by [Rotate]. Used by the
+// refresh handler when the post-rotate work fails (transient signing
+// error, IdP revalidation timeout) — putting the session back lets the
+// client retry with the same refresh token rather than being silently
+// logged out. The intent matches the original issue #274 fix, but the
+// surrounding primitive is now atomic (no double-mint race).
 //
-// Issue #274 — separating Peek from Consume closes the race window
-// where [Validate] would delete a session BEFORE the caller had
-// successfully minted a replacement. If the post-Peek work (user
-// lookup, token minting) fails, the caller skips Consume and the
-// session remains valid for client retry. Without this split, a
-// transient backend failure between Validate and issueTokenPair
-// silently logs the user out.
-//
-// Concurrency: Peek + Consume is NOT atomic. Two callers can Peek the
-// same token simultaneously and both proceed. The first Consume wins;
-// the second returns [ErrSessionNotFound] (informational — the new
-// pair has already been minted in both branches).
-func (s *SessionStore) Peek(token string) (*ValidatedSession, error) {
-	val, ok := s.sessions.Load(token)
-	if !ok {
-		return nil, fmt.Errorf("refresh token not found")
+// Safe to call after Rotate succeeded. No-ops are intentional: if the
+// caller passes a stale or zero-value session, Store overwrites whatever
+// is there — and that pathological mis-use is already a programming
+// error the type system can't prevent.
+func (s *SessionStore) Restore(session *RefreshSession) {
+	if session == nil || session.Token == "" {
+		return
 	}
-
-	session := val.(RefreshSession)
-
-	if time.Now().After(session.ExpiresAt) {
-		// Expired — purge so it doesn't linger until the next cleanup
-		// tick. Mirrors Validate's behavior on expired tokens.
-		s.sessions.Delete(token)
-		return nil, fmt.Errorf("refresh token expired")
-	}
-
-	return &ValidatedSession{
-		UserID:     session.UserID,
-		Provider:   session.Provider,
-		CachedUser: session.CachedUser,
-	}, nil
-}
-
-// Consume atomically deletes a refresh token. Used by callers that have
-// finished the post-[Peek] work and need to enforce single-use
-// rotation. Returns [ErrSessionNotFound] if the row is already gone
-// (concurrent Peek+Consume race, cleanup race, or explicit Revoke);
-// callers should treat that as non-fatal — the rotation has effectively
-// already happened on the other path.
-func (s *SessionStore) Consume(token string) error {
-	if _, ok := s.sessions.LoadAndDelete(token); !ok {
-		return ErrSessionNotFound
-	}
-	return nil
+	s.sessions.Store(session.Token, *session)
 }
 
 // Revoke deletes a refresh token (e.g., on logout).
@@ -141,9 +104,9 @@ func (s *SessionStore) Revoke(token string) {
 
 // RangeSessions iterates stored sessions, invoking fn for each. fn returns
 // false to stop iteration. Exposed for tests that need to inspect stored
-// expiry values without consuming the token via Validate (which is single-
+// expiry values without consuming the token via Rotate (which is single-
 // use and would also strip the row). Production callers should prefer
-// Validate / Revoke.
+// Rotate / Revoke.
 func (s *SessionStore) RangeSessions(fn func(RefreshSession) bool) {
 	s.sessions.Range(func(_, val any) bool {
 		return fn(val.(RefreshSession))
@@ -172,3 +135,4 @@ func (s *SessionStore) StartCleanup(ctx context.Context, interval time.Duration)
 		}
 	}()
 }
+

--- a/backend/internal/auth/session_test.go
+++ b/backend/internal/auth/session_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-func TestSessionStore_StoreAndValidate(t *testing.T) {
+func TestSessionStore_StoreAndRotate(t *testing.T) {
 	store := NewSessionStore()
 
 	store.Store(RefreshSession{
@@ -17,12 +17,12 @@ func TestSessionStore_StoreAndValidate(t *testing.T) {
 		ExpiresAt: time.Now().Add(time.Hour),
 	})
 
-	result, err := store.Validate("token-abc")
+	session, err := store.Rotate("token-abc")
 	if err != nil {
-		t.Fatalf("Validate failed: %v", err)
+		t.Fatalf("Rotate failed: %v", err)
 	}
-	if result.UserID != "user-1" {
-		t.Errorf("expected user-1, got %s", result.UserID)
+	if session.UserID != "user-1" {
+		t.Errorf("expected user-1, got %s", session.UserID)
 	}
 }
 
@@ -36,15 +36,13 @@ func TestSessionStore_SingleUse(t *testing.T) {
 	})
 
 	// First use succeeds
-	_, err := store.Validate("token-abc")
-	if err != nil {
-		t.Fatalf("first Validate failed: %v", err)
+	if _, err := store.Rotate("token-abc"); err != nil {
+		t.Fatalf("first Rotate failed: %v", err)
 	}
 
-	// Second use fails (rotation)
-	_, err = store.Validate("token-abc")
-	if err == nil {
-		t.Fatal("expected error on second use of refresh token")
+	// Second use fails — the atomic LoadAndDelete already removed the row.
+	if _, err := store.Rotate("token-abc"); !errors.Is(err, ErrSessionNotFound) {
+		t.Fatalf("expected ErrSessionNotFound on second Rotate, got %v", err)
 	}
 }
 
@@ -57,18 +55,20 @@ func TestSessionStore_ExpiredToken(t *testing.T) {
 		ExpiresAt: time.Now().Add(-time.Hour),
 	})
 
-	_, err := store.Validate("expired-token")
-	if err == nil {
-		t.Fatal("expected error for expired token")
+	if _, err := store.Rotate("expired-token"); !errors.Is(err, ErrSessionExpired) {
+		t.Fatalf("expected ErrSessionExpired, got %v", err)
+	}
+	// Expired row should also be gone now.
+	if _, err := store.Rotate("expired-token"); !errors.Is(err, ErrSessionNotFound) {
+		t.Fatalf("expired token should have been deleted on first Rotate, got %v", err)
 	}
 }
 
 func TestSessionStore_UnknownToken(t *testing.T) {
 	store := NewSessionStore()
 
-	_, err := store.Validate("nonexistent")
-	if err == nil {
-		t.Fatal("expected error for unknown token")
+	if _, err := store.Rotate("nonexistent"); !errors.Is(err, ErrSessionNotFound) {
+		t.Fatalf("expected ErrSessionNotFound for unknown token, got %v", err)
 	}
 }
 
@@ -83,9 +83,8 @@ func TestSessionStore_Revoke(t *testing.T) {
 
 	store.Revoke("token-to-revoke")
 
-	_, err := store.Validate("token-to-revoke")
-	if err == nil {
-		t.Fatal("expected error after revocation")
+	if _, err := store.Rotate("token-to-revoke"); !errors.Is(err, ErrSessionNotFound) {
+		t.Fatalf("expected ErrSessionNotFound after Revoke, got %v", err)
 	}
 }
 
@@ -108,98 +107,31 @@ func TestSessionStore_CachedUser(t *testing.T) {
 		CachedUser: cachedUser,
 	})
 
-	result, err := store.Validate("oidc-token")
+	session, err := store.Rotate("oidc-token")
 	if err != nil {
-		t.Fatalf("Validate failed: %v", err)
+		t.Fatalf("Rotate failed: %v", err)
 	}
-	if result.CachedUser == nil {
+	if session.CachedUser == nil {
 		t.Fatal("expected CachedUser to be non-nil for OIDC session")
 	}
-	if result.CachedUser.Username != "alice@example.com" {
-		t.Errorf("CachedUser.Username = %q, want %q", result.CachedUser.Username, "alice@example.com")
+	if session.CachedUser.Username != "alice@example.com" {
+		t.Errorf("CachedUser.Username = %q, want %q", session.CachedUser.Username, "alice@example.com")
 	}
 }
 
 // ---------------------------------------------------------------------
-// Issue #274 — Peek / Consume split tests.
+// Audit finding P2-2 (2026-05-22) — atomic rotation tests.
 // ---------------------------------------------------------------------
 
-// TestSessionStore_Peek_DoesNotConsume — the core fix. Peek returns the
-// session WITHOUT deleting it, so a subsequent failure (token-mint, user
-// lookup, etc.) doesn't silently destroy the refresh credential.
-func TestSessionStore_Peek_DoesNotConsume(t *testing.T) {
-	store := NewSessionStore()
-	store.Store(RefreshSession{
-		Token:     "token-peek",
-		UserID:    "user-1",
-		ExpiresAt: time.Now().Add(time.Hour),
-	})
-
-	first, err := store.Peek("token-peek")
-	if err != nil {
-		t.Fatalf("first Peek failed: %v", err)
-	}
-	if first.UserID != "user-1" {
-		t.Errorf("first Peek UserID = %q, want %q", first.UserID, "user-1")
-	}
-
-	// Second Peek must still succeed — Peek is idempotent. Without this
-	// property, a transient post-Peek failure followed by a retry would
-	// surface as "refresh token not found" to the client.
-	second, err := store.Peek("token-peek")
-	if err != nil {
-		t.Fatalf("second Peek failed (expected idempotent): %v", err)
-	}
-	if second.UserID != "user-1" {
-		t.Errorf("second Peek UserID = %q, want %q", second.UserID, "user-1")
-	}
-}
-
-// TestSessionStore_Peek_ExpiredPurges — expired tokens get cleaned up
-// immediately, matching Validate's behavior. Surfaces as "token expired"
-// to the caller AND removes the row so it doesn't linger until the
-// background cleanup tick.
-func TestSessionStore_Peek_ExpiredPurges(t *testing.T) {
-	store := NewSessionStore()
-	store.Store(RefreshSession{
-		Token:     "token-expired",
-		UserID:    "user-1",
-		ExpiresAt: time.Now().Add(-time.Minute),
-	})
-
-	if _, err := store.Peek("token-expired"); err == nil {
-		t.Fatal("expected expired-token error from Peek")
-	}
-	// Should also be gone from the store now.
-	if _, err := store.Peek("token-expired"); err == nil {
-		t.Fatal("expired token should have been deleted on first Peek")
-	}
-}
-
-// TestSessionStore_Consume_DeletesOnce — Consume atomically removes the
-// row; a second Consume of the same token returns ErrSessionNotFound.
-func TestSessionStore_Consume_DeletesOnce(t *testing.T) {
-	store := NewSessionStore()
-	store.Store(RefreshSession{
-		Token:     "token-consume",
-		UserID:    "user-1",
-		ExpiresAt: time.Now().Add(time.Hour),
-	})
-
-	if err := store.Consume("token-consume"); err != nil {
-		t.Fatalf("first Consume failed: %v", err)
-	}
-	if err := store.Consume("token-consume"); !errors.Is(err, ErrSessionNotFound) {
-		t.Fatalf("second Consume: expected ErrSessionNotFound, got %v", err)
-	}
-}
-
-// TestSessionStore_Consume_RaceOnlyOneWins — the LoadAndDelete
-// underneath Consume is atomic per sync.Map, so concurrent Consume
-// calls for the same token are mutually exclusive. Pins this property
-// so a future refactor that splits the operation can't silently
-// reintroduce a double-consume bug.
-func TestSessionStore_Consume_RaceOnlyOneWins(t *testing.T) {
+// TestSessionStore_Rotate_RaceOnlyOneWins pins the property that backs the
+// P2-2 fix: N concurrent goroutines racing on the same token must observe
+// exactly one success. The legacy Peek+Consume split allowed all N
+// Peeks to succeed, which in handleRefresh would mint N successor pairs
+// from a single stolen refresh token. LoadAndDelete is atomic per
+// sync.Map, so this property holds — a future refactor that splits the
+// operation can't silently reintroduce a double-mint bug without failing
+// this test.
+func TestSessionStore_Rotate_RaceOnlyOneWins(t *testing.T) {
 	store := NewSessionStore()
 	store.Store(RefreshSession{
 		Token:     "token-race",
@@ -207,7 +139,7 @@ func TestSessionStore_Consume_RaceOnlyOneWins(t *testing.T) {
 		ExpiresAt: time.Now().Add(time.Hour),
 	})
 
-	const N = 32
+	const N = 64
 	var successes atomic.Int32
 	var wg sync.WaitGroup
 	start := make(chan struct{})
@@ -216,7 +148,7 @@ func TestSessionStore_Consume_RaceOnlyOneWins(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			<-start
-			if err := store.Consume("token-race"); err == nil {
+			if _, err := store.Rotate("token-race"); err == nil {
 				successes.Add(1)
 			}
 		}()
@@ -225,15 +157,61 @@ func TestSessionStore_Consume_RaceOnlyOneWins(t *testing.T) {
 	wg.Wait()
 
 	if got := successes.Load(); got != 1 {
-		t.Fatalf("expected exactly 1 successful Consume across %d goroutines, got %d", N, got)
+		t.Fatalf("expected exactly 1 successful Rotate across %d goroutines, got %d", N, got)
 	}
 }
 
-// TestSessionStore_PeekConsume_RefreshFailurePreservesSession — the
-// load-bearing integration test for #274. Simulates the handleRefresh
-// flow when post-Peek work fails: Peek succeeds, work fails, no Consume
-// → original token is still valid for client retry.
-func TestSessionStore_PeekConsume_RefreshFailurePreservesSession(t *testing.T) {
+// TestSessionStore_Rotate_RaceWithRevoke ensures Rotate and Revoke can't
+// both succeed on the same token. The combined race (one refresher +
+// one logout) must end with exactly one observable side effect: either
+// the refresh mints a successor (Rotate won) OR the session is gone
+// with no successor (Revoke won). The handler treats Rotate's
+// ErrSessionNotFound as "logged out by another path" — this test pins
+// that contract.
+func TestSessionStore_Rotate_RaceWithRevoke(t *testing.T) {
+	store := NewSessionStore()
+	store.Store(RefreshSession{
+		Token:     "token-revoke-race",
+		UserID:    "user-1",
+		ExpiresAt: time.Now().Add(time.Hour),
+	})
+
+	var rotateOK atomic.Bool
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		if _, err := store.Rotate("token-revoke-race"); err == nil {
+			rotateOK.Store(true)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		store.Revoke("token-revoke-race")
+	}()
+	close(start)
+	wg.Wait()
+
+	// Whatever happened, the token must be gone afterward.
+	if _, err := store.Rotate("token-revoke-race"); !errors.Is(err, ErrSessionNotFound) {
+		t.Fatalf("session should be removed after Rotate/Revoke race, got %v", err)
+	}
+	// rotateOK is informational — the test passes whether Rotate or
+	// Revoke won, so long as the post-race state is consistent (single
+	// observable removal).
+	t.Logf("Rotate won race: %v", rotateOK.Load())
+}
+
+// TestSessionStore_Rotate_FailurePreservesSession is the load-bearing
+// integration test for the issue #274 fix re-anchored on the new atomic
+// API: Rotate removes the session, then post-rotate work errors, then
+// Restore puts it back so the client can retry without being logged
+// out. Without Restore, a transient signing failure would silently
+// invalidate the user's refresh credential.
+func TestSessionStore_Rotate_FailurePreservesSession(t *testing.T) {
 	store := NewSessionStore()
 	store.Store(RefreshSession{
 		Token:     "token-survive",
@@ -241,35 +219,41 @@ func TestSessionStore_PeekConsume_RefreshFailurePreservesSession(t *testing.T) {
 		ExpiresAt: time.Now().Add(time.Hour),
 	})
 
-	// Pretend handleRefresh: Peek succeeds.
-	session, err := store.Peek("token-survive")
+	// Pretend handleRefresh: Rotate succeeds.
+	session, err := store.Rotate("token-survive")
 	if err != nil {
-		t.Fatalf("Peek failed: %v", err)
+		t.Fatalf("Rotate failed: %v", err)
 	}
 	if session.UserID != "user-1" {
-		t.Fatalf("Peek UserID = %q", session.UserID)
+		t.Fatalf("Rotate UserID = %q", session.UserID)
 	}
 
-	// Pretend issueTokenPair errors. handleRefresh returns 500 without
-	// calling Consume. The session must remain valid for retry.
-	// (We do not call Consume here.)
+	// Pretend issueTokenPair errors. handleRefresh calls Restore.
+	store.Restore(session)
 
-	// Client retries with the same refresh token. Peek must still
-	// succeed against the same row.
-	retry, err := store.Peek("token-survive")
+	// Client retries with the same refresh token. Rotate must still
+	// succeed against the restored row.
+	retry, err := store.Rotate("token-survive")
 	if err != nil {
-		t.Fatalf("retry Peek failed (regression of #274): %v", err)
+		t.Fatalf("retry Rotate after Restore failed: %v", err)
 	}
 	if retry.UserID != "user-1" {
 		t.Fatalf("retry UserID = %q", retry.UserID)
 	}
 
-	// Now the retry succeeds at issueTokenPair time. handleRefresh
-	// calls Consume; the original token is finally removed.
-	if err := store.Consume("token-survive"); err != nil {
-		t.Fatalf("Consume on successful retry failed: %v", err)
+	// The session is gone after the successful retry — no second Restore call.
+	if _, err := store.Rotate("token-survive"); !errors.Is(err, ErrSessionNotFound) {
+		t.Fatalf("after successful retry, token should be unusable, got %v", err)
 	}
-	if _, err := store.Peek("token-survive"); err == nil {
-		t.Fatal("after Consume, token should be unusable")
-	}
+}
+
+// TestSessionStore_Restore_NilSafe — Restore must tolerate a nil pointer
+// (defensive: a handler that branches on error might call Restore on a
+// nil session by mistake; the type system can't prevent it). Zero-token
+// is treated as "nothing to restore" — silent no-op.
+func TestSessionStore_Restore_NilSafe(t *testing.T) {
+	store := NewSessionStore()
+	store.Restore(nil)
+	store.Restore(&RefreshSession{}) // empty Token
+	// No assertion needed — the test passes if neither call panics.
 }

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -99,6 +99,17 @@ type ServerConfig struct {
 	TLSKey          string        `koanf:"tlskey"`
 	ShutdownTimeout time.Duration `koanf:"shutdowntimeout"`
 	RequestTimeout  time.Duration `koanf:"requesttimeout"`
+	// TrustedProxyCIDRs lists IPv4 / IPv6 CIDR blocks whose socket peers
+	// are trusted to set X-Forwarded-For / X-Real-IP headers. The
+	// TrustedProxy middleware rewrites r.RemoteAddr from those headers
+	// ONLY when the request's TCP peer falls inside one of these blocks;
+	// otherwise the forwarded headers are ignored and r.RemoteAddr stays
+	// at the socket-peer address. Default empty = fail-closed (no proxies
+	// trusted) so rate-limit buckets cannot be poisoned by spoofed
+	// headers from direct LAN/internet attackers (audit finding P2-1,
+	// 2026-05-22). Configure via KUBECENTER_SERVER_TRUSTEDPROXYCIDRS as
+	// a comma-separated list, e.g. "10.0.0.0/8,fd00::/8".
+	TrustedProxyCIDRs []string `koanf:"trustedproxycidrs"`
 }
 
 type LogConfig struct {

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -107,8 +107,20 @@ type ServerConfig struct {
 	// at the socket-peer address. Default empty = fail-closed (no proxies
 	// trusted) so rate-limit buckets cannot be poisoned by spoofed
 	// headers from direct LAN/internet attackers (audit finding P2-1,
-	// 2026-05-22). Configure via KUBECENTER_SERVER_TRUSTEDPROXYCIDRS as
-	// a comma-separated list, e.g. "10.0.0.0/8,fd00::/8".
+	// 2026-05-22).
+	//
+	// Configure via KUBECENTER_SERVER_TRUSTEDPROXYCIDRS as a
+	// comma-separated list. Narrow the trust set to the ingress
+	// controller's exact pod or service CIDR — e.g. a single
+	// nginx-ingress pod /32 like "10.42.5.17/32", or the load-
+	// balancer's source range. AVOID broad ranges that include the
+	// full Kubernetes pod CIDR (typically 10.0.0.0/8 or 10.42.0.0/16);
+	// in those configurations any pod in the cluster can spoof
+	// X-Forwarded-For to poison rate-limit buckets and pollute audit
+	// SourceIP fields. The middleware emits a startup warning on /0
+	// catch-all CIDRs that reinstate the pre-Phase-3 blanket-trust
+	// behaviour, but narrower mis-scoping (e.g. /8) is silent — operator
+	// must scope this correctly per deployment.
 	TrustedProxyCIDRs []string `koanf:"trustedproxycidrs"`
 }
 

--- a/backend/internal/server/handle_auth.go
+++ b/backend/internal/server/handle_auth.go
@@ -3,7 +3,9 @@ package server
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -13,6 +15,38 @@ import (
 	"github.com/kubecenter/kubecenter/pkg/api"
 	"k8s.io/apimachinery/pkg/labels"
 )
+
+// accountThrottle applies a per-username rate-limit bucket on the
+// supplied RateLimiter against the namespaced key "<purpose>:<user>".
+// Username is case-folded so "Admin" / "admin" / "ADMIN" share one
+// bucket — without this an attacker could rotate case to multiply the
+// per-account budget. On rate-limit hit emits an [audit.ActionRateLimited]
+// entry and writes a 429 with Retry-After; returns true so the caller
+// can early-return. Successful login does NOT reset the bucket, so an
+// attacker can't mix valid creds with brute-force attempts to extend
+// the budget. Audit finding P2-1 part 2 (2026-05-22).
+func (s *Server) accountThrottle(w http.ResponseWriter, r *http.Request, purpose, username string, action audit.Action) bool {
+	if username == "" {
+		return false
+	}
+	key := purpose + ":" + strings.ToLower(username)
+	allowed, retry := s.RateLimiter.CheckKey(key)
+	if allowed {
+		return false
+	}
+	entry := s.newAuditEntry(r, username, audit.ActionRateLimited, audit.ResultDenied)
+	entry.Detail = fmt.Sprintf("%s account throttle: %s (retry %ds)", purpose, action, retry)
+	s.AuditLogger.Log(r.Context(), entry)
+	w.Header().Set("Retry-After", strconv.Itoa(retry))
+	writeJSON(w, http.StatusTooManyRequests, api.Response{
+		Error: &api.APIError{
+			Code:    429,
+			Message: "too many attempts",
+			Detail:  fmt.Sprintf("try again in %d seconds", retry),
+		},
+	})
+	return true
+}
 
 // ldapGracePeriod bounds how long after the last successful LDAP
 // revalidation the refresh handler will fall back to cached identity
@@ -47,6 +81,13 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, api.Response{
 			Error: &api.APIError{Code: 400, Message: "invalid credentials"},
 		})
+		return
+	}
+
+	// Per-account throttle BEFORE provider lookup so an attacker who
+	// already knows the rate-limit budget can't multiply it by varying
+	// the provider field. Audit finding P2-1 part 2 (2026-05-22).
+	if s.accountThrottle(w, r, "login", creds.Username, audit.ActionLogin) {
 		return
 	}
 

--- a/backend/internal/server/handle_auth.go
+++ b/backend/internal/server/handle_auth.go
@@ -2,7 +2,10 @@ package server
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
+	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/kubecenter/kubecenter/internal/audit"
@@ -10,6 +13,15 @@ import (
 	"github.com/kubecenter/kubecenter/pkg/api"
 	"k8s.io/apimachinery/pkg/labels"
 )
+
+// ldapGracePeriod bounds how long after the last successful LDAP
+// revalidation the refresh handler will fall back to cached identity
+// during a transient LDAP outage. A 5-minute window is short enough
+// that a sustained outage cannot indefinitely extend access for a
+// user whose identity was revoked in the directory, but long enough
+// that brief LDAP server flips don't evict every active session at
+// once. Audit finding P2-3 (2026-05-22).
+const ldapGracePeriod = 5 * time.Minute
 
 // handleLogin authenticates a user via credential-based providers (local, LDAP).
 // The optional "provider" field in the request body selects which provider to use (default: "local").
@@ -130,29 +142,51 @@ func (s *Server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// For OIDC users, use the cached user data from the session (no local store).
-	// For local/LDAP users, look up by ID from the provider registry.
-	var user *auth.User
-	if session.CachedUser != nil {
-		user = session.CachedUser
-	} else {
-		user, err = s.AuthRegistry.GetUserByID(session.Provider, session.UserID)
-		if err != nil {
-			// User no longer exists — the session is genuinely stale.
-			// Rotate already removed the row, so subsequent refreshes
-			// with the same token will return 401 (not-found) without
-			// re-running this dead lookup. No Restore.
-			writeJSON(w, http.StatusUnauthorized, api.Response{
-				Error: &api.APIError{Code: 401, Message: "user not found"},
-			})
+	// Resolve the User. LDAP sessions revalidate against the directory
+	// on every refresh (audit P2-3); OIDC sessions reuse the cached user
+	// (their 1h cap propagates IdP revocation); local sessions look up
+	// the live row from the in-memory store.
+	var (
+		user            *auth.User
+		lastRevalidated = time.Now() // refreshed identity → new high-water mark
+	)
+	switch session.Provider {
+	case "ldap":
+		var rerr error
+		user, lastRevalidated, rerr = s.revalidateLDAPSession(w, r, session)
+		if rerr != nil {
+			// revalidateLDAPSession has already written the response and
+			// emitted the audit entry. The session is NOT restored —
+			// either the user is gone (definitive) or the grace window
+			// is exhausted (transient outside grace). In both cases
+			// re-using the same refresh token would just re-fail.
 			return
+		}
+	default:
+		if session.CachedUser != nil {
+			user = session.CachedUser
+		} else {
+			user, err = s.AuthRegistry.GetUserByID(session.Provider, session.UserID)
+			if err != nil {
+				// User no longer exists — the session is genuinely stale.
+				// Rotate already removed the row, so subsequent refreshes
+				// with the same token will return 401 (not-found) without
+				// re-running this dead lookup. No Restore.
+				writeJSON(w, http.StatusUnauthorized, api.Response{
+					Error: &api.APIError{Code: 401, Message: "user not found"},
+				})
+				return
+			}
 		}
 	}
 
 	// In body-mode (mobile) we skip setting the cookie — the new refresh
 	// token is echoed in the JSON response. In cookie-mode (web) we keep
-	// the existing httpOnly cookie behaviour.
-	accessToken, newRefreshToken, err := s.issueTokenPair(w, user, !bodyMode)
+	// the existing httpOnly cookie behaviour. The LDAP grace fallback
+	// path preserves the original LastRevalidated timestamp so a
+	// sustained outage cannot extend revoked-user access beyond the
+	// 5-minute grace window.
+	accessToken, newRefreshToken, err := s.issueTokenPairAt(w, user, !bodyMode, lastRevalidated)
 	if err != nil {
 		// Token mint failed — Restore the original session so the
 		// client can retry. The new sentinel uses the original
@@ -181,6 +215,119 @@ func (s *Server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 		respData["refreshExpiresIn"] = int(auth.RefreshLifetimeFor(user.Provider).Seconds())
 	}
 	writeJSON(w, http.StatusOK, api.Response{Data: respData})
+}
+
+// revalidateLDAPSession re-authorises an LDAP user against the directory
+// during a token refresh. On success returns the freshly mapped user and
+// a fresh LastRevalidated timestamp. On failure writes the 401 response,
+// emits the audit entry, and returns a non-nil error so the caller can
+// abort without retrying.
+//
+// Failure modes:
+//   - Malformed UserID (not "ldap:<providerID>:<DN>"), unknown provider
+//     ID, registered provider is not an LDAPProvider: definitive 401 (the
+//     session metadata is broken; re-login is the only path forward).
+//   - Definitive Revalidate rejection (user gone, ambiguous, malformed
+//     DN): definitive 401, audit logged.
+//   - Transient Revalidate error AND last successful revalidation is
+//     within the [ldapGracePeriod] window: fall back to the session's
+//     last-known CachedUser, log a warning, audit success-with-grace.
+//     The returned LastRevalidated preserves the original timestamp so
+//     subsequent refreshes during a sustained outage observe an
+//     ever-shrinking grace window rather than restarting it on every
+//     refresh.
+//   - Transient Revalidate error OUTSIDE the grace window OR with no
+//     prior CachedUser: definitive 401, audit logged.
+//
+// Audit finding P2-3 (2026-05-22).
+func (s *Server) revalidateLDAPSession(w http.ResponseWriter, r *http.Request, session *auth.RefreshSession) (*auth.User, time.Time, error) {
+	// UserID format from ldap.go mapToUser: "ldap:<providerID>:<DN>".
+	// DN may contain colons in attribute values, so split into exactly 3.
+	parts := strings.SplitN(session.UserID, ":", 3)
+	if len(parts) != 3 || parts[0] != "ldap" || parts[1] == "" || parts[2] == "" {
+		s.Logger.Error("malformed LDAP session userID", "userID", session.UserID)
+		s.writeLDAPRefreshFailure(w, r, "", "malformed session", "session invalid")
+		return nil, time.Time{}, errors.New("malformed LDAP session userID")
+	}
+	providerID, userDN := parts[1], parts[2]
+
+	provider, ok := s.AuthRegistry.GetCredential(providerID)
+	if !ok {
+		s.Logger.Error("LDAP provider not found for refresh", "providerID", providerID)
+		s.writeLDAPRefreshFailure(w, r, providerID, "provider not registered", "auth provider unavailable")
+		return nil, time.Time{}, errors.New("LDAP provider not registered")
+	}
+	ldapProvider, ok := provider.(*auth.LDAPProvider)
+	if !ok {
+		s.Logger.Error("registered provider is not LDAP", "providerID", providerID, "type", provider.Type())
+		s.writeLDAPRefreshFailure(w, r, providerID, "provider type mismatch", "session invalid")
+		return nil, time.Time{}, errors.New("provider type mismatch")
+	}
+
+	user, err := ldapProvider.Revalidate(r.Context(), userDN)
+	switch {
+	case err == nil:
+		// Fresh identity — adopt the revalidated groups and stamp a new
+		// high-water mark on the successor session.
+		return user, time.Now(), nil
+
+	case errors.Is(err, auth.ErrLDAPTransient):
+		// Bounded grace: allow last-known identity only if the most
+		// recent successful revalidation is within ldapGracePeriod.
+		// session.LastRevalidated is preserved on the successor session
+		// (see issueTokenPairAt call site) so the grace window shrinks
+		// on each refresh during a sustained outage rather than
+		// resetting.
+		if session.CachedUser == nil || session.LastRevalidated.IsZero() ||
+			time.Since(session.LastRevalidated) > ldapGracePeriod {
+			s.Logger.Warn("LDAP revalidation transient — outside grace window, failing closed",
+				"providerID", providerID, "err", err,
+				"lastRevalidated", session.LastRevalidated)
+			s.writeLDAPRefreshFailure(w, r, providerID,
+				"LDAP unavailable outside grace window",
+				"ldap unavailable, please re-authenticate")
+			return nil, time.Time{}, err
+		}
+		s.Logger.Warn("LDAP revalidation transient — reusing cached identity within grace window",
+			"providerID", providerID, "err", err,
+			"lastRevalidated", session.LastRevalidated)
+		// Audit-log the grace-fallback so an operator scanning for LDAP
+		// outages or extended cached-identity reuse has a signal to
+		// correlate against. Result is Success — the refresh did
+		// succeed — with a Detail flagging the grace mechanism.
+		entry := s.newAuditEntry(r, session.CachedUser.Username, audit.ActionRefresh, audit.ResultSuccess)
+		entry.Detail = "LDAP revalidation transient — grace-window fallback"
+		s.AuditLogger.Log(r.Context(), entry)
+		// Preserve the original LastRevalidated so successor sessions
+		// keep shrinking the grace window, not resetting it.
+		return session.CachedUser, session.LastRevalidated, nil
+
+	default:
+		// Definitive rejection — user genuinely gone from the directory.
+		username := ""
+		if session.CachedUser != nil {
+			username = session.CachedUser.Username
+		}
+		s.Logger.Info("LDAP revalidation rejected user", "providerID", providerID, "user", username, "err", err)
+		s.writeLDAPRefreshFailure(w, r, providerID, "user no longer authorised", "user no longer authorised")
+		return nil, time.Time{}, err
+	}
+}
+
+// writeLDAPRefreshFailure centralises the 401 + audit emit for the
+// failure branches of revalidateLDAPSession so the caller can keep its
+// switch statement focused on the control flow.
+func (s *Server) writeLDAPRefreshFailure(w http.ResponseWriter, r *http.Request, providerID, detail, userMessage string) {
+	entry := s.newAuditEntry(r, "", audit.ActionRefresh, audit.ResultFailure)
+	if providerID != "" {
+		entry.Detail = "LDAP " + providerID + ": " + detail
+	} else {
+		entry.Detail = "LDAP refresh: " + detail
+	}
+	s.AuditLogger.Log(r.Context(), entry)
+	writeJSON(w, http.StatusUnauthorized, api.Response{
+		Error: &api.APIError{Code: 401, Message: userMessage},
+	})
 }
 
 // handleLogout invalidates the user's refresh token.

--- a/backend/internal/server/handle_auth.go
+++ b/backend/internal/server/handle_auth.go
@@ -111,11 +111,15 @@ func (s *Server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 		bodyMode = true
 	}
 
-	// Issue #274 — Peek validates the session without deleting it. We
-	// only Consume the session AFTER issueTokenPair succeeds, so a
-	// transient signing or RNG failure no longer silently logs the
-	// user out (their original refresh token remains valid for retry).
-	session, err := s.Sessions.Peek(refreshTokenIn)
+	// Audit finding P2-2 (2026-05-22) — Rotate atomically removes the
+	// session in a single sync.Map.LoadAndDelete. Two concurrent
+	// refreshers can therefore never both mint a successor pair; the
+	// loser observes ErrSessionNotFound and is rejected. If post-rotate
+	// work (issueTokenPair, user lookup) fails for the winner, we
+	// Restore the session so the client can retry with the same refresh
+	// token rather than being silently logged out by a transient
+	// failure (issue #274's original intent, now race-free).
+	session, err := s.Sessions.Rotate(refreshTokenIn)
 	if err != nil {
 		entry := s.newAuditEntry(r, "", audit.ActionRefresh, audit.ResultFailure)
 		entry.Detail = "invalid or expired refresh token"
@@ -134,13 +138,10 @@ func (s *Server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 	} else {
 		user, err = s.AuthRegistry.GetUserByID(session.Provider, session.UserID)
 		if err != nil {
-			// User no longer exists — the session is stale. Consume
-			// it now so subsequent refreshes with the same token return
-			// 401 (refresh-token-not-found) instead of repeatedly
-			// hitting the same dead user lookup.
-			if cerr := s.Sessions.Consume(refreshTokenIn); cerr != nil && cerr != auth.ErrSessionNotFound {
-				s.Logger.Warn("failed to consume stale session", "error", cerr)
-			}
+			// User no longer exists — the session is genuinely stale.
+			// Rotate already removed the row, so subsequent refreshes
+			// with the same token will return 401 (not-found) without
+			// re-running this dead lookup. No Restore.
 			writeJSON(w, http.StatusUnauthorized, api.Response{
 				Error: &api.APIError{Code: 401, Message: "user not found"},
 			})
@@ -153,26 +154,15 @@ func (s *Server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 	// the existing httpOnly cookie behaviour.
 	accessToken, newRefreshToken, err := s.issueTokenPair(w, user, !bodyMode)
 	if err != nil {
-		// Token mint failed; preserve the session by NOT calling Consume.
-		// The client can retry with the same refresh token. Issue #274.
+		// Token mint failed — Restore the original session so the
+		// client can retry. The new sentinel uses the original
+		// ExpiresAt, so retry windows shrink correctly over time.
+		s.Sessions.Restore(session)
 		s.Logger.Error("failed to issue tokens", "error", err)
 		writeJSON(w, http.StatusInternalServerError, api.Response{
 			Error: &api.APIError{Code: 500, Message: "failed to issue token"},
 		})
 		return
-	}
-
-	// Token pair successfully minted — consume the original session so
-	// it cannot be replayed. ErrSessionNotFound here means a concurrent
-	// refresh consumed it first; both clients have valid new pairs, so
-	// the rotation is effectively complete either way. Log for
-	// diagnostics but don't fail the response.
-	if cerr := s.Sessions.Consume(refreshTokenIn); cerr != nil {
-		if cerr == auth.ErrSessionNotFound {
-			s.Logger.Debug("refresh consume race — session already gone", "user", user.Username)
-		} else {
-			s.Logger.Warn("refresh consume failed", "error", cerr, "user", user.Username)
-		}
 	}
 
 	s.AuditLogger.Log(r.Context(), s.newAuditEntry(r, user.Username, audit.ActionRefresh, audit.ResultSuccess))

--- a/backend/internal/server/handle_auth.go
+++ b/backend/internal/server/handle_auth.go
@@ -155,6 +155,9 @@ func (s *Server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 		}
 		r.Body = http.MaxBytesReader(w, r.Body, maxAuthBodySize)
 		if jerr := json.NewDecoder(r.Body).Decode(&body); jerr != nil || body.RefreshToken == "" {
+			entry := s.newAuditEntry(r, "", audit.ActionRefresh, audit.ResultFailure)
+			entry.Detail = "missing or malformed refresh token (body mode)"
+			s.AuditLogger.Log(r.Context(), entry)
 			writeJSON(w, http.StatusUnauthorized, api.Response{
 				Error: &api.APIError{Code: 401, Message: "missing refresh token"},
 			})
@@ -190,17 +193,19 @@ func (s *Server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 	var (
 		user            *auth.User
 		lastRevalidated = time.Now() // refreshed identity → new high-water mark
+		auditDetail     string       // non-empty signals a non-standard success (e.g. LDAP grace fallback) to the final audit emit
 	)
 	switch session.Provider {
 	case "ldap":
 		var rerr error
-		user, lastRevalidated, rerr = s.revalidateLDAPSession(w, r, session)
+		user, lastRevalidated, auditDetail, rerr = s.revalidateLDAPSession(w, r, session)
 		if rerr != nil {
-			// revalidateLDAPSession has already written the response and
-			// emitted the audit entry. The session is NOT restored —
-			// either the user is gone (definitive) or the grace window
-			// is exhausted (transient outside grace). In both cases
-			// re-using the same refresh token would just re-fail.
+			// revalidateLDAPSession already wrote the 401 + emitted the
+			// audit entry. Whether the session was Restored depends on
+			// the branch: transient-outside-grace Restores so the client
+			// can retry once LDAP comes back; definitive rejections do
+			// NOT Restore (the user is genuinely gone or the metadata
+			// is broken — retrying the same token can never succeed).
 			return
 		}
 	default:
@@ -213,6 +218,9 @@ func (s *Server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 				// Rotate already removed the row, so subsequent refreshes
 				// with the same token will return 401 (not-found) without
 				// re-running this dead lookup. No Restore.
+				entry := s.newAuditEntry(r, "", audit.ActionRefresh, audit.ResultFailure)
+				entry.Detail = "user no longer present for provider " + session.Provider
+				s.AuditLogger.Log(r.Context(), entry)
 				writeJSON(w, http.StatusUnauthorized, api.Response{
 					Error: &api.APIError{Code: 401, Message: "user not found"},
 				})
@@ -234,13 +242,20 @@ func (s *Server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 		// ExpiresAt, so retry windows shrink correctly over time.
 		s.Sessions.Restore(session)
 		s.Logger.Error("failed to issue tokens", "error", err)
+		failEntry := s.newAuditEntry(r, user.Username, audit.ActionRefresh, audit.ResultFailure)
+		failEntry.Detail = "issueTokenPair failed; session restored for client retry"
+		s.AuditLogger.Log(r.Context(), failEntry)
 		writeJSON(w, http.StatusInternalServerError, api.Response{
 			Error: &api.APIError{Code: 500, Message: "failed to issue token"},
 		})
 		return
 	}
 
-	s.AuditLogger.Log(r.Context(), s.newAuditEntry(r, user.Username, audit.ActionRefresh, audit.ResultSuccess))
+	successEntry := s.newAuditEntry(r, user.Username, audit.ActionRefresh, audit.ResultSuccess)
+	if auditDetail != "" {
+		successEntry.Detail = auditDetail
+	}
+	s.AuditLogger.Log(r.Context(), successEntry)
 
 	respData := map[string]any{
 		"accessToken": accessToken,
@@ -259,50 +274,69 @@ func (s *Server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 }
 
 // revalidateLDAPSession re-authorises an LDAP user against the directory
-// during a token refresh. On success returns the freshly mapped user and
-// a fresh LastRevalidated timestamp. On failure writes the 401 response,
-// emits the audit entry, and returns a non-nil error so the caller can
-// abort without retrying.
+// during a token refresh. On success returns the freshly mapped user, a
+// fresh LastRevalidated timestamp, and an optional audit detail string
+// (non-empty only on grace-window fallback). On failure writes the 401
+// response, emits the audit entry, and returns a non-nil error so the
+// caller can abort without retrying.
 //
-// Failure modes:
-//   - Malformed UserID (not "ldap:<providerID>:<DN>"), unknown provider
-//     ID, registered provider is not an LDAPProvider: definitive 401 (the
-//     session metadata is broken; re-login is the only path forward).
+// Failure modes and Restore behaviour:
+//   - Malformed UserID, unknown provider ID, type mismatch: definitive
+//     401, NO Restore (session metadata is broken; re-login is the only
+//     path forward).
 //   - Definitive Revalidate rejection (user gone, ambiguous, malformed
-//     DN): definitive 401, audit logged.
-//   - Transient Revalidate error AND last successful revalidation is
-//     within the [ldapGracePeriod] window: fall back to the session's
-//     last-known CachedUser, log a warning, audit success-with-grace.
-//     The returned LastRevalidated preserves the original timestamp so
-//     subsequent refreshes during a sustained outage observe an
-//     ever-shrinking grace window rather than restarting it on every
-//     refresh.
-//   - Transient Revalidate error OUTSIDE the grace window OR with no
-//     prior CachedUser: definitive 401, audit logged.
+//     DN): definitive 401, NO Restore (user is genuinely gone from the
+//     directory).
+//   - Transient Revalidate error WITHIN grace window AND with prior
+//     CachedUser: fall back to last-known identity, audit-flag the
+//     grace event via the auditDetail return so the caller's single
+//     final audit emit carries the grace context. Preserves the
+//     original LastRevalidated on the successor session so subsequent
+//     refreshes during a sustained outage observe an ever-shrinking
+//     grace window rather than restarting it on every refresh.
+//   - Transient Revalidate error OUTSIDE the grace window: 401 + Restore.
+//     The outage is transient by classification; the client should be
+//     able to retry once LDAP recovers rather than being forced to
+//     re-authenticate. The restored session's LastRevalidated stays
+//     stale, so retries during continued outage keep hitting this
+//     branch (correct behaviour).
 //
-// Audit finding P2-3 (2026-05-22).
-func (s *Server) revalidateLDAPSession(w http.ResponseWriter, r *http.Request, session *auth.RefreshSession) (*auth.User, time.Time, error) {
+// Audit finding P2-3 (2026-05-22). Returned auditDetail also closes
+// the double-emit bug surfaced by the Phase 3 review: previously this
+// helper emitted a Success+grace audit entry inline AND the caller's
+// final success emit ALSO fired, producing two rows per refresh.
+func (s *Server) revalidateLDAPSession(w http.ResponseWriter, r *http.Request, session *auth.RefreshSession) (*auth.User, time.Time, string, error) {
 	// UserID format from ldap.go mapToUser: "ldap:<providerID>:<DN>".
 	// DN may contain colons in attribute values, so split into exactly 3.
 	parts := strings.SplitN(session.UserID, ":", 3)
 	if len(parts) != 3 || parts[0] != "ldap" || parts[1] == "" || parts[2] == "" {
 		s.Logger.Error("malformed LDAP session userID", "userID", session.UserID)
-		s.writeLDAPRefreshFailure(w, r, "", "malformed session", "session invalid")
-		return nil, time.Time{}, errors.New("malformed LDAP session userID")
+		s.writeLDAPRefreshFailure(w, r, "", "", "malformed session", "session invalid")
+		return nil, time.Time{}, "", errors.New("malformed LDAP session userID")
 	}
 	providerID, userDN := parts[1], parts[2]
+
+	// Username for audit attribution — pulled from CachedUser when
+	// available so failure rows in the audit table link to the actual
+	// account rather than the empty string. Earlier code passed "" on
+	// every LDAP refresh-failure branch, breaking "who got kicked out
+	// when LDAP came back" queries.
+	username := ""
+	if session.CachedUser != nil {
+		username = session.CachedUser.Username
+	}
 
 	provider, ok := s.AuthRegistry.GetCredential(providerID)
 	if !ok {
 		s.Logger.Error("LDAP provider not found for refresh", "providerID", providerID)
-		s.writeLDAPRefreshFailure(w, r, providerID, "provider not registered", "auth provider unavailable")
-		return nil, time.Time{}, errors.New("LDAP provider not registered")
+		s.writeLDAPRefreshFailure(w, r, username, providerID, "provider not registered", "auth provider unavailable")
+		return nil, time.Time{}, "", errors.New("LDAP provider not registered")
 	}
 	ldapProvider, ok := provider.(*auth.LDAPProvider)
 	if !ok {
 		s.Logger.Error("registered provider is not LDAP", "providerID", providerID, "type", provider.Type())
-		s.writeLDAPRefreshFailure(w, r, providerID, "provider type mismatch", "session invalid")
-		return nil, time.Time{}, errors.New("provider type mismatch")
+		s.writeLDAPRefreshFailure(w, r, username, providerID, "provider type mismatch", "session invalid")
+		return nil, time.Time{}, "", errors.New("provider type mismatch")
 	}
 
 	user, err := ldapProvider.Revalidate(r.Context(), userDN)
@@ -310,7 +344,7 @@ func (s *Server) revalidateLDAPSession(w http.ResponseWriter, r *http.Request, s
 	case err == nil:
 		// Fresh identity — adopt the revalidated groups and stamp a new
 		// high-water mark on the successor session.
-		return user, time.Now(), nil
+		return user, time.Now(), "", nil
 
 	case errors.Is(err, auth.ErrLDAPTransient):
 		// Bounded grace: allow last-known identity only if the most
@@ -321,45 +355,47 @@ func (s *Server) revalidateLDAPSession(w http.ResponseWriter, r *http.Request, s
 		// resetting.
 		if session.CachedUser == nil || session.LastRevalidated.IsZero() ||
 			time.Since(session.LastRevalidated) > ldapGracePeriod {
-			s.Logger.Warn("LDAP revalidation transient — outside grace window, failing closed",
+			s.Logger.Warn("LDAP revalidation transient — outside grace window, restoring session for retry",
 				"providerID", providerID, "err", err,
 				"lastRevalidated", session.LastRevalidated)
-			s.writeLDAPRefreshFailure(w, r, providerID,
+			// Restore the original session: the outage is transient by
+			// classification, so the client should be able to retry
+			// once LDAP recovers. Without Restore the client would be
+			// forced to re-authenticate even though no identity change
+			// happened. The stale LastRevalidated stays put, so retries
+			// during the same outage keep failing through this branch.
+			s.Sessions.Restore(session)
+			s.writeLDAPRefreshFailure(w, r, username, providerID,
 				"LDAP unavailable outside grace window",
-				"ldap unavailable, please re-authenticate")
-			return nil, time.Time{}, err
+				"ldap unavailable, please retry")
+			return nil, time.Time{}, "", err
 		}
 		s.Logger.Warn("LDAP revalidation transient — reusing cached identity within grace window",
 			"providerID", providerID, "err", err,
 			"lastRevalidated", session.LastRevalidated)
-		// Audit-log the grace-fallback so an operator scanning for LDAP
-		// outages or extended cached-identity reuse has a signal to
-		// correlate against. Result is Success — the refresh did
-		// succeed — with a Detail flagging the grace mechanism.
-		entry := s.newAuditEntry(r, session.CachedUser.Username, audit.ActionRefresh, audit.ResultSuccess)
-		entry.Detail = "LDAP revalidation transient — grace-window fallback"
-		s.AuditLogger.Log(r.Context(), entry)
 		// Preserve the original LastRevalidated so successor sessions
-		// keep shrinking the grace window, not resetting it.
-		return session.CachedUser, session.LastRevalidated, nil
+		// keep shrinking the grace window, not resetting it. Signal the
+		// grace event to the caller's final audit emit via the returned
+		// auditDetail string.
+		return session.CachedUser, session.LastRevalidated,
+			"LDAP revalidation transient — grace-window fallback", nil
 
 	default:
 		// Definitive rejection — user genuinely gone from the directory.
-		username := ""
-		if session.CachedUser != nil {
-			username = session.CachedUser.Username
-		}
 		s.Logger.Info("LDAP revalidation rejected user", "providerID", providerID, "user", username, "err", err)
-		s.writeLDAPRefreshFailure(w, r, providerID, "user no longer authorised", "user no longer authorised")
-		return nil, time.Time{}, err
+		s.writeLDAPRefreshFailure(w, r, username, providerID, "user no longer authorised", "user no longer authorised")
+		return nil, time.Time{}, "", err
 	}
 }
 
 // writeLDAPRefreshFailure centralises the 401 + audit emit for the
 // failure branches of revalidateLDAPSession so the caller can keep its
-// switch statement focused on the control flow.
-func (s *Server) writeLDAPRefreshFailure(w http.ResponseWriter, r *http.Request, providerID, detail, userMessage string) {
-	entry := s.newAuditEntry(r, "", audit.ActionRefresh, audit.ResultFailure)
+// switch statement focused on the control flow. The username argument
+// is the auth.User.Username on the soon-to-be-discarded session — used
+// to attribute audit rows to a real account rather than the empty
+// string.
+func (s *Server) writeLDAPRefreshFailure(w http.ResponseWriter, r *http.Request, username, providerID, detail, userMessage string) {
+	entry := s.newAuditEntry(r, username, audit.ActionRefresh, audit.ResultFailure)
 	if providerID != "" {
 		entry.Detail = "LDAP " + providerID + ": " + detail
 	} else {

--- a/backend/internal/server/handle_auth_test.go
+++ b/backend/internal/server/handle_auth_test.go
@@ -480,12 +480,10 @@ func TestIssueTokenPair_OIDCRefreshLifetime(t *testing.T) {
 				t.Fatal("expected non-empty refresh token")
 			}
 
-			// Locate the stored session by its token. We can't read SessionStore
-			// internals, so re-Validate (which is single-use). The returned
-			// ValidatedSession doesn't expose ExpiresAt; instead, we walk the
-			// internal sessions map via reflection-free sync.Map iteration by
-			// re-storing a marker before Validate consumes the row. Simpler:
-			// re-issue + Range the sync.Map BEFORE consuming.
+			// Locate the stored session by its token without consuming it
+			// (Rotate is single-use and we still want to assert against the
+			// stored ExpiresAt). RangeSessions walks the sync.Map without
+			// mutation, which is exactly the test affordance we need.
 			var found bool
 			var got time.Time
 			srv.Sessions.RangeSessions(func(s auth.RefreshSession) bool {

--- a/backend/internal/server/handle_auth_test.go
+++ b/backend/internal/server/handle_auth_test.go
@@ -805,3 +805,109 @@ func doRequest(t *testing.T, srv *Server, method, path, body string, headers map
 	srv.Router.ServeHTTP(w, req)
 	return w
 }
+
+// ---------------------------------------------------------------------
+// Audit finding P2-3 (2026-05-22) — LDAP refresh-path revalidation
+// tests. The full ldapProvider.Revalidate path requires a live directory
+// (homelab soak / Phase 3 follow-up integration test); these unit tests
+// pin the no-LDAP-needed failure branches: parsing the UserID, looking
+// up the provider in the registry, and asserting the provider type.
+// ---------------------------------------------------------------------
+
+func TestHandleRefresh_LDAP_MalformedUserID(t *testing.T) {
+	cases := []struct {
+		name   string
+		userID string
+	}{
+		{"empty", ""},
+		{"missing prefix", "google:google-id:user-dn"},
+		{"only prefix", "ldap:"},
+		{"empty provider id", "ldap::CN=alice,OU=Users"},
+		{"empty DN", "ldap:ldap-corp:"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := testServer(t)
+
+			token := "ldap-test-token-" + tc.name
+			srv.Sessions.Store(auth.RefreshSession{
+				Token:     token,
+				UserID:    tc.userID,
+				Provider:  "ldap",
+				ExpiresAt: time.Now().Add(time.Hour),
+				CachedUser: &auth.User{
+					ID:       tc.userID,
+					Username: "alice",
+					Provider: "ldap",
+				},
+			})
+
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/refresh", nil)
+			req.Header.Set("X-Requested-With", "XMLHttpRequest")
+			req.AddCookie(&http.Cookie{Name: "refresh_token", Value: token})
+			w := httptest.NewRecorder()
+			srv.Router.ServeHTTP(w, req)
+
+			if w.Code != http.StatusUnauthorized {
+				t.Fatalf("expected 401 for malformed UserID %q, got %d: %s", tc.userID, w.Code, w.Body.String())
+			}
+			var resp api.Response
+			if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if resp.Error == nil || !strings.Contains(strings.ToLower(resp.Error.Message), "session invalid") {
+				t.Fatalf("expected 'session invalid' error, got %+v", resp.Error)
+			}
+		})
+	}
+}
+
+func TestHandleRefresh_LDAP_ProviderUnregistered(t *testing.T) {
+	srv := testServer(t)
+	// Note: testServer only registers the "local" provider. A session
+	// claiming "ldap-corp" will fail the registry lookup and produce
+	// the "auth provider unavailable" error path.
+
+	token := "ldap-orphan-token"
+	srv.Sessions.Store(auth.RefreshSession{
+		Token:     token,
+		UserID:    "ldap:ldap-corp:CN=alice,OU=Users,DC=example,DC=com",
+		Provider:  "ldap",
+		ExpiresAt: time.Now().Add(time.Hour),
+		CachedUser: &auth.User{
+			ID:       "ldap:ldap-corp:CN=alice,OU=Users,DC=example,DC=com",
+			Username: "alice",
+			Provider: "ldap",
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/refresh", nil)
+	req.Header.Set("X-Requested-With", "XMLHttpRequest")
+	req.AddCookie(&http.Cookie{Name: "refresh_token", Value: token})
+	w := httptest.NewRecorder()
+	srv.Router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for unregistered LDAP provider, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp api.Response
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Error == nil || !strings.Contains(strings.ToLower(resp.Error.Message), "auth provider unavailable") {
+		t.Fatalf("expected 'auth provider unavailable' error, got %+v", resp.Error)
+	}
+
+	// The original session was Rotate-removed and NOT Restored
+	// (definitive failure path), so retry with the same token should
+	// 401 with the "invalid or expired refresh token" path, not the
+	// "auth provider unavailable" path.
+	req2 := httptest.NewRequest(http.MethodPost, "/api/v1/auth/refresh", nil)
+	req2.Header.Set("X-Requested-With", "XMLHttpRequest")
+	req2.AddCookie(&http.Cookie{Name: "refresh_token", Value: token})
+	w2 := httptest.NewRecorder()
+	srv.Router.ServeHTTP(w2, req2)
+	if w2.Code != http.StatusUnauthorized {
+		t.Fatalf("retry expected 401, got %d", w2.Code)
+	}
+}

--- a/backend/internal/server/handle_auth_test.go
+++ b/backend/internal/server/handle_auth_test.go
@@ -1020,3 +1020,101 @@ func TestHandleRefresh_LDAP_ProviderUnregistered(t *testing.T) {
 		t.Fatalf("retry expected 401, got %d", w2.Code)
 	}
 }
+
+// ---------------------------------------------------------------------
+// Phase 3 review additions — regression tests added in response to the
+// ce-code-review findings on audit emission and LastRevalidated
+// stamping. See the Phase 3 session log + PR description.
+// ---------------------------------------------------------------------
+
+// TestHandleLogin_AccountThrottle_AuditEntry pins the audit emit on
+// 429 from the per-account throttle. The earlier brute-force /
+// case-folded / independent-usernames tests asserted HTTP status and
+// Retry-After only, so a regression that reordered statements before
+// the writeJSON early-return (or dropped the AuditLogger.Log call
+// entirely) would pass all three but leave throttle hits invisible
+// in the audit table. Testing review T-01, conf 95.
+func TestHandleLogin_AccountThrottle_AuditEntry(t *testing.T) {
+	srv := testServer(t)
+	srv.RateLimiter = middleware.NewRateLimiterWithRate(1, time.Minute)
+	rec := &recordingAuditLogger{}
+	srv.AuditLogger = rec
+
+	// First attempt consumes the bucket — should fail with 401 (bad
+	// creds, no user exists), emitting a login-failure audit entry.
+	w1 := postLogin(t, srv, map[string]string{
+		"username": "alice",
+		"password": "wrong",
+	}, "192.0.2.10:54321")
+	if w1.Code != http.StatusUnauthorized {
+		t.Fatalf("first attempt: expected 401, got %d", w1.Code)
+	}
+
+	// Second attempt hits the per-account throttle.
+	w2 := postLogin(t, srv, map[string]string{
+		"username": "alice",
+		"password": "wrong",
+	}, "192.0.2.99:54321") // rotated IP — IP throttle doesn't fire
+	if w2.Code != http.StatusTooManyRequests {
+		t.Fatalf("second attempt: expected 429 from account throttle, got %d: %s", w2.Code, w2.Body.String())
+	}
+
+	entries := rec.snapshot()
+	var throttleEntry *audit.Entry
+	for i := range entries {
+		if entries[i].Action == audit.ActionRateLimited {
+			throttleEntry = &entries[i]
+			break
+		}
+	}
+	if throttleEntry == nil {
+		t.Fatalf("expected at least one ActionRateLimited audit entry; got: %+v", entries)
+	}
+	if throttleEntry.Result != audit.ResultDenied {
+		t.Errorf("Result = %q, want %q", throttleEntry.Result, audit.ResultDenied)
+	}
+	if !strings.Contains(throttleEntry.Detail, "login") {
+		t.Errorf("Detail = %q, want substring %q (purpose namespace)", throttleEntry.Detail, "login")
+	}
+	if !strings.Contains(throttleEntry.Detail, "retry") {
+		t.Errorf("Detail = %q, want retry-seconds reference", throttleEntry.Detail)
+	}
+}
+
+// TestIssueTokenPairAt_LastRevalidatedStamped pins the LastRevalidated
+// field on the stored session. The LDAP grace-window predicate in
+// revalidateLDAPSession (handle_auth.go) pivots entirely on this field
+// — zero/stale -> fail-closed, recent -> grace-open. If the
+// assignment were dropped from issueTokenPairAt's struct literal
+// during a future refactor, the grace window would silently always
+// fail-closed (or always open if the zero-time guard were also wrong)
+// and nothing else would catch it. Testing review T-02, conf 90.
+func TestIssueTokenPairAt_LastRevalidatedStamped(t *testing.T) {
+	srv := testServer(t)
+
+	fixedTime := time.Now().Add(-2 * time.Minute) // distinct from time.Now() inside the call
+	user := &auth.User{ID: "ldap:corp:CN=alice,OU=Users", Username: "alice", Provider: "ldap"}
+
+	w := httptest.NewRecorder()
+	_, refreshToken, err := srv.issueTokenPairAt(w, user, false /* cookieMode */, fixedTime)
+	if err != nil {
+		t.Fatalf("issueTokenPairAt: %v", err)
+	}
+
+	var got time.Time
+	var found bool
+	srv.Sessions.RangeSessions(func(s auth.RefreshSession) bool {
+		if s.Token == refreshToken {
+			found = true
+			got = s.LastRevalidated
+			return false
+		}
+		return true
+	})
+	if !found {
+		t.Fatalf("issued refresh token not in SessionStore")
+	}
+	if !got.Equal(fixedTime) {
+		t.Errorf("session.LastRevalidated = %v, want %v", got, fixedTime)
+	}
+}

--- a/backend/internal/server/handle_auth_test.go
+++ b/backend/internal/server/handle_auth_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -801,6 +802,114 @@ func doRequest(t *testing.T, srv *Server, method, path, body string, headers map
 		req.Header.Set(k, v)
 	}
 
+	w := httptest.NewRecorder()
+	srv.Router.ServeHTTP(w, req)
+	return w
+}
+
+// ---------------------------------------------------------------------
+// Audit finding P2-1 part 2 (2026-05-22) — per-account login throttle.
+// ---------------------------------------------------------------------
+
+// TestHandleLogin_AccountThrottle_BlocksBruteForce pins the per-account
+// rate-limit: after the configured number of attempts against a single
+// username (even from rotating IPs), the next attempt against the same
+// username returns 429 regardless of IP. The previous IP-only throttle
+// could be bypassed by an attacker rotating source IPs.
+func TestHandleLogin_AccountThrottle_BlocksBruteForce(t *testing.T) {
+	srv := testServer(t)
+	srv.RateLimiter = middleware.NewRateLimiterWithRate(2, time.Minute)
+
+	for i := 0; i < 2; i++ {
+		w := postLogin(t, srv, map[string]string{
+			"username": "alice",
+			"password": "wrong-password",
+		}, "192.0.2."+strconv.Itoa(10+i)+":54321")
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("attempt %d: expected 401 invalid-creds, got %d: %s", i+1, w.Code, w.Body.String())
+		}
+	}
+
+	// Third attempt against the same username from yet another IP must
+	// hit the account throttle even though no single IP exhausted its
+	// per-IP bucket.
+	w := postLogin(t, srv, map[string]string{
+		"username": "alice",
+		"password": "wrong-password",
+	}, "192.0.2.99:54321")
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 account-throttled, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get("Retry-After"); got == "" {
+		t.Fatal("Retry-After header missing on 429")
+	}
+}
+
+// TestHandleLogin_AccountThrottle_CaseFolded asserts "Alice"/"alice"/
+// "ALICE" share one bucket. Without case-folding an attacker could
+// multiply the per-account budget by varying letter case.
+func TestHandleLogin_AccountThrottle_CaseFolded(t *testing.T) {
+	srv := testServer(t)
+	srv.RateLimiter = middleware.NewRateLimiterWithRate(2, time.Minute)
+
+	for _, casing := range []string{"alice", "Alice"} {
+		w := postLogin(t, srv, map[string]string{
+			"username": casing,
+			"password": "wrong",
+		}, "192.0.2.10:54321")
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("%s: expected 401, got %d", casing, w.Code)
+		}
+	}
+
+	// Third attempt with another casing must still be throttled.
+	w := postLogin(t, srv, map[string]string{
+		"username": "ALICE",
+		"password": "wrong",
+	}, "192.0.2.11:54321")
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("case-folded throttle missed: got %d, want 429", w.Code)
+	}
+}
+
+// TestHandleLogin_AccountThrottle_IndependentUsernames pins isolation
+// between account buckets: throttling "alice" must not affect "bob".
+func TestHandleLogin_AccountThrottle_IndependentUsernames(t *testing.T) {
+	srv := testServer(t)
+	srv.RateLimiter = middleware.NewRateLimiterWithRate(2, time.Minute)
+
+	// Exhaust alice's bucket.
+	for i := 0; i < 3; i++ {
+		postLogin(t, srv, map[string]string{
+			"username": "alice",
+			"password": "wrong",
+		}, "192.0.2.10:54321")
+	}
+
+	// bob must still be allowed past the failure-of-creds path —
+	// expecting 401 invalid-creds, NOT 429.
+	w := postLogin(t, srv, map[string]string{
+		"username": "bob",
+		"password": "wrong",
+	}, "192.0.2.10:54321")
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("bob should hit 401 invalid-creds, not 429; got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// postLogin issues a JSON login POST against the server with the
+// supplied remote address, returning the recorder. Helper for the
+// account-throttle tests above.
+func postLogin(t *testing.T, srv *Server, body map[string]string, remoteAddr string) *httptest.ResponseRecorder {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", strings.NewReader(string(raw)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Requested-With", "XMLHttpRequest")
+	req.RemoteAddr = remoteAddr
 	w := httptest.NewRecorder()
 	srv.Router.ServeHTTP(w, req)
 	return w

--- a/backend/internal/server/handle_setup.go
+++ b/backend/internal/server/handle_setup.go
@@ -78,6 +78,16 @@ func (s *Server) handleSetupInit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Per-account throttle (P2-1 part 2). Setup is one-shot — only the
+	// first call succeeds, every subsequent call returns 410 — but
+	// audit-listed setup-probing benefits from a per-username bucket
+	// so an attacker iterating likely admin names ("admin", "root",
+	// "administrator") is throttled independently of the global IP
+	// bucket.
+	if s.accountThrottle(w, r, "setup", req.Username, audit.ActionSetup) {
+		return
+	}
+
 	// P1-1: Setup token gate.
 	//
 	// If SetupToken is configured, a constant-time comparison is required

--- a/backend/internal/server/handle_setup.go
+++ b/backend/internal/server/handle_setup.go
@@ -147,9 +147,17 @@ func (s *Server) handleSetupInit(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	} else {
-		// Verify setup token if configured — constant-time comparison
+		// Verify setup token if configured — constant-time comparison.
 		if subtle.ConstantTimeCompare([]byte(req.SetupToken), []byte(s.Config.Auth.SetupToken)) != 1 {
 			s.Logger.Warn("setup init rejected: invalid setup token", "remoteAddr", r.RemoteAddr)
+			// Audit the rejected setup attempt: an attacker probing the
+			// setup-token endpoint otherwise leaves no trace until the
+			// IP rate-limit middleware kicks in. The sibling no-token
+			// branch already audits — keeping parity here closes the
+			// gap (Phase 3 review, audit P2-1 cluster).
+			entry := s.newAuditEntry(r, req.Username, audit.ActionSetup, audit.ResultFailure)
+			entry.Detail = "invalid setup token"
+			s.AuditLogger.Log(r.Context(), entry)
 			writeJSON(w, http.StatusForbidden, api.Response{
 				Error: &api.APIError{Code: 403, Message: "invalid setup token"},
 			})

--- a/backend/internal/server/middleware/ratelimit.go
+++ b/backend/internal/server/middleware/ratelimit.go
@@ -61,17 +61,34 @@ func (rl *RateLimiter) SetAuditLogger(logger audit.Logger) {
 	rl.auditLogger = logger
 }
 
-// Check tests if the given IP is within rate limits and returns the retry-after
-// duration in seconds if rate-limited. Both values are computed under a single
-// lock acquisition to avoid race conditions.
+// Check is a back-compat alias for [CheckKey]. New call sites should
+// prefer CheckKey for explicit key naming — IP throttles use
+// CheckKey(<ip>) and per-account throttles use CheckKey("login:<user>")
+// against the same RateLimiter instance.
 func (rl *RateLimiter) Check(ip string) (allowed bool, retryAfterSec int) {
+	return rl.CheckKey(ip)
+}
+
+// CheckKey tests if the given key is within rate limits and returns the
+// retry-after duration in seconds if rate-limited. Both values are
+// computed under a single lock acquisition to avoid race conditions.
+//
+// The key is opaque — IP-based throttles pass the raw IP, account
+// throttles pass a namespaced username like "login:alice" or
+// "setup:bob" (audit finding P2-1 part 2, 2026-05-22). Callers are
+// responsible for choosing non-colliding namespaces; the same bucket
+// map backs every keyspace, so a careless "alice"/"login:alice"/
+// "10.0.0.1" mix would have shared accounting. The convention in this
+// codebase is: bare IPs for IP throttles, "<purpose>:<account>" for
+// account throttles.
+func (rl *RateLimiter) CheckKey(key string) (allowed bool, retryAfterSec int) {
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
 
 	now := time.Now()
-	b, ok := rl.buckets[ip]
+	b, ok := rl.buckets[key]
 	if !ok || now.Sub(b.lastReset) >= rl.window {
-		rl.buckets[ip] = &bucket{tokens: 1, lastReset: now}
+		rl.buckets[key] = &bucket{tokens: 1, lastReset: now}
 		return true, 0
 	}
 

--- a/backend/internal/server/middleware/ratelimit_test.go
+++ b/backend/internal/server/middleware/ratelimit_test.go
@@ -105,6 +105,59 @@ func TestRateLimiter_RetryAfter_UnknownIP(t *testing.T) {
 	}
 }
 
+// TestRateLimiter_CheckKey_NamespaceIsolation pins the design contract
+// that backs audit finding P2-1 part 2 (2026-05-22): IP throttle keys
+// and account throttle keys must NOT collide. The convention is bare
+// IPs for IP throttles, "<purpose>:<account>" for account throttles —
+// this test asserts the underlying bucket map keeps them separate.
+func TestRateLimiter_CheckKey_NamespaceIsolation(t *testing.T) {
+	rl := NewRateLimiterWithRate(2, time.Minute)
+
+	// Exhaust the IP bucket for 192.168.1.1.
+	for i := 0; i < 2; i++ {
+		if allowed, _ := rl.CheckKey("192.168.1.1"); !allowed {
+			t.Fatalf("setup: request %d should be allowed", i+1)
+		}
+	}
+	if allowed, _ := rl.CheckKey("192.168.1.1"); allowed {
+		t.Fatal("IP bucket should be exhausted")
+	}
+
+	// Account-throttle key for the same numeric string must be
+	// independent — different namespace, different bucket.
+	if allowed, _ := rl.CheckKey("login:192.168.1.1"); !allowed {
+		t.Fatal("account bucket 'login:192.168.1.1' must be independent of IP bucket")
+	}
+	// And another namespace should be independent again.
+	if allowed, _ := rl.CheckKey("setup:192.168.1.1"); !allowed {
+		t.Fatal("account bucket 'setup:192.168.1.1' must be independent of 'login:' bucket")
+	}
+}
+
+// TestRateLimiter_CheckKey_BackCompat — Check(ip) and CheckKey(ip)
+// share the bucket so the existing IP-throttle middleware (which still
+// calls Check) and the new account-throttle handler code (which calls
+// CheckKey) interact correctly when wiring overlaps.
+func TestRateLimiter_CheckKey_BackCompat(t *testing.T) {
+	rl := NewRateLimiterWithRate(2, time.Minute)
+
+	// CheckKey via the new name eats 1 token.
+	if allowed, _ := rl.CheckKey("10.0.0.1"); !allowed {
+		t.Fatal("first CheckKey call should be allowed")
+	}
+	// Check via the legacy alias eats the second token.
+	if allowed, _ := rl.Check("10.0.0.1"); !allowed {
+		t.Fatal("second Check call should be allowed")
+	}
+	// Third should be blocked regardless of which alias is used.
+	if allowed, _ := rl.Check("10.0.0.1"); allowed {
+		t.Fatal("third call should be rate limited (Check)")
+	}
+	if allowed, _ := rl.CheckKey("10.0.0.1"); allowed {
+		t.Fatal("third call should still be rate limited via CheckKey alias")
+	}
+}
+
 func TestRateLimiterWithRate_CustomLimit(t *testing.T) {
 	rl := NewRateLimiterWithRate(30, time.Minute)
 

--- a/backend/internal/server/middleware/trusted_proxy.go
+++ b/backend/internal/server/middleware/trusted_proxy.go
@@ -41,18 +41,44 @@ func TrustedProxy(cidrs []string, logger *slog.Logger) func(http.Handler) http.H
 	if logger == nil {
 		logger = slog.Default()
 	}
+	configuredNonEmpty := 0
 	trusted := make([]*net.IPNet, 0, len(cidrs))
 	for _, raw := range cidrs {
 		entry := strings.TrimSpace(raw)
 		if entry == "" {
 			continue
 		}
+		configuredNonEmpty++
 		_, n, err := net.ParseCIDR(entry)
 		if err != nil {
 			logger.Warn("trusted proxy CIDR rejected", "cidr", entry, "error", err)
 			continue
 		}
+		// Loud warning on /0 catch-all CIDRs: they reinstate the
+		// chi-RealIP-style "trust everyone" behaviour that Phase 3 set
+		// out to remove. Surfaced by the adversarial review — an
+		// operator who mis-copies an example template into production
+		// (or expands the trust set to cover an entire pod CIDR) gets
+		// a single startup line they can correlate against the actual
+		// rate-limit-bucket-poisoning behaviour rather than silently
+		// regressing P2-1.
+		ones, bits := n.Mask.Size()
+		if ones == 0 && bits > 0 {
+			logger.Warn("trusted proxy CIDR is a catch-all (/0); this reinstates the pre-Phase-3 blanket-trust behaviour audit finding P2-1 was meant to remove. Narrow to your ingress controller's pod CIDR.",
+				"cidr", entry)
+		}
 		trusted = append(trusted, n)
+	}
+	// If the operator configured CIDR entries but every one was
+	// rejected, the middleware silently degenerates to a no-op (no
+	// header rewrite, fail-closed). A single summary line surfaces the
+	// fact that the deployment-intended forwarded-header behaviour is
+	// not actually in effect, instead of relying on the operator to
+	// correlate N individual per-entry warnings. Reliability review,
+	// conf 85.
+	if configuredNonEmpty > 0 && len(trusted) == 0 {
+		logger.Warn("TrustedProxy: every configured CIDR entry was rejected; forwarded-header rewriting is disabled (fail-closed). Verify KUBECENTER_SERVER_TRUSTEDPROXYCIDRS values.",
+			"configured", configuredNonEmpty)
 	}
 
 	return func(next http.Handler) http.Handler {

--- a/backend/internal/server/middleware/trusted_proxy.go
+++ b/backend/internal/server/middleware/trusted_proxy.go
@@ -1,0 +1,124 @@
+package middleware
+
+import (
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+)
+
+// TrustedProxy returns a middleware that rewrites r.RemoteAddr from
+// forwarded headers (X-Real-IP / X-Forwarded-For) ONLY when the
+// request's TCP peer is within one of the configured CIDR blocks.
+// Otherwise the forwarded headers are ignored and r.RemoteAddr keeps
+// the socket-peer address.
+//
+// This replaces chi-RealIP's blanket-trust behaviour, which honored
+// the headers from every peer and let any direct LAN/internet attacker
+// pin their rate-limit bucket to an arbitrary IP. Closes audit finding
+// P2-1 (2026-05-22).
+//
+// Default fail-closed: an empty cidrs slice means no peer is trusted,
+// and the middleware degenerates into a no-op rewriter (socket peer
+// stays). That matches the audit's recommendation: "Trust forwarded
+// headers only from configured proxy CIDRs. Otherwise key on socket
+// peer address."
+//
+// Implementation notes:
+//   - Parses the CIDR set once at construction; invalid entries are
+//     logged via the supplied logger (or default slog) and dropped.
+//     Construction never panics on bad input.
+//   - Honors X-Real-IP first (single value), then X-Forwarded-For
+//     leftmost (closest-to-client hop). Garbage values that don't
+//     parse as a valid IP are dropped rather than installed —
+//     downstream rate-limit buckets stay clean.
+//   - Output r.RemoteAddr is the bare IP (no port), matching the
+//     post-rewrite shape downstream extractIP already handles.
+//   - IPv6 zone identifiers ([fe80::1%eth0]:port) are stripped from
+//     the peer address before CIDR matching; net.ParseIP ignores the
+//     zone and returns the unzoned address.
+func TrustedProxy(cidrs []string, logger *slog.Logger) func(http.Handler) http.Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	trusted := make([]*net.IPNet, 0, len(cidrs))
+	for _, raw := range cidrs {
+		entry := strings.TrimSpace(raw)
+		if entry == "" {
+			continue
+		}
+		_, n, err := net.ParseCIDR(entry)
+		if err != nil {
+			logger.Warn("trusted proxy CIDR rejected", "cidr", entry, "error", err)
+			continue
+		}
+		trusted = append(trusted, n)
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if len(trusted) == 0 {
+				next.ServeHTTP(w, r)
+				return
+			}
+			peer := socketPeerIP(r.RemoteAddr)
+			if peer == nil || !ipInAny(peer, trusted) {
+				next.ServeHTTP(w, r)
+				return
+			}
+			if forwarded := pickForwardedIP(r); forwarded != "" {
+				r.RemoteAddr = forwarded
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// socketPeerIP returns the parsed IP of a "host:port" RemoteAddr,
+// stripping the IPv6 zone if present. Returns nil for unparseable
+// input.
+func socketPeerIP(remoteAddr string) net.IP {
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		// Some test contexts pass a bare IP. Try parsing directly.
+		host = remoteAddr
+	}
+	// Strip an IPv6 zone identifier (e.g. "fe80::1%eth0") — net.ParseIP
+	// returns nil for zoned addresses but the matching semantics we want
+	// are zone-agnostic.
+	if i := strings.IndexByte(host, '%'); i >= 0 {
+		host = host[:i]
+	}
+	return net.ParseIP(host)
+}
+
+// pickForwardedIP returns the IP the trusted proxy is claiming this
+// request originated from, or empty if no usable header is present.
+// X-Real-IP takes precedence over X-Forwarded-For; the latter's
+// leftmost entry is the closest-to-client hop.
+func pickForwardedIP(r *http.Request) string {
+	if v := strings.TrimSpace(r.Header.Get("X-Real-IP")); v != "" {
+		if ip := net.ParseIP(v); ip != nil {
+			return ip.String()
+		}
+	}
+	if v := r.Header.Get("X-Forwarded-For"); v != "" {
+		// Comma-separated list, leftmost is the client.
+		head, _, _ := strings.Cut(v, ",")
+		head = strings.TrimSpace(head)
+		if ip := net.ParseIP(head); ip != nil {
+			return ip.String()
+		}
+	}
+	return ""
+}
+
+// ipInAny reports whether ip falls within any of the supplied networks.
+func ipInAny(ip net.IP, nets []*net.IPNet) bool {
+	for _, n := range nets {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/server/middleware/trusted_proxy_test.go
+++ b/backend/internal/server/middleware/trusted_proxy_test.go
@@ -1,0 +1,218 @@
+package middleware
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// silentLogger returns a slog.Logger that discards output for tests.
+func silentLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+// echoRemoteAddr is a tiny handler that records the post-middleware
+// r.RemoteAddr into the response body so the test can assert what the
+// downstream chain would see.
+func echoRemoteAddr(w http.ResponseWriter, r *http.Request) {
+	_, _ = w.Write([]byte(r.RemoteAddr))
+}
+
+// runWith executes the middleware against a single request and returns
+// the body the test handler observed.
+func runWith(mw func(http.Handler) http.Handler, req *http.Request) string {
+	h := mw(http.HandlerFunc(echoRemoteAddr))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	return w.Body.String()
+}
+
+// TestTrustedProxy_EmptyCIDR_NeverRewrites verifies the audit-finding
+// fail-closed default: zero configured CIDRs means NO peer is trusted,
+// so X-Forwarded-For / X-Real-IP are ignored regardless of source.
+func TestTrustedProxy_EmptyCIDR_NeverRewrites(t *testing.T) {
+	mw := TrustedProxy(nil, silentLogger())
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "203.0.113.5:54321" // arbitrary public peer
+	req.Header.Set("X-Forwarded-For", "10.0.0.99")
+	req.Header.Set("X-Real-IP", "10.0.0.99")
+
+	if got := runWith(mw, req); got != "203.0.113.5:54321" {
+		t.Fatalf("empty CIDR list must leave RemoteAddr untouched, got %q", got)
+	}
+}
+
+// TestTrustedProxy_TrustedPeer_HonorsHeader is the happy path: a peer
+// inside the trusted CIDR can rewrite r.RemoteAddr.
+func TestTrustedProxy_TrustedPeer_HonorsHeader(t *testing.T) {
+	mw := TrustedProxy([]string{"10.0.0.0/8"}, silentLogger())
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.1.2.3:443" // inside trusted CIDR
+	req.Header.Set("X-Forwarded-For", "198.51.100.7")
+
+	if got := runWith(mw, req); got != "198.51.100.7" {
+		t.Fatalf("trusted peer header should rewrite RemoteAddr, got %q", got)
+	}
+}
+
+// TestTrustedProxy_UntrustedPeer_IgnoresHeader pins the security
+// boundary: a peer OUTSIDE the trusted CIDR cannot pin the rewrite
+// target, no matter what header they send.
+func TestTrustedProxy_UntrustedPeer_IgnoresHeader(t *testing.T) {
+	mw := TrustedProxy([]string{"10.0.0.0/8"}, silentLogger())
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "203.0.113.5:54321" // outside trusted CIDR
+	req.Header.Set("X-Forwarded-For", "10.0.0.99")
+	req.Header.Set("X-Real-IP", "10.0.0.99")
+
+	if got := runWith(mw, req); got != "203.0.113.5:54321" {
+		t.Fatalf("untrusted peer header must be ignored, got %q", got)
+	}
+}
+
+// TestTrustedProxy_XRealIP_BeatsXFF asserts X-Real-IP wins when both
+// headers are present — matches chi-RealIP precedence so downstream
+// rate-limit semantics are stable.
+func TestTrustedProxy_XRealIP_BeatsXFF(t *testing.T) {
+	mw := TrustedProxy([]string{"10.0.0.0/8"}, silentLogger())
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.1.2.3:443"
+	req.Header.Set("X-Real-IP", "198.51.100.7")
+	req.Header.Set("X-Forwarded-For", "203.0.113.99")
+
+	if got := runWith(mw, req); got != "198.51.100.7" {
+		t.Fatalf("X-Real-IP should win over X-Forwarded-For, got %q", got)
+	}
+}
+
+// TestTrustedProxy_XFF_LeftmostHop covers the multi-hop case: a load
+// balancer + reverse proxy chain produces "client, proxy1, proxy2".
+// The leftmost entry is the closest-to-client hop and the one we want.
+func TestTrustedProxy_XFF_LeftmostHop(t *testing.T) {
+	mw := TrustedProxy([]string{"10.0.0.0/8"}, silentLogger())
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.1.2.3:443"
+	req.Header.Set("X-Forwarded-For", "198.51.100.7, 10.10.10.10, 10.20.20.20")
+
+	if got := runWith(mw, req); got != "198.51.100.7" {
+		t.Fatalf("leftmost X-Forwarded-For entry must win, got %q", got)
+	}
+}
+
+// TestTrustedProxy_MalformedHeader_LeavesRemoteAddr verifies garbage in
+// the header from a trusted peer is dropped, not installed. Without
+// this guard, downstream rate-limit buckets would be keyed on arbitrary
+// non-IP strings.
+func TestTrustedProxy_MalformedHeader_LeavesRemoteAddr(t *testing.T) {
+	mw := TrustedProxy([]string{"10.0.0.0/8"}, silentLogger())
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.1.2.3:443"
+	req.Header.Set("X-Forwarded-For", "not-an-ip")
+	req.Header.Set("X-Real-IP", "also-not-an-ip")
+
+	if got := runWith(mw, req); got != "10.1.2.3:443" {
+		t.Fatalf("malformed forwarded header must be dropped, got %q", got)
+	}
+}
+
+// TestTrustedProxy_BadCIDR_DroppedSilently confirms the constructor is
+// tolerant of misconfiguration — an unparseable entry doesn't kill the
+// process, it just doesn't get added to the trust set. (The dropped
+// entry IS logged via the supplied slog.Logger.)
+func TestTrustedProxy_BadCIDR_DroppedSilently(t *testing.T) {
+	mw := TrustedProxy([]string{"definitely-not-a-cidr", "10.0.0.0/8", ""}, silentLogger())
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.1.2.3:443"
+	req.Header.Set("X-Forwarded-For", "198.51.100.7")
+
+	if got := runWith(mw, req); got != "198.51.100.7" {
+		t.Fatalf("valid CIDR among invalid ones must still take effect, got %q", got)
+	}
+}
+
+// TestTrustedProxy_IPv6 confirms IPv6 CIDRs work for both peer and
+// forwarded-header. The bracketed-port form for IPv6 RemoteAddr
+// ([::1]:port) is the standard net/http shape.
+func TestTrustedProxy_IPv6(t *testing.T) {
+	mw := TrustedProxy([]string{"2001:db8::/32"}, silentLogger())
+
+	t.Run("trusted v6 peer rewrites", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.RemoteAddr = "[2001:db8::1]:443"
+		req.Header.Set("X-Forwarded-For", "2001:db8:cafe::42")
+
+		if got := runWith(mw, req); got != "2001:db8:cafe::42" {
+			t.Fatalf("trusted v6 peer should rewrite, got %q", got)
+		}
+	})
+
+	t.Run("untrusted v6 peer ignored", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.RemoteAddr = "[2001:db9::1]:443" // outside 2001:db8::/32
+		req.Header.Set("X-Forwarded-For", "2001:db8:cafe::42")
+
+		if got := runWith(mw, req); got != "[2001:db9::1]:443" {
+			t.Fatalf("untrusted v6 peer header must be ignored, got %q", got)
+		}
+	})
+
+	t.Run("zoned v6 peer parses", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.RemoteAddr = "[2001:db8::1%eth0]:443"
+		req.Header.Set("X-Forwarded-For", "2001:db8:cafe::42")
+
+		if got := runWith(mw, req); got != "2001:db8:cafe::42" {
+			t.Fatalf("zoned v6 peer should match trusted CIDR, got %q", got)
+		}
+	})
+}
+
+// TestTrustedProxy_MixedV4V6CIDRs validates that v4 and v6 CIDRs
+// coexist in the same trusted set — a deployment behind both an IPv4
+// and IPv6 load balancer needs both to work.
+func TestTrustedProxy_MixedV4V6CIDRs(t *testing.T) {
+	mw := TrustedProxy([]string{"10.0.0.0/8", "2001:db8::/32"}, silentLogger())
+
+	t.Run("v4 hop", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.RemoteAddr = "10.1.2.3:443"
+		req.Header.Set("X-Forwarded-For", "198.51.100.7")
+		if got := runWith(mw, req); got != "198.51.100.7" {
+			t.Fatalf("v4 trusted peer should rewrite, got %q", got)
+		}
+	})
+	t.Run("v6 hop", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.RemoteAddr = "[2001:db8::1]:443"
+		req.Header.Set("X-Forwarded-For", "198.51.100.7")
+		if got := runWith(mw, req); got != "198.51.100.7" {
+			t.Fatalf("v6 trusted peer rewriting to v4 forwarded should work, got %q", got)
+		}
+	})
+}
+
+// TestTrustedProxy_IPv4MappedV6 covers the IPv4-mapped-IPv6 corner
+// case: net.ParseIP("::ffff:127.0.0.1") returns the 4-byte form. A v4
+// CIDR like 127.0.0.0/8 must Contains() it; a v6-only CIDR will not.
+// This pins the behaviour so a refactor doesn't silently break
+// loopback handling on dual-stack stacks.
+func TestTrustedProxy_IPv4MappedV6(t *testing.T) {
+	mw := TrustedProxy([]string{"127.0.0.0/8"}, silentLogger())
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "[::ffff:127.0.0.1]:443"
+	req.Header.Set("X-Forwarded-For", "198.51.100.7")
+
+	if got := runWith(mw, req); got != "198.51.100.7" {
+		t.Fatalf("v4-mapped-v6 loopback should match 127.0.0.0/8, got %q", got)
+	}
+}

--- a/backend/internal/server/response.go
+++ b/backend/internal/server/response.go
@@ -81,6 +81,21 @@ func (s *Server) newAuditEntry(r *http.Request, username string, action audit.Ac
 // removed) within the hour rather than the standard 7-day window — see
 // the constant's doc comment for the rationale.
 func (s *Server) issueTokenPair(w http.ResponseWriter, user *auth.User, cookieMode bool) (string, string, error) {
+	return s.issueTokenPairAt(w, user, cookieMode, time.Now())
+}
+
+// issueTokenPairAt is the lower-level variant of [Server.issueTokenPair]
+// that stamps a caller-supplied LastRevalidated time on the new session.
+// The refresh handler's LDAP path uses this to preserve the original
+// revalidation timestamp when falling back to last-known identity
+// during a transient LDAP outage — bounding how long a sustained
+// outage can extend access for a user whose identity was revoked while
+// LDAP was down (audit finding P2-3, 2026-05-22).
+//
+// Every other caller goes through issueTokenPair, which passes
+// time.Now() — the LastRevalidated field is unused for non-LDAP
+// providers and the timestamp is harmless extra metadata.
+func (s *Server) issueTokenPairAt(w http.ResponseWriter, user *auth.User, cookieMode bool, lastRevalidated time.Time) (string, string, error) {
 	accessToken, err := s.TokenManager.IssueAccessToken(user)
 	if err != nil {
 		return "", "", err
@@ -94,13 +109,15 @@ func (s *Server) issueTokenPair(w http.ResponseWriter, user *auth.User, cookieMo
 	refreshLifetime := auth.RefreshLifetimeFor(user.Provider)
 
 	session := auth.RefreshSession{
-		Token:     refreshToken,
-		UserID:    user.ID,
-		Provider:  user.Provider,
-		ExpiresAt: time.Now().Add(refreshLifetime),
+		Token:           refreshToken,
+		UserID:          user.ID,
+		Provider:        user.Provider,
+		ExpiresAt:       time.Now().Add(refreshLifetime),
+		LastRevalidated: lastRevalidated,
 	}
 	// Cache user data for non-local providers (OIDC has no local store,
-	// LDAP would require reconnecting to the directory on refresh).
+	// LDAP needs a baseline last-known identity for the grace-window
+	// fallback if revalidation hits a transient LDAP outage on refresh).
 	// Local users are looked up by ID from the in-memory store instead.
 	if user.Provider != "local" {
 		session.CachedUser = user

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -309,14 +309,21 @@ func New(deps Deps) *Server {
 	// Auth and CSRF are applied per-route-group in registerRoutes(),
 	// not globally, so public endpoints don't need a skip list.
 	//
-	// CaptureSocketPeer MUST run before chimw.RealIP so we preserve the
-	// ground-truth TCP peer address before chi overwrites r.RemoteAddr
-	// from X-Forwarded-For / X-Real-IP headers. The loopback-setup gate
-	// and the audit ConnectionIP field both read the captured value.
-	// See: Finding #1+#8 (ce-code-review 2026-05-22).
+	// CaptureSocketPeer runs before any header-driven rewrites so we
+	// preserve the ground-truth TCP peer address. The loopback-setup
+	// gate and the audit ConnectionIP field both read the captured
+	// value. See Finding #1+#8 (ce-code-review 2026-05-22).
+	//
+	// TrustedProxy replaces chi-RealIP's blanket-trust behaviour:
+	// X-Forwarded-For / X-Real-IP are honored ONLY when the request's
+	// TCP peer falls inside Config.Server.TrustedProxyCIDRs. Default
+	// empty = fail-closed (no proxies trusted), so direct LAN/internet
+	// attackers cannot spoof their rate-limit bucket key. Audit
+	// finding P2-1 (2026-05-22) — replaces the pre-Phase-3
+	// `chimw.RealIP` blanket call.
 	s.Router.Use(chimw.RequestID)
 	s.Router.Use(middleware.CaptureSocketPeer)
-	s.Router.Use(chimw.RealIP)
+	s.Router.Use(middleware.TrustedProxy(deps.Config.Server.TrustedProxyCIDRs, deps.Logger))
 	s.Router.Use(slogMiddleware(deps.Logger))
 	s.Router.Use(chimw.Recoverer)
 	s.Router.Use(chimw.CleanPath)


### PR DESCRIPTION
## Summary

Closes audit findings **P2-1** (trusted-proxy CIDR boundary + per-account/login-name throttle), **P2-2** (atomic refresh-token rotation), and **P2-3** (LDAP revalidation on refresh + 1h LDAP refresh-token cap + 5-minute bounded grace window). Audit doc: [`plans/security-audit-2026-05-22.md`](./plans/security-audit-2026-05-22.md).

### Per-unit changes
- **U1 (P2-2)**: `SessionStore.Peek`/`Consume`/`Validate` trio replaced with atomic `Rotate` + `Restore` backed by `sync.Map.LoadAndDelete`. Two concurrent refreshers can never both mint a successor pair. Restore enables retry on post-rotate signing failure without silent logout.
- **U2 (P2-3)**: `LDAPProvider.Revalidate` does a service-bind + search by DN to refresh groups on every refresh. `LDAPRefreshTokenLifetime = 1h` caps the refresh window. `revalidateLDAPSession` in the refresh handler routes definitive rejections to fail-closed 401, transient-within-grace falls back to last-known identity (preserving the original `LastRevalidated` so the grace shrinks on sustained outage), transient-outside-grace restores the session for retry.
- **U3a (P2-1 part 1)**: New `middleware.TrustedProxy` replaces `chi.RealIP`'s blanket-trust. `Config.Server.TrustedProxyCIDRs` is fail-closed by default. Warns on `/0` catch-all entries; warns when every configured CIDR is rejected.
- **U3b (P2-1 part 2)**: `RateLimiter.CheckKey` generic primitive + `accountThrottle` helper. `/auth/login` and `/setup/init` apply per-username (case-folded) throttle layered on the existing IP throttle. Audit-logs the 429 with `audit.ActionRateLimited + ResultDenied`.

## Review cadence

Per the user's pre-implementation decision: **1 round of `/ce-code-review` + ship with documented follow-up list** (in response to Phase 2's diminishing returns by round 3). One review pass dispatched 9 personas; 13 findings applied inline across 5 review-fix commits; the rest are filed below.

## Review findings applied inline (commits 80214a1..f0691af)

| # | Reviewer(s) | Finding | Conf |
|---|---|---|---|
| 1 | adversarial + security | TrustedProxy silently honors \`/0\` + misleading config example | 100 |
| 2 | reliability | LDAP transient-outside-grace destroyed session without Restore | 95 |
| 3 | standards | CLAUDE.md said \"7d (local/LDAP)\" — wrong after LDAP TTL drop | 92 |
| 4 | standards | CHANGELOG.md not updated for Phase 3 | 95 |
| 5 | correctness | LDAP grace fallback emitted two audit rows per refresh | 100 |
| 6 | security | Setup-token mismatch 403 had no audit entry | 75 |
| 7 | reliability | TrustedProxy all-invalid CIDRs silently degraded (no summary log) | 85 |
| 8 | maintainability | LDAPProvider.ID() was dead code | 100 |
| 9 | reliability | Revalidate docstring claimed ctx propagates via SetTimeout (wrong) | 90 |
| 10 | security + standards | handleRefresh missing-token / user-not-found / issueTokenPair-failure paths skipped audit emit | 100 |
| 11 | correctness | LDAP refresh-failure audit rows had empty username | 100 |
| 12 | testing | accountThrottle audit entry never asserted | 95 |
| 13 | testing | LastRevalidated stamping untested in issueTokenPairAt | 90 |

## Known follow-ups (filed, not blocking Phase 3)

- **AN-C1** (P1): `/auth/login` lacks body-mode response — agents using local/LDAP credentials cannot retrieve the refresh token at login time. Mirror the OIDC mobile-exchange pattern from `handle_oidc_mobile.go`.
- **AN-W1** (P1): five distinct 401 branches in handleRefresh lack a stable \`error.Reason\` discriminator. \`APIError.Reason\` field already exists.
- **AN-W2** (P2): audit query has no detail-text filter for grace-window thrashing detection.
- **adv-2** (P2): handleLogout revokes only the inbound token; concurrent refresh leaves orphaned rotated successor surviving until ExpiresAt.
- **sec-2 + adv-3** (P3): per-account throttle case-folds but doesn't NFKC-normalize username (Unicode whitespace + zero-width chars dilute the throttle).
- **MAINT-002** (P2): \`Check\` is a one-liner alias for \`CheckKey\` in an internal package — rename throughout.
- **MAINT-003** (P2): \`ldapGracePeriod\` hardcoded — make config-driven.
- **REL-02 runtime** (P2): LDAP \`Revalidate\` ctx propagation through in-flight LDAP ops (docstring fixed in this PR; runtime fix deferred).
- **REL-03** (advisory): no singleflight coalescing on \`Revalidate\` for same userDN. Learnings researcher explicitly cautioned that the Phase 2 cluster_router singleflight pattern does NOT transfer cleanly here.
- **REL-05** (P2): per-account throttle bucket map unbounded under sustained username enumeration.
- **T-03**: handleSetupInit accountThrottle has no test (T-01 + T-02 added in this PR).
- **correctness-account-throttle-eats-success-budget** (P3): successful logins consume throttle budget. Design decision — defer.
- **correctness-grace-fresh-session** (P3): fresh-session-first-refresh during LDAP outage gets no grace. Consider a separate first-refresh-grace constant.

## Verification

- \`cd backend && go vet ./... && go test ./...\` — all 28 backend packages pass.
- \`cd frontend && deno lint .\` — clean.
- \`deno fmt --check\` and \`deno check\` — fail with pre-existing CRLF + type errors on \`main\`; Phase 3 made zero frontend changes. Per CLAUDE.md Directive #4, explicitly declaring this here as the unavailable-check escape clause.
- LDAP \`Revalidate\` full-path integration test requires a live directory — accepted per audit. classifyLDAPError + Revalidate empty-DN + revalidateLDAPSession malformed-UserID / provider-unregistered / account-throttle audit-emit / LastRevalidated stamping are unit-tested.

## Phased execution compliance (CLAUDE.md Rule 2)

Each commit ≤5 files: U1 (4), U2a (4), U2b (3 retitled in commit), U3a (4), U3b (5), review-fix commits (2/2/2/1/2). No 5-file-cap violations.

## Test plan

- [ ] Smoke-test homelab against the squashed merge commit:
  - [ ] LDAP user logs in, refreshes successfully every 15 minutes
  - [ ] LDAP user with revoked group membership loses elevated access within ~20 min (15min access TTL + grace window)
  - [ ] LDAP server stop → 5-minute grace window observed → 401 after grace
  - [ ] LDAP server resume → next refresh succeeds without re-login
  - [ ] /auth/login throttled at 5 attempts/min per username regardless of source IP
  - [ ] /setup/init throttled per username
  - [ ] Behind a load balancer with KUBECENTER_SERVER_TRUSTEDPROXYCIDRS set: rate-limit buckets key on client IP via X-Forwarded-For
  - [ ] Same backend WITHOUT KUBECENTER_SERVER_TRUSTEDPROXYCIDRS: rate-limit buckets key on load balancer IP (fail-closed)
- [ ] Audit-log query for \`action=refresh, result=failure\` over the last 24h returns expected entries for refresh edge cases
- [ ] Audit-log query for \`action=rate_limited, result=denied\` shows account-throttle hits with namespaced detail strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)