### PR TITLE
feat(security): Phase 4 — network/SSRF/TLS hardening (P2-6/P2-7/P2-8/P3-8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,150 @@ correlate findings back to the audit reports under `docs/security/`.
 
 ---
 
+## Phase 4 — Network / SSRF / TLS hardening (2026-05 audit)
+
+Phase 4 closes audit findings P2-6 (SSRF DNS rebinding window on
+remote-cluster and monitoring URLs), P2-7 (backend NetworkPolicy
+egress allowed all destinations on sensitive ports), P2-8 (chart
+permitted plaintext exposure of authenticated app traffic), and P3-8
+(dev PostgreSQL compose service bound to LAN with weak fixed
+credentials). The audit report is `plans/security-audit-2026-05-22.md`.
+
+### Breaking changes (operator action required)
+
+- **TLS-by-default chart guard** (audit P2-8). The Helm chart now
+  refuses to render any of three plaintext-exposed configurations
+  unless the new top-level `security.insecureExposureAcknowledged`
+  value is explicitly set to `true`:
+  1. `ingress.enabled=true` with empty `ingress.tls`.
+  2. `service.type=LoadBalancer` or `service.type=NodePort`.
+  3. `backend.config.dev=true` combined with any externally-reachable
+     service mode (LoadBalancer / NodePort / ingress-without-TLS).
+  The acknowledgement is intended for fully internal trust-domain
+  deployments where TLS termination happens upstream (managed LB with
+  cert, service-mesh gateway) and the network path stays inside a
+  trusted boundary. Default is `false` (safest posture). The bundled
+  `values-homelab.yaml.example` opts in explicitly with a comment
+  documenting the LAN-only trust boundary.
+
+- **SSRF DNS resolution fails closed** (audit P2-6 part 1).
+  `k8s.ValidateRemoteURL` previously allowed a connection through when
+  DNS resolution failed; the rationale was that the k8s client would
+  produce a more specific error. That left a window where transient
+  NXDOMAIN, poisoned records, or rebinding flips between validation and
+  dial could deliver requests to private endpoints the IP-block was
+  supposed to refuse. Operators with broken DNS will now see an
+  unambiguous "DNS resolution failed" error at remote-cluster
+  registration / connection time and at admin-UI settings updates,
+  rather than an SSRF-shaped silent success.
+
+- **Dev PostgreSQL compose loopback bind** (audit P3-8). The
+  developer compose file's port mapping changed from `5432:5432` (LAN
+  reachable) to `127.0.0.1:5432:5432` (loopback only). Credentials are
+  now sourced from `POSTGRES_PASSWORD` / `POSTGRES_USER` /
+  `POSTGRES_DB` environment variables (or `.env` file) with the
+  previous weak defaults preserved as fall-throughs for `make dev-db`.
+  Operators whose developer DB was being accessed from other LAN hosts
+  must now configure that connection through SSH tunnels or change the
+  bind explicitly. Production and staging Postgres deployments are
+  unaffected — they use the Helm chart, not this compose file.
+
+### Non-breaking changes
+
+- **SSRF-safe DialContext on long-lived HTTP transports** (audit P2-6
+  part 2). New `k8s.SafeHTTPTransport` and `k8s.SafeDialContext`
+  wired into:
+  - Remote-cluster `rest.Config.Dial` (cluster_router) — every k8s
+    API call through the impersonating clients re-validates the API
+    server IP, defending against DNS rebinding and the cluster URL
+    flipping to an internal address mid-session.
+  - Grafana reverse proxy transport — each Grafana 30x redirect
+    re-runs the IP check, so a misbehaving Grafana returning
+    `Location: http://169.254.169.254/` can't pivot the proxy.
+  - Grafana API client and Prometheus API client transports — same
+    protection for dashboard provisioning and PromQL queries.
+
+  Behaviour: each TCP dial re-resolves the host, pins to the
+  validated IP before dialing (a racy resolver can't substitute a
+  private IP), and rejects any candidate in the loopback / RFC1918 /
+  link-local-metadata / CGNAT / unspecified ranges.
+
+- **Hostname-resolving validation on admin-UI URL inputs** (audit
+  P2-6 part 1). `validateSettingsURL` previously only blocked literal
+  IPs. Settings paths (monitoring Prometheus / Grafana URLs, OIDC
+  issuer test, LDAP server test) now resolve the hostname and apply
+  the full SSRF block-list. Admins who need to point monitoring at
+  an in-cluster service should configure it via Helm values rather
+  than the UI.
+
+- **NetworkPolicy backend egress destinations** (audit P2-7). The
+  previous port-only egress rules let the backend reach any host on
+  the LAN, public internet, or in-cluster on the allowed ports.
+  Tightened to structured `to:` selectors with universal SSRF block:
+  - DNS: `namespaceSelector kube-system + podSelector k8s-app=kube-dns`
+    (tunable via `networkPolicy.egress.dnsNamespace/dnsPodLabel`).
+  - Kubernetes API: `ipBlock` allowlist via
+    `networkPolicy.egress.kubernetesApiCIDRs`, falling back to
+    `0.0.0.0/0 minus link-local/metadata` when empty.
+  - In-cluster Postgres / Prometheus / Grafana: `podSelector` by
+    standard `app.kubernetes.io/name` labels.
+  - External monitoring: `networkPolicy.egress.monitoringCIDRs` (opt-in).
+  - LDAP: `networkPolicy.egress.ldapCIDRs` (opt-in).
+  - Extra allowed: `networkPolicy.egress.extraAllowedCIDRs`.
+  - Extra blocked: `networkPolicy.egress.extraBlockedCIDRs` (appended
+    to the universal link-local + metadata block on every IP rule).
+
+  Default values preserve current reachability for homelab / single-
+  cluster deployments; operators with out-of-cluster dependencies opt
+  into the new knobs.
+
+- **Test seam: `NewPrometheusClientWithTransport`**. Production code
+  continues to use `NewPrometheusClient`, which wires
+  `SafeHTTPTransport` by default. The new variant accepts a caller-
+  supplied `http.RoundTripper` so tests using `httptest.Server` URLs
+  on loopback (which the safe-by-default transport correctly refuses)
+  can construct the client. The doc comment is explicit that
+  production callers must keep using the safe-by-default constructor.
+
+### Known follow-ups (Phase 4 deferred — single review round)
+
+This phase follows the Phase 3 cadence: one round of `/ce-code-review`
+plus this documented follow-up list rather than chasing every regression
+through additional cycles. The deferred items below are tracked here
+for the next audit:
+
+- **SafeDialContext IPv6 dual-stack pinning.** Current implementation
+  pins to `ips[0]` — fine for single-stack hosts, but for dual-stack
+  resolvers returning both an IPv4 and IPv6 candidate, the pin
+  forecloses on the dialer's happy-eyeballs preference. Acceptable
+  trade-off (every candidate is already validated to be non-private)
+  but worth revisiting if dual-stack-only environments report
+  connectivity regressions.
+- **NetworkPolicy egress: subchart Postgres labelSelector assumes
+  bitnami/CrunchyData conventions.** Operators with custom Postgres
+  deployments may need to add `extraAllowedCIDRs` even for in-cluster
+  Postgres. Could be tightened by exposing
+  `networkPolicy.egress.postgresPodLabels` similar to the dns pod
+  label knob.
+- **Cookie Secure flag still gated on global Dev flag, not per-request
+  loopback.** `Secure: !s.Config.Dev` means an admin who bypasses the
+  chart guard with `security.insecureExposureAcknowledged=true` AND
+  runs dev mode will ship non-Secure cookies. Acceptable given the
+  explicit acknowledgement, but a future hardening could tie the
+  Secure flag to the request's TLS state rather than the global Dev
+  config.
+- **Monitoring URL validation at boot-time helm/env path.** The
+  config-override path (`KUBECENTER_MONITORING_PROMETHEUSURL` set via
+  Helm) is not subjected to SafeDialContext at boot — only at first
+  dial. Operators set this consciously at deploy time and the dial-
+  time check still applies, but a boot-time fail-fast would surface
+  misconfiguration earlier.
+- **`internal/monitoring/discovery.go:263` pre-existing unusedparams
+  diagnostic.** Not introduced by Phase 4; flag for a future cleanup
+  PR.
+
+---
+
 ## Phase 3 — Auth primitives hardening (2026-05 audit)
 
 Phase 3 closes audit findings P2-1 (trusted-proxy CIDR boundary +

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,49 @@ credentials). The audit report is `plans/security-audit-2026-05-22.md`.
   can construct the client. The doc comment is explicit that
   production callers must keep using the safe-by-default constructor.
 
+### Applied during Phase 4 code review (one round of `/ce-code-review`)
+
+The review surfaced several issues that were fixed inline before merge:
+
+- **Split SafeDialContext / StrictDialContext** (correctness C1,
+  testing TG-1, maintainability M-2). The original blanket RFC1918
+  block would have silently broken every operator running
+  `monitoring.deploy=true` because in-cluster Service ClusterIPs are
+  RFC1918. SafeDialContext (used by the monitoring clients) now
+  allows RFC1918 while still blocking loopback / link-local-metadata /
+  CGNAT / unspecified. StrictDialContext (used by cluster_router for
+  remote API server URLs) keeps the full block-list including RFC1918.
+- **`monitoring_test.go` migrated to NewPrometheusClientWithTransport**
+  (testing TG-1, maintainability M-2). I missed two call sites when
+  adding the test seam in commit a0a4a9e.
+- **Insecure-exposure ack string bypass** (adversarial, reliability
+  R-5). `--set-string security.insecureExposureAcknowledged="false"`
+  previously bypassed the guard because Helm's `not` evaluates non-
+  empty strings as truthy. Now coerces through `toString | eq "true"`.
+- **`ingress.tls: [{}]` empty-map bypass** (adversarial, reliability
+  R-5). A single empty-map entry passed `not (empty)` and rendered
+  an Ingress with `secretName: ""`. Now requires at least one entry
+  with a non-empty secretName.
+- **NetworkPolicy podSelector cross-namespace breakage** (correctness
+  C3, reliability R-3, adversarial 4). Bare podSelector matches only
+  same-namespace pods. Added `namespaceSelector: {}` to Postgres,
+  Prometheus, and Grafana egress rules so the typical
+  Prometheus-in-`monitoring`-namespace layout works.
+- **External Postgres silently blocked** (reliability R-3). Operators
+  using `externalDatabase.host` without populating
+  `networkPolicy.egress.extraAllowedCIDRs` lost DB connectivity. Added
+  a port-5432 ipBlock fallback with the universal link-local except.
+- **`networkPolicy.egress.postgresPodLabels` knob** (adversarial 7).
+  Defaults to bitnami convention; operators on CrunchyData / CNPG /
+  Zalando override the label map.
+- **DNS values comment expanded** (reliability R-2, adversarial 5).
+  Calls out Talos / RKE2 / OpenShift label divergences explicitly.
+- **`ValidateRemoteURL` context+timeout** (reliability R-1). Previous
+  `net.LookupHost` had no deadline and could stall goroutines for
+  ~90s. New `ValidateRemoteURLContext` propagates caller context;
+  the no-arg shim applies a 5s deadline so existing call sites get
+  fail-fast behavior without a refactor.
+
 ### Known follow-ups (Phase 4 deferred — single review round)
 
 This phase follows the Phase 3 cadence: one round of `/ce-code-review`
@@ -124,35 +167,60 @@ plus this documented follow-up list rather than chasing every regression
 through additional cycles. The deferred items below are tracked here
 for the next audit:
 
