### PR TITLE
feat(security): Phase 5 — mobile UX hardening (P2-9/P2-10/P3-6/P3-7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,24 +113,162 @@ mobile-app-only — no backend, Helm, or web-frontend changes.
 
 ### Verification
 
-- `flutter test` — 1193 mobile tests pass (20 skipped, unrelated to
-  Phase 5). New tests:
+- `flutter test` — all mobile tests pass after the Phase 5 work AND
+  the review-fix commits below. New + extended tests:
   - `test/notifications/fcm_revoke_test.dart` — 6 tests covering
     happy path, no-match, empty list, GET failure, DELETE failure,
     malformed response.
-  - `test/observability/pii_scrubber_test.dart` — 4 new tests covering
-    query stripping, fragment stripping, non-k8s URL passthrough, null
-    URL. One existing test renamed and extended.
+  - `test/observability/pii_scrubber_test.dart` — 4 new tests for the
+    initial scrub (query / fragment / non-k8s passthrough / null URL)
+    plus 4 review-driven regression tests for the percent-encoded
+    delimiter bypass (`%3F`, `%23`, breadcrumb parity, malformed
+    encoding fallback). One existing test extended.
   - `test/auth/oidc_controller_test.dart` — 2 new tests for no-state
     and wrong-state error-callback drops; existing "consent denied"
-    test extended to carry `&state=`.
+    test extended to carry `&state=`; 5 review-driven tests covering
+    `login_required`, `interaction_required`, `temporarily_unavailable`,
+    `server_error`, and unknown error codes through the matched-state
+    path.
   - `test/auth/universal_link_listener_test.dart` — 1 new test for
     http-scheme rejection.
-  - `test/auth/secure_storage_test.dart` (new file) — 7 tests covering
-    current-hit, legacy-fallback-and-migrate, no-data, repeated reads,
-    migration-write-failure preservation, write isolation, dual
-    delete.
-- `dart analyze` — clean across all changed files.
+  - `test/auth/secure_storage_test.dart` (new file) — 7 base tests
+    covering current-hit, legacy-fallback-and-migrate, no-data,
+    repeated reads, migration-write-failure preservation, write
+    isolation, dual delete; plus 3 review-driven tests covering the
+    Android BFU op-timeout fallback (current hang, both hang, write
+    hang during migration).
+- `dart analyze` — clean repo-wide across the mobile tree
+  (`dart analyze` from `mobile/`, no scope filter).
+
+### Applied during Phase 5 code review (one round of `/ce-code-review`)
+
+The review surfaced several issues that were fixed inline before merge:
+
+- **`fcm.dispose()` uncaught in logout** (reliability R-1, P1). The
+  outer try/catch wrapped `revokeCurrentDevice` but not the immediately-
+  following `dispose()`. `StreamSubscription.cancel()` returns a Future
+  that can reject when the underlying stream has faulted (Firebase
+  network drop, permission revocation mid-session); a rejection would
+  propagate out of `logout()`, skipping `authTokenHolder.clear()` and
+  `state = AuthUnauthenticated()` — the user would stay signed in with
+  live credentials. Added a sibling try/catch.
+- **`_scrubUrl` URL-encoded delimiter bypass** (adversarial ADV-3 +
+  testing T-2, P2, cross-reviewer ×2). A URL like
+  `https://kubecenter.local/v1/resources/secrets/ns/name%3Ftoken=leak`
+  defeats `indexOf('?')`: the encoded `%3F` is literal text, not `?`,
+  so the slice misses it and the segment regex stops at `%` — `token=leak`
+  survives in the scrubbed output. Now percent-decodes via
+  `Uri.decodeFull` BEFORE slicing. 4 regression tests added covering
+  `%3F`, `%23`, breadcrumb parity, and malformed-encoding fallback.
+- **Android BFU hang on migration** (learnings #1, P2). The new
+  `readRefreshToken` migration sequence ran three sequential `await`s
+  on FlutterSecureStorage with no timeout — Android EncryptedSharedPreferences
+  can hang indefinitely in the Before-First-Unlock state (issue #270's
+  earlier SharedPreferences fix established the `hydratePrefsWithTimeout`
+  pattern). Now wraps each read in a 5s op-timeout; on timeout the call
+  returns null and bootstrap falls through to the unauthenticated path —
+  same disposition as "no stored refresh token". 3 timeout-branch tests
+  added.
+- **FCM revoke total-time bound** (reliability R-2, P2). The revoke
+  flow issues two sequential Dio calls (`GET /devices` + `DELETE
+  /devices/{id}`). Each call has a 30s `receiveTimeout` from
+  `dio_client.dart`, so a hung backend could block logout for ~90s
+  total. `revokeCurrentDevice` now bounds the inner `revokeDeviceByToken`
+  call at 5s.
+- **Device-ID leak in debugPrint** (reliability R-3, P2). The revoke
+  list and delete error paths used `e.message` which Dio populates with
+  the full request URL including the device ID. Now logs only the
+  ApiError message or Dio error type name.
+- **OIDC error-code coverage** (testing T-1, P2). The matched-state
+  switch routes five distinct error codes (`access_denied`,
+  `login_required`, `interaction_required`, `temporarily_unavailable`,
+  `server_error`, wildcard) to four `OIDCFlowErrorReason` values. Only
+  `access_denied` was tested through the matched-state path. Added 5
+  tests so the switch can't drift undetected.
+- **CHANGELOG verification language** (project-standards PS-2, P2).
+  The verification line said "across all changed files" — accurate for
+  the actual run command (`dart analyze` from `mobile/` with no scope
+  filter, which IS repo-wide for the mobile tree) but the wording
+  could read as scoped. Rewritten to be unambiguous.
+
+### Known follow-ups (Phase 5 deferred — single review round)
+
+This phase follows the Phase 3 and Phase 4 cadence: one round of
+`/ce-code-review` plus this documented follow-up list rather than
+chasing every regression through additional cycles. The deferred
+items below are tracked here for the next audit:
+
+- **Auth → Notifications import inversion** (maintainability M-1).
+  `auth_repository.dart` now imports `notifications/fcm_registration.dart`.
+  The domain-correct boundary is: auth emits a logout signal,
+  notifications observes auth state and self-revokes (symmetric with
+  the register-on-login `container.listen` in `main.dart`). The
+  refactor requires designing a logout-event surface (an
+  `AuthLoggingOut` intermediate state or a dedicated stream) — deferred
+  to a follow-up because it's bigger than a review fix.
+- **Logout-test wiring assertion** (testing T-3, maintainability T-1).
+  The existing `logout: clears tokens` test in `auth_repository_test.dart`
+  passes after Phase 5's change because `revokeCurrentDevice` is a no-op
+  in the headless test environment (`!_supportedPlatform`). The
+  order-of-operations contract — revoke fires while access token is
+  still live, then clear — is not asserted. A spy-based test would
+  close this gap; it lands naturally if M-1 (the inversion) is taken
+  next.
+- **revoke-during-ensureRegistered race** (correctness-1). If logout
+  fires after `ensureRegistered` POSTs the device but before
+  `_initialized = true`, the revoke is skipped and the backend row
+  survives. Narrow window (Firebase token resolution latency); could
+  be closed by setting `_initialized` immediately after the POST.
+- **iOS Keychain accessibility-class persistence** (correctness-2).
+  When the accessibility class changes between writes, the legacy
+  Keychain item may persist with the old class rather than being
+  replaced. Low confidence; needs real-device verification.
+- **Stale rotated FCM device rows** (correctness-3 + adversarial ADV-1,
+  cross-reviewer ×2, P2). Revoke deletes only the device row for the
+  CURRENT FCM token. Rotated-and-orphaned device rows from prior
+  registrations are left intact and could cross-bind if the same token
+  is later assigned to another user. This is a pre-existing concern
+  documented at `fcm_registration.dart:11`; resolution belongs in a
+  backend old-token sweep PR.
+- **`_scrubUrl` preserves user-info** (correctness-4). URLs like
+  `https://user:pass@host/path` pass through with credentials intact.
+  Mobile app never constructs such URLs, but Sentry breadcrumbs from
+  third-party Dio interceptors could in theory. Worth a future
+  defensive normalization.
+- **OIDC error-callback silent-drop undebuggable** (reliability R-4).
+  The silent-drop disposition prevents an attacker from confirming
+  receipt of a crafted callback — but also blocks operator debugging
+  of legitimate IdP misconfigurations that send unexpected state.
+  Debug-build-only `debugPrint` or a scrubbed Sentry breadcrumb would
+  preserve diagnostics without confirming receipt.
+- **Migration delete-failure swallowed without log** (reliability R-5).
+  When `_current.writeRefreshToken(legacy)` succeeds but
+  `_legacy.deleteRefreshToken()` throws, the `catch (_)` block swallows
+  silently. Session is safe; the stale legacy entry sits until next
+  logout. A `debugPrint` in the catch would make persistent Keychain
+  delete failures diagnosable.
+- **`_FlutterBacked` premature abstraction** (maintainability M-2).
+  Zero-behavior passthrough adapter introduced for type-coercion
+  reasons. Could be inlined once migration completes and the legacy
+  backend is removed.
+- **`InMemoryTokenStore` missing `@visibleForTesting`** (maintainability
+  M-3). Used by 100+ test files but lives in production lib/ without
+  the annotation. One-line addition.
+- **Migration partial-success test gap** (adversarial ADV-4). The
+  `_WriteFailingStore` test covers write failure but not the symmetric
+  delete failure after write succeeds. Mirrors reliability R-5's
+  concern from a test-coverage angle.
+- **fcm.dispose silences onTokenRefresh between sign-out and sign-in**
+  (adversarial ADV-7). Pre-Phase-5, dispose only ran at container
+  teardown. Now every logout cancels the subscription, so any FCM
+  rotation between sign-out and the next sign-in is unobserved
+  (re-synced on next `ensureRegistered`). Combined with ADV-1, extends
+  the cross-user push leakage window slightly.
+- **Sentry tags/extra/contexts structured-field audit** (learnings #5).
+  `_scrubEventBody` covers `request`, `exceptions`, `breadcrumbs`, and
+  `message`. The `tags`, `extra` map values, and `contexts` structured
+  fields are not scrubbed. No known caller currently populates them
+  with raw resource identifiers but a grep audit would confirm.
 
 ### Out of scope for Phase 5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,142 @@ correlate findings back to the audit reports under `docs/security/`.
 
 ---
 
+## Phase 5 — Mobile UX hardening (2026-05 audit)
+
+Phase 5 closes four mobile-side audit findings: P2-9 (FCM device
+registrations not revoked on logout), P2-10 (Sentry preserves raw
+request URLs), P3-6 (OIDC error callbacks clear pending PKCE before
+validating state), and P3-7 (refresh-token secure-storage options
+less explicit than pending-OIDC storage). The audit report is
+`plans/security-audit-2026-05-22.md`. All four findings are
+mobile-app-only — no backend, Helm, or web-frontend changes.
+
+### Non-breaking changes
+
+- **FCM device revoke on logout** (audit P2-9). `AuthRepository.logout`
+  now calls `FcmRegistration.revokeCurrentDevice` BEFORE clearing the
+  access token. The revoke flow resolves the current FCM token via
+  `FirebaseMessaging.instance.getToken`, looks up the matching device
+  record via `GET /api/v1/notifications/devices`, and issues
+  `DELETE /api/v1/notifications/devices/{id}`. Then disposes the
+  token-refresh and opened-app listeners. Best-effort throughout —
+  Firebase-init failure, network blip, 4xx all swallowed so a flaky
+  push backend can't strand the user signed in. Closes the gap where a
+  signed-out device kept receiving notifications for the prior account.
+
+- **Sentry `SentryRequest.url` scrub** (audit P2-10). `scrubEvent`
+  previously copied `event.request.url` unchanged while nulling the
+  sibling `queryString`, `data`, and `cookies` fields, so the audit-
+  flagged leak of namespace/name path segments and any embedded
+  `?token=…` query remained open. A shared `_scrubUrl` helper now
+  slices `?query` and `#fragment` from the URL and runs the bare path
+  through `_scrubText`; the same helper services HTTP breadcrumb
+  `url` values so the two surfaces can't diverge. The sibling
+  `SentryRequest.fragment` field is also nulled (it can carry the same
+  identifiers as the URL fragment).
+
+- **OIDC error-callback CSRF bind** (audit P3-6 part 1).
+  `OIDCController.completeFlow` previously cleared pending PKCE+state
+  on any callback with `error=…`, regardless of whether the callback's
+  `state` matched the persisted pending. An attacker who could deliver
+  a crafted error universal-link (Android intent spoofing, hostile
+  webpage on iOS) could wipe the verifier/state of an in-flight
+  legitimate flow — targeted login DoS. The error branch now reads
+  `state` first and requires `callbackState == pending.state` to honor
+  the error. Missing/mismatched state drops silently — same disposition
+  as the existing "no pending" guard. Surfacing an error here would
+  both confirm the crafted callback was received AND clobber whatever
+  banner a previous legitimate failure had placed on the login screen.
+
+- **Universal-link callbacks reject `http://`** (audit P3-6 part 2).
+  `UniversalLinkListener._maybeDispatch` previously accepted both
+  `https` and `http`. App Links / Universal Links rely on the
+  OS-verified domain binding that AASA + assetlinks.json provide,
+  which is a property of the https scheme only; honoring http opened a
+  downgrade vector where an attacker who could serve content on
+  `http://<host>/m/auth/callback` could intercept the redirect. Now
+  scheme-restricted to https.
+
+- **Refresh-token secure-storage explicit options** (audit P3-7).
+  `FlutterSecureTokenStore` now mirrors the explicit-options pattern
+  `FlutterSecurePendingOidcStore` already uses:
+  - iOS: `KeychainAccessibility.first_unlock_this_device` — readable
+    after first device unlock, not synced to iCloud, not restored from
+    backups. The refresh token is a per-device credential; cross-device
+    sync would defeat session-scoped revocation on the issuing device.
+  - Android: `AndroidOptions(encryptedSharedPreferences: true)` —
+    Jetpack EncryptedSharedPreferences (AES-GCM-256, key material in
+    the Android Keystore) instead of the default per-value AES wrapper.
+
+  Forward migration: a default-options legacy backend is held alongside
+  the current one. On first post-upgrade read, the legacy backend is
+  consulted, the value is migrated forward, and the legacy entry is
+  deleted. Best-effort — if the migration write fails, the legacy
+  value is still returned so bootstrap can refresh, and the legacy
+  entry stays put for the next try. `deleteRefreshToken` clears both
+  backends so a logout that happens before the first post-upgrade read
+  can't leave a stale legacy entry that re-migrates on next launch.
+
+### Operator notes
+
+- **No re-login required on upgrade.** P3-7's forward migration is
+  transparent: the first post-upgrade `readRefreshToken` finds the
+  legacy entry, writes it under the new options, and deletes the
+  legacy. Users stay signed-in across the version bump.
+
+- **Push notifications stop on logout.** P2-9's silent revoke means
+  users will no longer receive push for the previous account after
+  signing out (previously they continued until the FCM token rotated,
+  the device was unregistered manually, or the backend GC swept the
+  row). No settings tile — silent revoke matches the "user signed out,
+  push stops" mental model. The deferred-from-PR-5a settings tile is
+  no longer needed; the stale comment in `settings_screen.dart` was
+  removed.
+
+- **Sentry projects only see scrubbed URLs going forward.** If the
+  operator has been opted-in and the Sentry project contains historical
+  events with raw URLs in `event.request.url`, those existing events
+  are not retroactively scrubbed (Sentry-side data retention applies).
+  Future events will arrive with paths scrubbed and query/fragment
+  removed.
+
+### Verification
+
+- `flutter test` — 1193 mobile tests pass (20 skipped, unrelated to
+  Phase 5). New tests:
+  - `test/notifications/fcm_revoke_test.dart` — 6 tests covering
+    happy path, no-match, empty list, GET failure, DELETE failure,
+    malformed response.
+  - `test/observability/pii_scrubber_test.dart` — 4 new tests covering
+    query stripping, fragment stripping, non-k8s URL passthrough, null
+    URL. One existing test renamed and extended.
+  - `test/auth/oidc_controller_test.dart` — 2 new tests for no-state
+    and wrong-state error-callback drops; existing "consent denied"
+    test extended to carry `&state=`.
+  - `test/auth/universal_link_listener_test.dart` — 1 new test for
+    http-scheme rejection.
+  - `test/auth/secure_storage_test.dart` (new file) — 7 tests covering
+    current-hit, legacy-fallback-and-migrate, no-data, repeated reads,
+    migration-write-failure preservation, write isolation, dual
+    delete.
+- `dart analyze` — clean across all changed files.
+
+### Out of scope for Phase 5
+
+The audit's remaining findings are tracked for subsequent phases:
+
+- **Phase 6** (scoping leaks): P3-2 CRD inventory per-user RBAC, P3-3
+  diagnostics related-resource RBAC, P3-4 CRD URL/body name mismatch,
+  P3-5 Loki label scoping.
+- **Phase 7** (supply chain + LDAP TLS): P2-11 govulncheck-clean Go
+  toolchain + `golang.org/x/net` bump, P3-1 LDAP plaintext bind reject,
+  P3-9 image digest pinning + gating Trivy.
+
+Phase 4 deferred follow-ups (12 items documented in this changelog
+above) remain open and tracked.
+
+---
+
 ## Phase 4 — Network / SSRF / TLS hardening (2026-05 audit)
 
 Phase 4 closes audit findings P2-6 (SSRF DNS rebinding window on

--- a/mobile/lib/auth/auth_repository.dart
+++ b/mobile/lib/auth/auth_repository.dart
@@ -138,7 +138,17 @@ class AuthRepository extends Notifier<AuthState> {
       // this catch is defense-in-depth against unexpected throws so
       // logout always proceeds to the local-clear path below.
     }
-    await fcm.dispose();
+    try {
+      await fcm.dispose();
+    } catch (e) {
+      // StreamSubscription.cancel() returns a Future that can complete
+      // with an error when the underlying stream has already faulted
+      // (Firebase messaging network drop, permission revocation
+      // mid-session). Without this guard the rejection would propagate
+      // out of logout(), skipping authTokenHolder.clear() and
+      // state=Unauthenticated below — the user would stay signed in
+      // with live credentials. Code-review finding R-1 (Phase 5).
+    }
 
     final dio = ref.read(dioProvider);
     try {

--- a/mobile/lib/auth/auth_repository.dart
+++ b/mobile/lib/auth/auth_repository.dart
@@ -11,6 +11,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../api/api_error.dart';
 import '../api/auth_token_holder.dart';
 import '../api/dio_client.dart';
+import '../notifications/fcm_registration.dart';
 import 'auth_state.dart';
 import 'secure_storage.dart';
 import 'user.dart';
@@ -124,6 +125,21 @@ class AuthRepository extends Notifier<AuthState> {
   }
 
   Future<void> logout() async {
+    // Revoke + dispose FCM BEFORE clearing the access token — the DELETE
+    // call routes through the authenticated Dio and middleware rejects
+    // unauthenticated requests. Best-effort: any failure (Firebase not
+    // initialised, network error, 4xx) is swallowed so a flaky push
+    // backend can't strand the user signed-in. Audit finding P2-9.
+    final fcm = ref.read(fcmRegistrationProvider);
+    try {
+      await fcm.revokeCurrentDevice();
+    } catch (e) {
+      // revokeCurrentDevice already swallows DioException internally;
+      // this catch is defense-in-depth against unexpected throws so
+      // logout always proceeds to the local-clear path below.
+    }
+    await fcm.dispose();
+
     final dio = ref.read(dioProvider);
     try {
       await dio.post<void>('/api/v1/auth/logout');

--- a/mobile/lib/auth/oidc_controller.dart
+++ b/mobile/lib/auth/oidc_controller.dart
@@ -272,8 +272,24 @@ class OIDCController extends Notifier<OIDCFlowState> {
     // BEFORE pulling `code` so we route the right error. RFC 6749 §4.1.2.1
     // OAuth error codes + OIDC core §3.1.2.6 mapped to controller reasons
     // so the inline banner reflects the actual condition.
+    //
+    // CSRF-bind error callbacks the same way we bind success callbacks:
+    // read `state` first and reject anything that doesn't match the
+    // persisted pending.state BEFORE touching pendingStore. Without this
+    // bind an attacker who can deliver a crafted error universal-link
+    // (intent spoofing on Android, hostile webpage on iOS) can wipe the
+    // verifier/state of an in-flight legitimate flow — targeted login
+    // DoS. Audit finding P3-6.
     final errorParam = callback.queryParameters['error'];
+    final callbackState = callback.queryParameters['state'];
     if (errorParam != null && errorParam.isNotEmpty) {
+      if (callbackState == null || callbackState != pending.state) {
+        // Silently drop — same disposition as the "no pending" branch
+        // above. Surfacing an error here would both confirm the crafted
+        // callback was received AND clobber the inline error banner that
+        // a previous real failure may have placed on the login screen.
+        return;
+      }
       await pendingStore.clear();
       final reason = switch (errorParam) {
         'access_denied' => OIDCFlowErrorReason.consentDenied,
@@ -296,7 +312,6 @@ class OIDCController extends Notifier<OIDCFlowState> {
     }
 
     final code = callback.queryParameters['code'];
-    final callbackState = callback.queryParameters['state'];
 
     if (code == null || code.isEmpty || callbackState == null) {
       await pendingStore.clear();

--- a/mobile/lib/auth/secure_storage.dart
+++ b/mobile/lib/auth/secure_storage.dart
@@ -2,6 +2,7 @@
 // Android EncryptedSharedPreferences). Single key. Riverpod-injected so
 // tests can substitute an in-memory implementation.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
@@ -23,10 +24,99 @@ abstract class SecureTokenStore {
   Future<void> deleteRefreshToken();
 }
 
-class FlutterSecureTokenStore implements SecureTokenStore {
-  FlutterSecureTokenStore({FlutterSecureStorage? storage})
-      : _storage = storage ?? const FlutterSecureStorage();
+/// Default-options FlutterSecureStorage instance held module-wide so the
+/// "legacy" backend pointer is identity-stable across reads — matters
+/// only on iOS where reads with default options can hit the same
+/// underlying Keychain item written before P3-7.
+const FlutterSecureStorage _legacyDefaults = FlutterSecureStorage();
 
+/// Production backend mirrors the explicit options from
+/// [FlutterSecurePendingOidcStore]:
+///   - iOS: first_unlock_this_device — readable after first device
+///     unlock, not synced to iCloud, not restored from backups. The
+///     refresh token is a per-device credential; cross-device sync
+///     would defeat session-scoped revocation on the issuing device.
+///   - Android: encryptedSharedPreferences — uses the Jetpack
+///     EncryptedSharedPreferences backend (AES-GCM-256 with key
+///     material in the Android Keystore) instead of the default
+///     per-value AES wrapper.
+///
+/// Audit finding P3-7.
+FlutterSecureStorage _defaultCurrentStorage() => const FlutterSecureStorage(
+      iOptions: IOSOptions(
+        accessibility: KeychainAccessibility.first_unlock_this_device,
+      ),
+      aOptions: AndroidOptions(encryptedSharedPreferences: true),
+    );
+
+class FlutterSecureTokenStore implements SecureTokenStore {
+  /// Production constructor: wires the audit-recommended explicit
+  /// storage backend AND a default-options legacy backend so values
+  /// written by older app versions migrate forward transparently on
+  /// first read after upgrade.
+  FlutterSecureTokenStore({
+    FlutterSecureStorage? storage,
+    FlutterSecureStorage? legacyStorage,
+  })  : _current = _FlutterBacked(storage ?? _defaultCurrentStorage()),
+        _legacy = _FlutterBacked(legacyStorage ?? _legacyDefaults);
+
+  /// Test seam — accepts arbitrary [SecureTokenStore] backends so
+  /// migration logic can be exercised without spinning up a real
+  /// FlutterSecureStorage method channel. The production constructor
+  /// builds these from concrete FlutterSecureStorage instances.
+  @visibleForTesting
+  FlutterSecureTokenStore.fromBackends({
+    required SecureTokenStore current,
+    required SecureTokenStore legacy,
+  })  : _current = current,
+        _legacy = legacy;
+
+  final SecureTokenStore _current;
+  final SecureTokenStore _legacy;
+
+  @override
+  Future<String?> readRefreshToken() async {
+    final current = await _current.readRefreshToken();
+    if (current != null) return current;
+
+    // Forward-migrate any value persisted under the pre-P3-7 default
+    // options. Best-effort: if the write to the new backend fails, leave
+    // the legacy entry intact so the next read tries again rather than
+    // losing the user's session.
+    final legacy = await _legacy.readRefreshToken();
+    if (legacy != null) {
+      try {
+        await _current.writeRefreshToken(legacy);
+        await _legacy.deleteRefreshToken();
+      } catch (_) {
+        // Swallow migration failures; the legacy value is still
+        // returned below so bootstrap can refresh.
+      }
+    }
+    return legacy;
+  }
+
+  @override
+  Future<void> writeRefreshToken(String token) =>
+      _current.writeRefreshToken(token);
+
+  @override
+  Future<void> deleteRefreshToken() async {
+    // Clear from both backends. Without the legacy clear, a logout that
+    // happens before the first post-upgrade read would leave a stale
+    // refresh token in default-options storage where a future read
+    // would re-migrate it forward.
+    await _current.deleteRefreshToken();
+    await _legacy.deleteRefreshToken();
+  }
+}
+
+/// Adapter that exposes a single [FlutterSecureStorage] under the
+/// [SecureTokenStore] interface so [FlutterSecureTokenStore] can hold
+/// either real or in-memory backends through one shape. Private — the
+/// public seam is [FlutterSecureTokenStore.fromBackends].
+class _FlutterBacked implements SecureTokenStore {
+  const _FlutterBacked(this._storage);
   final FlutterSecureStorage _storage;
 
   @override

--- a/mobile/lib/auth/secure_storage.dart
+++ b/mobile/lib/auth/secure_storage.dart
@@ -2,6 +2,8 @@
 // Android EncryptedSharedPreferences). Single key. Riverpod-injected so
 // tests can substitute an in-memory implementation.
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
@@ -58,42 +60,72 @@ class FlutterSecureTokenStore implements SecureTokenStore {
     FlutterSecureStorage? storage,
     FlutterSecureStorage? legacyStorage,
   })  : _current = _FlutterBacked(storage ?? _defaultCurrentStorage()),
-        _legacy = _FlutterBacked(legacyStorage ?? _legacyDefaults);
+        _legacy = _FlutterBacked(legacyStorage ?? _legacyDefaults),
+        _opTimeout = _defaultOpTimeout;
 
   /// Test seam — accepts arbitrary [SecureTokenStore] backends so
   /// migration logic can be exercised without spinning up a real
-  /// FlutterSecureStorage method channel. The production constructor
-  /// builds these from concrete FlutterSecureStorage instances.
+  /// FlutterSecureStorage method channel. The [opTimeout] override lets
+  /// timeout-branch tests use a tight bound (e.g., 50ms) so the suite
+  /// doesn't have to wait through the production 5s budget.
   @visibleForTesting
   FlutterSecureTokenStore.fromBackends({
     required SecureTokenStore current,
     required SecureTokenStore legacy,
+    Duration opTimeout = _defaultOpTimeout,
   })  : _current = current,
-        _legacy = legacy;
+        _legacy = legacy,
+        _opTimeout = opTimeout;
 
   final SecureTokenStore _current;
   final SecureTokenStore _legacy;
+  final Duration _opTimeout;
+
+  /// Per-op upper bound on platform-channel calls into FlutterSecureStorage.
+  /// On Android in the Before-First-Unlock state (post-reboot, pre-PIN),
+  /// EncryptedSharedPreferences can hang indefinitely — same failure mode
+  /// closed for SharedPreferences in issue #270 via `prefs_bootstrap.dart`.
+  /// 5s is tighter than the 10s SharedPreferences budget because bootstrap
+  /// has already passed `hydratePrefsWithTimeout` by the time it reaches
+  /// here, so the device has more recently demonstrated storage liveness.
+  /// On timeout the call returns null / completes silently, and bootstrap
+  /// falls through to the unauthenticated path — same disposition as
+  /// "no stored refresh token". Code-review finding (learnings #1, Phase 5).
+  static const Duration _defaultOpTimeout = Duration(seconds: 5);
 
   @override
   Future<String?> readRefreshToken() async {
-    final current = await _current.readRefreshToken();
+    final current = await _readWithTimeout(_current);
     if (current != null) return current;
 
     // Forward-migrate any value persisted under the pre-P3-7 default
-    // options. Best-effort: if the write to the new backend fails, leave
-    // the legacy entry intact so the next read tries again rather than
-    // losing the user's session.
-    final legacy = await _legacy.readRefreshToken();
+    // options. Best-effort: if the write to the new backend fails or
+    // times out, leave the legacy entry intact so the next read tries
+    // again rather than losing the user's session.
+    final legacy = await _readWithTimeout(_legacy);
     if (legacy != null) {
       try {
-        await _current.writeRefreshToken(legacy);
-        await _legacy.deleteRefreshToken();
+        await _current.writeRefreshToken(legacy).timeout(_opTimeout);
+        await _legacy.deleteRefreshToken().timeout(_opTimeout);
       } catch (_) {
-        // Swallow migration failures; the legacy value is still
-        // returned below so bootstrap can refresh.
+        // Swallow migration failures (including TimeoutException);
+        // the legacy value is still returned below so bootstrap can
+        // refresh.
       }
     }
     return legacy;
+  }
+
+  Future<String?> _readWithTimeout(SecureTokenStore store) async {
+    try {
+      return await store.readRefreshToken().timeout(_opTimeout);
+    } on Exception catch (error) {
+      debugPrint(
+        'secure_storage: read exceeded ${_opTimeout.inMilliseconds}ms '
+        '— falling through to unauthenticated path. $error',
+      );
+      return null;
+    }
   }
 
   @override

--- a/mobile/lib/auth/universal_link_listener.dart
+++ b/mobile/lib/auth/universal_link_listener.dart
@@ -94,7 +94,14 @@ class UniversalLinkListener {
   Future<void> _maybeDispatch(Uri uri) async {
     // Only consume the OIDC callback path. Notification deep-links and
     // any other /m/* paths flow through their own handlers.
-    if (uri.scheme != 'https' && uri.scheme != 'http') return;
+    //
+    // https-only — App Links / Universal Links chosen specifically for
+    // the OS-verified domain binding (AASA + assetlinks.json) that
+    // custom schemes and http can't provide. Accepting http here would
+    // open a downgrade vector: an attacker who can serve content on
+    // http://<host>/m/auth/callback could intercept the callback before
+    // it reaches the legitimate https handler. Audit finding P3-6.
+    if (uri.scheme != 'https') return;
     if (uri.host != _host) return;
     if (uri.path != oidcCallbackPath) return;
 

--- a/mobile/lib/features/settings/settings_screen.dart
+++ b/mobile/lib/features/settings/settings_screen.dart
@@ -10,8 +10,10 @@
 // the section without the feature would be misleading metadata under
 // App Store guideline 2.3.
 //
-// FCM device-token revoke tile is deferred from PR-5a — see
-// docs/OBSERVABILITY.md for the rationale.
+// FCM device-token revoke happens automatically on logout (Phase 5
+// audit finding P2-9, wired in [AuthRepository.logout]). No dedicated
+// settings tile — silent revoke matches the "user signed out, push
+// stops" mental model.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';

--- a/mobile/lib/notifications/fcm_registration.dart
+++ b/mobile/lib/notifications/fcm_registration.dart
@@ -149,6 +149,15 @@ class FcmRegistration {
     }
   }
 
+  /// Upper bound on the whole revoke flow. Dio's per-request receive
+  /// timeout is 30s (dio_client.dart) and revoke issues two sequential
+  /// calls — without this bound a hung backend would block logout for
+  /// ~60s on the FCM path plus another 30s on `/auth/logout`. 5s is
+  /// generous for the well-behaved case (sub-second list + sub-second
+  /// delete) and decisive on the failure case. Code-review finding R-2
+  /// (Phase 5).
+  static const Duration _revokeTotalTimeout = Duration(seconds: 5);
+
   /// Called from [AuthRepository.logout] before clearing the access token —
   /// the DELETE requires the still-valid access token to pass auth
   /// middleware. Best-effort: any failure short-circuits silently so a
@@ -167,7 +176,14 @@ class FcmRegistration {
       return;
     }
     if (token == null || token.isEmpty) return;
-    await revokeDeviceByToken(token);
+    try {
+      await revokeDeviceByToken(token).timeout(_revokeTotalTimeout);
+    } on TimeoutException {
+      debugPrint(
+        '[fcm] revoke: exceeded ${_revokeTotalTimeout.inSeconds}s — '
+        'logout proceeding without revoke confirmation',
+      );
+    }
   }
 
   /// Looks up the device record for [token] via the per-user list endpoint,
@@ -191,20 +207,23 @@ class FcmRegistration {
       if (id == null || id.isEmpty) return false;
       deviceId = id;
     } on DioException catch (e) {
+      // Log only the type — Dio's e.message can include the request URL,
+      // which would land the FCM device-token (or stale device ID) in
+      // debugPrint output. Code-review finding R-3 (Phase 5).
       final err = e.error;
-      debugPrint(
-        '[fcm] revoke list failed: ${err is ApiError ? err.message : e.message}',
-      );
+      final reason = err is ApiError ? err.message : e.type.name;
+      debugPrint('[fcm] revoke list failed: $reason');
       return false;
     }
     try {
       await _dio.delete<dynamic>('/api/v1/notifications/devices/$deviceId');
       return true;
     } on DioException catch (e) {
+      // Same scrub as the list path — Dio error messages on the DELETE
+      // include the full request URL, which embeds the device ID.
       final err = e.error;
-      debugPrint(
-        '[fcm] revoke delete failed: ${err is ApiError ? err.message : e.message}',
-      );
+      final reason = err is ApiError ? err.message : e.type.name;
+      debugPrint('[fcm] revoke delete failed: $reason');
       return false;
     }
   }

--- a/mobile/lib/notifications/fcm_registration.dart
+++ b/mobile/lib/notifications/fcm_registration.dart
@@ -149,6 +149,66 @@ class FcmRegistration {
     }
   }
 
+  /// Called from [AuthRepository.logout] before clearing the access token —
+  /// the DELETE requires the still-valid access token to pass auth
+  /// middleware. Best-effort: any failure short-circuits silently so a
+  /// network blip can't strand the user signed-in. Audit finding P2-9.
+  ///
+  /// Skips entirely when Firebase isn't initialised (no platform config,
+  /// permission denied, unsupported platform) — there is nothing to revoke
+  /// because [ensureRegistered] never ran a POST.
+  Future<void> revokeCurrentDevice() async {
+    if (!_supportedPlatform || !_initialized) return;
+    String? token;
+    try {
+      token = await FirebaseMessaging.instance.getToken();
+    } catch (e) {
+      debugPrint('[fcm] revoke: getToken failed: $e');
+      return;
+    }
+    if (token == null || token.isEmpty) return;
+    await revokeDeviceByToken(token);
+  }
+
+  /// Looks up the device record for [token] via the per-user list endpoint,
+  /// then DELETEs it. Visible for tests so the network path can be
+  /// exercised without a Firebase platform channel. Returns true when a
+  /// matching device was found and deleted.
+  @visibleForTesting
+  Future<bool> revokeDeviceByToken(String token) async {
+    final String deviceId;
+    try {
+      final res = await _dio.get<Map<String, dynamic>>(
+        '/api/v1/notifications/devices',
+      );
+      final data = res.data?['data'];
+      if (data is! List) return false;
+      final match = data.whereType<Map<String, dynamic>>().firstWhere(
+            (d) => (d['deviceToken'] as String?) == token,
+            orElse: () => const <String, dynamic>{},
+          );
+      final id = match['id'] as String?;
+      if (id == null || id.isEmpty) return false;
+      deviceId = id;
+    } on DioException catch (e) {
+      final err = e.error;
+      debugPrint(
+        '[fcm] revoke list failed: ${err is ApiError ? err.message : e.message}',
+      );
+      return false;
+    }
+    try {
+      await _dio.delete<dynamic>('/api/v1/notifications/devices/$deviceId');
+      return true;
+    } on DioException catch (e) {
+      final err = e.error;
+      debugPrint(
+        '[fcm] revoke delete failed: ${err is ApiError ? err.message : e.message}',
+      );
+      return false;
+    }
+  }
+
   bool get _supportedPlatform {
     // Web/desktop builds skip FCM entirely. M1 ships iOS + Android only.
     if (kIsWeb) return false;

--- a/mobile/lib/observability/pii_scrubber.dart
+++ b/mobile/lib/observability/pii_scrubber.dart
@@ -117,14 +117,22 @@ SentryEvent _scrubEventBody(SentryEvent event) {
   final scrubbedRequest = origRequest == null
       ? null
       : SentryRequest(
-          url: origRequest.url,
+          // Strip query + fragment, then run the path through the same
+          // positional scrubber that handles message text and breadcrumb
+          // URLs. Without this, SentryRequest.url leaks namespace/name
+          // segments and any ?token=… that the request happened to carry,
+          // even though the sibling queryString field is nulled below.
+          // Audit finding P2-10.
+          url: origRequest.url == null ? null : _scrubUrl(origRequest.url!),
           method: origRequest.method,
-          // data/queryString/cookies dropped; SentryRequest constructor
-          // accepts null for each, which clears them.
+          // data/queryString/cookies/fragment dropped; SentryRequest
+          // constructor accepts null for each, which clears them. The
+          // fragment field is a sibling of `url` and can carry the same
+          // identifiers, so it must be nulled even when url is scrubbed.
           data: null,
           queryString: null,
           cookies: null,
-          fragment: origRequest.fragment,
+          fragment: null,
           apiTarget: origRequest.apiTarget,
           headers: _scrubHeaders(origRequest.headers),
           env: origRequest.env,
@@ -254,17 +262,11 @@ Map<String, dynamic>? _scrubBreadcrumbData(Map<String, dynamic>? data) {
   if (data == null) return null;
   final clean = <String, dynamic>{};
   data.forEach((key, value) {
-    // HTTP breadcrumbs carry the URL under `url`. Strip query string +
-    // fragment, then scrub path segments. We slice off `?` / `#` rather
-    // than `Uri.replace(query: '')` so the output is canonical (no
-    // dangling `?` from an empty query string).
+    // HTTP breadcrumbs carry the URL under `url`. Shares the same
+    // strip-and-scrub treatment as SentryRequest.url so the two surfaces
+    // can't diverge.
     if (key == 'url' && value is String) {
-      var stripped = value;
-      final qIdx = stripped.indexOf('?');
-      if (qIdx >= 0) stripped = stripped.substring(0, qIdx);
-      final fIdx = stripped.indexOf('#');
-      if (fIdx >= 0) stripped = stripped.substring(0, fIdx);
-      clean[key] = _scrubText(stripped);
+      clean[key] = _scrubUrl(value);
       return;
     }
     if (value is String) {
@@ -275,6 +277,21 @@ Map<String, dynamic>? _scrubBreadcrumbData(Map<String, dynamic>? data) {
     }
   });
   return clean;
+}
+
+/// Strips `?query` and `#fragment` from [url], then runs the bare path
+/// through [_scrubText]. We slice off `?`/`#` rather than calling
+/// `Uri.replace(query: '')` so the output is canonical (no dangling `?`
+/// from an empty query string) and stays a valid URL when the path
+/// scrubber rewrites segments. Single source of truth for URL scrub:
+/// SentryRequest.url and HTTP breadcrumb `url` both pass through here.
+String _scrubUrl(String url) {
+  var stripped = url;
+  final qIdx = stripped.indexOf('?');
+  if (qIdx >= 0) stripped = stripped.substring(0, qIdx);
+  final fIdx = stripped.indexOf('#');
+  if (fIdx >= 0) stripped = stripped.substring(0, fIdx);
+  return _scrubText(stripped);
 }
 
 /// Public for tests. Applies positional k8s-path + key-value + FCM

--- a/mobile/lib/observability/pii_scrubber.dart
+++ b/mobile/lib/observability/pii_scrubber.dart
@@ -285,8 +285,25 @@ Map<String, dynamic>? _scrubBreadcrumbData(Map<String, dynamic>? data) {
 /// from an empty query string) and stays a valid URL when the path
 /// scrubber rewrites segments. Single source of truth for URL scrub:
 /// SentryRequest.url and HTTP breadcrumb `url` both pass through here.
+///
+/// Percent-decodes via `Uri.decodeFull` BEFORE slicing so an attacker
+/// can't smuggle a fake query string into the path with `%3F` or `%23`.
+/// Without the decode pass, `/v1/resources/secrets/ns/name%3Ftoken=leak`
+/// would land in `_scrubText` unchanged — the regex char class
+/// `[A-Za-z0-9._-]` stops at `%`, so the segment scrub catches only
+/// `.../ns/name`, and `%3Ftoken=leak` survives in the output. Code-
+/// review finding (adversarial ADV-3 + testing T-2, Phase 5).
 String _scrubUrl(String url) {
-  var stripped = url;
+  String decoded;
+  try {
+    decoded = Uri.decodeFull(url);
+  } catch (_) {
+    // Malformed percent-encoding (e.g., bare `%` not followed by hex).
+    // Fall back to the raw string — better to scrub literal text than
+    // to skip scrubbing entirely.
+    decoded = url;
+  }
+  var stripped = decoded;
   final qIdx = stripped.indexOf('?');
   if (qIdx >= 0) stripped = stripped.substring(0, qIdx);
   final fIdx = stripped.indexOf('#');

--- a/mobile/test/auth/oidc_controller_test.dart
+++ b/mobile/test/auth/oidc_controller_test.dart
@@ -272,21 +272,74 @@ void main() {
       expect(await s.pending.read(), isNull);
     });
 
-    test('consent denied: consentDenied error', () async {
+    test(
+        'consent denied with matched state: consentDenied error, clears '
+        'pending (P3-6 happy path)', () async {
       final s = _setup();
       addTearDown(s.container.dispose);
-      await seedPending(s.pending, s.now());
+      await seedPending(s.pending, s.now(), state: 'STATE123');
 
+      // Audit finding P3-6: error callbacks must carry a matched state
+      // to be honored. The legitimate IdP redirect always includes the
+      // state it received in the auth request.
       await s.container
           .read(oidcControllerProvider.notifier)
           .completeFlow(Uri.parse(
-              'https://k8scenter.test/m/auth/callback?error=access_denied&error_description=User+declined'));
+              'https://k8scenter.test/m/auth/callback?error=access_denied&error_description=User+declined&state=STATE123'));
 
       final state =
           s.container.read(oidcControllerProvider) as OIDCFlowError;
       expect(state.reason, OIDCFlowErrorReason.consentDenied);
       expect(state.detail, 'User declined');
       expect(await s.pending.read(), isNull);
+    });
+
+    test(
+        'error callback with NO state: silently dropped, pending preserved '
+        '(P3-6 — login DoS guard)', () async {
+      final s = _setup();
+      addTearDown(s.container.dispose);
+      await seedPending(s.pending, s.now(), state: 'EXPECTED');
+
+      await s.container
+          .read(oidcControllerProvider.notifier)
+          .completeFlow(Uri.parse(
+              'https://k8scenter.test/m/auth/callback?error=access_denied'));
+
+      // No state surfaced — controller stays idle so the legitimate
+      // success callback can still race-in and complete the flow.
+      expect(
+        s.container.read(oidcControllerProvider),
+        isA<OIDCFlowIdle>(),
+        reason: 'no error banner should appear from an unbound callback',
+      );
+      // Pending state preserved — the legitimate callback still has its
+      // verifier/state intact.
+      expect(
+        await s.pending.read(),
+        isNotNull,
+        reason: 'attacker callback must not wipe in-flight verifier/state',
+      );
+    });
+
+    test(
+        'error callback with WRONG state: silently dropped, pending preserved '
+        '(P3-6 — login DoS guard)', () async {
+      final s = _setup();
+      addTearDown(s.container.dispose);
+      await seedPending(s.pending, s.now(), state: 'EXPECTED');
+
+      await s.container
+          .read(oidcControllerProvider.notifier)
+          .completeFlow(Uri.parse(
+              'https://k8scenter.test/m/auth/callback?error=access_denied&state=ATTACKER_STATE'));
+
+      expect(s.container.read(oidcControllerProvider), isA<OIDCFlowIdle>());
+      expect(
+        await s.pending.read(),
+        isNotNull,
+        reason: 'mismatched state must not clear pending',
+      );
     });
 
     test('ttl expired: ttlExpired error', () async {

--- a/mobile/test/auth/oidc_controller_test.dart
+++ b/mobile/test/auth/oidc_controller_test.dart
@@ -342,6 +342,91 @@ void main() {
       );
     });
 
+    // Cross-reviewer testing T-1 (Phase 5): the error-code switch routes
+    // five distinct OAuth/OIDC error values to different controller
+    // reasons. Only access_denied was exercised before. A subtle swap
+    // (e.g., routing temporarily_unavailable to exchangeRejected instead
+    // of networkError) would not be caught. One test per branch through
+    // the matched-state path so the switch can't drift undetected.
+
+    test('login_required → consentDenied (matched state)', () async {
+      final s = _setup();
+      addTearDown(s.container.dispose);
+      await seedPending(s.pending, s.now(), state: 'S');
+
+      await s.container
+          .read(oidcControllerProvider.notifier)
+          .completeFlow(Uri.parse(
+              'https://k8scenter.test/m/auth/callback?error=login_required&state=S'));
+
+      final state =
+          s.container.read(oidcControllerProvider) as OIDCFlowError;
+      expect(state.reason, OIDCFlowErrorReason.consentDenied);
+      expect(await s.pending.read(), isNull);
+    });
+
+    test('interaction_required → consentDenied (matched state)', () async {
+      final s = _setup();
+      addTearDown(s.container.dispose);
+      await seedPending(s.pending, s.now(), state: 'S');
+
+      await s.container
+          .read(oidcControllerProvider.notifier)
+          .completeFlow(Uri.parse(
+              'https://k8scenter.test/m/auth/callback?error=interaction_required&state=S'));
+
+      final state =
+          s.container.read(oidcControllerProvider) as OIDCFlowError;
+      expect(state.reason, OIDCFlowErrorReason.consentDenied);
+    });
+
+    test('temporarily_unavailable → networkError (matched state)', () async {
+      final s = _setup();
+      addTearDown(s.container.dispose);
+      await seedPending(s.pending, s.now(), state: 'S');
+
+      await s.container
+          .read(oidcControllerProvider.notifier)
+          .completeFlow(Uri.parse(
+              'https://k8scenter.test/m/auth/callback?error=temporarily_unavailable&state=S'));
+
+      final state =
+          s.container.read(oidcControllerProvider) as OIDCFlowError;
+      expect(state.reason, OIDCFlowErrorReason.networkError);
+    });
+
+    test('server_error → networkError (matched state)', () async {
+      final s = _setup();
+      addTearDown(s.container.dispose);
+      await seedPending(s.pending, s.now(), state: 'S');
+
+      await s.container
+          .read(oidcControllerProvider.notifier)
+          .completeFlow(Uri.parse(
+              'https://k8scenter.test/m/auth/callback?error=server_error&state=S'));
+
+      final state =
+          s.container.read(oidcControllerProvider) as OIDCFlowError;
+      expect(state.reason, OIDCFlowErrorReason.networkError);
+    });
+
+    test(
+        'unknown error code → exchangeRejected (matched state, wildcard '
+        'branch)', () async {
+      final s = _setup();
+      addTearDown(s.container.dispose);
+      await seedPending(s.pending, s.now(), state: 'S');
+
+      await s.container
+          .read(oidcControllerProvider.notifier)
+          .completeFlow(Uri.parse(
+              'https://k8scenter.test/m/auth/callback?error=teapot&state=S'));
+
+      final state =
+          s.container.read(oidcControllerProvider) as OIDCFlowError;
+      expect(state.reason, OIDCFlowErrorReason.exchangeRejected);
+    });
+
     test('ttl expired: ttlExpired error', () async {
       // Create pending 6 minutes ago, advance clock 10 minutes.
       final past = DateTime.utc(2026, 5, 16, 12, 0, 0);

--- a/mobile/test/auth/secure_storage_test.dart
+++ b/mobile/test/auth/secure_storage_test.dart
@@ -9,6 +9,8 @@
 // the production code relies on (writes to one don't appear in reads
 // from the other).
 
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kubecenter/auth/secure_storage.dart';
 
@@ -140,6 +142,73 @@ void main() {
     });
   });
 
+  group('FlutterSecureTokenStore BFU timeout (learnings #1)', () {
+    const Duration tightTimeout = Duration(milliseconds: 50);
+
+    test(
+        'read returns null when the current-backend read hangs past the '
+        'op timeout (Android BFU fallback)', () async {
+      final current = _HangingStore();
+      final legacy = InMemoryTokenStore();
+      await legacy.writeRefreshToken('legacy-value');
+      final store = FlutterSecureTokenStore.fromBackends(
+        current: current,
+        legacy: legacy,
+        opTimeout: tightTimeout,
+      );
+
+      final result = await store.readRefreshToken();
+      expect(
+        result,
+        'legacy-value',
+        reason: 'hanging current read should fall through to the legacy '
+            'fallback path after the op timeout fires',
+      );
+    });
+
+    test(
+        'read returns null when BOTH backends hang past the op timeout '
+        '(forces re-auth instead of stalling cold-start)', () async {
+      final current = _HangingStore();
+      final legacy = _HangingStore();
+      final store = FlutterSecureTokenStore.fromBackends(
+        current: current,
+        legacy: legacy,
+        opTimeout: tightTimeout,
+      );
+
+      final result = await store.readRefreshToken();
+      expect(
+        result,
+        isNull,
+        reason: 'both reads timing out should yield null so bootstrap '
+            'falls through to the unauthenticated path instead of hanging',
+      );
+    });
+
+    test(
+        'migration write timeout preserves legacy value AND returns it '
+        'so the session survives a slow current-backend write', () async {
+      // current.read() returns null fast; current.write() hangs forever.
+      final current = _ReadNullWriteHangsStore();
+      final legacy = InMemoryTokenStore();
+      await legacy.writeRefreshToken('precious');
+      final store = FlutterSecureTokenStore.fromBackends(
+        current: current,
+        legacy: legacy,
+        opTimeout: tightTimeout,
+      );
+
+      final result = await store.readRefreshToken();
+      expect(result, 'precious');
+      expect(
+        await legacy.readRefreshToken(),
+        'precious',
+        reason: 'failed-write migration must not delete legacy data',
+      );
+    });
+  });
+
   group('FlutterSecureTokenStore.deleteRefreshToken', () {
     test('clears BOTH backends so a logout before first read can\'t leave '
         'a stale legacy entry that re-migrates on next launch', () async {
@@ -179,4 +248,36 @@ class _WriteFailingStore implements SecureTokenStore {
   Future<void> deleteRefreshToken() async {
     _value = null;
   }
+}
+
+/// SecureTokenStore whose every method returns a never-completing
+/// Future. Models the Android EncryptedSharedPreferences platform-
+/// channel hang under Before-First-Unlock. Used to exercise the
+/// op-timeout fallback path in FlutterSecureTokenStore.
+class _HangingStore implements SecureTokenStore {
+  @override
+  Future<String?> readRefreshToken() => Completer<String?>().future;
+
+  @override
+  Future<void> writeRefreshToken(String token) =>
+      Completer<void>().future;
+
+  @override
+  Future<void> deleteRefreshToken() => Completer<void>().future;
+}
+
+/// SecureTokenStore that returns null fast on read but hangs on write.
+/// Models the migration-time failure where the current backend can be
+/// queried (empty) but a write to it stalls — covers the inner timeout
+/// inside the legacy-migrate branch.
+class _ReadNullWriteHangsStore implements SecureTokenStore {
+  @override
+  Future<String?> readRefreshToken() async => null;
+
+  @override
+  Future<void> writeRefreshToken(String token) =>
+      Completer<void>().future;
+
+  @override
+  Future<void> deleteRefreshToken() async {}
 }

--- a/mobile/test/auth/secure_storage_test.dart
+++ b/mobile/test/auth/secure_storage_test.dart
@@ -1,0 +1,182 @@
+// Tests for FlutterSecureTokenStore — focused on the audit-finding-P3-7
+// forward migration from default-options secure-storage to the explicit
+// first_unlock_this_device / encryptedSharedPreferences backend.
+//
+// FlutterSecureStorage itself is platform-channel-backed, so the
+// migration is exercised via the @visibleForTesting `fromBackends`
+// constructor that accepts SecureTokenStore implementations directly.
+// In-memory backends faithfully model the per-instance isolation that
+// the production code relies on (writes to one don't appear in reads
+// from the other).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kubecenter/auth/secure_storage.dart';
+
+void main() {
+  group('FlutterSecureTokenStore.readRefreshToken (P3-7 migration)', () {
+    test(
+        'reads from current backend when present without touching legacy',
+        () async {
+      final current = InMemoryTokenStore();
+      final legacy = InMemoryTokenStore();
+      await current.writeRefreshToken('current-token');
+      await legacy.writeRefreshToken('legacy-stale');
+
+      final store = FlutterSecureTokenStore.fromBackends(
+        current: current,
+        legacy: legacy,
+      );
+
+      expect(await store.readRefreshToken(), 'current-token');
+      // Legacy is left intact on a current-backend hit. (Hygiene cleanup
+      // happens on deleteRefreshToken so this remnant gets cleaned up on
+      // the next logout.)
+      expect(await legacy.readRefreshToken(), 'legacy-stale');
+    });
+
+    test(
+        'falls back to legacy backend when current is empty and forward-'
+        'migrates the value', () async {
+      final current = InMemoryTokenStore();
+      final legacy = InMemoryTokenStore();
+      await legacy.writeRefreshToken('pre-upgrade-token');
+
+      final store = FlutterSecureTokenStore.fromBackends(
+        current: current,
+        legacy: legacy,
+      );
+
+      expect(
+        await store.readRefreshToken(),
+        'pre-upgrade-token',
+        reason: 'first post-upgrade read should return the legacy value',
+      );
+      expect(
+        await current.readRefreshToken(),
+        'pre-upgrade-token',
+        reason: 'value should be migrated to the current-options backend',
+      );
+      expect(
+        await legacy.readRefreshToken(),
+        isNull,
+        reason: 'legacy entry should be cleared after successful migration',
+      );
+    });
+
+    test(
+        'returns null when neither backend has a value, no writes performed',
+        () async {
+      final current = InMemoryTokenStore();
+      final legacy = InMemoryTokenStore();
+      final store = FlutterSecureTokenStore.fromBackends(
+        current: current,
+        legacy: legacy,
+      );
+
+      expect(await store.readRefreshToken(), isNull);
+      expect(await current.readRefreshToken(), isNull);
+      expect(await legacy.readRefreshToken(), isNull);
+    });
+
+    test(
+        'subsequent reads after migration come from current backend (legacy '
+        'already cleared)', () async {
+      final current = InMemoryTokenStore();
+      final legacy = InMemoryTokenStore();
+      await legacy.writeRefreshToken('migrating');
+      final store = FlutterSecureTokenStore.fromBackends(
+        current: current,
+        legacy: legacy,
+      );
+
+      // First read triggers migration.
+      expect(await store.readRefreshToken(), 'migrating');
+      // Second read hits the current backend directly.
+      expect(await store.readRefreshToken(), 'migrating');
+      expect(await legacy.readRefreshToken(), isNull);
+    });
+
+    test(
+        'when current-backend write fails during migration, legacy value '
+        'is still returned (don\'t lose the session)', () async {
+      final current = _WriteFailingStore();
+      final legacy = InMemoryTokenStore();
+      await legacy.writeRefreshToken('precious');
+      final store = FlutterSecureTokenStore.fromBackends(
+        current: current,
+        legacy: legacy,
+      );
+
+      // Read returns the legacy value even though the migration write
+      // threw. The legacy entry is left intact (delete is gated by a
+      // successful write).
+      expect(await store.readRefreshToken(), 'precious');
+      expect(
+        await legacy.readRefreshToken(),
+        'precious',
+        reason: 'failed migration must not delete legacy data',
+      );
+    });
+  });
+
+  group('FlutterSecureTokenStore.writeRefreshToken', () {
+    test('writes only to current backend, leaving legacy untouched',
+        () async {
+      final current = InMemoryTokenStore();
+      final legacy = InMemoryTokenStore();
+      final store = FlutterSecureTokenStore.fromBackends(
+        current: current,
+        legacy: legacy,
+      );
+
+      await store.writeRefreshToken('new-token');
+
+      expect(await current.readRefreshToken(), 'new-token');
+      expect(
+        await legacy.readRefreshToken(),
+        isNull,
+        reason: 'writes do not flow into legacy backend',
+      );
+    });
+  });
+
+  group('FlutterSecureTokenStore.deleteRefreshToken', () {
+    test('clears BOTH backends so a logout before first read can\'t leave '
+        'a stale legacy entry that re-migrates on next launch', () async {
+      final current = InMemoryTokenStore();
+      final legacy = InMemoryTokenStore();
+      await current.writeRefreshToken('current-token');
+      await legacy.writeRefreshToken('legacy-token');
+      final store = FlutterSecureTokenStore.fromBackends(
+        current: current,
+        legacy: legacy,
+      );
+
+      await store.deleteRefreshToken();
+
+      expect(await current.readRefreshToken(), isNull);
+      expect(await legacy.readRefreshToken(), isNull);
+    });
+  });
+}
+
+/// SecureTokenStore that throws on write but behaves normally on read /
+/// delete. Models a Keychain item that can be queried but whose
+/// attributes block update (e.g., device just rebooted, item set to
+/// AfterFirstUnlock but first-unlock hasn't happened yet).
+class _WriteFailingStore implements SecureTokenStore {
+  String? _value;
+
+  @override
+  Future<String?> readRefreshToken() async => _value;
+
+  @override
+  Future<void> writeRefreshToken(String token) async {
+    throw StateError('simulated Keychain write failure');
+  }
+
+  @override
+  Future<void> deleteRefreshToken() async {
+    _value = null;
+  }
+}

--- a/mobile/test/auth/universal_link_listener_test.dart
+++ b/mobile/test/auth/universal_link_listener_test.dart
@@ -67,10 +67,22 @@ void main() {
       expect(recorder.completedFlows.single.path, '/m/auth/callback');
     });
 
-    test('custom-scheme link ignored (only https/http handled here)',
+    test('custom-scheme link ignored (only https handled here)',
         () async {
       await listener
           .dispatch(Uri.parse('k8scenter://cluster/local/Pod/ns/foo'));
+      expect(recorder.completedFlows, isEmpty);
+    });
+
+    test(
+        'http (cleartext) callback ignored — only https accepted '
+        '(P3-6 downgrade guard)', () async {
+      // App Links / Universal Links rely on the OS-verified domain
+      // binding that AASA + assetlinks.json provide. http:// callbacks
+      // bypass that binding entirely; an attacker who can serve content
+      // on http://<host>/m/auth/callback could intercept the redirect.
+      await listener.dispatch(
+          Uri.parse('http://k8scenter.test/m/auth/callback?code=X&state=Y'));
       expect(recorder.completedFlows, isEmpty);
     });
 

--- a/mobile/test/notifications/fcm_revoke_test.dart
+++ b/mobile/test/notifications/fcm_revoke_test.dart
@@ -1,0 +1,194 @@
+// Tests for FcmRegistration.revokeDeviceByToken — the inner network unit
+// of the audit-finding-P2-9 logout-revoke flow.
+//
+// We exercise revokeDeviceByToken directly (bypassing FirebaseMessaging
+// platform channels) so the test suite stays green on the headless Dart
+// runner where Firebase is never initialised. The outer revokeCurrentDevice
+// wraps this same call after pulling the token from
+// FirebaseMessaging.instance.getToken().
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kubecenter/api/dio_client.dart';
+import 'package:kubecenter/notifications/fcm_registration.dart';
+
+import '../support/mock_dio_adapter.dart';
+
+({FcmRegistration fcm, MockDioAdapter mock, ProviderContainer container})
+    _makeFcm() {
+  final mock = MockDioAdapter();
+  final container = ProviderContainer(
+    overrides: [
+      backendUrlProvider.overrideWithValue('http://test'),
+    ],
+  );
+  // Attach the adapter BEFORE pulling fcmRegistrationProvider so the
+  // FcmRegistration instance the provider builds uses the mock-backed Dio.
+  container.read(dioProvider).httpClientAdapter = mock;
+  final fcm = container.read(fcmRegistrationProvider);
+  return (fcm: fcm, mock: mock, container: container);
+}
+
+void main() {
+  test(
+      'revokeDeviceByToken: lists devices, deletes the one whose deviceToken '
+      'matches, and returns true', () async {
+    final (:fcm, :mock, :container) = _makeFcm();
+    addTearDown(container.dispose);
+
+    mock.onJson(
+      'GET',
+      '/api/v1/notifications/devices',
+      body: {
+        'data': [
+          {
+            'id': 'dev-other',
+            'userId': 'u1',
+            'deviceToken': 'other-token',
+            'platform': 'ios',
+          },
+          {
+            'id': 'dev-mine',
+            'userId': 'u1',
+            'deviceToken': 'my-token',
+            'platform': 'android',
+          },
+        ],
+      },
+    );
+    mock.onJson(
+      'DELETE',
+      '/api/v1/notifications/devices/dev-mine',
+      body: <String, dynamic>{},
+      status: 204,
+    );
+
+    final ok = await fcm.revokeDeviceByToken('my-token');
+
+    expect(ok, isTrue);
+    expect(
+      mock.requests.map((r) => '${r.method} ${r.path}').toList(),
+      [
+        'GET /api/v1/notifications/devices',
+        'DELETE /api/v1/notifications/devices/dev-mine',
+      ],
+    );
+  });
+
+  test(
+      'revokeDeviceByToken: when no device matches the token, skips DELETE '
+      'and returns false', () async {
+    final (:fcm, :mock, :container) = _makeFcm();
+    addTearDown(container.dispose);
+
+    mock.onJson(
+      'GET',
+      '/api/v1/notifications/devices',
+      body: {
+        'data': [
+          {
+            'id': 'dev-other',
+            'userId': 'u1',
+            'deviceToken': 'other-token',
+            'platform': 'ios',
+          },
+        ],
+      },
+    );
+
+    final ok = await fcm.revokeDeviceByToken('missing-token');
+
+    expect(ok, isFalse);
+    expect(
+      mock.requests.map((r) => r.method),
+      ['GET'],
+      reason: 'no DELETE should be issued when token has no matching device',
+    );
+  });
+
+  test(
+      'revokeDeviceByToken: empty devices list returns false without DELETE',
+      () async {
+    final (:fcm, :mock, :container) = _makeFcm();
+    addTearDown(container.dispose);
+
+    mock.onJson(
+      'GET',
+      '/api/v1/notifications/devices',
+      body: {'data': <Map<String, dynamic>>[]},
+    );
+
+    final ok = await fcm.revokeDeviceByToken('any');
+
+    expect(ok, isFalse);
+    expect(
+      mock.requests.where((r) => r.method == 'DELETE'),
+      isEmpty,
+    );
+  });
+
+  test(
+      'revokeDeviceByToken: GET error swallowed (returns false) so logout '
+      'can still proceed', () async {
+    final (:fcm, :mock, :container) = _makeFcm();
+    addTearDown(container.dispose);
+    // No handler registered → MockDioAdapter returns 404, which Dio
+    // surfaces as a DioException.
+
+    final ok = await fcm.revokeDeviceByToken('my-token');
+
+    expect(ok, isFalse);
+  });
+
+  test(
+      'revokeDeviceByToken: DELETE error swallowed (returns false) when '
+      'list succeeds but server rejects the delete', () async {
+    final (:fcm, :mock, :container) = _makeFcm();
+    addTearDown(container.dispose);
+
+    mock.onJson(
+      'GET',
+      '/api/v1/notifications/devices',
+      body: {
+        'data': [
+          {
+            'id': 'dev-mine',
+            'userId': 'u1',
+            'deviceToken': 'my-token',
+            'platform': 'android',
+          },
+        ],
+      },
+    );
+    mock.onJson(
+      'DELETE',
+      '/api/v1/notifications/devices/dev-mine',
+      status: 500,
+      body: {
+        'error': {'code': 500, 'message': 'kaboom'},
+      },
+    );
+
+    final ok = await fcm.revokeDeviceByToken('my-token');
+
+    expect(ok, isFalse);
+  });
+
+  test(
+      'revokeDeviceByToken: malformed list response (data not a list) returns '
+      'false without DELETE', () async {
+    final (:fcm, :mock, :container) = _makeFcm();
+    addTearDown(container.dispose);
+
+    mock.onJson(
+      'GET',
+      '/api/v1/notifications/devices',
+      body: {'data': 'not-a-list'},
+    );
+
+    final ok = await fcm.revokeDeviceByToken('my-token');
+
+    expect(ok, isFalse);
+    expect(mock.requests.where((r) => r.method == 'DELETE'), isEmpty);
+  });
+}

--- a/mobile/test/observability/pii_scrubber_test.dart
+++ b/mobile/test/observability/pii_scrubber_test.dart
@@ -219,6 +219,84 @@ void main() {
       expect(scrubbed.request!.url, isNull);
     });
 
+    test(
+        'SentryRequest.url with %3F (encoded ?) is decoded before slicing — '
+        'attacker cannot smuggle a fake query into the path (ADV-3)', () {
+      final event = SentryEvent(
+        request: SentryRequest(
+          url:
+              'https://kubecenter.local/v1/resources/secrets/team/vault-token%3Fapi_key=abc123def',
+          method: 'GET',
+        ),
+      );
+      final scrubbed = scrubEventForTest(event);
+      expect(
+        scrubbed.request!.url,
+        'https://kubecenter.local/v1/resources/secrets/<namespace>/<name>',
+        reason:
+            '%3F must be decoded to ? before the slice so api_key=… does not survive',
+      );
+    });
+
+    test(
+        'SentryRequest.url with %23 (encoded #) is decoded before slicing '
+        '(ADV-3 variant)', () {
+      final event = SentryEvent(
+        request: SentryRequest(
+          url:
+              'https://kubecenter.local/v1/resources/secrets/team/vault-token%23fragment=leak',
+          method: 'GET',
+        ),
+      );
+      final scrubbed = scrubEventForTest(event);
+      expect(
+        scrubbed.request!.url,
+        'https://kubecenter.local/v1/resources/secrets/<namespace>/<name>',
+        reason: '%23 must be decoded to # before the slice',
+      );
+    });
+
+    test(
+        'breadcrumb url with %3F is also decoded before slicing — both '
+        'surfaces share _scrubUrl (ADV-3)', () {
+      final event = SentryEvent(
+        breadcrumbs: [
+          Breadcrumb(
+            type: 'http',
+            data: {
+              'url':
+                  'https://kubecenter.local/v1/resources/secrets/team/v%3Ftoken=leak',
+              'method': 'GET',
+            },
+          ),
+        ],
+      );
+      final scrubbed = scrubEventForTest(event);
+      final crumb = scrubbed.breadcrumbs!.single;
+      expect(
+        crumb.data!['url'],
+        'https://kubecenter.local/v1/resources/secrets/<namespace>/<name>',
+      );
+    });
+
+    test('SentryRequest.url with malformed percent-encoding still scrubs '
+        '(fallback path)', () {
+      final event = SentryEvent(
+        request: SentryRequest(
+          url:
+              'https://kubecenter.local/v1/resources/secrets/team/v%ZZbad?token=leak',
+          method: 'GET',
+        ),
+      );
+      final scrubbed = scrubEventForTest(event);
+      // Uri.decodeFull would throw on `%ZZ`; we fall back to raw and
+      // still slice off the literal `?` and run the segment scrubber.
+      // The path segment match stops at `%` in the regex char class, so
+      // we accept that the prefix up to `%ZZbad` survives untransformed
+      // — but the query string is gone, which is the primary defence.
+      expect(scrubbed.request!.url, isNot(contains('token=leak')));
+    });
+
     test('drops Authorization, Cookie, X-CSRF-* headers from requests', () {
       final event = SentryEvent(
         request: SentryRequest(

--- a/mobile/test/observability/pii_scrubber_test.dart
+++ b/mobile/test/observability/pii_scrubber_test.dart
@@ -149,7 +149,9 @@ void main() {
       );
     });
 
-    test('strips request body + query but keeps method/url', () {
+    test(
+        'strips request body, query, cookies, fragment and scrubs url path '
+        '(P2-10)', () {
       final event = SentryEvent(
         request: SentryRequest(
           url: 'https://kubecenter.local/v1/resources/secrets/team/v',
@@ -157,13 +159,64 @@ void main() {
           data: {'secret': 'should-not-leak'},
           queryString: 'token=abc',
           cookies: 'session=xyz',
+          fragment: 'leaky-anchor',
         ),
       );
       final scrubbed = scrubEventForTest(event);
       expect(scrubbed.request!.data, isNull);
       expect(scrubbed.request!.queryString, isNull);
       expect(scrubbed.request!.cookies, isNull);
+      expect(
+        scrubbed.request!.fragment,
+        isNull,
+        reason: 'fragment is a sibling of url and can carry identifiers',
+      );
       expect(scrubbed.request!.method, 'GET');
+      expect(
+        scrubbed.request!.url,
+        'https://kubecenter.local/v1/resources/secrets/<namespace>/<name>',
+        reason: 'path segments must be scrubbed, not preserved (P2-10)',
+      );
+    });
+
+    test('strips query + fragment from SentryRequest.url (P2-10)', () {
+      final event = SentryEvent(
+        request: SentryRequest(
+          url:
+              'https://kubecenter.local/v1/resources/secrets/team/v?token=leak#anchor-leak',
+          method: 'GET',
+        ),
+      );
+      final scrubbed = scrubEventForTest(event);
+      expect(
+        scrubbed.request!.url,
+        'https://kubecenter.local/v1/resources/secrets/<namespace>/<name>',
+        reason: 'query and fragment must be sliced before path scrubbing',
+      );
+    });
+
+    test('SentryRequest.url passes through unchanged when no scrub-worthy '
+        'segments are present (P2-10)', () {
+      final event = SentryEvent(
+        request: SentryRequest(
+          url: 'https://pub.dev/packages/sentry_flutter',
+          method: 'GET',
+        ),
+      );
+      final scrubbed = scrubEventForTest(event);
+      expect(
+        scrubbed.request!.url,
+        'https://pub.dev/packages/sentry_flutter',
+        reason: 'non-k8sCenter URLs should be left intact',
+      );
+    });
+
+    test('SentryRequest.url null passes through as null (P2-10)', () {
+      final event = SentryEvent(
+        request: SentryRequest(method: 'GET'),
+      );
+      final scrubbed = scrubEventForTest(event);
+      expect(scrubbed.request!.url, isNull);
     });
 
     test('drops Authorization, Cookie, X-CSRF-* headers from requests', () {


### PR DESCRIPTION
## Summary

Closes four mobile-side audit findings from `plans/security-audit-2026-05-22.md`. All changes are mobile-app-only (Flutter/Dart under `mobile/`); no backend, Helm, web-frontend, or CI changes.

- **P2-9** — FCM device revoke on logout. `AuthRepository.logout` now calls `FcmRegistration.revokeCurrentDevice` before clearing the access token. The revoke flow pulls the current FCM token from `FirebaseMessaging`, looks up the matching device via `GET /api/v1/notifications/devices`, and `DELETE`s it. Best-effort throughout — Firebase-init or network failures are swallowed so the user is never stranded signed-in.
- **P2-10** — Sentry `SentryRequest.url` scrub. The audit-flagged leak path was preserved while sibling fields (`queryString`, `data`, `cookies`) were already nulled. A shared `_scrubUrl` helper now slices `?query` and `#fragment` and runs the bare path through the existing `_scrubText`; the same helper services HTTP breadcrumb URLs so the two surfaces can't diverge. `SentryRequest.fragment` is also nulled.
- **P3-6 (part 1)** — OIDC error-callback CSRF bind. `completeFlow` now reads `state` BEFORE evaluating the error branch and requires `callbackState == pending.state` to honor an error. Missing/mismatched state drops silently — same disposition as the existing "no pending" guard. Without this guard an attacker who can deliver a crafted error universal-link (Android intent spoofing, hostile webpage on iOS) could wipe the verifier/state of an in-flight legitimate flow — targeted login DoS.
- **P3-6 (part 2)** — `UniversalLinkListener` now rejects `http://` callbacks. The OS-verified domain binding from AASA + assetlinks.json is a property of the https scheme only.
- **P3-7** — Refresh-token secure-storage gets the same explicit options `FlutterSecurePendingOidcStore` already uses (iOS `first_unlock_this_device`, Android `encryptedSharedPreferences`). Forward migration: a default-options legacy backend reads through on first post-upgrade access and migrates the value forward. Best-effort — failed migrations preserve the legacy entry. `deleteRefreshToken` clears both backends so a pre-read logout can't leave a stale legacy entry.

## Test plan

Backend tests are not affected — no backend code changed. Verification was run via `flutter test` repo-wide.

- [x] `flutter test` — **1193 pass, 20 skipped** (skipped tests are unrelated to Phase 5)
- [x] `dart analyze` — clean across all changed files
- [x] New tests:
  - `mobile/test/notifications/fcm_revoke_test.dart` — 6 tests (happy path, no-match, empty list, GET fail, DELETE fail, malformed response)
  - `mobile/test/observability/pii_scrubber_test.dart` — 4 new tests (query strip, fragment strip, non-k8s URL passthrough, null URL); 1 existing test extended
  - `mobile/test/auth/oidc_controller_test.dart` — 2 new tests (no-state, wrong-state); 1 existing test extended
  - `mobile/test/auth/universal_link_listener_test.dart` — 1 new test (http rejection)
  - `mobile/test/auth/secure_storage_test.dart` (new file) — 7 tests covering all migration branches

Smoke-test plan (operator-side, post-merge):

- [ ] Sign in on a real device with FCM configured. Confirm `POST /notifications/devices` lands.
- [ ] Sign out. Confirm matching `DELETE /notifications/devices/<id>` is logged backend-side.
- [ ] Upgrade an existing build (with a stored refresh token) to this PR. Confirm bootstrap silently refreshes (no re-login prompt) and a fresh `kc_refresh_token` exists under the new accessibility class. Best confirmed via `xcrun simctl get_app_container` + `security find-generic-password` on iOS sim.
- [ ] Trigger an OIDC sign-in, then deliver a crafted `?error=access_denied` callback (without state) before completing. Confirm the legitimate IdP redirect still completes successfully.

## Files changed (13 total)

- `CHANGELOG.md` (Phase 5 entry, +136)
- `mobile/lib/auth/auth_repository.dart`, `oidc_controller.dart`, `secure_storage.dart`, `universal_link_listener.dart`
- `mobile/lib/notifications/fcm_registration.dart`
- `mobile/lib/observability/pii_scrubber.dart`
- `mobile/lib/features/settings/settings_screen.dart` (comment update)
- `mobile/test/...` (5 test files: 1 new + 4 extended)

## Out of scope for Phase 5

- **Phase 6** (scoping leaks): P3-2 CRD inventory per-user RBAC, P3-3 diagnostics related-resource RBAC, P3-4 CRD URL/body name mismatch, P3-5 Loki label scoping.
- **Phase 7** (supply chain + LDAP TLS): P2-11 govulncheck Go bump, P3-1 LDAP plaintext reject, P3-9 image digest pinning.

Phase 4 deferred follow-ups (12 items documented in CHANGELOG.md) remain open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)