### PR TITLE
fix(helm): grant backend SA watch on argoproj applicationsets

### DIFF
--- a/helm/kubecenter/templates/clusterrole.yaml
+++ b/helm/kubecenter/templates/clusterrole.yaml
@@ -101,7 +101,7 @@ rules:
     verbs: ["get", "list", "watch"]
   # GitOps CRDs (dynamic informers for real-time WebSocket updates)
   - apiGroups: ["argoproj.io"]
-    resources: ["applications"]
+    resources: ["applications", "applicationsets"]
     verbs: ["list", "watch"]
   - apiGroups: ["kustomize.toolkit.fluxcd.io"]
     resources: ["kustomizations"]


### PR DESCRIPTION
## Why
The backend runs dynamic informers for Argo CD Applications **and** ApplicationSets (real-time WebSocket updates), but the ClusterRole informer rule granted `list`/`watch` on `applications` only. The current backend image logs a repeating reflector error:

```
applicationsets.argoproj.io is forbidden: User "system:serviceaccount:k8scenter:k8scenter-kubecenter" cannot watch resource "applicationsets" in API group "argoproj.io" at the cluster scope
```

Surfaced live on the homelab after it was unfrozen to the current backend (#316).

## What
Add `applicationsets` to the GitOps informer rule (`list`, `watch`). The separate Extensions-Hub *counts* rule already listed it; this aligns the informer rule.

Verified: `helm template` (applicationsets present in the list/watch rule) + `helm lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)