-- **SafeDialContext IPv6 dual-stack pinning.** Current implementation
-  pins to `ips[0]` — fine for single-stack hosts, but for dual-stack
-  resolvers returning both an IPv4 and IPv6 candidate, the pin
-  forecloses on the dialer's happy-eyeballs preference. Acceptable
-  trade-off (every candidate is already validated to be non-private)
-  but worth revisiting if dual-stack-only environments report
-  connectivity regressions.
-- **NetworkPolicy egress: subchart Postgres labelSelector assumes
-  bitnami/CrunchyData conventions.** Operators with custom Postgres
-  deployments may need to add `extraAllowedCIDRs` even for in-cluster
-  Postgres. Could be tightened by exposing
-  `networkPolicy.egress.postgresPodLabels` similar to the dns pod
-  label knob.
+- **Loki HTTP client missed SafeHTTPTransport** (reliability R-4).
+  `internal/loki/client.go` still uses bare `&http.Transport{}` while
+  every other monitoring client was migrated. Same DNS-rebinding gap
+  applies post-registration. Low-effort follow-up.
+- **SafeDialContext IPv6 dual-stack pinning** (correctness C2).
+  Current implementation pins to `ips[0]` — fine for single-stack
+  hosts but forecloses on happy-eyeballs preference for dual-stack
+  resolvers. Acceptable trade-off (every candidate is validated to
+  be non-blocked) but iterating the validated list would preserve
+  both protections and Happy Eyeballs.
+- **NAT64-wrapped metadata IPs not blocked** (adversarial 3).
+  `64:ff9b::169.254.169.254` evades `IsLinkLocalUnicast()`. Narrow
+  attack surface (IPv6-only/NAT64 AWS deployments) but worth a
+  custom-CIDR check in the next pass. NetworkPolicy `except` block
+  also only lists IPv4 `169.254.0.0/16`.
+- **`validateSettingsURL` wrapper can be inlined** (maintainability
+  M-1). After delegating to `k8s.ValidateRemoteURL`, the wrapper is
+  three lines of trivial dispatch and the string-sentinel return type
+  is inconsistent with the OIDC/LDAP handlers in the same file.
+- **`validateSettingsURL` admin-UI .svc DNS rejection** (correctness
+  C4). Operators trying to set `http://prometheus.monitoring:9090`
+  via the UI get an opaque "URL resolves to private address" error.
+  Workaround: configure via Helm values instead. UI hint or per-URL
+  trust knob could improve the UX.
+- **DNS-rebinding integration tests** (testing TG-2/TG-3/TG-4, RR-1).
+  Core security claim — hostname resolves to private IP at dial time —
+  is not covered by direct tests. Requires injecting a fake resolver
+  (package-level `lookupHost` var or `SafeDialer` struct with resolver
+  field). Literal-IP, DNS-failure, and IP-pin TOCTOU branches are
+  also untested.
+- **Helm `_validate.tpl` no negative-case CI coverage** (testing TG-5).
+  Three new fail() branches with no automated tests asserting they
+  fire. Phase 4 verified by manual matrix; future CI should run a
+  `helm template` per fail condition.
+- **`safeDialerTimeout` / `safeDialerKeepAlive` unexported** (M-3).
+  Three sibling 30s hardcoded values in the monitoring subsystem
+  cannot reference the dialer constants. Either export them or add
+  a comment cross-reference.
+- **NetworkPolicy ipBlock `except` block duplicated 6 times** (M-4).
+  Helm doesn't have a clean partial-template extraction for the
+  except stanza alone. Mitigated by sharing the `$blockedRanges` var
+  but the rendering loop repeats. Worth a comment flagging the
+  parallel-edit requirement.
 - **Cookie Secure flag still gated on global Dev flag, not per-request
   loopback.** `Secure: !s.Config.Dev` means an admin who bypasses the
   chart guard with `security.insecureExposureAcknowledged=true` AND
   runs dev mode will ship non-Secure cookies. Acceptable given the
-  explicit acknowledgement, but a future hardening could tie the
-  Secure flag to the request's TLS state rather than the global Dev
-  config.
-- **Monitoring URL validation at boot-time helm/env path.** The
-  config-override path (`KUBECENTER_MONITORING_PROMETHEUSURL` set via
-  Helm) is not subjected to SafeDialContext at boot — only at first
-  dial. Operators set this consciously at deploy time and the dial-
-  time check still applies, but a boot-time fail-fast would surface
+  explicit acknowledgement.
+- **Monitoring URL validation at boot-time helm/env path.** Operator-
+  set URLs via Helm bypass `validateSettingsURL`. The dial-time check
+  still applies but boot-time fail-fast would surface
   misconfiguration earlier.
 - **`internal/monitoring/discovery.go:263` pre-existing unusedparams
-  diagnostic.** Not introduced by Phase 4; flag for a future cleanup
-  PR.
+  diagnostic.** Not introduced by Phase 4.
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ dev: dev-backend
 
 dev-db:
 	docker compose up -d
-	@echo "PostgreSQL: postgresql://k8scenter:k8scenter@localhost:5432/k8scenter?sslmode=disable"
+	@echo "PostgreSQL: postgresql://k8scenter:k8scenter@127.0.0.1:5432/k8scenter?sslmode=disable (loopback-only; override POSTGRES_PASSWORD via .env)"
 
 dev-db-stop:
 	docker compose down

--- a/backend/internal/k8s/cluster_router.go
+++ b/backend/internal/k8s/cluster_router.go
@@ -410,6 +410,14 @@ func (cr *ClusterRouter) buildRemoteConfig(ctx context.Context, clusterID, usern
 		},
 		QPS:   50,
 		Burst: 100,
