### PR TITLE
feat(dashboard): back Overview sparklines with real Prometheus history

### DIFF
--- a/backend/internal/k8s/resources/dashboard.go
+++ b/backend/internal/k8s/resources/dashboard.go
@@ -58,6 +58,26 @@ type Utilization struct {
 	Limits     string  `json:"limits"`
 }
 
+// DashboardTrends holds short historical series (one value per sample step) that
+// back the sparklines on the dashboard metric cards. Each slice is ordered
+// oldest→newest. A slice may be empty when Prometheus or kube-state-metrics is
+// unavailable; the frontend renders no sparkline in that case rather than a
+// misleading flat line. Window and Step describe the range that produced the
+// series (e.g. "1h" / "2m").
+type DashboardTrends struct {
+	Nodes    []float64 `json:"nodes"`
+	Pods     []float64 `json:"pods"`
+	Services []float64 `json:"services"`
+	Alerts   []float64 `json:"alerts"`
+	// CPU and Memory are cluster-wide utilization percentages (0–100), one
+	// value per step — the historical companions to the instant percentages
+	// in DashboardSummary.CPU/Memory.
+	CPU    []float64 `json:"cpu"`
+	Memory []float64 `json:"memory"`
+	Window string    `json:"window"`
+	Step   string    `json:"step"`
+}
+
 // HandleDashboardSummary returns aggregated cluster health data from the informer cache.
 // Prometheus metrics (CPU/Memory) are fetched asynchronously with a 1-second timeout.
 // Only available for the local cluster (informer cache is not available for remote clusters).
@@ -254,4 +274,42 @@ func (h *Handler) HandleDashboardSummary(w http.ResponseWriter, r *http.Request)
 	}
 
 	writeJSON(w, http.StatusOK, api.Response{Data: summary})
+}
+
+// HandleDashboardTrends returns short historical series for the dashboard metric
+// cards (node/pod/service/alert counts) sourced from Prometheus range queries.
+// Kept separate from HandleDashboardSummary so its multi-second range queries do
+// not eat into that endpoint's 1-second Prometheus budget. Local cluster only.
+//
+// When monitoring is unavailable (h.Trends == nil) or a query fails, the
+// response carries empty series and HTTP 200 — the dashboard degrades to no
+// sparklines rather than erroring.
+func (h *Handler) HandleDashboardTrends(w http.ResponseWriter, r *http.Request) {
+	if _, ok := requireUser(w, r); !ok {
+		return
+	}
+
+	clusterID := middleware.ClusterIDFromContext(r.Context())
+	if clusterID != "" && clusterID != "local" {
+		writeError(w, http.StatusBadRequest, "dashboard trends are only available for the local cluster", "")
+		return
+	}
+
+	if h.Trends == nil {
+		writeJSON(w, http.StatusOK, api.Response{Data: DashboardTrends{}})
+		return
+	}
+
+	trends, err := h.Trends.DashboardTrends(r.Context())
+	if err != nil {
+		// Prometheus hiccups should not surface as a dashboard error — log and
+		// return empty series so the cards still render their current counts.
+		if h.Logger != nil {
+			h.Logger.Warn("dashboard trends query failed", "error", err)
+		}
+		writeJSON(w, http.StatusOK, api.Response{Data: DashboardTrends{}})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, api.Response{Data: trends})
 }

