### PR TITLE
fix(helm): secret-free GitOps render + dev-in-cluster opt-in (unfreeze ArgoCD)

### DIFF
--- a/helm/kubecenter/templates/configmap-app.yaml
+++ b/helm/kubecenter/templates/configmap-app.yaml
@@ -9,6 +9,12 @@ metadata:
 data:
   KUBECENTER_SERVER_PORT: {{ .Values.backend.port | quote }}
   KUBECENTER_DEV: {{ .Values.backend.config.dev | quote }}
+  {{- if .Values.backend.config.devInClusterAllow }}
+  # Explicit opt-in to run dev mode in-cluster (P1-1-cascade guard in
+  # backend/cmd/kubecenter/main.go). Only consulted by the backend when
+  # dev mode is enabled; without it an in-cluster dev pod refuses to start.
+  KUBECENTER_DEV_IN_CLUSTER_ALLOW: "true"
+  {{- end }}
   KUBECENTER_LOG_LEVEL: {{ .Values.backend.config.logLevel | quote }}
   KUBECENTER_LOG_FORMAT: {{ .Values.backend.config.logFormat | quote }}
   KUBECENTER_CLUSTERID: {{ .Values.backend.config.clusterID | quote }}

--- a/helm/kubecenter/templates/deployment-backend.yaml
+++ b/helm/kubecenter/templates/deployment-backend.yaml
@@ -1,4 +1,12 @@
 {{- include "kubecenter.validatePlaceholders" . }}
+{{- /* App secret source. When auth.existingSecret is set, the backend reads
+       jwt-secret / setup-token / database-url from that operator-managed
+       Secret via secretKeyRef instead of the chart-managed Secret. This is
+       required for GitOps/ArgoCD, where Helm's `lookup` returns nothing
+       (so the chart's persistence fallback would emit a fresh random secret
+       on every render) and committing secrets to values is unacceptable
+       (Finding P0-1). Empty → default chart-managed Secret. */}}
+{{- $appSecret := .Values.auth.existingSecret | default (include "kubecenter.fullname" .) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -85,20 +93,20 @@ spec:
             - name: KUBECENTER_AUTH_JWTSECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "kubecenter.fullname" . }}
+                  name: {{ $appSecret }}
                   key: jwt-secret
             {{- if or .Values.postgresql.enabled .Values.externalDatabase.host }}
             - name: KUBECENTER_DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "kubecenter.fullname" . }}
+                  name: {{ $appSecret }}
                   key: database-url
             {{- end }}
             {{- if or .Values.auth.setupToken (not .Values.backend.config.dev) }}
             - name: KUBECENTER_AUTH_SETUPTOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "kubecenter.fullname" . }}
+                  name: {{ $appSecret }}
                   key: setup-token
             {{- end }}
             {{- if .Values.alerting.enabled }}

--- a/helm/kubecenter/templates/secret-app.yaml
+++ b/helm/kubecenter/templates/secret-app.yaml
@@ -8,6 +8,14 @@ metadata:
     {{- include "kubecenter.labels" . | nindent 4 }}
 type: Opaque
 data:
+  {{- /* Core secrets (jwt-secret, database-url, setup-token) are emitted by
+         the chart only when auth.existingSecret is NOT set. When it IS set,
+         the backend reads them from that operator-managed Secret (see
+         deployment-backend.yaml's $appSecret) and the chart must neither
+         emit nor auto-generate them — this is what makes a secret-free,
+         GitOps-renderable values file possible (Helm `lookup` returns
+         nothing under `helm template`/ArgoCD). */}}
+  {{- if not .Values.auth.existingSecret }}
   {{- /* JWT secret: use provided value, or look up existing secret, or generate random */}}
   {{- if .Values.auth.jwtSecret }}
   jwt-secret: {{ .Values.auth.jwtSecret | b64enc | quote }}
@@ -36,6 +44,7 @@ data:
   setup-token: {{ index $existingSetupSecret.data "setup-token" }}
   {{- else }}
   setup-token: {{ randAlphaNum 48 | b64enc | quote }}
+  {{- end }}
   {{- end }}
   {{- end }}
   {{- if .Values.alerting.webhookToken }}

