### PR TITLE
fix(helm): restore service-account RBAC for CRD-discovered features (#305 regression)

### DIFF
--- a/helm/kubecenter/templates/clusterrole.yaml
+++ b/helm/kubecenter/templates/clusterrole.yaml
@@ -171,6 +171,52 @@ rules:
       - issuers
       - clusterissuers
     verbs: ["list", "watch"]
+  # Gateway API CRDs — list for the discoverer + 30s cache in
+  # `internal/gateway`. fetchAll lists these cluster-wide as the service
+  # account; handlers then apply per-user RBAC via SelfSubjectAccessReview
+  # before returning data. Detail reads use the impersonated client, so no
+  # `get` grant is needed here. TCP/TLS/UDP routes live in v1alpha2 but RBAC
+  # is version-agnostic, so the single group grant covers every version.
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources:
+      - gatewayclasses
+      - gateways
+      - httproutes
+      - grpcroutes
+      - tcproutes
+      - tlsroutes
+      - udproutes
+    verbs: ["list", "watch"]
+  # Velero CRDs — list for the discoverer + 30s cache in `internal/velero`.
+  # The dashboard lists these cluster-wide as the service account, then applies
+  # per-user RBAC via SelfSubjectAccessReview. Backup/restore/schedule write
+  # actions and detail reads use the impersonated client.
+  - apiGroups: ["velero.io"]
+    resources:
+      - backups
+      - restores
+      - schedules
+      - backupstoragelocations
+      - volumesnapshotlocations
+      - deletebackuprequests
+      - downloadrequests
+    verbs: ["list", "watch"]
+  # Trivy / Aqua Security CRDs — list for the scanning observatory in
+  # `internal/scanning`. VulnerabilityReports are listed as the service account
+  # (with an SSAR precheck) for the namespace-scoped vulnerability view.
+  - apiGroups: ["aquasecurity.github.io"]
+    resources:
+      - vulnerabilityreports
+    verbs: ["list", "watch"]
+  # Flux Notification CRDs — list for the notification surface in
+  # `internal/notification`. Providers/Alerts/Receivers are listed as the
+  # service account; creates/updates use the impersonated client.
+  - apiGroups: ["notification.toolkit.fluxcd.io"]
+    resources:
+      - providers
+      - alerts
+      - receivers
+    verbs: ["list", "watch"]
   # CRD discovery — list/watch CustomResourceDefinitions for Extensions Hub.
   # The CRDDiscovery informer (internal/k8s/crd_discovery.go) uses the
   # apiextensions typed client — not a dynamic wildcard list. The SA needs
@@ -198,6 +244,10 @@ rules:
   #   policy.linkerd.io        → Linkerd Server / HTTPRoute counts
   #   external-secrets.io      → ESO ExternalSecret / SecretStore etc counts
   #   cert-manager.io          → cert-manager Certificate / Issuer counts
+  #   gateway.networking.k8s.io → Gateway API Gateway / HTTPRoute / etc counts
+  #   velero.io                → Velero Backup / Restore / Schedule counts
+  #   aquasecurity.github.io   → Trivy VulnerabilityReport counts
+  #   notification.toolkit.fluxcd.io → Flux Provider / Alert / Receiver counts
   #   cilium.io                → Cilium CNI resource counts
   #   snapshot.storage.k8s.io  → VolumeSnapshot counts
   #   monitoring.coreos.com    → ServiceMonitor / Prometheus counts
@@ -239,6 +289,18 @@ rules:
     verbs: ["list"]
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "issuers", "clusterissuers"]
+    verbs: ["list"]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["gatewayclasses", "gateways", "httproutes", "grpcroutes", "tcproutes", "tlsroutes", "udproutes"]
+    verbs: ["list"]
+  - apiGroups: ["velero.io"]
+    resources: ["backups", "restores", "schedules", "backupstoragelocations", "volumesnapshotlocations", "deletebackuprequests", "downloadrequests"]
+    verbs: ["list"]
+  - apiGroups: ["aquasecurity.github.io"]
+    resources: ["vulnerabilityreports"]
+    verbs: ["list"]
+  - apiGroups: ["notification.toolkit.fluxcd.io"]
+    resources: ["providers", "alerts", "receivers"]
     verbs: ["list"]
   - apiGroups: ["cilium.io"]
     resources: ["ciliumnetworkpolicies", "ciliumbgpclusterconfigs", "ciliumbgppeerconfigs", "ciliumbgpnodeconfigs", "ciliumnodes", "ciliumendpoints"]


### PR DESCRIPTION
## Problem

Multiple CRD-integration screens fail to load with *"Failed to load … status"*:

- **Gateway API** — reported
- **Velero** — reported
- **Trivy scanning** and **Flux notifications** — same latent break wherever those CRDs are installed (not yet reported, fixed proactively)

## Root cause

PR #305 (`feat(security): Phase 2 — RBAC + multi-cluster routing`) dropped the ClusterRole `[*]` wildcard and re-added explicit per-group CRD grants — a good least-privilege change — but **omitted four groups that the backend lists *as the service account*** (`BaseDynamicClient`, then per-user `SelfSubjectAccessReview` filtering):

| Group | Package | Surface |
|---|---|---|
| `gateway.networking.k8s.io` | `internal/gateway` | Gateway API dashboard |
| `velero.io` | `internal/velero` | Backup dashboard |
| `aquasecurity.github.io` | `internal/scanning` | Trivy vulnerability reports |
| `notification.toolkit.fluxcd.io` | `internal/notification` | Flux providers/alerts/receivers |

Failure chain: the SA `List` calls returned `Forbidden` → the cache `fetchAll` returned an error → the `/summary` (or equivalent) handler returned **500** → the frontend `Promise.all([...status, ...summary])` rejected → the dashboard rendered its error state. The matching `/status` endpoints still succeeded because Kubernetes **discovery** needs no resource-level RBAC — which is why each screen actively tried to load and errored instead of showing its "not detected" empty state.

## Fix

Adds all four groups to **both** RBAC sections of `helm/kubecenter/templates/clusterrole.yaml`:

- the **CRD-feature `list`/`watch` block** (what the broken handlers actually need), and
- the **Extensions Hub instance-count block** + comment enumeration,

matching the existing cert-manager / ESO / Istio convention. RBAC is version-agnostic, so the single `gateway.networking.k8s.io` grant also covers the v1alpha2 TCP/TLS/UDP routes.

## Scope audit

Audited every `BaseDynamicClient` / informer SA-list path in `backend/internal` (policy, gitops, servicemesh, externalsecrets, certmanager, storage, networking, monitoring, alerting). All other groups were already granted; **these four were the complete set of gaps.** cert-manager's `acme.cert-manager.io` subgroup (orders/challenges) is impersonated-only and needs no SA grant.

## Verification

- `helm lint` — clean
- `helm template` — full chart renders; all four groups present in both blocks

## Deployment

ClusterRole-only change — no image rebuild. **ArgoCD-managed**: merging here triggers the sync that patches the live ClusterRole; the per-feature 30s cache means each screen recovers within ~30s of the sync. The application-controller already applies cluster-scoped RBAC for this app, so no extra ArgoCD permission is needed.

## Follow-up (not in this PR)

PR #305's `check-cluster-routing.sh` guard didn't catch this class of regression. A CI check asserting that every typed CRD integration group with an SA-list path has a matching ClusterRole grant would prevent the next "dropped the wildcard, forgot a group" break. Happy to add it as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
