### PR TITLE
fix(mobile): give every drawer-reached screen a working back button

### DIFF
--- a/mobile/lib/features/notifications_center/feed_screen.dart
+++ b/mobile/lib/features/notifications_center/feed_screen.dart
@@ -26,6 +26,14 @@ class NotificationFeedScreen extends ConsumerWidget {
 
     return Scaffold(
       appBar: AppBar(
+        // Explicit back affordance. Reached via the drawer's `context.push`,
+        // so the default pop returns to the originating page; fall back to
+        // the dashboard for a deep link / cold start straight to
+        // /notifications (the automatic leading only appears when the route
+        // can be popped). Mirrors settings_screen.dart.
+        leading: BackButton(
+          onPressed: () => context.canPop() ? context.pop() : context.go('/'),
+        ),
         title: MergeSemantics(
           child: Row(
             children: [

--- a/mobile/lib/features/settings/settings_screen.dart
+++ b/mobile/lib/features/settings/settings_screen.dart
@@ -17,6 +17,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -63,7 +64,18 @@ class SettingsScreen extends ConsumerWidget {
     final rateEnabled = !isIOS || appStoreListingConfigured;
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Settings')),
+      appBar: AppBar(
+        // Explicit back affordance. The drawer reaches this screen via
+        // `context.push`, so the default pop returns to the originating
+        // page. When there is nothing to pop — a deep link or cold start
+        // straight to /settings — fall back to the dashboard so the user
+        // is never stranded with no way back (the AppBar's automatic
+        // leading only appears when the route can be popped).
+        leading: BackButton(
+          onPressed: () => context.canPop() ? context.pop() : context.go('/'),
+        ),
+        title: const Text('Settings'),
+      ),
       body: ListView(
         children: [
           _SectionHeader(label: 'Appearance', colors: colors),

--- a/mobile/lib/widgets/domain_navigation_drawer.dart
+++ b/mobile/lib/widgets/domain_navigation_drawer.dart
@@ -61,7 +61,9 @@ class DomainNavigationDrawer extends ConsumerWidget {
             trailing: _UnreadBadge(),
             onTap: () {
               Navigator.of(context).pop();
-              context.go('/notifications');
+              // push (not go) so the feed keeps a back stack — its AppBar
+              // back button returns to the originating page. See feed_screen.
+              context.push('/notifications');
             },
           ),
           // --- M5 PR-5a: Settings (theme picker, Sentry opt-in, About).
@@ -71,7 +73,10 @@ class DomainNavigationDrawer extends ConsumerWidget {
             title: const Text('Settings'),
             onTap: () {
               Navigator.of(context).pop();
-              context.go('/settings');
+              // push (not go) so the Settings screen keeps a back stack —
+              // its AppBar back button then returns to the originating
+              // page instead of stranding the user. See settings_screen.dart.
+              context.push('/settings');
             },
           ),
           // --- M3 PR-3a: "Create" submenu — RBAC-gated wizard launcher.
@@ -106,7 +111,12 @@ class DomainNavigationDrawer extends ConsumerWidget {
                           clusterId: clusterId,
                         )
                       : '/clusters/$clusterId/${section.pathSegment}/${kind.kind}';
-                  context.go(target);
+                  // push (not go) so the destination stacks on the dashboard
+                  // (the only screen that hosts this drawer): the list screen's
+                  // AppBar then shows a back button returning here. `go` would
+                  // replace the dashboard, leaving the list with no drawer and
+                  // no back stack — a dead end.
+                  context.push(target);
                 },
               ),
           ],
@@ -159,7 +169,9 @@ class _CreateSubmenu extends ConsumerWidget {
             dense: true,
             onTap: () {
               Navigator.of(context).pop();
-              context.go(
+              // push so the wizard stacks on the dashboard; its Cancel/back
+              // returns here instead of replacing the stack.
+              context.push(
                 '/clusters/$clusterId/wizards/${entry.type}/new',
               );
             },

--- a/mobile/lib/widgets/resource_detail_scaffold.dart
+++ b/mobile/lib/widgets/resource_detail_scaffold.dart
@@ -183,7 +183,13 @@ class ResourceDetailScaffold extends ConsumerWidget {
           leading: IconButton(
             tooltip: 'Back',
             icon: const Icon(Icons.arrow_back),
-            onPressed: () => Navigator.of(context).maybePop(),
+            // Pop when there's a stack; otherwise fall back to the dashboard.
+            // A bare maybePop() silently no-ops when the detail was reached
+            // with no back stack (wizard post-apply pushReplacement, or a
+            // deep link / notification tap straight into a resource), leaving
+            // the user stranded on the page.
+            onPressed: () =>
+                context.canPop() ? context.pop() : context.go('/'),
           ),
           actions: [
             if (canDiagnose)

--- a/mobile/lib/wizards/widgets/wizard_screen_scaffold.dart
+++ b/mobile/lib/wizards/widgets/wizard_screen_scaffold.dart
@@ -166,7 +166,11 @@ class WizardScreenScaffold<TForm> extends ConsumerWidget {
     if (!context.mounted) return;
     if (outcome.firstResultName.isNotEmpty &&
         outcome.firstResultNamespace != null) {
-      context.go(kindDetailPath(
+      // pushReplacement (not go): swap the just-submitted wizard for the new
+      // resource's detail while keeping whatever launched the wizard
+      // (dashboard / list) below it, so the detail's back button returns there
+      // instead of dead-ending on a stackless route.
+      context.pushReplacement(kindDetailPath(
         clusterId: wizardKey.clusterId,
         kind: entry.kind,
         namespace: outcome.firstResultNamespace!,
@@ -183,7 +187,9 @@ class WizardScreenScaffold<TForm> extends ConsumerWidget {
       context.go('/');
       return;
     }
-    context.go('/clusters/${wizardKey.clusterId}/'
+    // pushReplacement so the resource list keeps the launcher below it and its
+    // back button works (see the detail branch above).
+    context.pushReplacement('/clusters/${wizardKey.clusterId}/'
         '${section.pathSegment}/${entry.kind}');
   }
 

--- a/mobile/test/features/notifications_center/feed_screen_test.dart
+++ b/mobile/test/features/notifications_center/feed_screen_test.dart
@@ -7,6 +7,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:kubecenter/features/notifications_center/feed_repository.dart';
 import 'package:kubecenter/features/notifications_center/feed_screen.dart';
 import 'package:kubecenter/theme/kube_theme_builder.dart';
@@ -124,5 +125,71 @@ void main() {
     ));
     await tester.pumpAndSettle();
     expect(find.textContaining('Showing'), findsNothing);
+  });
+
+  // Back-navigation contract: the AppBar must always offer a way off the
+  // feed. Pushed (drawer) returns to the origin; deep-linked (no back
+  // stack) falls back to the dashboard. Mirrors settings_screen_test.
+  GoRouter backNavRouter({required String initialLocation}) => GoRouter(
+        initialLocation: initialLocation,
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (_, _) => const Scaffold(body: Text('ORIGIN_PAGE')),
+          ),
+          GoRoute(
+            path: '/notifications',
+            builder: (_, _) => const NotificationFeedScreen(),
+          ),
+        ],
+      );
+
+  Future<void> pumpRouter(WidgetTester tester, GoRouter router) async {
+    addTearDown(router.dispose);
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          notificationsFeedProvider
+              .overrideWith((ref) async => const NotificationsPage(
+                    items: [],
+                    total: 0,
+                  )),
+          unreadCountProvider.overrideWith((ref) async => 0),
+        ],
+        child: MaterialApp.router(
+          theme: buildKubeTheme('nexus'),
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('AppBar back button returns to the originating screen',
+      (tester) async {
+    final router = backNavRouter(initialLocation: '/');
+    await pumpRouter(tester, router);
+
+    router.push('/notifications');
+    await tester.pumpAndSettle();
+    expect(find.widgetWithText(AppBar, 'Notifications'), findsOneWidget);
+
+    await tester.tap(find.byType(BackButton));
+    await tester.pumpAndSettle();
+
+    expect(find.text('ORIGIN_PAGE'), findsOneWidget);
+    expect(find.widgetWithText(AppBar, 'Notifications'), findsNothing);
+  });
+
+  testWidgets('AppBar back button falls back to the dashboard with no stack',
+      (tester) async {
+    final router = backNavRouter(initialLocation: '/notifications');
+    await pumpRouter(tester, router);
+    expect(find.widgetWithText(AppBar, 'Notifications'), findsOneWidget);
+
+    await tester.tap(find.byType(BackButton));
+    await tester.pumpAndSettle();
+
+    expect(find.text('ORIGIN_PAGE'), findsOneWidget);
   });
 }

--- a/mobile/test/features/settings/settings_screen_test.dart
+++ b/mobile/test/features/settings/settings_screen_test.dart
@@ -11,6 +11,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:kubecenter/features/settings/settings_screen.dart';
 import 'package:kubecenter/observability/sentry_init.dart';
 import 'package:kubecenter/theme/kube_theme_builder.dart';
@@ -226,5 +227,75 @@ void main() {
       reason:
           'Play URL must use the actual package id (issue #272 regression)',
     );
+  });
+
+  // Back-navigation contract: the AppBar must always offer a way off the
+  // Settings screen. Two paths — pushed (drawer) returns to the origin;
+  // deep-linked (no back stack) falls back to the dashboard.
+  Future<void> pumpRouter(WidgetTester tester, GoRouter router) async {
+    final prefs = await SharedPreferences.getInstance();
+    addTearDown(router.dispose);
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+        child: MaterialApp.router(
+          theme: buildKubeTheme('nexus'),
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('AppBar back button returns to the originating screen',
+      (tester) async {
+    final router = GoRouter(
+      initialLocation: '/',
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (_, _) => const Scaffold(body: Text('ORIGIN_PAGE')),
+        ),
+        GoRoute(
+          path: '/settings',
+          builder: (_, _) => const SettingsScreen(),
+        ),
+      ],
+    );
+    await pumpRouter(tester, router);
+
+    router.push('/settings');
+    await tester.pumpAndSettle();
+    expect(find.widgetWithText(AppBar, 'Settings'), findsOneWidget);
+
+    await tester.tap(find.byType(BackButton));
+    await tester.pumpAndSettle();
+
+    expect(find.text('ORIGIN_PAGE'), findsOneWidget);
+    expect(find.widgetWithText(AppBar, 'Settings'), findsNothing);
+  });
+
+  testWidgets('AppBar back button falls back to the dashboard with no stack',
+      (tester) async {
+    final router = GoRouter(
+      initialLocation: '/settings',
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (_, _) => const Scaffold(body: Text('DASHBOARD_PAGE')),
+        ),
+        GoRoute(
+          path: '/settings',
+          builder: (_, _) => const SettingsScreen(),
+        ),
+      ],
+    );
+    await pumpRouter(tester, router);
+    expect(find.widgetWithText(AppBar, 'Settings'), findsOneWidget);
+
+    await tester.tap(find.byType(BackButton));
+    await tester.pumpAndSettle();
+
+    expect(find.text('DASHBOARD_PAGE'), findsOneWidget);
   });
 }

--- a/mobile/test/widgets/domain_navigation_drawer_test.dart
+++ b/mobile/test/widgets/domain_navigation_drawer_test.dart
@@ -84,4 +84,82 @@ void main() {
 
     expect(find.text('SETTINGS_PAGE'), findsOneWidget);
   });
+
+  // Regression: domain destinations must be *pushed*, not go'd. `go` replaced
+  // the dashboard (the only screen hosting this drawer), leaving the list with
+  // neither a drawer nor a back button — a dead end. Pushing stacks the list
+  // on the dashboard so its AppBar shows a back button that returns here.
+  testWidgets('tapping a domain kind pushes it with a working back button',
+      (tester) async {
+    final router = GoRouter(
+      initialLocation: '/',
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (context, state) => const Scaffold(
+            drawer: DomainNavigationDrawer(),
+            body: Text('DASHBOARD_HOME'),
+          ),
+        ),
+        GoRoute(
+          // Mirrors the real PodListScreen: bare Scaffold + AppBar(title),
+          // relying on the AppBar's default auto-leading for the back button.
+          path: '/clusters/:clusterId/workloads/pods',
+          builder: (context, state) => Scaffold(
+            appBar: AppBar(title: const Text('Pods')),
+            body: const Text('PODS_LIST'),
+          ),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    final user = UserInfo(
+      id: 'u1',
+      username: 'admin',
+      provider: 'local',
+      roles: const ['admin'],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authRepositoryProvider.overrideWith(
+            () => _FakeAuth(
+              AuthAuthenticated(
+                user: user,
+                rbac: RBACSummary.fromJson(<String, dynamic>{}),
+              ),
+            ),
+          ),
+          unreadCountProvider.overrideWith((ref) async => 0),
+        ],
+        child: MaterialApp.router(
+          theme: buildKubeTheme('nexus'),
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final scaffoldState =
+        tester.state<ScaffoldState>(find.byType(Scaffold).first);
+    scaffoldState.openDrawer();
+    await tester.pumpAndSettle();
+
+    final podsTile = find.byKey(const ValueKey('drawer-kind-pods'));
+    await tester.ensureVisible(podsTile);
+    await tester.pumpAndSettle();
+    await tester.tap(podsTile);
+    await tester.pumpAndSettle();
+
+    // Pushed (not go'd): the list shows AND has a back button.
+    expect(find.text('PODS_LIST'), findsOneWidget);
+    expect(find.byType(BackButton), findsOneWidget);
+
+    // Back returns to the dashboard — not a dead end.
+    await tester.tap(find.byType(BackButton));
+    await tester.pumpAndSettle();
+    expect(find.text('DASHBOARD_HOME'), findsOneWidget);
+  });
 }


### PR DESCRIPTION
## Summary

The navigation drawer is mounted **only on the dashboard (`/`)** and reached every destination with `context.go(...)`, which *replaces* the dashboard. Since destination screens build their own bare `Scaffold` with no drawer, they were left with **neither a hamburger nor a back button — a dead end.** Reported on Pods; an audit confirmed it hit **every** domain list screen, plus Settings and Notifications.

## Root cause (from a full nav audit)

- The drawer is only on the dashboard; everything else is a separate top-level route.
- `go` replaces the stack → destinations had no back stack and no drawer.
- No screen disables `automaticallyImplyLeading`, so a back button appears automatically **once a screen has a stack** — meaning the fix is to *push* destinations, plus harden two shared chokepoints.

## Fixes (5 sites, concentrated at leverage points — no per-screen edits)

| File | Change |
|---|---|
| `domain_navigation_drawer.dart` | domain destinations + wizard launcher: `go` → **`push`** (Settings/Notifications too) |
| `wizard_screen_scaffold.dart` | post-apply nav to created resource: `go` → **`pushReplacement`** (keeps launcher below; back works) |
| `resource_detail_scaffold.dart` | back button `maybePop()` → **`canPop() ? pop() : go('/')`** — one chokepoint fixes all detail screens |
| `settings_screen.dart` + `feed_screen.dart` | explicit adaptive `BackButton` with pop-or-home fallback |

List screens funnel through the drawer-push; detail screens funnel through `ResourceDetailScaffold` — so two chokepoints + the drawer cover all ~40 screens.

## Cross-platform (iOS included)

All shared Dart. `BackButton` auto-renders the iOS chevron, and switching the drawer to `push` **restores the iOS edge-swipe-back gesture** (only works on pushed routes).

## Tests

- Drawer regression: tap a kind → pushes → back button present → returns to dashboard.
- Settings + Notifications: pop-to-origin and fall-back-to-dashboard.
- `flutter analyze` clean · `flutter test` **1240 passed / 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)