### PR TITLE
style(frontend): fix deno fmt violation in PromQLAdminGate

### DIFF
--- a/frontend/islands/PromQLAdminGate.tsx
+++ b/frontend/islands/PromQLAdminGate.tsx
@@ -53,15 +53,15 @@ export default function PromQLAdminGate(
           Admin access required
         </h2>
         <p class="text-sm text-text-secondary">
-          Raw PromQL access is reserved for cluster administrators. The
-          backend rejects non-admin queries against this endpoint, and the
-          UI matches that boundary.
+          Raw PromQL access is reserved for cluster administrators. The backend
+          rejects non-admin queries against this endpoint, and the UI matches
+          that boundary.
         </p>
         <p class="text-sm text-text-secondary">
           For per-resource metrics, open the resource's detail page (Pods,
-          Deployments, Nodes, etc.) and switch to the Metrics tab — those
-          panels use curated, server-owned queries that respect your
-          Kubernetes RBAC scope.
+          Deployments, Nodes, etc.) and switch to the Metrics tab — those panels
+          use curated, server-owned queries that respect your Kubernetes RBAC
+          scope.
         </p>
         <div class="pt-2">
           <a


### PR DESCRIPTION
Fixes the `deno fmt --check` failure in the **Frontend** CI job — 1 of 505 files (`islands/PromQLAdminGate.tsx`) had JSX help-text wrapped past deno's 80-col width. Reflowed to match; whitespace-only, no behavior change.

This was a pre-existing violation on `main` (surfaced while merging the Dependabot PRs) that fails Frontend CI on every frontend PR. With this merged, the Frontend check goes green again.

Verified locally with deno 2.7.14: `deno fmt --check` → `Checked 505 files`, clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)