### PR TITLE
fix(mobile): repair Android build under AGP 8.11 / Kotlin 2.2.20

### DIFF
--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -1,3 +1,4 @@
+import java.io.File
 import java.io.FileInputStream
 import java.util.Properties
 
@@ -16,7 +17,7 @@ plugins {
 // file from the ANDROID_UPLOAD_* secrets at run time; finding P1-5 of the
 // audit: release builds must NOT fall back to debug signing.
 val keyPropertiesFile = System.getenv("ANDROID_KEY_PROPERTIES_PATH")
-    ?.let { java.io.File(it) }
+    ?.let { File(it) }
     ?: rootProject.file("key.properties")
 
 val keyProperties = Properties().apply {
@@ -38,6 +39,11 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
+        // flutter_local_notifications >=18 (and the timezone DB it bundles)
+        // calls into java.time APIs that are not available below API 26, so
+        // AGP requires core-library desugaring to be enabled on :app. The
+        // desugar_jdk_libs dependency is wired in the `dependencies` block.
+        isCoreLibraryDesugaringEnabled = true
     }
 
     kotlinOptions {
@@ -126,4 +132,11 @@ tasks.matching { task ->
 
 flutter {
     source = "../.."
+}
+
+dependencies {
+    // Required by flutter_local_notifications >=18 so the app's minSdk can
+    // stay below API 26 while the plugin uses java.time. Version pinned to
+    // the plugin's documented minimum (2.1.4); see README "Android Setup".
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
 }

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- POST_NOTIFICATIONS runtime permission (Android 13+, API 33). Must be a
+         direct child of <manifest>, not nested inside <application> (AAPT2
+         rejects the latter under AGP 8). -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <application
         android:label="kubecenter"
         android:name="${applicationName}"
@@ -50,8 +54,6 @@
                       android:pathPrefix="/m/"/>
             </intent-filter>
         </activity>
-        <!-- POST_NOTIFICATIONS runtime permission (Android 13+, API 33). -->
-        <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/mobile/android/build.gradle.kts
+++ b/mobile/android/build.gradle.kts
@@ -19,6 +19,28 @@ subprojects {
     project.evaluationDependsOn(":app")
 }
 
+// Several Flutter plugins (e.g. sentry_flutter 8.x) pin their Kotlin language
+// and API version to 1.6, which the project's Kotlin 2.2.20 toolchain no longer
+// supports ("Language version 1.6 is no longer supported; please, use version
+// 1.8 or greater"). Raise any sub-project Kotlin compile task that requests a
+// version below 1.8 up to 1.8. Raising a language/api version is backward
+// compatible, and gating on the current value avoids forcing a version onto
+// tasks that never set one. This fixes the whole class of plugins at once
+// rather than patching each plugin's build.gradle individually.
+subprojects {
+    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+        val floor = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_8
+        compilerOptions {
+            languageVersion.set(
+                languageVersion.orNull?.let { if (it < floor) floor else it },
+            )
+            apiVersion.set(
+                apiVersion.orNull?.let { if (it < floor) floor else it },
+            )
+        }
+    }
+}
+
 tasks.register<Delete>("clean") {
     delete(rootProject.layout.buildDirectory)
 }

--- a/mobile/lib/widgets/secure_screen_mixin.dart
+++ b/mobile/lib/widgets/secure_screen_mixin.dart
@@ -38,7 +38,7 @@ import 'dart:ui';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_windowmanager/flutter_windowmanager.dart';
+import 'package:flutter_windowmanager_plus/flutter_windowmanager_plus.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
 /// Channel into `mobile/ios/Runner/SceneDelegate.swift` for the native
@@ -80,6 +80,21 @@ mixin SecureScreenMixin<T extends StatefulWidget> on State<T> {
   /// forget when adding new ones.)
   @visibleForTesting
   static bool kIgnoreDebugForTests = kDebugMode;
+
+  /// Test seam for the Android secure-flag platform calls. Production wires
+  /// these to the real `flutter_windowmanager_plus` methods, which self-guard
+  /// on `dart:io` `Platform.isAndroid` and therefore no-op (returning without
+  /// touching the MethodChannel) under `flutter test` on a host OS. The
+  /// mixin's own `defaultTargetPlatform` gate already scopes these calls to
+  /// Android, so the plugin's redundant host guard is irrelevant in
+  /// production but un-mockable in tests — hence this indirection, which lets
+  /// tests observe the calls without faking `Platform.isAndroid`.
+  @visibleForTesting
+  static Future<bool> Function(int flags) addSecureFlags =
+      FlutterWindowManagerPlus.addFlags;
+  @visibleForTesting
+  static Future<bool> Function(int flags) clearSecureFlags =
+      FlutterWindowManagerPlus.clearFlags;
 
   bool _sensitive = false;
   OverlayEntry? _blurOverlay;
@@ -252,12 +267,12 @@ mixin SecureScreenMixin<T extends StatefulWidget> on State<T> {
 
   Future<void> _addFlagSecure() async {
     if (kIsWeb || defaultTargetPlatform != TargetPlatform.android) return;
-    await FlutterWindowManager.addFlags(FlutterWindowManager.FLAG_SECURE);
+    await addSecureFlags(FlutterWindowManagerPlus.FLAG_SECURE);
   }
 
   Future<void> _clearFlagSecure() async {
     if (kIsWeb || defaultTargetPlatform != TargetPlatform.android) return;
-    await FlutterWindowManager.clearFlags(FlutterWindowManager.FLAG_SECURE);
+    await clearSecureFlags(FlutterWindowManagerPlus.FLAG_SECURE);
   }
 
   /// Notifies the iOS [SceneDelegate] of the sensitive state via the

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -552,14 +552,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_windowmanager:
+  flutter_windowmanager_plus:
     dependency: "direct main"
     description:
-      name: flutter_windowmanager
-      sha256: b4d0bc06f6777952b729c0cdb7ce9ad1ecabd8b8b1cb0acb57a36621457dab1b
+      name: flutter_windowmanager_plus
+      sha256: "4e2bf7c7f374699fd74d59785f1d74efd40052c24a5edde5a4d825cc72608d40"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "1.0.1"
   freezed:
     dependency: "direct dev"
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -74,7 +74,10 @@ dependencies:
   # Android FLAG_SECURE for the Secret detail screen (PR-5d). Exact-pinned
   # because the platform-channel surface is small and accidental upgrades on
   # a security primitive are not worth the risk of silent behavioural drift.
-  flutter_windowmanager: 0.2.0
+  # Uses the maintained `_plus` fork: the original flutter_windowmanager 0.2.0
+  # is abandoned and ships an AGP-7-era android/build.gradle with no namespace,
+  # which fails to configure under AGP 8 ("Namespace not specified").
+  flutter_windowmanager_plus: 1.0.1
 
   # External URLs from the Settings "About" tiles + the onboarding "How to
   # set up your server" CTA (PR-5g).

--- a/mobile/test/features/resources/secret_screens_test.dart
+++ b/mobile/test/features/resources/secret_screens_test.dart
@@ -13,8 +13,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kubecenter/api/dio_client.dart';
 import 'package:kubecenter/auth/secure_storage.dart';
+import 'package:flutter_windowmanager_plus/flutter_windowmanager_plus.dart';
 import 'package:kubecenter/features/resources/secret_screens.dart';
 import 'package:kubecenter/theme/kube_theme_builder.dart';
+import 'package:kubecenter/widgets/secure_screen_mixin.dart';
 
 import '../../support/mock_dio_adapter.dart';
 import '../../support/platform_helpers.dart';
@@ -140,25 +142,27 @@ void main() {
       );
     }
 
-    /// Mocks the `flutter_windowmanager` MethodChannel and returns the
-    /// captured calls list for assertions. Caller is responsible for
-    /// `addTearDown` cleanup (registered here).
+    /// Stubs [SecureScreenMixin]'s secure-flag seam and returns the captured
+    /// calls list for assertions. The seam is used instead of mocking the
+    /// `flutter_windowmanager_plus` MethodChannel directly because the plugin
+    /// self-guards on `dart:io` `Platform.isAndroid` (false under `flutter
+    /// test`) and would never reach the channel. Synthesizes `MethodCall`s so
+    /// the per-test assertions (method name + `flags` argument) are unchanged.
+    /// Caller is responsible for nothing — `addTearDown` cleanup is registered
+    /// here.
     List<MethodCall> mockWindowManager() {
       final calls = <MethodCall>[];
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(
-        const MethodChannel('flutter_windowmanager'),
-        (call) async {
-          calls.add(call);
-          return true;
-        },
-      );
+      SecureScreenMixin.addSecureFlags = (flags) async {
+        calls.add(MethodCall('addFlags', <String, dynamic>{'flags': flags}));
+        return true;
+      };
+      SecureScreenMixin.clearSecureFlags = (flags) async {
+        calls.add(MethodCall('clearFlags', <String, dynamic>{'flags': flags}));
+        return true;
+      };
       addTearDown(() {
-        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMethodCallHandler(
-          const MethodChannel('flutter_windowmanager'),
-          null,
-        );
+        SecureScreenMixin.addSecureFlags = FlutterWindowManagerPlus.addFlags;
+        SecureScreenMixin.clearSecureFlags = FlutterWindowManagerPlus.clearFlags;
       });
       return calls;
     }

--- a/mobile/test/widgets/secure_screen_mixin_test.dart
+++ b/mobile/test/widgets/secure_screen_mixin_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_windowmanager_plus/flutter_windowmanager_plus.dart';
 import 'package:kubecenter/widgets/secure_screen_mixin.dart';
 
 import '../support/platform_helpers.dart';
@@ -17,22 +18,23 @@ void main() {
 
     setUp(() {
       calls = <MethodCall>[];
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(
-        const MethodChannel('flutter_windowmanager'),
-        (call) async {
-          calls.add(call);
-          return true;
-        },
-      );
+      // Drive the mixin's secure-flag seam rather than the
+      // flutter_windowmanager_plus MethodChannel: the plugin self-guards on
+      // `dart:io` `Platform.isAndroid` (false here) and never reaches the
+      // channel. Synthesized MethodCalls keep the assertions below unchanged.
+      SecureScreenMixin.addSecureFlags = (flags) async {
+        calls.add(MethodCall('addFlags', <String, dynamic>{'flags': flags}));
+        return true;
+      };
+      SecureScreenMixin.clearSecureFlags = (flags) async {
+        calls.add(MethodCall('clearFlags', <String, dynamic>{'flags': flags}));
+        return true;
+      };
     });
 
     tearDown(() {
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(
-        const MethodChannel('flutter_windowmanager'),
-        null,
-      );
+      SecureScreenMixin.addSecureFlags = FlutterWindowManagerPlus.addFlags;
+      SecureScreenMixin.clearSecureFlags = FlutterWindowManagerPlus.clearFlags;
     });
 
     testWidgets('setSensitive(true) adds FLAG_SECURE', (tester) async {
@@ -757,20 +759,20 @@ void main() {
 
       await withPlatform(TargetPlatform.android, () async {
         final platformCalls = <MethodCall>[];
-        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMethodCallHandler(
-          const MethodChannel('flutter_windowmanager'),
-          (call) async {
-            platformCalls.add(call);
-            return true;
-          },
-        );
+        SecureScreenMixin.addSecureFlags = (flags) async {
+          platformCalls
+              .add(MethodCall('addFlags', <String, dynamic>{'flags': flags}));
+          return true;
+        };
+        SecureScreenMixin.clearSecureFlags = (flags) async {
+          platformCalls
+              .add(MethodCall('clearFlags', <String, dynamic>{'flags': flags}));
+          return true;
+        };
         addTearDown(() {
-          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-              .setMockMethodCallHandler(
-            const MethodChannel('flutter_windowmanager'),
-            null,
-          );
+          SecureScreenMixin.addSecureFlags = FlutterWindowManagerPlus.addFlags;
+          SecureScreenMixin.clearSecureFlags =
+              FlutterWindowManagerPlus.clearFlags;
         });
 
         await tester.pumpWidget(const MaterialApp(home: _Host()));


### PR DESCRIPTION
## Summary

The Flutter Android app had **never been assembled** under its pinned **AGP 8.11.1 / Kotlin 2.2.20 / Gradle 8.14** toolchain. A debug build (`flutter run`) failed through **six distinct latent breakages**, each fixed here so debug and release-AAB builds succeed.

Surfaced while bringing the app up on an Android emulator for local testing.

## The six fixes

| # | Failure | Root cause | Fix |
|---|---|---|---|
| 1 | `Unresolved reference: io` | `java.io.File(it)` — Kotlin 2.2 DSL resolves bare `java` to a plugin accessor, not the package | import `java.io.File`, call unqualified (matches existing `FileInputStream` usage) |
| 2 | `Namespace not specified` | `flutter_windowmanager 0.2.0` is abandoned, ships no AGP-8 `namespace` | swap to maintained drop-in `flutter_windowmanager_plus 1.0.1` |
| 3 | `requires core library desugaring` | `flutter_local_notifications 18` needs desugaring | `isCoreLibraryDesugaringEnabled = true` + `desugar_jdk_libs:2.1.4` |
| 4 | `<uses-permission> in <application>` | `POST_NOTIFICATIONS` misplaced in manifest | move to direct child of `<manifest>` |
| 5 | `Language version 1.6 is no longer supported` | `sentry_flutter 8.x` pins Kotlin `languageVersion 1.6` | root `subprojects` floor raising any Kotlin lang/api version below 1.8 → 1.8 (fixes the whole class) |
| 6 | 8 `FLAG_SECURE` tests fail | the `_plus` fork self-guards on `dart:io Platform.isAndroid` (false under `flutter test`), so channel mocks never fire | overridable seam `SecureScreenMixin.addSecureFlags`/`clearSecureFlags`, driven from tests; on-device behavior unchanged |

## Supply chain

Both added artifacts clear the 7-day cooldown: `flutter_windowmanager_plus 1.0.1` (published 2024-10-04) and `desugar_jdk_libs 2.1.4` (2024). `_plus` is an API-identical successor — `FlutterWindowManager` → `FlutterWindowManagerPlus`, same `FLAG_SECURE` semantics — so the Secret-detail screenshot/recording protection is preserved.

## Verification

- `flutter analyze` — **clean**
- `flutter test` — **1235 passed / 0 failed** (20 platform-skipped)
- Debug APK **builds, installs, and launches** on an Android emulator (API 37)

🤖 Generated with [Claude Code](https://claude.com/claude-code)