+		// P2-6 part 2: defend against DNS rebinding and unintended
+		// server-controlled redirects by re-resolving the cluster host
+		// on every dial and rejecting any candidate IP in the SSRF
+		// block-list. rest.Config.Dial is invoked by client-go's
+		// underlying http transport for each new TCP connection, so
+		// this protects every API call routed through the returned
+		// config — not just the first dial after validation.
+		Dial: SafeDialContext,
 	}
 
 	if err := applyClusterTLS(cfg, clusterID, caData, cluster.AllowInsecureTLS, cr.logger); err != nil {

--- a/backend/internal/k8s/cluster_router.go
+++ b/backend/internal/k8s/cluster_router.go
@@ -412,12 +412,15 @@ func (cr *ClusterRouter) buildRemoteConfig(ctx context.Context, clusterID, usern
 		Burst: 100,
 		// P2-6 part 2: defend against DNS rebinding and unintended
 		// server-controlled redirects by re-resolving the cluster host
-		// on every dial and rejecting any candidate IP in the SSRF
-		// block-list. rest.Config.Dial is invoked by client-go's
+		// on every dial and rejecting any candidate IP in the strict
+		// block-list (including RFC1918 — a remote cluster API server
+		// that resolves to a private address either was never legitimate
+		// or has been rebound mid-session, and either case warrants
+		// fail-closed). rest.Config.Dial is invoked by client-go's
 		// underlying http transport for each new TCP connection, so
 		// this protects every API call routed through the returned
 		// config — not just the first dial after validation.
-		Dial: SafeDialContext,
+		Dial: StrictDialContext,
 	}
 
 	if err := applyClusterTLS(cfg, clusterID, caData, cluster.AllowInsecureTLS, cr.logger); err != nil {
@@ -520,17 +523,48 @@ func ValidateRemoteURL(apiServerURL string) error {
 }
 
 // checkIPNotPrivate returns an error when ip is in any range we treat
-// as off-limits for outbound requests built from user-supplied URLs:
-// loopback, private RFC1918, link-local (which includes 169.254.169.254
-// cloud metadata), CGNAT, and the unspecified 0.0.0.0/:: addresses.
-// Centralised so ValidateRemoteURL and the SSRF DialContext share one
-// blocklist — adding a range later automatically tightens both paths.
+// as off-limits for outbound requests built from user-supplied URLs
+// targeting external endpoints: loopback, RFC1918 private, link-local
+// (which includes 169.254.169.254 cloud metadata), CGNAT, and the
+// unspecified 0.0.0.0/:: addresses. Used by ValidateRemoteURL +
+// StrictDialContext for remote cluster URLs and other admin-supplied
+// inputs that must not resolve to anything cluster-internal.
 func checkIPNotPrivate(ip net.IP) error {
 	if ip.IsLoopback() {
 		return fmt.Errorf("URL resolves to loopback address %s", ip)
 	}
 	if ip.IsPrivate() {
 		return fmt.Errorf("URL resolves to private address %s", ip)
+	}
+	if ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+		return fmt.Errorf("URL resolves to link-local/metadata address %s", ip)
+	}
+	if ip.IsUnspecified() {
+		return fmt.Errorf("URL resolves to unspecified address %s", ip)
+	}
+	if cgnatNet.Contains(ip) {
+		return fmt.Errorf("URL resolves to CGNAT address %s", ip)
+	}
+	return nil
+}
+
+// checkIPAlwaysBad returns an error for IP ranges that are off-limits
+// even from inside the cluster: loopback (DNS-rebinding to localhost),
+// link-local (cloud metadata IAM theft via 169.254.169.254), CGNAT
+// (carrier infrastructure), and unspecified. RFC1918 is INTENTIONALLY
+// allowed — every in-cluster Service ClusterIP falls inside RFC1918,
+// and SafeDialContext is used by the in-cluster monitoring clients
+// where blocking RFC1918 would silently break the bundled monitoring
+// subchart.
+//
+// The audit's "block private/loopback" recommendation in P2-6 was
+// framed for admin-supplied URLs targeting external endpoints. For
+// those, use checkIPNotPrivate via StrictDialContext. For URLs that
+// may legitimately resolve to a cluster-internal ClusterIP, use this
+// looser check via SafeDialContext.
+func checkIPAlwaysBad(ip net.IP) error {
+	if ip.IsLoopback() {
+		return fmt.Errorf("URL resolves to loopback address %s", ip)
 	}
 	if ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
 		return fmt.Errorf("URL resolves to link-local/metadata address %s", ip)

--- a/backend/internal/k8s/cluster_router.go
+++ b/backend/internal/k8s/cluster_router.go
@@ -457,8 +457,20 @@ var cgnatNet = &net.IPNet{
 }
 
 // ValidateRemoteURL checks that a remote cluster URL does not resolve to
-// private/loopback/CGNAT IP addresses. This prevents SSRF attacks.
-// Called both at registration time and at connection time (DNS rebinding defense).
+// private/loopback/CGNAT/link-local/metadata IP addresses. This prevents
+// SSRF attacks. Called both at registration time and at connection time
+// (DNS rebinding defense).
+//
+// Phase 4 of the 2026-05-22 security audit (P2-6) — fails closed on
+// DNS resolution errors. The previous implementation allowed the
+// connection through on lookup failure, on the theory that the
+// underlying client would produce a more specific error. That left a
+// window where a transient DNS server response (NXDOMAIN intermittently
+// returned for a poisoned response, or a rebinding flip between
+// validation and dial) could let a request reach a private endpoint
+// the IP-based block was supposed to refuse. Fail-closed is the safer
+// posture: operators with broken DNS see an unambiguous error instead
+// of an SSRF-shaped silent success.
 func ValidateRemoteURL(apiServerURL string) error {
 	u, err := url.Parse(apiServerURL)
 	if err != nil {
@@ -470,12 +482,20 @@ func ValidateRemoteURL(apiServerURL string) error {
 		return fmt.Errorf("empty hostname")
 	}
 
-	// Resolve hostname to IPs
+	// If the host is already a literal IP, validate it directly without
+	// going through DNS. Skipping resolution avoids spurious DNS-error
+	// failures in environments without a resolver (in-cluster sidecar
+	// configurations using IP-only endpoints).
+	if ip := net.ParseIP(host); ip != nil {
+		return checkIPNotPrivate(ip)
+	}
+
 	ips, err := net.LookupHost(host)
 	if err != nil {
-		// If DNS resolution fails, allow the connection — the k8s client will
-		// produce a more specific error. We only block known-private IPs.
-		return nil
+		return fmt.Errorf("DNS resolution failed for %s: %w", host, err)
+	}
+	if len(ips) == 0 {
+		return fmt.Errorf("DNS resolution returned no IPs for %s", host)
 	}
 
 	for _, ipStr := range ips {
@@ -483,13 +503,35 @@ func ValidateRemoteURL(apiServerURL string) error {
 		if ip == nil {
 			continue
 		}
-		if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified() {
-			return fmt.Errorf("URL resolves to private/loopback address %s", ipStr)
-		}
-		if cgnatNet.Contains(ip) {
-			return fmt.Errorf("URL resolves to CGNAT address %s", ipStr)
+		if err := checkIPNotPrivate(ip); err != nil {
+			return err
 		}
 	}
 
+	return nil
+}
+
+// checkIPNotPrivate returns an error when ip is in any range we treat
+// as off-limits for outbound requests built from user-supplied URLs:
+// loopback, private RFC1918, link-local (which includes 169.254.169.254
+// cloud metadata), CGNAT, and the unspecified 0.0.0.0/:: addresses.
+// Centralised so ValidateRemoteURL and the SSRF DialContext share one
+// blocklist — adding a range later automatically tightens both paths.
+func checkIPNotPrivate(ip net.IP) error {
+	if ip.IsLoopback() {
+		return fmt.Errorf("URL resolves to loopback address %s", ip)
+	}
+	if ip.IsPrivate() {
+		return fmt.Errorf("URL resolves to private address %s", ip)
+	}
+	if ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+		return fmt.Errorf("URL resolves to link-local/metadata address %s", ip)
+	}
+	if ip.IsUnspecified() {
+		return fmt.Errorf("URL resolves to unspecified address %s", ip)
+	}
+	if cgnatNet.Contains(ip) {
+		return fmt.Errorf("URL resolves to CGNAT address %s", ip)
+	}
 	return nil
 }

--- a/backend/internal/k8s/cluster_router.go
+++ b/backend/internal/k8s/cluster_router.go
@@ -467,10 +467,28 @@ var cgnatNet = &net.IPNet{
 	Mask: net.CIDRMask(10, 32),
 }
 
-// ValidateRemoteURL checks that a remote cluster URL does not resolve to
-// private/loopback/CGNAT/link-local/metadata IP addresses. This prevents
-// SSRF attacks. Called both at registration time and at connection time
-// (DNS rebinding defense).
+// validateURLLookupTimeout caps the DNS resolver wait when callers
+// don't supply a deadline. 5s is well below the 30s safeDialerTimeout
+// downstream and well above the typical kube-dns response. Phase 4
+// review (reliability R-1) — net.LookupHost without a deadline can
+// stall the calling goroutine for up to the OS resolver timeout
+// (~90s on default glibc), stacking goroutines in the cluster prober.
+const validateURLLookupTimeout = 5 * time.Second
+
+// ValidateRemoteURL is the no-context shim retained for callers that
+// can't easily plumb a context. Prefer ValidateRemoteURLContext.
+// Internally creates a 5-second deadline so a slow / broken resolver
+// can't stall the caller for 90s.
+func ValidateRemoteURL(apiServerURL string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), validateURLLookupTimeout)
+	defer cancel()
+	return ValidateRemoteURLContext(ctx, apiServerURL)
+}
+
+// ValidateRemoteURLContext checks that a remote cluster URL does not
+// resolve to private/loopback/CGNAT/link-local/metadata IP addresses.
+// This prevents SSRF attacks. Called both at registration time and at
+// connection time (DNS rebinding defense).
 //
 // Phase 4 of the 2026-05-22 security audit (P2-6) — fails closed on
 // DNS resolution errors. The previous implementation allowed the
@@ -482,7 +500,11 @@ var cgnatNet = &net.IPNet{
 // the IP-based block was supposed to refuse. Fail-closed is the safer
 // posture: operators with broken DNS see an unambiguous error instead
 // of an SSRF-shaped silent success.
-func ValidateRemoteURL(apiServerURL string) error {
+//
+// Phase 4 review (reliability R-1) — the ctx parameter caps the
+// resolver wait. Callers without a context should use ValidateRemoteURL
+// (which applies a 5s deadline internally).
+func ValidateRemoteURLContext(ctx context.Context, apiServerURL string) error {
 	u, err := url.Parse(apiServerURL)
 	if err != nil {
 		return fmt.Errorf("invalid URL: %w", err)
@@ -501,7 +523,7 @@ func ValidateRemoteURL(apiServerURL string) error {
 		return checkIPNotPrivate(ip)
 	}
 
-	ips, err := net.LookupHost(host)
+	ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
 	if err != nil {
 		return fmt.Errorf("DNS resolution failed for %s: %w", host, err)
 	}
@@ -509,8 +531,8 @@ func ValidateRemoteURL(apiServerURL string) error {
 		return fmt.Errorf("DNS resolution returned no IPs for %s", host)
 	}
 
-	for _, ipStr := range ips {
-		ip := net.ParseIP(ipStr)
+	for _, ipAddr := range ips {
+		ip := ipAddr.IP
 		if ip == nil {
 			continue
 		}

--- a/backend/internal/k8s/safe_dialer.go
+++ b/backend/internal/k8s/safe_dialer.go
@@ -1,0 +1,100 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+)
+
+// safeDialerTimeout is the connect deadline applied to every dial that
+// goes through SafeDialContext. Matches the existing 30s window used by
+// the cluster prober, monitoring discovery, and rest.Config defaults.
+const safeDialerTimeout = 30 * time.Second
+
+// safeDialerKeepAlive is the TCP keepalive window applied to dials. The
+// http stdlib default is 30s; mirrored so the safe dialer doesn't quietly
+// shorten reuse windows for proxy connections.
+const safeDialerKeepAlive = 30 * time.Second
+
+// SafeDialContext is a net.Dialer.DialContext-compatible function that
+// re-resolves the address on every connection and rejects the dial when
+// any candidate IP falls inside the SSRF block-list (loopback, RFC1918,
+// link-local/metadata, CGNAT, unspecified).
+//
+// Phase 4 of the 2026-05-22 security audit (P2-6) wired this in front
+// of every long-lived HTTP transport that operators can point at a
+// user-supplied URL — cluster_router remote rest.Config, the Grafana
+// reverse proxy, the Grafana API client, and the Prometheus API client.
+// Catches the gap between validation-time DNS resolution and connect-
+// time resolution (DNS rebinding) and protects against server-side
+// redirect chains that try to pivot to internal addresses, since each
+// new dial re-runs the IP check.
+func SafeDialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, fmt.Errorf("invalid dial address %q: %w", address, err)
+	}
+
+	// Literal-IP fast path — no resolver round-trip needed.
+	if ip := net.ParseIP(host); ip != nil {
+		if err := checkIPNotPrivate(ip); err != nil {
+			return nil, fmt.Errorf("SSRF dial refused: %w", err)
+		}
+		return baseDialer().DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+	}
+
+	// Resolve host and validate every candidate IP before connecting.
+	// Failing closed on resolution error matches ValidateRemoteURL's
+	// posture — operators with broken DNS see a clear error rather than
+	// a silent fallback.
+	resolver := net.DefaultResolver
+	ips, err := resolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, fmt.Errorf("SSRF dial DNS lookup failed for %s: %w", host, err)
+	}
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("SSRF dial DNS returned no IPs for %s", host)
+	}
+	for _, ipAddr := range ips {
+		if err := checkIPNotPrivate(ipAddr.IP); err != nil {
+			return nil, fmt.Errorf("SSRF dial refused for %s: %w", host, err)
+		}
+	}
+
+	// Pin to the first validated IP so what we just checked is exactly
+	// what gets dialled. Without pinning, a racy resolver could return
+	// a different (private) IP on the underlying Dial call, defeating
+	// the check we just performed.
+	pinned := net.JoinHostPort(ips[0].IP.String(), port)
+	return baseDialer().DialContext(ctx, network, pinned)
+}
+
+// baseDialer returns the dialer shared by every SafeDialContext call.
+// Kept as a function (not a package var) so each call gets its own
+// timeout context and the stdlib doesn't share connection state across
+// unrelated callers.
+func baseDialer() *net.Dialer {
+	return &net.Dialer{
+		Timeout:   safeDialerTimeout,
+		KeepAlive: safeDialerKeepAlive,
+	}
+}
+
+// SafeHTTPTransport returns an *http.Transport pre-wired with
+// SafeDialContext. Use for HTTP clients that talk to operator-supplied
+// URLs (Grafana, Prometheus, monitoring proxies). The transport's
+// other settings mirror http.DefaultTransport so connection pooling
+// stays comparable.
+func SafeHTTPTransport() *http.Transport {
+	return &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           SafeDialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+}

--- a/backend/internal/k8s/safe_dialer.go
+++ b/backend/internal/k8s/safe_dialer.go
@@ -20,18 +20,49 @@ const safeDialerKeepAlive = 30 * time.Second
 
 // SafeDialContext is a net.Dialer.DialContext-compatible function that
 // re-resolves the address on every connection and rejects the dial when
-// any candidate IP falls inside the SSRF block-list (loopback, RFC1918,
-// link-local/metadata, CGNAT, unspecified).
+// any candidate IP falls inside the always-bad block-list (loopback,
+// link-local/metadata, CGNAT, unspecified). RFC1918 IPs are ALLOWED —
+// they're the normal home of in-cluster Kubernetes Service ClusterIPs.
 //
-// Phase 4 of the 2026-05-22 security audit (P2-6) wired this in front
-// of every long-lived HTTP transport that operators can point at a
-// user-supplied URL — cluster_router remote rest.Config, the Grafana
-// reverse proxy, the Grafana API client, and the Prometheus API client.
-// Catches the gap between validation-time DNS resolution and connect-
-// time resolution (DNS rebinding) and protects against server-side
-// redirect chains that try to pivot to internal addresses, since each
-// new dial re-runs the IP check.
+// Use for HTTP transports that talk to URLs which may legitimately
+// resolve to in-cluster RFC1918 ClusterIPs (the bundled monitoring
+// subchart's Prometheus / Grafana, in-cluster Postgres, etc.). The
+// audit's "block private/loopback" recommendation in P2-6 was framed
+// for external-only endpoints; applying it to in-cluster auto-
+// discovery would silently break the entire bundled-monitoring path
+// because every ClusterIP falls inside 10.0.0.0/8 / 172.16.0.0/12 /
+// 192.168.0.0/16. SafeDialContext still defends against the audit's
+// real threats: DNS rebinding to localhost (loopback block) and IAM-
+// credential theft via cloud metadata endpoints (link-local block).
+//
+// For URLs that should NEVER resolve to an internal address — remote
+// cluster API servers, admin-UI-configured monitoring endpoints — use
+// StrictDialContext, which adds RFC1918 to the block-list.
+//
+// Phase 4 of the 2026-05-22 security audit (P2-6 part 2). The split
+// between Safe and Strict was added during review when reviewers
+// flagged that the original blanket RFC1918 block would break in-
+// cluster monitoring (correctness C1, testing TG-1, maintainability
+// M-2 in the Phase 4 review).
 func SafeDialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	return dialContextWith(ctx, network, address, checkIPAlwaysBad)
+}
+
+// StrictDialContext mirrors SafeDialContext but additionally rejects
+// RFC1918 candidates. Use for HTTP transports that target operator-
+// supplied URLs which must terminate outside the cluster — primarily
+// the remote cluster API server reached via cluster_router. A remote
+// cluster URL that resolves to RFC1918 either was never legitimate or
+// has been rebound mid-session, both of which warrant fail-closed.
+func StrictDialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	return dialContextWith(ctx, network, address, checkIPNotPrivate)
+}
+
+// dialContextWith is the shared dial path, parameterised on the IP
+// block-list. Same re-resolve / iterate / pin-to-validated-IP shape;
+// the only difference between Safe and Strict is which IP ranges the
+// check function rejects.
+func dialContextWith(ctx context.Context, network, address string, check func(net.IP) error) (net.Conn, error) {
 	host, port, err := net.SplitHostPort(address)
 	if err != nil {
 		return nil, fmt.Errorf("invalid dial address %q: %w", address, err)
@@ -39,7 +70,7 @@ func SafeDialContext(ctx context.Context, network, address string) (net.Conn, er
 
 	// Literal-IP fast path — no resolver round-trip needed.
 	if ip := net.ParseIP(host); ip != nil {
-		if err := checkIPNotPrivate(ip); err != nil {
+		if err := check(ip); err != nil {
 			return nil, fmt.Errorf("SSRF dial refused: %w", err)
 		}
 		return baseDialer().DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
@@ -58,7 +89,7 @@ func SafeDialContext(ctx context.Context, network, address string) (net.Conn, er
 		return nil, fmt.Errorf("SSRF dial DNS returned no IPs for %s", host)
 	}
 	for _, ipAddr := range ips {
-		if err := checkIPNotPrivate(ipAddr.IP); err != nil {
+		if err := check(ipAddr.IP); err != nil {
 			return nil, fmt.Errorf("SSRF dial refused for %s: %w", host, err)
 		}
 	}
@@ -83,14 +114,29 @@ func baseDialer() *net.Dialer {
 }
 
 // SafeHTTPTransport returns an *http.Transport pre-wired with
-// SafeDialContext. Use for HTTP clients that talk to operator-supplied
-// URLs (Grafana, Prometheus, monitoring proxies). The transport's
-// other settings mirror http.DefaultTransport so connection pooling
-// stays comparable.
+// SafeDialContext (allows in-cluster RFC1918, blocks loopback /
+// link-local / metadata / CGNAT / unspecified). Use for HTTP clients
+// that talk to URLs which may legitimately resolve to a cluster-
+// internal Service ClusterIP — the bundled monitoring subchart's
+// Prometheus / Grafana clients and the Grafana reverse proxy. The
+// transport's other settings mirror http.DefaultTransport so
+// connection pooling stays comparable.
 func SafeHTTPTransport() *http.Transport {
+	return transportWithDial(SafeDialContext)
+}
+
+// StrictHTTPTransport returns an *http.Transport pre-wired with
+// StrictDialContext (also blocks RFC1918). Use for HTTP clients that
+// talk to URLs which must resolve outside the cluster — currently
+// only the remote cluster API server reached via cluster_router.
+func StrictHTTPTransport() *http.Transport {
+	return transportWithDial(StrictDialContext)
+}
+
+func transportWithDial(dial func(context.Context, string, string) (net.Conn, error)) *http.Transport {
 	return &http.Transport{
 		Proxy:                 http.ProxyFromEnvironment,
-		DialContext:           SafeDialContext,
+		DialContext:           dial,
 		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          100,
 		IdleConnTimeout:       90 * time.Second,

--- a/backend/internal/k8s/safe_dialer_test.go
+++ b/backend/internal/k8s/safe_dialer_test.go
@@ -1,0 +1,86 @@
+package k8s
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestSafeDialContext_LiteralPrivateIPRefused exercises the literal-IP
+// fast path: a private/loopback/link-local destination must be refused
+// before any TCP connection is attempted, so the IP block-list applies
+// even when the caller bypasses DNS by passing a literal address.
+func TestSafeDialContext_LiteralPrivateIPRefused(t *testing.T) {
+	cases := []struct {
+		name    string
+		address string
+		needle  string
+	}{
+		{"loopback IPv4", "127.0.0.1:1234", "loopback"},
+		{"loopback IPv6", "[::1]:1234", "loopback"},
+		{"RFC1918", "10.0.0.5:443", "private"},
+		{"link-local / metadata", "169.254.169.254:80", "link-local"},
+		{"CGNAT", "100.64.1.1:443", "CGNAT"},
+		{"unspecified", "0.0.0.0:443", "unspecified"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			_, err := SafeDialContext(ctx, "tcp", tc.address)
+			if err == nil {
+				t.Fatalf("expected dial refusal containing %q, got nil", tc.needle)
+			}
+			if !strings.Contains(err.Error(), "SSRF") {
+				t.Fatalf("expected error to mention SSRF, got: %v", err)
+			}
+			if !strings.Contains(err.Error(), tc.needle) {
+				t.Fatalf("expected error to mention %q, got: %v", tc.needle, err)
+			}
+		})
+	}
+}
+
+// TestSafeDialContext_DNSFailureFailsClosed verifies the DNS-resolution
+// path matches ValidateRemoteURL's posture: a lookup failure surfaces as
+// an explicit dial refusal instead of silently allowing the connection.
+func TestSafeDialContext_DNSFailureFailsClosed(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, err := SafeDialContext(ctx, "tcp", "this-host-cannot-exist.invalid:443")
+	if err == nil {
+		t.Fatal("expected DNS failure to fail closed, got nil error")
+	}
+	if !strings.Contains(err.Error(), "DNS") {
+		t.Fatalf("expected error to mention DNS, got: %v", err)
+	}
+}
+
+// TestSafeDialContext_MalformedAddress covers the SplitHostPort failure
+// branch — defensive coverage for callers that hand the dialer a value
+// the stdlib transport would otherwise accept and then quietly fail on.
+func TestSafeDialContext_MalformedAddress(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	_, err := SafeDialContext(ctx, "tcp", "not-a-valid-address")
+	if err == nil {
+		t.Fatal("expected malformed-address rejection, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid dial address") {
+		t.Fatalf("expected error to mention invalid dial address, got: %v", err)
+	}
+}
+
+// TestSafeHTTPTransport_NotNil is a tiny smoke test that the constructor
+// returns a usable transport object with the DialContext hook set — the
+// callers that use SafeHTTPTransport directly rely on this being wired.
+func TestSafeHTTPTransport_NotNil(t *testing.T) {
+	tr := SafeHTTPTransport()
+	if tr == nil {
+		t.Fatal("SafeHTTPTransport returned nil")
+	}
+	if tr.DialContext == nil {
+		t.Fatal("SafeHTTPTransport returned transport with nil DialContext — dial-time SSRF check would be bypassed")
+	}
+}

--- a/backend/internal/k8s/safe_dialer_test.go
+++ b/backend/internal/k8s/safe_dialer_test.go
@@ -7,11 +7,11 @@ import (
 	"time"
 )
 
-// TestSafeDialContext_LiteralPrivateIPRefused exercises the literal-IP
-// fast path: a private/loopback/link-local destination must be refused
-// before any TCP connection is attempted, so the IP block-list applies
-// even when the caller bypasses DNS by passing a literal address.
-func TestSafeDialContext_LiteralPrivateIPRefused(t *testing.T) {
+// TestSafeDialContext_LiteralBadIPRefused exercises the literal-IP
+// fast path on the always-bad ranges. SafeDialContext (unlike
+// StrictDialContext) deliberately allows RFC1918 so it doesn't break
+// in-cluster Service ClusterIPs, so RFC1918 is NOT in this list.
+func TestSafeDialContext_LiteralBadIPRefused(t *testing.T) {
 	cases := []struct {
 		name    string
 		address string
@@ -19,7 +19,6 @@ func TestSafeDialContext_LiteralPrivateIPRefused(t *testing.T) {
 	}{
 		{"loopback IPv4", "127.0.0.1:1234", "loopback"},
 		{"loopback IPv6", "[::1]:1234", "loopback"},
-		{"RFC1918", "10.0.0.5:443", "private"},
 		{"link-local / metadata", "169.254.169.254:80", "link-local"},
 		{"CGNAT", "100.64.1.1:443", "CGNAT"},
 		{"unspecified", "0.0.0.0:443", "unspecified"},
@@ -40,6 +39,64 @@ func TestSafeDialContext_LiteralPrivateIPRefused(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestStrictDialContext_LiteralPrivateIPRefused covers the strict
+// variant — same always-bad ranges as Safe PLUS RFC1918.
+func TestStrictDialContext_LiteralPrivateIPRefused(t *testing.T) {
+	cases := []struct {
+		name    string
+		address string
+		needle  string
+	}{
+		{"loopback IPv4", "127.0.0.1:1234", "loopback"},
+		{"loopback IPv6", "[::1]:1234", "loopback"},
+		{"RFC1918", "10.0.0.5:443", "private"},
+		{"RFC1918 192.168", "192.168.5.5:443", "private"},
+		{"link-local / metadata", "169.254.169.254:80", "link-local"},
+		{"CGNAT", "100.64.1.1:443", "CGNAT"},
+		{"unspecified", "0.0.0.0:443", "unspecified"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			_, err := StrictDialContext(ctx, "tcp", tc.address)
+			if err == nil {
+				t.Fatalf("expected dial refusal containing %q, got nil", tc.needle)
+			}
+			if !strings.Contains(err.Error(), "SSRF") {
+				t.Fatalf("expected error to mention SSRF, got: %v", err)
+			}
+			if !strings.Contains(err.Error(), tc.needle) {
+				t.Fatalf("expected error to mention %q, got: %v", tc.needle, err)
+			}
+		})
+	}
+}
+
+// TestSafeDialContext_AllowsRFC1918LiteralIP confirms the Safe variant
+// permits RFC1918 destinations (in-cluster Service ClusterIPs). The
+// dial will fail at the TCP layer because no service is listening,
+// but it must NOT fail at the SSRF check. A regression that hoisted
+// RFC1918 into checkIPAlwaysBad would surface here as an "SSRF dial
+// refused: ... private" error before the TCP attempt.
+func TestSafeDialContext_AllowsRFC1918LiteralIP(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	// Use a port that's unlikely to be open on any RFC1918 host; the
+	// expected outcome is a dial timeout / connection refusal at the
+	// network layer, not an SSRF block.
+	_, err := SafeDialContext(ctx, "tcp", "10.255.255.254:1")
+	if err == nil {
+		// Surprising — something accepted the connection. Test still
+		// passes because the SSRF check didn't fire.
+		return
+	}
+	if strings.Contains(err.Error(), "SSRF") {
+		t.Fatalf("SafeDialContext incorrectly refused RFC1918 destination as SSRF: %v", err)
+	}
+	// Any other error (network unreachable, timeout, refused) is fine.
 }
 
 // TestSafeDialContext_DNSFailureFailsClosed verifies the DNS-resolution

--- a/backend/internal/k8s/validate_remote_url_test.go
+++ b/backend/internal/k8s/validate_remote_url_test.go
@@ -1,0 +1,80 @@
+package k8s
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestValidateRemoteURL_LiteralIPs covers the IP-only fast path. These
+// cases must work without DNS — checkIPNotPrivate runs directly when
+// the URL host parses as a literal IP.
+func TestValidateRemoteURL_LiteralIPs(t *testing.T) {
+	cases := []struct {
+		name       string
+		url        string
+		wantErrSub string // empty → expect no error
+	}{
+		{"public IPv4 v4 host", "https://1.1.1.1:6443", ""},
+		{"public IPv4 in v6 brackets", "https://[2606:4700:4700::1111]:6443", ""},
+		{"loopback IPv4", "https://127.0.0.1:6443", "loopback"},
+		{"loopback IPv6", "https://[::1]:6443", "loopback"},
+		{"RFC1918 10.0.0.0/8", "https://10.1.2.3:6443", "private"},
+		{"RFC1918 172.16.0.0/12", "https://172.16.5.5:6443", "private"},
+		{"RFC1918 192.168.0.0/16", "https://192.168.1.1:6443", "private"},
+		{"link-local 169.254.0.0/16 (metadata)", "https://169.254.169.254:6443", "link-local"},
+		{"IPv6 link-local fe80::/10", "https://[fe80::1]:6443", "link-local"},
+		{"CGNAT 100.64.0.0/10", "https://100.64.0.1:6443", "CGNAT"},
+		{"unspecified 0.0.0.0", "https://0.0.0.0:6443", "unspecified"},
+		{"unspecified ::", "https://[::]:6443", "unspecified"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateRemoteURL(tc.url)
+			if tc.wantErrSub == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErrSub)
+			}
+			if !strings.Contains(err.Error(), tc.wantErrSub) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tc.wantErrSub)
+			}
+		})
+	}
+}
+
+// TestValidateRemoteURL_DNSFailureFailsClosed covers the P2-6 hardening:
+// previous implementation allowed connections through on lookup failure.
+// Now lookup failure is a fatal validation error.
+func TestValidateRemoteURL_DNSFailureFailsClosed(t *testing.T) {
+	// Use a deliberately invalid TLD that no resolver can answer.
+	err := ValidateRemoteURL("https://this-host-cannot-exist.invalid:6443")
+	if err == nil {
+		t.Fatal("expected DNS failure to fail closed, got nil error")
+	}
+	if !strings.Contains(err.Error(), "DNS") {
+		t.Fatalf("expected error to mention DNS, got: %v", err)
+	}
+}
+
+// TestValidateRemoteURL_MalformedInputs covers parse-stage rejections.
+func TestValidateRemoteURL_MalformedInputs(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+	}{
+		{"unparseable", "://not a url"},
+		{"empty hostname", "https://"},
+		{"scheme only", "https:///path"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ValidateRemoteURL(tc.url); err == nil {
+				t.Fatalf("expected error for input %q, got nil", tc.url)
+			}
+		})
+	}
+}

--- a/backend/internal/monitoring/discovery.go
+++ b/backend/internal/monitoring/discovery.go
@@ -421,8 +421,15 @@ func newGrafanaProxy(grafanaURL, token string) (http.Handler, error) {
 	// F#17: bound the response-header wait so a slow/hung Grafana backend
 	// can't tie up proxy goroutines indefinitely. Matches the 30s timeouts on
 	// GrafanaClient.QueryRange / PrometheusClient.QueryRange.
-	proxy.Transport = &http.Transport{
-		ResponseHeaderTimeout: 30 * time.Second,
-	}
+	//
+	// P2-6 part 2 (Phase 4 security audit 2026-05-22): the dial path uses
+	// SafeDialContext so each new connection re-resolves the Grafana host
+	// and rejects private/loopback/link-local/metadata IPs. Defends against
+	// DNS rebinding (an attacker's resolver flipping between validation
+	// and dial) and against Grafana issuing a 30x redirect to an internal
+	// address — every dial in the redirect chain re-runs the IP check.
+	safeTransport := k8s.SafeHTTPTransport()
+	safeTransport.ResponseHeaderTimeout = 30 * time.Second
+	proxy.Transport = safeTransport
 	return proxy, nil
 }

--- a/backend/internal/monitoring/grafana.go
+++ b/backend/internal/monitoring/grafana.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/kubecenter/kubecenter/internal/k8s"
 	"github.com/kubecenter/kubecenter/internal/monitoring/dashboards"
 )
 
@@ -20,12 +21,18 @@ type GrafanaClient struct {
 	httpClient *http.Client
 }
 
-// NewGrafanaClient creates a Grafana API client.
+// NewGrafanaClient creates a Grafana API client. The underlying
+// transport uses k8s.SafeHTTPTransport so every TCP dial re-resolves
+// the Grafana host and blocks private/loopback/link-local/metadata
+// candidate IPs (P2-6 part 2, Phase 4 security audit 2026-05-22).
 func NewGrafanaClient(baseURL, token string) *GrafanaClient {
 	return &GrafanaClient{
-		baseURL:    baseURL,
-		token:      token,
-		httpClient: &http.Client{Timeout: 30 * time.Second},
+		baseURL: baseURL,
+		token:   token,
+		httpClient: &http.Client{
+			Timeout:   30 * time.Second,
+			Transport: k8s.SafeHTTPTransport(),
+		},
 	}
 }
 

--- a/backend/internal/monitoring/monitoring_test.go
+++ b/backend/internal/monitoring/monitoring_test.go
@@ -231,7 +231,7 @@ func TestHandleQuery_MissingQuery(t *testing.T) {
 	}))
 	defer mockProm.Close()
 
-	pc, _ := NewPrometheusClient(mockProm.URL)
+	pc, _ := NewPrometheusClientWithTransport(mockProm.URL, http.DefaultTransport)
 	d := &Discoverer{
 		status:     &MonitoringStatus{Prometheus: ComponentStatus{Available: true}},
 		promClient: pc,
@@ -248,7 +248,7 @@ func TestHandleQuery_MissingQuery(t *testing.T) {
 }
 
 func TestHandleQuery_QueryTooLong(t *testing.T) {
-	pc, _ := NewPrometheusClient("http://localhost:9090")
+	pc, _ := NewPrometheusClientWithTransport("http://localhost:9090", http.DefaultTransport)
 	d := &Discoverer{
 		status:     &MonitoringStatus{Prometheus: ComponentStatus{Available: true}},
 		promClient: pc,

--- a/backend/internal/monitoring/prometheus.go
+++ b/backend/internal/monitoring/prometheus.go
@@ -25,22 +25,23 @@ type PrometheusClient struct {
 // loopback/link-local/metadata candidate IPs (P2-6 part 2, Phase 4
 // security audit 2026-05-22).
 func NewPrometheusClient(address string) (*PrometheusClient, error) {
+	return NewPrometheusClientWithTransport(address, k8s.SafeHTTPTransport())
+}
+
+// NewPrometheusClientWithTransport builds the same client as
+// NewPrometheusClient but with a caller-supplied http.RoundTripper. Use
+// in tests that talk to httptest.Server URLs on loopback (which the
+// safe-by-default transport rejects). Production code MUST use
+// NewPrometheusClient so the SSRF defense stays wired by default.
+func NewPrometheusClientWithTransport(address string, rt http.RoundTripper) (*PrometheusClient, error) {
 	client, err := api.NewClient(api.Config{
 		Address:      address,
-		RoundTripper: safePromRoundTripper(),
+		RoundTripper: rt,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("creating prometheus client: %w", err)
 	}
 	return &PrometheusClient{api: v1.NewAPI(client)}, nil
-}
-
-// safePromRoundTripper returns the http.RoundTripper used by every
-// Prometheus client instance. Built as a function (not a package var)
-// so each client gets its own connection pool, matching the stdlib
-// default and the prometheus client_golang convention.
-func safePromRoundTripper() http.RoundTripper {
-	return k8s.SafeHTTPTransport()
 }
 
 // Query runs a PromQL instant query.

--- a/backend/internal/monitoring/prometheus.go
+++ b/backend/internal/monitoring/prometheus.go
@@ -3,12 +3,15 @@ package monitoring
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/api"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
+
+	"github.com/kubecenter/kubecenter/internal/k8s"
 )
 
 // PrometheusClient wraps the Prometheus v1 API for KubeCenter queries.
@@ -16,13 +19,28 @@ type PrometheusClient struct {
 	api v1.API
 }
 
-// NewPrometheusClient creates a typed API client for the given Prometheus address.
+// NewPrometheusClient creates a typed API client for the given Prometheus
+// address. The underlying HTTP transport uses k8s.SafeHTTPTransport so
+// every TCP dial re-resolves the Prometheus host and blocks private/
+// loopback/link-local/metadata candidate IPs (P2-6 part 2, Phase 4
+// security audit 2026-05-22).
 func NewPrometheusClient(address string) (*PrometheusClient, error) {
-	client, err := api.NewClient(api.Config{Address: address})
+	client, err := api.NewClient(api.Config{
+		Address:      address,
+		RoundTripper: safePromRoundTripper(),
+	})
 	if err != nil {
 		return nil, fmt.Errorf("creating prometheus client: %w", err)
 	}
 	return &PrometheusClient{api: v1.NewAPI(client)}, nil
+}
+
+// safePromRoundTripper returns the http.RoundTripper used by every
+// Prometheus client instance. Built as a function (not a package var)
+// so each client gets its own connection pool, matching the stdlib
+// default and the prometheus client_golang convention.
+func safePromRoundTripper() http.RoundTripper {
+	return k8s.SafeHTTPTransport()
 }
 
 // Query runs a PromQL instant query.

--- a/backend/internal/server/handle_settings.go
+++ b/backend/internal/server/handle_settings.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"encoding/json"
-	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -121,7 +120,14 @@ func (s *Server) handleTestLDAP(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// validateSettingsURL checks that a URL is http/https and not pointing at private/loopback addresses.
+// validateSettingsURL checks that a URL is http/https and resolves to a
+// non-private/non-loopback/non-metadata IP.
+//
+// Phase 4 of the 2026-05-22 security audit (P2-6) — previous implementation
+// only blocked literal-IP loopback/private values, leaving hostnames that
+// resolved to those ranges unchecked. Now delegates to k8s.ValidateRemoteURL
+// so the same DNS-resolving + fail-closed policy applies everywhere
+// user-supplied URLs reach the backend.
 // Returns an error message string, or empty string if valid.
 func validateSettingsURL(raw string) string {
 	if raw == "" {
@@ -135,11 +141,8 @@ func validateSettingsURL(raw string) string {
 	if scheme != "http" && scheme != "https" {
 		return "URL must use http or https scheme"
 	}
-	host := u.Hostname()
-	if ip := net.ParseIP(host); ip != nil {
-		if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
-			return "URL must not point to private/loopback addresses"
-		}
+	if err := k8s.ValidateRemoteURL(raw); err != nil {
+		return "URL rejected: " + err.Error()
 	}
 	return ""
 }

--- a/backend/internal/servicemesh/metrics_test.go
+++ b/backend/internal/servicemesh/metrics_test.go
@@ -148,7 +148,7 @@ func TestGoldenSignalsForService_UnsupportedMesh(t *testing.T) {
 // handler can emit 400. We build a Prometheus client against an unreachable
 // address — Render fires before Query would ever touch the network.
 func TestGoldenSignalsForService_RenderFailureSurfacesError(t *testing.T) {
-	pc, err := monitoring.NewPrometheusClient("http://127.0.0.1:1")
+	pc, err := monitoring.NewPrometheusClientWithTransport("http://127.0.0.1:1", http.DefaultTransport)
 	if err != nil {
 		t.Fatalf("prom client: %v", err)
 	}
@@ -318,7 +318,7 @@ func TestGoldenSignalsForService_HappyPath(t *testing.T) {
 		{"histogram_quantile(0.99", 99.0}, // p99
 	})
 	defer srv.Close()
-	pc, err := monitoring.NewPrometheusClient(srv.URL)
+	pc, err := monitoring.NewPrometheusClientWithTransport(srv.URL, http.DefaultTransport)
 	if err != nil {
 		t.Fatalf("prom client: %v", err)
 	}
@@ -372,7 +372,7 @@ func TestGoldenSignalsForService_PartialFailure(t *testing.T) {
 			`{"status":"success","data":{"resultType":"vector","result":[{"metric":{},"value":[1,"%g"]}]}}`, value)
 	}))
 	defer srv.Close()
-	pc, err := monitoring.NewPrometheusClient(srv.URL)
+	pc, err := monitoring.NewPrometheusClientWithTransport(srv.URL, http.DefaultTransport)
 	if err != nil {
 		t.Fatalf("prom client: %v", err)
 	}
@@ -412,7 +412,7 @@ func TestGoldenSignalsForService_AllSucceedHasNoMissingQueries(t *testing.T) {
 		fmt.Fprintf(w, `{"status":"success","data":{"resultType":"vector","result":[{"metric":{},"value":[1,"42"]}]}}`)
 	}))
 	defer srv.Close()
-	pc, err := monitoring.NewPrometheusClient(srv.URL)
+	pc, err := monitoring.NewPrometheusClientWithTransport(srv.URL, http.DefaultTransport)
 	if err != nil {
 		t.Fatalf("prom client: %v", err)
 	}
@@ -451,7 +451,7 @@ func TestGoldenSignalsForService_AllQueriesFailReportsUnavailable(t *testing.T) 
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer srv.Close()
-	pc, err := monitoring.NewPrometheusClient(srv.URL)
+	pc, err := monitoring.NewPrometheusClientWithTransport(srv.URL, http.DefaultTransport)
 	if err != nil {
 		t.Fatalf("prom client: %v", err)
 	}
@@ -477,7 +477,7 @@ func TestHandler_GoldenSignals_RenderFailureSurfacesAs400(t *testing.T) {
 	// the render path is the one that fails.
 	srv := newFakePromServer(t, []promStub{{"istio_requests_total", 1}})
 	defer srv.Close()
-	pc, err := monitoring.NewPrometheusClient(srv.URL)
+	pc, err := monitoring.NewPrometheusClientWithTransport(srv.URL, http.DefaultTransport)
 	if err != nil {
 		t.Fatalf("prom client: %v", err)
 	}

--- a/backend/internal/servicemesh/mtls_test.go
+++ b/backend/internal/servicemesh/mtls_test.go
@@ -536,7 +536,7 @@ func TestHandler_MTLSPosture_ClusterWideMetricOverride(t *testing.T) {
 		}`)
 	}))
 	defer srv.Close()
-	pc, err := monitoring.NewPrometheusClient(srv.URL)
+	pc, err := monitoring.NewPrometheusClientWithTransport(srv.URL, http.DefaultTransport)
 	if err != nil {
 		t.Fatalf("prom client: %v", err)
 	}
@@ -611,7 +611,7 @@ func TestHandler_MTLSPosture_LinkerdOnlySkipsPromCrossCheck(t *testing.T) {
 		_, _ = io.WriteString(w, `{"status":"success","data":{"resultType":"vector","result":[]}}`)
 	}))
 	defer srv.Close()
-	pc, err := monitoring.NewPrometheusClient(srv.URL)
+	pc, err := monitoring.NewPrometheusClientWithTransport(srv.URL, http.DefaultTransport)
 	if err != nil {
 		t.Fatalf("prom client: %v", err)
 	}
@@ -713,7 +713,7 @@ func TestQueryIstioMTLSRatios_DropsNaNAndInfSamples(t *testing.T) {
 		}`)
 	}))
 	defer srv.Close()
-	pc, err := monitoring.NewPrometheusClient(srv.URL)
+	pc, err := monitoring.NewPrometheusClientWithTransport(srv.URL, http.DefaultTransport)
 	if err != nil {
 		t.Fatalf("prom client: %v", err)
 	}
@@ -766,7 +766,7 @@ func TestQueryIstioMTLSRatios_DropsEmptyNamespaceSample(t *testing.T) {
 		}`)
 	}))
 	defer srv.Close()
-	pc, err := monitoring.NewPrometheusClient(srv.URL)
+	pc, err := monitoring.NewPrometheusClientWithTransport(srv.URL, http.DefaultTransport)
 	if err != nil {
 		t.Fatalf("prom client: %v", err)
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,33 @@
-# Local development PostgreSQL
+# Local development PostgreSQL — LOCAL DEVELOPMENT ONLY.
+#
+# The port is bound to 127.0.0.1 so the database is unreachable from the
+# LAN even when the host firewall is permissive. Phase 4 of the
+# 2026-05-22 security audit (P3-8) tightened this from the previous
+# host-wide bind, which exposed a fixed-credential developer DB to every
+# device on the operator's network.
+#
+# Password is sourced from the POSTGRES_PASSWORD environment variable
+# (drop a `.env` file next to this compose file, or export it in your
+# shell). The fall-through default keeps `make dev-db` working out of
+# the box; override it for anything that isn't a throwaway local DB.
+# Production / staging deployments use the Helm chart's PostgreSQL
+# settings, NOT this compose file.
+#
 # Usage: docker compose up -d
-# Connect: postgresql://k8scenter:k8scenter@localhost:5432/k8scenter?sslmode=disable
+# Connect (default creds): postgresql://k8scenter:k8scenter@127.0.0.1:5432/k8scenter?sslmode=disable
 services:
   postgres:
     image: postgres:17-alpine
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     environment:
-      POSTGRES_USER: k8scenter
-      POSTGRES_PASSWORD: k8scenter
-      POSTGRES_DB: k8scenter
+      POSTGRES_USER: ${POSTGRES_USER:-k8scenter}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-k8scenter}
+      POSTGRES_DB: ${POSTGRES_DB:-k8scenter}
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U k8scenter"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-k8scenter}"]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/helm/kubecenter/templates/_validate.tpl
+++ b/helm/kubecenter/templates/_validate.tpl
@@ -54,4 +54,46 @@ The parity test in backend/internal/config/known_leaked_helm_parity_test.go enfo
 {{- end -}}
 {{- end -}}
 
+{{- /* ── TLS-by-default exposure guard (P2-8) ──────────────────────────
+The previous chart let an operator expose the backend over plaintext
+HTTP by enabling `ingress.enabled` without `ingress.tls`, or by
+flipping `service.type` to LoadBalancer / NodePort. Either path leaks
+access tokens, refresh tokens, setup tokens, and API traffic in the
+clear. Dev mode (`backend.config.dev=true`) compounds the issue: it
+relaxes the cookie Secure flag, so an exposed dev deployment ships
+session cookies recoverable over the wire.
+
+The chart now refuses to render if any of those exposure modes are
+configured without an explicit acknowledgement via
+`security.insecureExposureAcknowledged=true`. Set the override only
+for fully internal trust-domain deployments where TLS termination
+happens upstream and the network path is private.
+*/}}
+{{- $sec := .Values.security | default dict }}
+{{- $ackInsecure := $sec.insecureExposureAcknowledged | default false }}
+{{- $svcType := .Values.service.type | default "ClusterIP" }}
+{{- $ingressOn := and .Values.ingress.enabled (not (empty .Values.ingress.enabled)) }}
+{{- $ingressHasTLS := and $ingressOn (not (empty .Values.ingress.tls)) }}
+{{- $devMode := and .Values.backend (and .Values.backend.config (eq (toString .Values.backend.config.dev) "true")) }}
+
+{{- if and $ingressOn (not $ingressHasTLS) -}}
+{{- if not $ackInsecure -}}
+{{- fail "ingress.enabled=true but ingress.tls is empty — exposing the backend over plaintext HTTP leaks tokens. Configure ingress.tls with a TLS secret, or set security.insecureExposureAcknowledged=true to accept the risk (only safe for internal-only deployments behind upstream TLS termination). Finding P2-8." -}}
+{{- end -}}
+{{- end -}}
+
+{{- if or (eq $svcType "LoadBalancer") (eq $svcType "NodePort") -}}
+{{- if not $ackInsecure -}}
+{{- fail (printf "service.type=%s exposes the backend on a raw network port without TLS termination — set service.type to ClusterIP and front the chart with an HTTPS ingress, or set security.insecureExposureAcknowledged=true to accept the risk. Finding P2-8." $svcType) -}}
+{{- end -}}
+{{- end -}}
+
+{{- if $devMode -}}
+{{- if or (eq $svcType "LoadBalancer") (eq $svcType "NodePort") (and $ingressOn (not $ingressHasTLS)) -}}
+{{- if not $ackInsecure -}}
+{{- fail "backend.config.dev=true combined with an externally-reachable service (LoadBalancer/NodePort, or ingress without TLS) — dev mode relaxes cookie Secure flags and rate limits. Use dev mode only with service.type=ClusterIP and no public ingress, or set security.insecureExposureAcknowledged=true to accept the risk. Finding P2-8." -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{- end -}}

--- a/helm/kubecenter/templates/_validate.tpl
+++ b/helm/kubecenter/templates/_validate.tpl
@@ -70,15 +70,30 @@ for fully internal trust-domain deployments where TLS termination
 happens upstream and the network path is private.
 */}}
 {{- $sec := .Values.security | default dict }}
-{{- $ackInsecure := $sec.insecureExposureAcknowledged | default false }}
+{{- /* Phase 4 review (adversarial, reliability R-5): `not` evaluates non-
+empty strings as truthy, so `--set-string security.insecureExposureAcknowledged="false"`
+slipped past the previous boolean coercion. `toString` + `eq "true"`
+matches the dev-mode check below and forces a literal-true comparison. */}}
+{{- $ackInsecure := eq (toString ($sec.insecureExposureAcknowledged | default false)) "true" }}
 {{- $svcType := .Values.service.type | default "ClusterIP" }}
-{{- $ingressOn := and .Values.ingress.enabled (not (empty .Values.ingress.enabled)) }}
-{{- $ingressHasTLS := and $ingressOn (not (empty .Values.ingress.tls)) }}
+{{- $ingressOn := .Values.ingress.enabled | default false }}
+{{- /* Phase 4 review (adversarial, reliability R-5): a single empty-map
+entry like `ingress.tls: [{}]` passes `not (empty .Values.ingress.tls)`
+and renders an Ingress with `secretName: ""`. Require at least one
+entry with a non-empty secretName. */}}
+{{- $ingressHasTLS := false }}
+{{- if $ingressOn }}
+{{- range .Values.ingress.tls }}
+{{- if .secretName }}
+{{- $ingressHasTLS = true }}
+{{- end }}
+{{- end }}
+{{- end }}
 {{- $devMode := and .Values.backend (and .Values.backend.config (eq (toString .Values.backend.config.dev) "true")) }}
 
 {{- if and $ingressOn (not $ingressHasTLS) -}}
 {{- if not $ackInsecure -}}
-{{- fail "ingress.enabled=true but ingress.tls is empty — exposing the backend over plaintext HTTP leaks tokens. Configure ingress.tls with a TLS secret, or set security.insecureExposureAcknowledged=true to accept the risk (only safe for internal-only deployments behind upstream TLS termination). Finding P2-8." -}}
+{{- fail "ingress.enabled=true but ingress.tls has no entry with a non-empty secretName — exposing the backend over plaintext HTTP leaks tokens. Configure ingress.tls with a TLS secret name, or set security.insecureExposureAcknowledged=true to accept the risk (only safe for internal-only deployments behind upstream TLS termination). Finding P2-8." -}}
 {{- end -}}
 {{- end -}}
 

--- a/helm/kubecenter/templates/networkpolicy.yaml
+++ b/helm/kubecenter/templates/networkpolicy.yaml
@@ -1,7 +1,39 @@
 {{- include "kubecenter.validatePlaceholders" . }}
 {{- if .Values.networkPolicy.enabled }}
+{{- /*
+Phase 4 of the 2026-05-22 security audit (P2-7) tightened backend egress.
+The previous policy was port-only — anything in the cluster, in the LAN,
+or on the public internet that happened to listen on 443/5432/6443/9090
+was reachable. The current policy adds structured `to:` selectors for the
+known destinations (kube-dns, in-namespace PostgreSQL, in-cluster
+Prometheus/Grafana when the subchart is deployed) plus IP allowlists for
+the cluster's Kubernetes API and any externally-configured monitoring
+endpoints. Every IP-based egress rule carries `except` blocks for
+link-local (169.254.0.0/16) and metadata IPs so a compromised backend
+pod can't pivot to cloud instance-metadata services for IAM credential
+theft. Tunable via the `networkPolicy.egress.*` value tree.
+*/}}
+{{- $egress := .Values.networkPolicy.egress | default dict }}
+{{- $dnsNs := $egress.dnsNamespace | default "kube-system" }}
+{{- $dnsLabel := $egress.dnsPodLabel | default "kube-dns" }}
+{{- $apiCIDRs := $egress.kubernetesApiCIDRs | default (list) }}
+{{- $monitorCIDRs := $egress.monitoringCIDRs | default (list) }}
+{{- $ldapCIDRs := $egress.ldapCIDRs | default (list) }}
+{{- $extraCIDRs := $egress.extraAllowedCIDRs | default (list) }}
+{{- /*
+$blockedRanges is the universal SSRF blocklist appended as `except`
+entries to every `ipBlock` egress rule. Covers link-local (which
+includes the 169.254.169.254 cloud metadata endpoint), IPv6
+link-local, and IPv4-mapped-IPv6 link-local. Operators can extend via
+`networkPolicy.egress.extraBlockedCIDRs` (for example to also block
+internal management VLANs or known-sensitive RFC1918 ranges).
+*/}}
+{{- $blockedRanges := concat (list "169.254.0.0/16") ($egress.extraBlockedCIDRs | default (list)) }}
 ---
-# Backend NetworkPolicy: allow ingress from frontend/ingress, allow egress to k8s API + DNS
+# Backend NetworkPolicy: allow ingress from frontend/ingress, allow egress
+# only to structured destinations (kube-dns, in-cluster PostgreSQL +
+# observability, configured external CIDRs). Metadata/link-local ranges
+# are explicitly blocked from every IP egress rule.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -38,30 +70,156 @@ spec:
           protocol: TCP
     {{- end }}
   egress:
-    # Allow all TCP/UDP egress to required ports (DNS, k8s API, PostgreSQL, Prometheus, Grafana, Hubble Relay)
-    - ports:
+    # --- DNS — kube-dns (or equivalent) in $dnsNs only ---
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ $dnsNs }}
+          podSelector:
+            matchLabels:
+              k8s-app: {{ $dnsLabel }}
+      ports:
         - port: 53
           protocol: UDP
         - port: 53
           protocol: TCP
+    # --- Kubernetes API server ---
+    # When $apiCIDRs is configured (typical: cluster control-plane VIP or
+    # the API service CIDR), restrict to those CIDRs. Otherwise fall back
+    # to port-only (still blocking link-local/metadata via `except`).
+    {{- if $apiCIDRs }}
+    - to:
+        {{- range $apiCIDRs }}
+        - ipBlock:
+            cidr: {{ . | quote }}
+            except:
+              {{- range $blockedRanges }}
+              - {{ . | quote }}
+              {{- end }}
+        {{- end }}
+      ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+    {{- else }}
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              {{- range $blockedRanges }}
+              - {{ . | quote }}
+              {{- end }}
+      ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+    {{- end }}
+    # --- In-cluster PostgreSQL (subchart pods) ---
+    # Targets the kube-prometheus-stack-shaped label conventions used by
+    # most Helm-deployed Postgres operators (bitnami, CrunchyData). When
+    # operators run PostgreSQL out of cluster, $extraAllowedCIDRs covers
+    # the route.
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: postgresql
+      ports:
+        - port: 5432
+          protocol: TCP
+    # --- In-cluster Prometheus + Grafana (subchart pods) ---
+    # `app.kubernetes.io/name` covers both the kube-prometheus-stack
+    # subchart and standalone Prometheus/Grafana installs that follow
+    # the standard label conventions.
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - port: 9090
+          protocol: TCP
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: grafana
+      ports:
+        - port: 3000
+          protocol: TCP
+    {{- if $monitorCIDRs }}
+    # --- External monitoring endpoints (operator-configured) ---
+    # When Prometheus/Grafana live outside the cluster, list their VIPs
+    # here so the backend can reach them while still blocking link-local
+    # and metadata IPs.
+    - to:
+        {{- range $monitorCIDRs }}
+        - ipBlock:
+            cidr: {{ . | quote }}
+            except:
+              {{- range $blockedRanges }}
+              - {{ . | quote }}
+              {{- end }}
+        {{- end }}
+      ports:
+        - port: 80
+          protocol: TCP
+        - port: 443
+          protocol: TCP
+        - port: 3000
+          protocol: TCP
+        - port: 9090
+          protocol: TCP
+    {{- end }}
+    {{- if .Values.auth.ldap }}
+    # --- LDAP / LDAPS (only when LDAP providers are configured) ---
+    {{- if $ldapCIDRs }}
+    - to:
+        {{- range $ldapCIDRs }}
+        - ipBlock:
+            cidr: {{ . | quote }}
+            except:
+              {{- range $blockedRanges }}
+              - {{ . | quote }}
+              {{- end }}
+        {{- end }}
+      ports:
+        - port: 389
+          protocol: TCP
+        - port: 636
+          protocol: TCP
+    {{- else }}
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              {{- range $blockedRanges }}
+              - {{ . | quote }}
+              {{- end }}
+      ports:
+        - port: 389
+          protocol: TCP
+        - port: 636
+          protocol: TCP
+    {{- end }}
+    {{- end }}
+    {{- if $extraCIDRs }}
+    # --- Extra operator-configured CIDRs (e.g. external Postgres,
+    # backup targets, internal mirrors). Still excludes metadata IPs. ---
+    - to:
+        {{- range $extraCIDRs }}
+        - ipBlock:
+            cidr: {{ . | quote }}
+            except:
+              {{- range $blockedRanges }}
+              - {{ . | quote }}
+              {{- end }}
+        {{- end }}
+      ports:
         - port: 80
           protocol: TCP
         - port: 443
           protocol: TCP
         - port: 5432
-          protocol: TCP
-        - port: 6443
-          protocol: TCP
-        - port: 9090
-          protocol: TCP
-        - port: 3000
-          protocol: TCP
-    {{- if .Values.auth.ldap }}
-    # LDAP/LDAPS (only when LDAP providers are configured)
-    - ports:
-        - port: 389
-          protocol: TCP
-        - port: 636
           protocol: TCP
     {{- end }}
 ---
@@ -98,8 +256,15 @@ spec:
         - port: {{ .Values.frontend.port }}
           protocol: TCP
   egress:
-    # DNS resolution
-    - ports:
+    # DNS — kube-dns only
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ $dnsNs }}
+          podSelector:
+            matchLabels:
+              k8s-app: {{ $dnsLabel }}
+      ports:
         - port: 53
           protocol: UDP
         - port: 53
@@ -148,9 +313,15 @@ spec:
           protocol: TCP
     {{- end }}
   egress:
-    # DNS only — well-known Pod serves static ConfigMap content and
-    # has no other outbound dependencies.
-    - ports:
+    # DNS only — kube-dns only.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ $dnsNs }}
+          podSelector:
+            matchLabels:
+              k8s-app: {{ $dnsLabel }}
+      ports:
         - port: 53
           protocol: UDP
         - port: 53

--- a/helm/kubecenter/templates/networkpolicy.yaml
+++ b/helm/kubecenter/templates/networkpolicy.yaml
@@ -116,31 +116,54 @@ spec:
         - port: 6443
           protocol: TCP
     {{- end }}
-    # --- In-cluster PostgreSQL (subchart pods) ---
-    # Targets the kube-prometheus-stack-shaped label conventions used by
-    # most Helm-deployed Postgres operators (bitnami, CrunchyData). When
-    # operators run PostgreSQL out of cluster, $extraAllowedCIDRs covers
-    # the route.
+    # --- In-cluster PostgreSQL ---
+    # Phase 4 review (correctness C3, reliability R-3, adversarial 7):
+    # bare `podSelector` without `namespaceSelector` matches only pods
+    # in the same namespace as the policy. The kube-prometheus-stack +
+    # subchart Postgres pattern (kubecenter in one namespace, Postgres
+    # in `database`/`postgres`/release-namespace) breaks silently. The
+    # rule now uses `namespaceSelector: {}` (any namespace) AND'd with
+    # the podSelector. When `networkPolicy.egress.postgresPodLabels`
+    # diverges from bitnami conventions (CrunchyData, CNPG, Zalando),
+    # operators override the label set.
+    # Plus a port-only fallback with the link-local except so externally-
+    # hosted Postgres reachable via `externalDatabase.host` is not
+    # silently cut off when the operator forgets to populate
+    # `extraAllowedCIDRs`.
     - to:
-        - podSelector:
+        - namespaceSelector: {}
+          podSelector:
             matchLabels:
-              app.kubernetes.io/name: postgresql
+              {{- ($egress.postgresPodLabels | default (dict "app.kubernetes.io/name" "postgresql")) | toYaml | nindent 14 }}
       ports:
         - port: 5432
           protocol: TCP
-    # --- In-cluster Prometheus + Grafana (subchart pods) ---
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              {{- range $blockedRanges }}
+              - {{ . | quote }}
+              {{- end }}
+      ports:
+        - port: 5432
+          protocol: TCP
+    # --- In-cluster Prometheus + Grafana ---
     # `app.kubernetes.io/name` covers both the kube-prometheus-stack
     # subchart and standalone Prometheus/Grafana installs that follow
-    # the standard label conventions.
+    # the standard label conventions. `namespaceSelector: {}` covers
+    # the common "Prometheus in `monitoring` namespace" deployment.
     - to:
-        - podSelector:
+        - namespaceSelector: {}
+          podSelector:
             matchLabels:
               app.kubernetes.io/name: prometheus
       ports:
         - port: 9090
           protocol: TCP
     - to:
-        - podSelector:
+        - namespaceSelector: {}
+          podSelector:
             matchLabels:
               app.kubernetes.io/name: grafana
       ports:

--- a/helm/kubecenter/values-homelab.yaml.example
+++ b/helm/kubecenter/values-homelab.yaml.example
@@ -47,6 +47,14 @@ auth:
   jwtSecret: "REPLACE_ME_JWT_SECRET_MIN_32_BYTES"
   setupToken: "REPLACE_ME_SETUP_TOKEN"
 
+# Homelab consciously accepts the plaintext-exposure risk: service.type
+# below is LoadBalancer (no upstream TLS termination), backend.config.dev
+# is true (relaxed rate limits + non-Secure cookies), and the LAN is
+# treated as a trust boundary. Set to false and add an HTTPS ingress for
+# anything that leaves the homelab.
+security:
+  insecureExposureAcknowledged: true
+
 service:
   type: LoadBalancer
   port: 8080

--- a/helm/kubecenter/values.yaml
+++ b/helm/kubecenter/values.yaml
@@ -217,9 +217,17 @@ networkPolicy:
   # extraAllowedCIDRs, and a private monitoring stack needs its CIDR in
   # monitoringCIDRs.
   egress:
-    # kube-dns location. The defaults match upstream Kubernetes; clusters
-    # that run CoreDNS in a different namespace (e.g. `coredns`) or
-    # under a different pod label must override.
+    # kube-dns location. The defaults match upstream Kubernetes / kubeadm /
+    # GKE. Known overrides:
+    #   - Talos / some RKE2 builds: dnsPodLabel: "rke2-coredns" or "coredns"
+    #   - OpenShift: dnsNamespace: "openshift-dns", dnsPodLabel: "dns-default"
+    #     (and operators on OpenShift typically also need to relax the
+    #     namespaceSelector on the egress rule via a custom NetworkPolicy
+    #     since openshift-dns uses different labels than upstream).
+    # When the selector misses, DNS resolution breaks cluster-wide and
+    # liveness probes (which hit `:8080` directly) keep passing while
+    # every functional operation times out. Verify after install with
+    # `kubectl exec backend-pod -- nslookup kubernetes.default`.
     dnsNamespace: "kube-system"
     dnsPodLabel: "kube-dns"
     # Allowlist of CIDRs that hold the Kubernetes API server endpoints.
@@ -244,6 +252,14 @@ networkPolicy:
     # backend dependencies not covered above.
     extraAllowedCIDRs: []
     # - 10.20.30.0/24
+    # Pod labels matched by the egress rule for in-cluster PostgreSQL.
+    # Defaults to bitnami / standard chart convention. Override for
+    # CrunchyData (postgres-operator.crunchydata.com/cluster),
+    # CloudNativePG (cnpg.io/cluster), Zalando (application=spilo),
+    # or any custom Postgres operator. Combined AND with `namespaceSelector: {}`
+    # so any namespace matches if the label is present.
+    postgresPodLabels:
+      app.kubernetes.io/name: postgresql
     # Additional ranges to block from every ipBlock egress rule (appended
     # to the universal link-local/metadata blocklist). Use for internal
     # management VLANs you never want the backend to reach.

--- a/helm/kubecenter/values.yaml
+++ b/helm/kubecenter/values.yaml
@@ -192,6 +192,47 @@ cors:
 networkPolicy:
   enabled: true
   ingressNamespace: "ingress-nginx"   # Namespace of the ingress controller (for backend ingress rule)
+  # Backend egress tuning (P2-7 of the 2026-05-22 security audit). The
+  # default rules restrict egress to kube-dns, in-cluster PostgreSQL +
+  # Prometheus + Grafana pods (by standard label conventions), and any
+  # IP route that's NOT link-local/metadata (169.254.0.0/16). Tune the
+  # knobs below when your cluster diverges from these defaults — for
+  # example, an out-of-cluster Postgres needs its CIDR in
+  # extraAllowedCIDRs, and a private monitoring stack needs its CIDR in
+  # monitoringCIDRs.
+  egress:
+    # kube-dns location. The defaults match upstream Kubernetes; clusters
+    # that run CoreDNS in a different namespace (e.g. `coredns`) or
+    # under a different pod label must override.
+    dnsNamespace: "kube-system"
+    dnsPodLabel: "kube-dns"
+    # Allowlist of CIDRs that hold the Kubernetes API server endpoints.
+    # Typical values: the control-plane node CIDR (bare-metal), the
+    # service CIDR (most managed clusters route the apiserver via the
+    # default/kubernetes Service VIP), or a single VIP /32. When empty,
+    # falls back to 0.0.0.0/0 minus link-local/metadata.
+    kubernetesApiCIDRs: []
+    # - 10.96.0.1/32
+    # CIDRs that hold externally-deployed Prometheus / Grafana / similar.
+    # Leave empty when monitoring runs in-cluster (the default rules
+    # already cover the subchart pods via labelSelector).
+    monitoringCIDRs: []
+    # - 10.10.20.0/24
+    # CIDRs that hold LDAP / Active Directory servers. Only takes effect
+    # when auth.ldap is configured. When empty, falls back to 0.0.0.0/0
+    # minus link-local/metadata on ports 389 + 636.
+    ldapCIDRs: []
+    # - 192.168.10.10/32
+    # Extra CIDRs to allow on common HTTPS / PostgreSQL ports (80, 443,
+    # 5432). Use for out-of-cluster Postgres, internal mirrors, or other
+    # backend dependencies not covered above.
+    extraAllowedCIDRs: []
+    # - 10.20.30.0/24
+    # Additional ranges to block from every ipBlock egress rule (appended
+    # to the universal link-local/metadata blocklist). Use for internal
+    # management VLANs you never want the backend to reach.
+    extraBlockedCIDRs: []
+    # - 192.168.100.0/24
 
 # -- Subchart overrides (only when monitoring.deploy=true)
 monitoring-stack:

--- a/helm/kubecenter/values.yaml
+++ b/helm/kubecenter/values.yaml
@@ -8,6 +8,22 @@ fullnameOverride: ""
 imagePullSecrets: []
 # - name: ghcr-pull-secret
 
+# -- Security posture (P2-8 of the 2026-05-22 security audit)
+#
+# Set insecureExposureAcknowledged=true to allow plaintext-exposed
+# deployment configurations: service.type=LoadBalancer / NodePort,
+# ingress.enabled=true without ingress.tls, or backend.config.dev=true
+# combined with any externally-reachable service. The chart refuses to
+# render any of those modes by default — exposing the backend without
+# TLS leaks access tokens, refresh tokens, setup tokens, and all API
+# traffic in the clear.
+#
+# Acknowledge the risk only when TLS termination happens upstream
+# (managed LB with cert, service mesh gateway, etc.) and the network
+# path stays inside a trusted boundary.
+security:
+  insecureExposureAcknowledged: false
+
 # -- Backend (Go API server)
 backend:
   image:


### PR DESCRIPTION
## Summary

Closes audit findings **P2-6** (SSRF DNS fail-closed + per-dial re-resolve), **P2-7** (NetworkPolicy egress destination scoping), **P2-8** (TLS-by-default chart guard), and **P3-8** (dev Postgres loopback bind) from \`plans/security-audit-2026-05-22.md\`.

11 commits, 18 files, +1003/-119 LOC. Followed the Phase 3 cadence: 1 round of \`/ce-code-review\` + ship with documented follow-up list (5 reviewers dispatched, 25+ findings, 13 applied inline across 4 review-fix commits, 12 deferred to follow-ups documented in CHANGELOG.md).

## Units

**U1 (P3-8): Dev Postgres loopback bind** — \`docker-compose.yml\` rebound from \`5432:5432\` (LAN-reachable) to \`127.0.0.1:5432:5432\`. \`POSTGRES_USER\`/\`POSTGRES_PASSWORD\`/\`POSTGRES_DB\` env-overridable via \`.env\` with safe defaults retained for \`make dev-db\`.

**U2 (P2-7): NetworkPolicy egress destinations** — port-only backend egress replaced with structured \`to:\` selectors: kube-dns (\`namespaceSelector + podSelector\`), Kubernetes API (\`ipBlock\` allowlist), in-cluster Postgres/Prometheus/Grafana (\`namespaceSelector: {} + podSelector\`), external monitoring (\`networkPolicy.egress.monitoringCIDRs\`), LDAP (\`networkPolicy.egress.ldapCIDRs\`). Every \`ipBlock\` rule carries \`except: [169.254.0.0/16]\` blocking link-local + cloud metadata. Tunable via \`networkPolicy.egress.*\`.

**U3 (P2-8): TLS-by-default chart guard** — \`_validate.tpl\` refuses to render \`service.type=LoadBalancer/NodePort\`, \`ingress.enabled=true\` without a TLS secret, or \`dev=true\` + externally-reachable service unless \`security.insecureExposureAcknowledged=true\` is explicitly set. \`values-homelab.yaml.example\` sets the ack with a comment documenting the LAN-only trust boundary.

**U4a (P2-6 part 1): SSRF DNS fail-closed + hostname resolution** — \`k8s.ValidateRemoteURL\` now fails closed on DNS errors (was: silently allowed). \`server.validateSettingsURL\` now resolves hostnames (was: literal-IP only). Factored shared block-list into \`checkIPNotPrivate\` so registration-time + admin-UI + connection-time validators stay consistent.

**U4b (P2-6 part 2): Per-dial SSRF re-resolve** — new \`k8s.SafeDialContext\` + \`k8s.SafeHTTPTransport\` wired into Grafana proxy, Grafana API client, Prometheus API client; \`k8s.StrictDialContext\` + \`k8s.StrictHTTPTransport\` wired into cluster_router's remote \`rest.Config.Dial\`. Re-resolves on every TCP dial, pins to validated IP before connecting, rejects any candidate in the block-list. New \`NewPrometheusClientWithTransport\` test seam for tests that need to dial loopback httptest.Server URLs.

## Code review fixes (1 round of \`/ce-code-review\`)

Five reviewers dispatched (correctness, adversarial, reliability, testing, maintainability — security agent returned API Overloaded). 13 high-confidence findings applied inline:

| Finding | Source | Fix |
|---|---|---|
| RFC1918 block kills in-cluster monitoring (ClusterIPs are RFC1918) | correctness C1, testing TG-1, maintainability M-2 | Split into SafeDialContext (allows RFC1918, blocks loopback/metadata/CGNAT) for monitoring vs StrictDialContext (blocks RFC1918) for remote clusters |
| \`monitoring_test.go\` not migrated to test seam | testing TG-1, maintainability M-2 | Migrated 2 call sites |
| \`--set-string security.insecureExposureAcknowledged="false"\` bypasses guard | adversarial, reliability R-5 | \`toString \| eq "true"\` coercion |
| \`ingress.tls: [{}]\` empty-map bypasses guard | adversarial, reliability R-5 | Range over tls, require non-empty secretName |
| NetworkPolicy podSelector matches only same-namespace pods | correctness C3, reliability R-3, adversarial 4 | Added \`namespaceSelector: {}\` to Postgres/Prometheus/Grafana rules |
| External Postgres silently blocked | reliability R-3 | Added port-5432 ipBlock fallback with link-local except |
| Custom Postgres operator labels | adversarial 7 | New \`networkPolicy.egress.postgresPodLabels\` knob |
| DNS rule too tight on Talos/RKE2/OpenShift | reliability R-2, adversarial 5 | Documented overrides in values.yaml comment |
| \`ValidateRemoteURL\` no context → ~90s hang | reliability R-1 | New \`ValidateRemoteURLContext\` + 5s fallback in shim |

12 deferred follow-ups (Loki SafeHTTPTransport, dual-stack IP pinning, NAT64 metadata, validateSettingsURL inline, DNS-rebinding integration tests, Helm negative-case CI coverage, etc.) — full list in CHANGELOG.md Phase 4 section.

## Verification

- \`go vet ./...\` clean (backend).
- \`go test ./...\` all 28 packages pass (backend).
- \`helm lint helm/kubecenter\` clean.
- \`helm template\` matrix verified for TLS chart guard (ClusterIP renders, LoadBalancer/NodePort/no-TLS ingress fail-closed, ack overrides render, custom postgresPodLabels render correctly).
- Frontend untouched this phase.

## Breaking changes (operator action required)

1. **\`security.insecureExposureAcknowledged\`** required for any plaintext-exposed configuration (LoadBalancer/NodePort, ingress without TLS, or dev mode + external exposure). Default \`false\`. \`values-homelab.yaml.example\` opts in explicitly.
2. **\`ValidateRemoteURL\` fails closed on DNS errors** — operators with broken DNS now see explicit errors at cluster registration / settings update.
3. **Dev Postgres loopback bind** — \`docker-compose.yml\` port rebound to \`127.0.0.1:5432:5432\`. Operators accessing the dev DB from another LAN host must use SSH tunnels.

See CHANGELOG.md Phase 4 section for full operator notes.

## Test plan

- [ ] Smoke-test homelab values render with the new chart (\`helm template -f values-homelab.yaml\` should succeed).
- [ ] Smoke-test default values.yaml render still works (ClusterIP, no ingress).
- [ ] Verify chart guard fires on a fresh \`helm install\` with \`ingress.enabled=true\` and no \`ingress.tls\` (should fail-closed with the P2-8 error message).
- [ ] Verify existing remote clusters in the registry still connect after merge (StrictDialContext + DNS fail-closed should not regress for healthy DNS).
- [ ] Verify in-cluster Prometheus/Grafana monitoring still works (SafeDialContext should allow ClusterIPs).
- [ ] Smoke-test \`POST /api/v1/settings\` with an invalid monitoring URL (hostname resolving to a private IP should now reject).

🤖 Generated with [Claude Code](https://claude.com/claude-code)