--- a/backend/internal/k8s/resources/dashboard_trends_test.go
+++ b/backend/internal/k8s/resources/dashboard_trends_test.go
@@ -1,0 +1,107 @@
+package resources
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kubecenter/kubecenter/internal/server/middleware"
+)
+
+// stubTrendProvider is a test double for the TrendProvider interface.
+type stubTrendProvider struct {
+	result DashboardTrends
+	err    error
+}
+
+func (s stubTrendProvider) DashboardTrends(_ context.Context) (DashboardTrends, error) {
+	return s.result, s.err
+}
+
+// decodeTrends pulls the DashboardTrends payload out of the {data:...} envelope.
+func decodeTrends(t *testing.T, rr *httptest.ResponseRecorder) DashboardTrends {
+	t.Helper()
+	var resp struct {
+		Data DashboardTrends `json:"data"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode body %q: %v", rr.Body.String(), err)
+	}
+	return resp.Data
+}
+
+func TestHandleDashboardTrends_NilProvider(t *testing.T) {
+	h, _ := testHandler(t)
+	// h.Trends is nil — monitoring unavailable. Must degrade to 200 + empty.
+	req := requestWithUser("GET", "/api/v1/cluster/dashboard-trends", "")
+	rr := httptest.NewRecorder()
+
+	h.HandleDashboardTrends(rr, req)
+
+	if rr.Code != 200 {
+		t.Fatalf("nil provider: want 200, got %d (%s)", rr.Code, rr.Body.String())
+	}
+	got := decodeTrends(t, rr)
+	if got.Nodes != nil || got.CPU != nil {
+		t.Fatalf("nil provider: want empty series, got %+v", got)
+	}
+}
+
+func TestHandleDashboardTrends_ProviderError(t *testing.T) {
+	h, _ := testHandler(t)
+	h.Trends = stubTrendProvider{err: context.DeadlineExceeded}
+	req := requestWithUser("GET", "/api/v1/cluster/dashboard-trends", "")
+	rr := httptest.NewRecorder()
+
+	h.HandleDashboardTrends(rr, req)
+
+	// A Prometheus error must not surface as a 5xx — graceful degradation.
+	if rr.Code != 200 {
+		t.Fatalf("provider error: want 200, got %d (%s)", rr.Code, rr.Body.String())
+	}
+	got := decodeTrends(t, rr)
+	if got.Nodes != nil {
+		t.Fatalf("provider error: want empty series, got %+v", got)
+	}
+}
+
+func TestHandleDashboardTrends_HappyPath(t *testing.T) {
+	h, _ := testHandler(t)
+	h.Trends = stubTrendProvider{result: DashboardTrends{
+		Nodes:  []float64{3, 3, 4},
+		CPU:    []float64{12.5, 18.0},
+		Window: "1h0m0s",
+		Step:   "2m0s",
+	}}
+	req := requestWithUser("GET", "/api/v1/cluster/dashboard-trends", "")
+	rr := httptest.NewRecorder()
+
+	h.HandleDashboardTrends(rr, req)
+
+	if rr.Code != 200 {
+		t.Fatalf("happy path: want 200, got %d (%s)", rr.Code, rr.Body.String())
+	}
+	got := decodeTrends(t, rr)
+	if len(got.Nodes) != 3 || got.Nodes[2] != 4 {
+		t.Fatalf("happy path: want nodes [3 3 4], got %v", got.Nodes)
+	}
+	if len(got.CPU) != 2 || got.Window != "1h0m0s" {
+		t.Fatalf("happy path: want cpu len 2 + window, got %+v", got)
+	}
+}
+
+func TestHandleDashboardTrends_RemoteClusterRejected(t *testing.T) {
+	h, _ := testHandler(t)
+	h.Trends = stubTrendProvider{result: DashboardTrends{Nodes: []float64{1, 2}}}
+	req := requestWithUser("GET", "/api/v1/cluster/dashboard-trends", "")
+	// Non-local cluster: trends are informer/Prometheus-local only.
+	req = req.WithContext(middleware.WithClusterID(req.Context(), "remote-1"))
+	rr := httptest.NewRecorder()
+
+	h.HandleDashboardTrends(rr, req)
+
+	if rr.Code != 400 {
+		t.Fatalf("remote cluster: want 400, got %d (%s)", rr.Code, rr.Body.String())
+	}
+}

--- a/backend/internal/k8s/resources/handler.go
+++ b/backend/internal/k8s/resources/handler.go
@@ -32,6 +32,13 @@ type AlertCounter interface {
 	ActiveAlertCounts(ctx context.Context) (active int, critical int, err error)
 }
 
+// TrendProvider abstracts short historical time-series for the dashboard metric
+// cards (node/pod/service/alert counts). Used by the dashboard trends endpoint.
+// Can be nil if monitoring is unavailable.
+type TrendProvider interface {
+	DashboardTrends(ctx context.Context) (DashboardTrends, error)
+}
+
 // Handler provides HTTP handler methods for Kubernetes resource operations.
 type Handler struct {
 	K8sClient     *k8s.ClientFactory
@@ -44,6 +51,7 @@ type Handler struct {
 	ClusterID     string
 	Utilization   UtilizationProvider // Optional — nil if monitoring unavailable
 	Alerts        AlertCounter        // Optional — nil if alerting unavailable
+	Trends        TrendProvider       // Optional — nil if monitoring unavailable
 	// OriginValidator checks the Origin header for WebSocket connections.
 	// Set by the server at wiring time. If nil, rejects all WS upgrades.
 	OriginValidator func(w http.ResponseWriter, r *http.Request) bool

--- a/backend/internal/monitoring/trends.go
+++ b/backend/internal/monitoring/trends.go
@@ -1,0 +1,119 @@
+package monitoring
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/prometheus/common/model"
+
+	"github.com/kubecenter/kubecenter/internal/k8s/resources"
+)
+
+// Dashboard trend window and resolution. A 1h window at a 2m step yields ~31
+// points — dense enough to read as a trend, cheap enough to range-query every
+// dashboard refresh.
+const (
+	trendWindow = time.Hour
+	trendStep   = 2 * time.Minute
+)
+
+// trendQueries are the PromQL expressions backing each metric card's sparkline.
+//
+//   - nodes/pods/services come from kube-state-metrics; if it is absent the
+//     range query returns an empty matrix and the series stays empty (the
+//     frontend then renders no sparkline rather than a misleading flat line).
+//   - alerts uses `or vector(0)` so a cluster with zero firing alerts over the
+//     window still produces a flat zero baseline — that reads as "all clear",
+//     which is meaningful, unlike the missing-data case above.
+//   - cpu/memory are the range-query companions of UtilizationAdapter's instant
+//     CPUPercent/MemoryPercent queries (same PromQL); they come from
+//     node-exporter, which is independent of kube-state-metrics.
+var trendQueries = []struct {
+	key   string
+	query string
+}{
+	{"nodes", `count(kube_node_info)`},
+	{"pods", `count(kube_pod_info)`},
+	{"services", `count(kube_service_info)`},
+	{"alerts", `count(ALERTS{alertstate="firing"}) or vector(0)`},
+	{"cpu", `100 - (avg(rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)`},
+	{"memory", `(1 - (avg(node_memory_MemAvailable_bytes) / avg(node_memory_MemTotal_bytes))) * 100`},
+}
+
+// DashboardTrends implements resources.TrendProvider. It range-queries
+// Prometheus for the four metric-card series concurrently and returns whatever
+// resolved; individual query failures yield an empty series for that metric
+// rather than failing the whole request.
+func (a *UtilizationAdapter) DashboardTrends(ctx context.Context) (resources.DashboardTrends, error) {
+	out := resources.DashboardTrends{
+		Window: trendWindow.String(),
+		Step:   trendStep.String(),
+	}
+
+	pc := a.Discoverer.PrometheusClient()
+	if pc == nil {
+		return out, fmt.Errorf("prometheus not available")
+	}
+
+	// Bound the whole fan-out; QueryRange also applies its own per-call timeout.
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	end := time.Now()
+	start := end.Add(-trendWindow)
+
+	series := make([][]float64, len(trendQueries))
+	var wg sync.WaitGroup
+	wg.Add(len(trendQueries))
+	for i, q := range trendQueries {
+		go func(i int, query string) {
+			defer wg.Done()
+			val, _, err := pc.QueryRange(ctx, query, start, end, trendStep)
+			if err != nil {
+				return // leave series[i] nil → empty slice in JSON
+			}
+			series[i] = parseMatrixSeries(val)
+		}(i, q.query)
+	}
+	wg.Wait()
+
+	for i, q := range trendQueries {
+		switch q.key {
+		case "nodes":
+			out.Nodes = series[i]
+		case "pods":
+			out.Pods = series[i]
+		case "services":
+			out.Services = series[i]
+		case "alerts":
+			out.Alerts = series[i]
+		case "cpu":
+			out.CPU = series[i]
+		case "memory":
+			out.Memory = series[i]
+		}
+	}
+
+	return out, nil
+}
+
+// parseMatrixSeries extracts the sample values of the first series from a range
+// query result. Our trend queries are scalar aggregates, so there is exactly
+// one series; anything else (empty matrix, wrong type) yields nil.
+func parseMatrixSeries(val model.Value) []float64 {
+	matrix, ok := val.(model.Matrix)
+	if !ok || len(matrix) == 0 {
+		return nil
+	}
+	pairs := matrix[0].Values
+	if len(pairs) == 0 {
+		return nil
+	}
+	values := make([]float64, len(pairs))
+	for i, p := range pairs {
+		values[i] = float64(p.Value)
+	}
+	return values
+}

--- a/backend/internal/monitoring/trends.go
+++ b/backend/internal/monitoring/trends.go
@@ -3,6 +3,7 @@ package monitoring
 import (
 	"context"
 	"fmt"
+	"math"
 	"sync"
 	"time"
 
@@ -30,20 +31,24 @@ const (
 //   - cpu/memory are the range-query companions of UtilizationAdapter's instant
 //     CPUPercent/MemoryPercent queries (same PromQL); they come from
 //     node-exporter, which is independent of kube-state-metrics.
+//
+// Each entry carries its own assign func so a new metric self-registers its
+// destination field — there is no separate key→field switch to keep in sync,
+// so it is impossible to add a query and silently drop its result.
 var trendQueries = []struct {
-	key   string
-	query string
+	query  string
+	assign func(*resources.DashboardTrends, []float64)
 }{
-	{"nodes", `count(kube_node_info)`},
-	{"pods", `count(kube_pod_info)`},
-	{"services", `count(kube_service_info)`},
-	{"alerts", `count(ALERTS{alertstate="firing"}) or vector(0)`},
-	{"cpu", `100 - (avg(rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)`},
-	{"memory", `(1 - (avg(node_memory_MemAvailable_bytes) / avg(node_memory_MemTotal_bytes))) * 100`},
+	{`count(kube_node_info)`, func(t *resources.DashboardTrends, v []float64) { t.Nodes = v }},
+	{`count(kube_pod_info)`, func(t *resources.DashboardTrends, v []float64) { t.Pods = v }},
+	{`count(kube_service_info)`, func(t *resources.DashboardTrends, v []float64) { t.Services = v }},
+	{`count(ALERTS{alertstate="firing"}) or vector(0)`, func(t *resources.DashboardTrends, v []float64) { t.Alerts = v }},
+	{`100 - (avg(rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)`, func(t *resources.DashboardTrends, v []float64) { t.CPU = v }},
+	{`(1 - (avg(node_memory_MemAvailable_bytes) / avg(node_memory_MemTotal_bytes))) * 100`, func(t *resources.DashboardTrends, v []float64) { t.Memory = v }},
 }
 
 // DashboardTrends implements resources.TrendProvider. It range-queries
-// Prometheus for the four metric-card series concurrently and returns whatever
+// Prometheus for the six metric-card series concurrently and returns whatever
 // resolved; individual query failures yield an empty series for that metric
 // rather than failing the whole request.
 func (a *UtilizationAdapter) DashboardTrends(ctx context.Context) (resources.DashboardTrends, error) {
@@ -80,20 +85,7 @@ func (a *UtilizationAdapter) DashboardTrends(ctx context.Context) (resources.Das
 	wg.Wait()
 
 	for i, q := range trendQueries {
-		switch q.key {
-		case "nodes":
-			out.Nodes = series[i]
-		case "pods":
-			out.Pods = series[i]
-		case "services":
-			out.Services = series[i]
-		case "alerts":
-			out.Alerts = series[i]
-		case "cpu":
-			out.CPU = series[i]
-		case "memory":
-			out.Memory = series[i]
-		}
+		q.assign(&out, series[i])
 	}
 
 	return out, nil
@@ -102,6 +94,12 @@ func (a *UtilizationAdapter) DashboardTrends(ctx context.Context) (resources.Das
 // parseMatrixSeries extracts the sample values of the first series from a range
 // query result. Our trend queries are scalar aggregates, so there is exactly
 // one series; anything else (empty matrix, wrong type) yields nil.
+//
+// Non-finite samples (NaN/±Inf) are dropped: Prometheus emits them from
+// division-by-zero (e.g. the memory query during a scrape gap) and counter
+// resets, and encoding/json fails on NaN/±Inf — which, because writeJSON has
+// already sent the 200 header, would truncate the body and silently blank
+// every sparkline. Dropping the bad points keeps the response valid JSON.
 func parseMatrixSeries(val model.Value) []float64 {
 	matrix, ok := val.(model.Matrix)
 	if !ok || len(matrix) == 0 {
@@ -111,9 +109,16 @@ func parseMatrixSeries(val model.Value) []float64 {
 	if len(pairs) == 0 {
 		return nil
 	}
-	values := make([]float64, len(pairs))
-	for i, p := range pairs {
-		values[i] = float64(p.Value)
+	values := make([]float64, 0, len(pairs))
+	for _, p := range pairs {
+		f := float64(p.Value)
+		if math.IsNaN(f) || math.IsInf(f, 0) {
+			continue
+		}
+		values = append(values, f)
+	}
+	if len(values) == 0 {
+		return nil
 	}
 	return values
 }

--- a/backend/internal/monitoring/trends_test.go
+++ b/backend/internal/monitoring/trends_test.go
@@ -1,0 +1,103 @@
+package monitoring
+
+import (
+	"math"
+	"testing"
+
+	"github.com/prometheus/common/model"
+)
+
+func sample(v float64) model.SamplePair {
+	return model.SamplePair{Timestamp: 0, Value: model.SampleValue(v)}
+}
+
+func TestParseMatrixSeries_Nil(t *testing.T) {
+	if got := parseMatrixSeries(nil); got != nil {
+		t.Fatalf("nil value: want nil, got %v", got)
+	}
+}
+
+func TestParseMatrixSeries_WrongType(t *testing.T) {
+	// A range query that resolved to a Vector (instant) instead of a Matrix.
+	if got := parseMatrixSeries(model.Vector{}); got != nil {
+		t.Fatalf("vector value: want nil, got %v", got)
+	}
+}
+
+func TestParseMatrixSeries_EmptyMatrix(t *testing.T) {
+	if got := parseMatrixSeries(model.Matrix{}); got != nil {
+		t.Fatalf("empty matrix: want nil, got %v", got)
+	}
+}
+
+func TestParseMatrixSeries_EmptyValues(t *testing.T) {
+	m := model.Matrix{&model.SampleStream{Values: []model.SamplePair{}}}
+	if got := parseMatrixSeries(m); got != nil {
+		t.Fatalf("series with no samples: want nil, got %v", got)
+	}
+}
+
+func TestParseMatrixSeries_HappyPath(t *testing.T) {
+	m := model.Matrix{&model.SampleStream{Values: []model.SamplePair{
+		sample(3), sample(5), sample(4),
+	}}}
+	got := parseMatrixSeries(m)
+	want := []float64{3, 5, 4}
+	if len(got) != len(want) {
+		t.Fatalf("length: want %d, got %d (%v)", len(want), len(got), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("index %d: want %v, got %v", i, want[i], got[i])
+		}
+	}
+}
+
+func TestParseMatrixSeries_FirstSeriesOnly(t *testing.T) {
+	// Scalar-aggregate queries return exactly one series; if a future query
+	// returns multiple, we intentionally take only the first. Pin that so the
+	// behavior is a conscious choice, not a silent surprise.
+	m := model.Matrix{
+		&model.SampleStream{Values: []model.SamplePair{sample(1), sample(2)}},
+		&model.SampleStream{Values: []model.SamplePair{sample(9), sample(9)}},
+	}
+	got := parseMatrixSeries(m)
+	if len(got) != 2 || got[0] != 1 || got[1] != 2 {
+		t.Fatalf("want first series [1 2], got %v", got)
+	}
+}
+
+func TestParseMatrixSeries_DropsNonFinite(t *testing.T) {
+	// Prometheus can emit NaN/±Inf (div-by-zero, counter resets). These must be
+	// dropped — encoding/json fails on them after the 200 header is sent, which
+	// would blank every sparkline.
+	m := model.Matrix{&model.SampleStream{Values: []model.SamplePair{
+		sample(10),
+		sample(math.NaN()),
+		sample(20),
+		sample(math.Inf(1)),
+		sample(math.Inf(-1)),
+		sample(30),
+	}}}
+	got := parseMatrixSeries(m)
+	want := []float64{10, 20, 30}
+	if len(got) != len(want) {
+		t.Fatalf("length: want %d, got %d (%v)", len(want), len(got), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("index %d: want %v, got %v", i, want[i], got[i])
+		}
+	}
+}
+
+func TestParseMatrixSeries_AllNonFinite(t *testing.T) {
+	// A series of only non-finite samples collapses to nil — the frontend then
+	// renders no sparkline rather than a broken one.
+	m := model.Matrix{&model.SampleStream{Values: []model.SamplePair{
+		sample(math.NaN()), sample(math.Inf(1)),
+	}}}
+	if got := parseMatrixSeries(m); got != nil {
+		t.Fatalf("all-non-finite: want nil, got %v", got)
+	}
+}

--- a/backend/internal/server/routes.go
+++ b/backend/internal/server/routes.go
@@ -109,6 +109,7 @@ func (s *Server) registerRoutes() {
 			// Dashboard summary — aggregated cluster health data
 			if s.ResourceHandler != nil {
 				ar.Get("/cluster/dashboard-summary", s.ResourceHandler.HandleDashboardSummary)
+				ar.Get("/cluster/dashboard-trends", s.ResourceHandler.HandleDashboardTrends)
 			}
 
 			// Resource routes — only registered if k8s dependencies are available

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -169,10 +169,15 @@ func New(deps Deps) *Server {
 			// Fallback for tests that don't provide an AccessChecker
 			ac = resources.NewAccessChecker(deps.K8sClient, deps.Logger)
 		}
-		// Build optional UtilizationProvider if monitoring is available
+		// Build optional UtilizationProvider + TrendProvider if monitoring is
+		// available. The same adapter implements both — one wraps the Prometheus
+		// Discoverer for instant utilization queries and range trend queries.
 		var utilProvider resources.UtilizationProvider
+		var trendProvider resources.TrendProvider
 		if deps.MonitoringHandler != nil && deps.MonitoringHandler.Discoverer != nil {
-			utilProvider = &monitoring.UtilizationAdapter{Discoverer: deps.MonitoringHandler.Discoverer}
+			adapter := &monitoring.UtilizationAdapter{Discoverer: deps.MonitoringHandler.Discoverer}
+			utilProvider = adapter
+			trendProvider = adapter
 		}
 
 		// Build optional AlertCounter if alerting is available
@@ -191,6 +196,7 @@ func New(deps Deps) *Server {
 			TaskManager:     resources.NewTaskManager(),
 			ClusterID:       deps.Config.ClusterID,
 			Utilization:     utilProvider,
+			Trends:          trendProvider,
 			Alerts:          alertCounter,
 			OriginValidator: s.validateWSOrigin,
 		}

--- a/frontend/components/ui/Skeleton.tsx
+++ b/frontend/components/ui/Skeleton.tsx
@@ -1,3 +1,5 @@
+import type { JSX } from "preact";
+
 /**
  * Animated loading skeleton placeholder.
  * Use to show content shape while data is loading.
@@ -6,14 +8,18 @@
  * <Skeleton class="h-4 w-32" /> // single line
  * <Skeleton class="h-8 w-full" /> // full-width bar
  * <Skeleton class="h-24 w-full rounded-lg" /> // card placeholder
+ * <Skeleton class="rounded-lg" style={{ gridColumn: "span 6" }} /> // grid cell
  */
 export function Skeleton(
-  { class: className = "" }: { class?: string },
+  { class: className = "", style }: {
+    class?: string;
+    style?: JSX.CSSProperties;
+  },
 ) {
   return (
     <div
       class={`animate-pulse rounded ${className}`}
-      style={{ background: "var(--bg-elevated)" }}
+      style={{ background: "var(--bg-elevated)", ...style }}
     />
   );
 }

--- a/frontend/components/ui/SparklineChart.tsx
+++ b/frontend/components/ui/SparklineChart.tsx
@@ -23,7 +23,10 @@ export function SparklineChart(
     [],
   );
 
-  if (data.length < 2) return null;
+  // Drop non-finite samples (NaN/±Infinity) so they cannot produce broken
+  // `M x,NaN` path coordinates that render an invisible, silently-empty chart.
+  const clean = data.filter((v) => Number.isFinite(v));
+  if (clean.length < 2) return null;
 
   // When no explicit pixel width is given, render fluid: the SVG fills its
   // container width and the path coordinates are computed against VIEW_W,
@@ -31,12 +34,12 @@ export function SparklineChart(
   const fluid = width === undefined;
   const w = fluid ? VIEW_W : width;
 
-  const min = Math.min(...data);
-  const max = Math.max(...data);
+  const min = Math.min(...clean);
+  const max = Math.max(...clean);
   const range = max - min || 1;
 
-  const points = data.map((v, i) => {
-    const x = (i / (data.length - 1)) * w;
+  const points = clean.map((v, i) => {
+    const x = (i / (clean.length - 1)) * w;
     const y = height - ((v - min) / range) * (height - 2) - 1;
     return `${x},${y}`;
   });

--- a/frontend/components/ui/SparklineChart.tsx
+++ b/frontend/components/ui/SparklineChart.tsx
@@ -3,12 +3,18 @@ import { useMemo } from "preact/hooks";
 interface SparklineChartProps {
   data: number[];
   color: string;
+  /** Fixed pixel width. Omit to fill the parent container (default). */
   width?: number;
   height?: number;
 }
 
+// Logical coordinate width used for point math when the SVG is rendered
+// fluid (width="100%"). The viewBox maps this to whatever pixel width the
+// container provides; preserveAspectRatio="none" stretches it horizontally.
+const VIEW_W = 100;
+
 export function SparklineChart(
-  { data, color, width = 100, height = 28 }: SparklineChartProps,
+  { data, color, width, height = 28 }: SparklineChartProps,
 ) {
   // Use Math.random instead of crypto.randomUUID — the latter requires
   // a secure context (HTTPS) and fails on HTTP-only deployments (homelab).
@@ -19,12 +25,18 @@ export function SparklineChart(
 
   if (data.length < 2) return null;
 
+  // When no explicit pixel width is given, render fluid: the SVG fills its
+  // container width and the path coordinates are computed against VIEW_W,
+  // then non-uniformly scaled to fit. vector-effect keeps the stroke crisp.
+  const fluid = width === undefined;
+  const w = fluid ? VIEW_W : width;
+
   const min = Math.min(...data);
   const max = Math.max(...data);
   const range = max - min || 1;
 
   const points = data.map((v, i) => {
-    const x = (i / (data.length - 1)) * width;
+    const x = (i / (data.length - 1)) * w;
     const y = height - ((v - min) / range) * (height - 2) - 1;
     return `${x},${y}`;
   });
@@ -32,14 +44,15 @@ export function SparklineChart(
   const polyline = points.join(" ");
   const areaPath = `M0,${height} L${
     points.map((p) => `${p}`).join(" L")
-  } L${width},${height} Z`;
+  } L${w},${height} Z`;
 
   return (
     <svg
-      width={width}
+      width={fluid ? "100%" : width}
       height={height}
-      viewBox={`0 0 ${width} ${height}`}
-      class="inline-block"
+      viewBox={`0 0 ${w} ${height}`}
+      preserveAspectRatio={fluid ? "none" : undefined}
+      class={fluid ? "block w-full" : "inline-block"}
     >
       <defs>
         <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
@@ -55,6 +68,7 @@ export function SparklineChart(
         stroke-width="1.5"
         stroke-linecap="round"
         stroke-linejoin="round"
+        vector-effect={fluid ? "non-scaling-stroke" : undefined}
       />
     </svg>
   );

--- a/frontend/islands/DashboardV2.tsx
+++ b/frontend/islands/DashboardV2.tsx
@@ -44,11 +44,27 @@ interface DashboardSummary {
   } | null;
 }
 
+// DashboardTrends mirrors the backend payload from GET
+// /v1/cluster/dashboard-trends — short historical series (oldest→newest) that
+// back the metric-card sparklines. Any series may be empty when Prometheus or
+// kube-state-metrics is unavailable; the cards then render no sparkline.
+interface DashboardTrends {
+  nodes: number[] | null;
+  pods: number[] | null;
+  services: number[] | null;
+  alerts: number[] | null;
+  cpu: number[] | null;
+  memory: number[] | null;
+  window: string;
+  step: string;
+}
+
 const REFRESH_INTERVAL = 60_000;
 
 export default function DashboardV2() {
   const clusterInfo = useSignal<ClusterInfoData | null>(null);
   const summary = useSignal<DashboardSummary | null>(null);
+  const trends = useSignal<DashboardTrends | null>(null);
   const events = useSignal<K8sEvent[]>([]);
   const loading = useSignal(true);
 
@@ -62,6 +78,16 @@ export default function DashboardV2() {
     }
   }
 
+  async function fetchTrends(signal?: AbortSignal) {
+    const trendsRes = await api<DashboardTrends>(
+      "/v1/cluster/dashboard-trends",
+      { method: "GET", signal },
+    );
+    if (trendsRes.data) {
+      trends.value = trendsRes.data;
+    }
+  }
+
   useEffect(() => {
     if (!IS_BROWSER) return;
 
@@ -70,17 +96,19 @@ export default function DashboardV2() {
     async function load() {
       loading.value = true;
 
-      const [infoRes, _summaryResult, eventsRes] = await Promise.allSettled([
-        api<ClusterInfoData>("/v1/cluster/info", {
-          method: "GET",
-          signal: controller.signal,
-        }),
-        fetchSummary(controller.signal),
-        api<K8sEvent[]>("/v1/resources/events?limit=10", {
-          method: "GET",
-          signal: controller.signal,
-        }),
-      ]);
+      const [infoRes, _summaryResult, _trendsResult, eventsRes] = await Promise
+        .allSettled([
+          api<ClusterInfoData>("/v1/cluster/info", {
+            method: "GET",
+            signal: controller.signal,
+          }),
+          fetchSummary(controller.signal),
+          fetchTrends(controller.signal),
+          api<K8sEvent[]>("/v1/resources/events?limit=10", {
+            method: "GET",
+            signal: controller.signal,
+          }),
+        ]);
 
       if (controller.signal.aborted) return;
 
@@ -103,7 +131,7 @@ export default function DashboardV2() {
     const interval = setInterval(async () => {
       if (document.hidden) return;
       try {
-        await fetchSummary();
+        await Promise.allSettled([fetchSummary(), fetchTrends()]);
       } catch {
         // Keep last known data on error
       }
@@ -163,6 +191,7 @@ export default function DashboardV2() {
 
   const info = clusterInfo.value;
   const s = summary.value;
+  const t = trends.value;
   const nodeCount = s?.nodes.total ?? info?.nodeCount ?? 0;
 
   const greeting = (() => {
@@ -320,7 +349,7 @@ export default function DashboardV2() {
             status={s?.nodes.ready === s?.nodes.total ? "success" : "warning"}
             statusText={s ? `${s.nodes.ready}/${s.nodes.total} Ready` : "—"}
             href="/cluster/nodes"
-            sparklineData={[3, 3, 3, 3, 3, 3, 3, 3]}
+            sparklineData={t?.nodes ?? undefined}
             sparklineColor="var(--success)"
             icon={
               <>
@@ -335,7 +364,7 @@ export default function DashboardV2() {
             status={(s?.pods.pending ?? 0) > 0 ? "warning" : "success"}
             statusText={s?.pods.total ? `${s.pods.running} Running` : "—"}
             href="/workloads/pods"
-            sparklineData={[30, 32, 31, 33, 35, 34, 36, 38, 40, 42, 44, 45]}
+            sparklineData={t?.pods ?? undefined}
             sparklineColor="var(--success)"
             icon={
               <>
@@ -350,7 +379,7 @@ export default function DashboardV2() {
             status="success"
             statusText="Active"
             href="/networking/services"
-            sparklineData={[40, 41, 41, 42, 42, 43, 43, 44]}
+            sparklineData={t?.services ?? undefined}
             sparklineColor="var(--success)"
             icon={
               <>
@@ -371,7 +400,7 @@ export default function DashboardV2() {
               ? `${s?.alerts.critical ?? 0} Critical`
               : "\u2713 All Clear"}
             href="/alerting"
-            sparklineData={[0, 0, 1, 0, 0, 0, 0, 0]}
+            sparklineData={t?.alerts ?? undefined}
             sparklineColor="var(--warning)"
             icon={
               <>
@@ -393,6 +422,7 @@ export default function DashboardV2() {
             limits={s?.cpu?.limits ?? "—"}
             color="var(--accent)"
             secondaryColor="var(--success)"
+            trendData={t?.cpu ?? undefined}
           />
         </div>
 
@@ -407,6 +437,7 @@ export default function DashboardV2() {
             limits={s?.memory?.limits ?? "—"}
             color="var(--accent-secondary)"
             secondaryColor="var(--accent)"
+            trendData={t?.memory ?? undefined}
           />
         </div>
 

--- a/frontend/islands/MetricCard.tsx
+++ b/frontend/islands/MetricCard.tsx
@@ -177,13 +177,12 @@ function MetricCardInner(
         {label}
       </div>
 
-      {/* Sparkline — pushed to bottom of card */}
+      {/* Sparkline — pushed to bottom of card, fills full card width */}
       {sparklineData && sparklineData.length >= 2 && (
         <div style={{ marginTop: "auto", paddingTop: "12px" }}>
           <SparklineChart
             data={sparklineData}
             color={sparklineColor ?? "var(--accent)"}
-            width={120}
             height={32}
           />
         </div>

--- a/frontend/islands/UtilizationGauge.tsx
+++ b/frontend/islands/UtilizationGauge.tsx
@@ -55,8 +55,11 @@ export default function UtilizationGauge({
 }: UtilizationGaugeProps) {
   const trendStroke = trendColor ?? color;
   const gradientId = `trend-${Math.random().toString(36).slice(2, 9)}`;
-  const trend = trendData && trendData.length >= 2
-    ? buildTrendPaths(trendData)
+  // Drop non-finite samples (NaN/±Infinity) before building the path — they
+  // would yield broken `M x,NaN` coordinates and an invisible, silent chart.
+  const trendClean = trendData?.filter((v) => Number.isFinite(v));
+  const trend = trendClean && trendClean.length >= 2
+    ? buildTrendPaths(trendClean)
     : null;
   const statRows: { label: string; value: string }[] = [
     { label: "Used", value: `${used} / ${total}` },

--- a/frontend/islands/UtilizationGauge.tsx
+++ b/frontend/islands/UtilizationGauge.tsx
@@ -10,6 +10,35 @@ interface UtilizationGaugeProps {
   color: string;
   secondaryColor?: string;
   trendColor?: string;
+  /**
+   * Historical utilization percentages (oldest→newest) for the trend line.
+   * Sourced from /v1/cluster/dashboard-trends. When absent or shorter than two
+   * points (Prometheus unavailable), no trend line renders.
+   */
+  trendData?: number[];
+}
+
+// Trend SVG coordinate space — fixed viewBox stretched to the card width via
+// preserveAspectRatio="none". 3px vertical padding keeps the line off the edges.
+const TREND_W = 300;
+const TREND_H = 48;
+
+// buildTrendPaths maps a utilization series to a line path and a filled-area
+// path. The series is min/max-normalized so recent movement is visible even
+// when utilization hovers in a narrow band (the gauge ring shows the absolute
+// level; this line shows the shape of the last hour).
+function buildTrendPaths(data: number[]): { line: string; area: string } {
+  const min = Math.min(...data);
+  const max = Math.max(...data);
+  const range = max - min || 1;
+  const pts = data.map((v, i) => {
+    const x = (i / (data.length - 1)) * TREND_W;
+    const y = TREND_H - ((v - min) / range) * (TREND_H - 6) - 3;
+    return `${x.toFixed(1)},${y.toFixed(1)}`;
+  });
+  const line = `M${pts.join(" L")}`;
+  const area = `${line} L${TREND_W},${TREND_H} L0,${TREND_H} Z`;
+  return { line, area };
 }
 
 export default function UtilizationGauge({
@@ -22,11 +51,13 @@ export default function UtilizationGauge({
   color,
   secondaryColor,
   trendColor,
+  trendData,
 }: UtilizationGaugeProps) {
   const trendStroke = trendColor ?? color;
   const gradientId = `trend-${Math.random().toString(36).slice(2, 9)}`;
-  const trendPath =
-    "M0,30 C20,28 40,32 60,26 C80,20 100,24 120,18 C140,22 160,16 180,20 C200,14 220,18 240,12 C260,16 280,10 300,14";
+  const trend = trendData && trendData.length >= 2
+    ? buildTrendPaths(trendData)
+    : null;
   const statRows: { label: string; value: string }[] = [
     { label: "Used", value: `${used} / ${total}` },
   ];
@@ -111,36 +142,41 @@ export default function UtilizationGauge({
         </div>
       </div>
 
-      {/* Trend line chart */}
-      <div style={{ marginTop: "16px", height: "48px" }}>
-        <svg
-          viewBox="0 0 300 48"
-          preserveAspectRatio="none"
-          width="100%"
-          height="48"
-        >
-          <defs>
-            <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
-              <stop offset="0%" stop-color={trendStroke} stop-opacity="0.15" />
-              <stop
-                offset="100%"
-                stop-color={trendStroke}
-                stop-opacity="0"
-              />
-            </linearGradient>
-          </defs>
-          <path
-            d={`${trendPath} L300,48 L0,48 Z`}
-            fill={`url(#${gradientId})`}
-          />
-          <path
-            d={trendPath}
-            fill="none"
-            stroke={trendStroke}
-            stroke-width="1.5"
-          />
-        </svg>
-      </div>
+      {/* Trend line chart — real last-hour utilization, or nothing if
+          Prometheus history is unavailable (no fake decorative line). */}
+      {trend && (
+        <div style={{ marginTop: "16px", height: "48px" }}>
+          <svg
+            viewBox={`0 0 ${TREND_W} ${TREND_H}`}
+            preserveAspectRatio="none"
+            width="100%"
+            height={TREND_H}
+          >
+            <defs>
+              <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+                <stop
+                  offset="0%"
+                  stop-color={trendStroke}
+                  stop-opacity="0.15"
+                />
+                <stop
+                  offset="100%"
+                  stop-color={trendStroke}
+                  stop-opacity="0"
+                />
+              </linearGradient>
+            </defs>
+            <path d={trend.area} fill={`url(#${gradientId})`} />
+            <path
+              d={trend.line}
+              fill="none"
+              stroke={trendStroke}
+              stroke-width="1.5"
+              vector-effect="non-scaling-stroke"
+            />
+          </svg>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/islands/UtilizationGauge.tsx
+++ b/frontend/islands/UtilizationGauge.tsx
@@ -142,8 +142,10 @@ export default function UtilizationGauge({
         </div>
       </div>
 
-      {/* Trend line chart — real last-hour utilization, or nothing if
-          Prometheus history is unavailable (no fake decorative line). */}
+      {
+        /* Trend line chart — real last-hour utilization, or nothing if
+          Prometheus history is unavailable (no fake decorative line). */
+      }
       {trend && (
         <div style={{ marginTop: "16px", height: "48px" }}>
           <svg


### PR DESCRIPTION
## Problem

The Overview page sparklines were fake. The Nodes/Pods/Services/Alerts metric cards rendered **hardcoded literal arrays** that never changed, and the CPU/Memory utilization gauges shared a **single static bezier path** (the same squiggle on both, unconnected to the cluster). None of them reflected real data or updated. The metric-card sparklines were also pinned to `120px`, so they stopped partway across the card.

The gauge **rings** (CPU/Mem %) were already real — only the trend lines were decorative.

## What changed

**New endpoint — `GET /api/v1/cluster/dashboard-trends`**
- Range-queries Prometheus (1h window, 2m step → ~31 points) for node/pod/service/alert counts plus cluster-wide CPU/memory utilization.
- Kept **off** the hot `dashboard-summary` path so its tight 1s Prometheus budget is untouched; the four/six queries fan out concurrently under a 5s bound.
- Counts come from kube-state-metrics; CPU/memory reuse the **exact PromQL the instant gauges already use** (node-exporter), so utilization trends populate even without KSM.
- Alerts use `or vector(0)` for a real flat-zero "all clear" baseline.
- **Graceful degradation:** when Prometheus/exporters are unavailable, series are empty and the frontend renders **no line** — honest absence over a misleading flat fake.

**Frontend**
- `DashboardV2` fetches trends alongside the summary on load and every 60s.
- `SparklineChart` now fills its container (`width="100%"` + `preserveAspectRatio="none"` + `vector-effect="non-scaling-stroke"`) instead of fixed `120px`.
- `UtilizationGauge` builds its trend path from real data (min/max-normalized so last-hour movement is visible while the ring shows absolute %); dropped the hardcoded bezier.
- `Skeleton` now declares the `style` prop it was already being passed (latent type error surfaced during verification).

## Verification

- **Backend:** `go build ./...`, `go vet ./...`, `go test ./...` — all clean.
- **Frontend:** `deno lint` clean (500 files); `deno check` type-clean on all touched files.
- ⚠️ Local `deno task build` (vite) fails on a **pre-existing** `monaco-editor@0.52.2` resolution issue in the local `.deno` cache, unrelated to this diff (no touched file imports Monaco). Relying on CI's clean `deno install` for the authoritative build.

## Notes
- Metric-card count trends depend on **kube-state-metrics**; CPU/Memory depend on **node-exporter**. Worth eyeballing on the homelab that the lines populate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)