--- a/helm/kubecenter/values.schema.json
+++ b/helm/kubecenter/values.schema.json
@@ -25,6 +25,7 @@
           "type": "object",
           "properties": {
             "dev": { "type": "boolean" },
+            "devInClusterAllow": { "type": "boolean" },
             "logLevel": { "type": "string", "enum": ["debug", "info", "warn", "error"] },
             "logFormat": { "type": "string", "enum": ["json", "text"] },
             "clusterID": { "type": "string", "minLength": 1 }

--- a/helm/kubecenter/values.schema.json
+++ b/helm/kubecenter/values.schema.json
@@ -78,6 +78,7 @@
       "properties": {
         "jwtSecret": { "type": "string" },
         "setupToken": { "type": "string" },
+        "existingSecret": { "type": "string" },
         "oidc": { "type": "array" },
         "ldap": { "type": "array" }
       }

--- a/helm/kubecenter/values.yaml
+++ b/helm/kubecenter/values.yaml
@@ -41,6 +41,13 @@ backend:
   goMemLimit: "230MiB"    # GOMEMLIMIT — set to ~90% of memory limit
   config:
     dev: false
+    # P1-1-cascade opt-in (see backend/cmd/kubecenter/main.go): when dev=true
+    # AND the backend runs in-cluster, it refuses to start unless this is true.
+    # Dev mode in-cluster disables the leaked-secret guard, the loopback-setup
+    # gate, and chart token auto-generation — enable this ONLY for trusted-LAN
+    # homelab installs that consciously accept that posture. No effect when
+    # dev=false.
+    devInClusterAllow: false
     logLevel: info     # debug, info, warn, error
     logFormat: json     # json, text
     clusterID: local

--- a/helm/kubecenter/values.yaml
+++ b/helm/kubecenter/values.yaml
@@ -102,6 +102,18 @@ auth:
   # from a loopback peer; non-loopback dev installs still require a
   # configured token. See finding P1-1 in plans/security-audit-2026-05-22.md.
   setupToken: ""
+  # Name of a pre-created Secret that supplies the core app secrets
+  # (keys: jwt-secret, database-url, and — when used — setup-token) via
+  # secretKeyRef. Set this for GitOps/ArgoCD, where Helm `lookup` is
+  # unavailable (so the chart's persistence fallback would emit a fresh
+  # random jwt-secret on every render) and committing secrets to a values
+  # file is unacceptable (Finding P0-1). When set, the chart does NOT
+  # render or auto-generate those keys, and the database-url is taken from
+  # the Secret rather than assembled from postgresql.auth.password — so the
+  # PG password need not appear in values either (point
+  # postgresql.auth.existingSecret at the same Secret for the subchart).
+  # Empty → default chart-managed Secret with lookup-based persistence.
+  existingSecret: ""
   # OIDC providers (array). Each entry maps to config.OIDCConfig.
   oidc: []
   # - id: google


### PR DESCRIPTION
## Why

The homelab ArgoCD app silently stopped syncing on 2026-05-23 and froze the backend at `sha-b71be6f` (#296) — 19 commits and 10 days stale. Two chart gaps made GitOps un-renderable:

1. **No secret-free render path.** ArgoCD renders with `helm template`, where Helm `lookup` returns nothing — so the chart's secret-persistence fallback emits a *fresh random* `jwt-secret` every render, and the `database-url` block hard-fails on a `required` PG password. Combined with #304 deleting the committed `values-homelab.yaml` (P0-1), every sync failed at `helm template` with `open …/values-homelab.yaml: no such file`.
2. **No dev-in-cluster opt-in.** #304 added a backend guard (`backend/cmd/kubecenter/main.go`): `KUBECENTER_DEV=true` in-cluster refuses to start unless `KUBECENTER_DEV_IN_CLUSTER_ALLOW=true`. The chart had no way to set that env, so a dev-mode in-cluster deploy CrashLoopBackOffs. Masked only because the frozen image predated the guard.

Net user-visible symptom: the mobile M4 Metrics tab 404s, because the stale backend lacks the `/monitoring/queries/*` slug endpoint (added #305, one day after the freeze).

## What

- `auth.existingSecret`: when set, the backend reads `jwt-secret` / `database-url` / `setup-token` via `secretKeyRef` from an operator-managed Secret; the chart skips emitting/auto-generating them (and the PG-password `required`). Enables a secret-free, GitOps-renderable config with credentials in a pre-created k8s Secret.
- `backend.config.devInClusterAllow`: when true, the app ConfigMap (consumed via `envFrom`) emits `KUBECENTER_DEV_IN_CLUSTER_ALLOW=true`.

Default behavior is unchanged on both paths.

## Verification

- `helm lint` clean; default `helm template` renders (14 objects).
- New existingSecret path: renders with no PG password / no jwt in values, backend env → `secretKeyRef` to the named Secret, chart emits none of the three core keys.
- Default path regression: `jwt-secret`/`database-url` still emitted, refs `<fullname>`.
- `devInClusterAllow`: env present when on, absent when off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)