### PR TITLE
fix(ci): bump Playwright to 1.60.0 — fixes Node 24.16+ install hang (#328)

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -6,18 +6,18 @@
     "": {
       "name": "k8scenter-e2e",
       "devDependencies": {
-        "@playwright/test": "^1.51.0",
+        "@playwright/test": "^1.60.0",
         "@types/node": "^22.0.0"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
-      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.58.2"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -52,13 +52,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.2"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -71,9 +71,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -7,7 +7,7 @@
     "test:smoke": "playwright test --grep @smoke"
   },
   "devDependencies": {
-    "@playwright/test": "^1.51.0",
+    "@playwright/test": "^1.60.0",
     "@types/node": "^22.0.0"
   }
 }


### PR DESCRIPTION
Fixes #328 — and it's a **known upstream bug**, not our infra.

## Root cause (found via research, confirmed against our logs)
[microsoft/playwright#40747](https://github.com/microsoft/playwright/pull/40747): a **yauzl extraction regression that hangs `playwright install` after the download completes**, on **Node 24.16.0+ / Node 26.x**, for Playwright **< 1.60.0**.

Our captured logs matched exactly: Chromium downloads to `100% of 167.3 MiB` in ~2s, then the step goes silent until timeout. The trigger was `actions/setup-node` with `node-version: lts/*` rolling to Node 24.16+ around 2026-05-26 (exactly when e2e started failing), while `@playwright/test` was pinned `^1.51.0` (lockfile ~1.55, in the buggy range).

## Fix
Bump `@playwright/test` `^1.51.0` → `^1.60.0` (the release that vendors the fix). Lockfile regenerated and verified with `npm ci`.

- **1.60.0 published 2026-05-11** → 26 days → clears the 7-day supply-chain cooldown.
- **No workflow change**: the browser cache + no-`--with-deps` install from #327 are correct once the install stops hanging. (An earlier reorder/retry commit on this branch — based on a wrong "kind contention" guess — was reverted.)

## Why it wasn't caught sooner
The bug is invisible on Node ≤ 24.15.0 (my local box runs 24.15.0, which is why it never reproduced locally). #327's fail-fast instrumentation is what produced the clean "download 100% then silence" signal that pinned it to extraction.

Closes #328
