### PR TITLE
fix(health): only critical-bucket certs affect cluster health

### DIFF
--- a/backend/internal/k8s/resources/dashboard.go
+++ b/backend/internal/k8s/resources/dashboard.go
@@ -472,10 +472,12 @@ func (h *Handler) gatherHealthInputs(
 		inputs.CertsAvailable = false
 		inputs.CertsUnavailableReason = "cert-manager not configured"
 	} else {
-		warn, crit, certErr := h.CertExpiry.ExpiringCounts(ctx, user)
+		// Only the critical bucket feeds health; the warning count is intentionally
+		// ignored here so certs that are still valid (8–30 days out) don't degrade
+		// the cluster. The observatory page surfaces the warning bucket separately.
+		_, crit, certErr := h.CertExpiry.ExpiringCounts(ctx, user)
 		if certErr == nil {
 			inputs.CertsAvailable = true
-			inputs.CertWarning = warn
 			inputs.CertCritical = crit
 		} else {
 			inputs.CertsAvailable = false

--- a/backend/internal/k8s/resources/dashboard_test.go
+++ b/backend/internal/k8s/resources/dashboard_test.go
@@ -621,6 +621,65 @@ func TestDashboardHealth_CertExpirySkipReasons(t *testing.T) {
 	}
 }
 
+// TestDashboardHealth_CertWarningDoesNotDegrade verifies that certs in the
+// warning expiry bucket (still valid, 8–30 days out) do not degrade the cluster
+// or surface a cert reason — only the critical bucket (≤7 days) affects health.
+func TestDashboardHealth_CertWarningDoesNotDegrade(t *testing.T) {
+	objs := []runtime.Object{
+		readyNode("node-1"),
+		runningPod("default", "pod-1"),
+		deployment1x1("default", "dep-1"),
+	}
+	h, _ := testHandler(t, objs...)
+	// 5 certs in the warning bucket, none critical.
+	h.CertExpiry = &fakeCertExpiry{warn: 5, crit: 0}
+
+	_, summary := callDashboard(t, h)
+	if summary.Health == nil {
+		t.Fatal("health must not be nil")
+	}
+	if summary.Health.Status != HealthStatusHealthy {
+		t.Errorf("warning-bucket certs must not degrade health; got %s, reasons: %v",
+			summary.Health.Status, summary.Health.Reasons)
+	}
+	for _, r := range summary.Health.Reasons {
+		if strings.Contains(r, "certificate") {
+			t.Errorf("warning-bucket certs must not produce a reason, got %q", r)
+		}
+	}
+}
+
+// TestDashboardHealth_CertCriticalDegrades verifies that certs in the critical
+// expiry bucket (≤7 days) degrade the cluster with a cert reason.
+func TestDashboardHealth_CertCriticalDegrades(t *testing.T) {
+	objs := []runtime.Object{
+		readyNode("node-1"),
+		runningPod("default", "pod-1"),
+		deployment1x1("default", "dep-1"),
+	}
+	h, _ := testHandler(t, objs...)
+	// Warning certs present but irrelevant; one critical cert must degrade.
+	h.CertExpiry = &fakeCertExpiry{warn: 3, crit: 1}
+
+	_, summary := callDashboard(t, h)
+	if summary.Health == nil {
+		t.Fatal("health must not be nil")
+	}
+	if summary.Health.Status != HealthStatusDegraded {
+		t.Errorf("critical-bucket cert must degrade health; got %s", summary.Health.Status)
+	}
+	found := false
+	for _, r := range summary.Health.Reasons {
+		if strings.Contains(r, "certificate") && strings.Contains(r, "critical") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a critical-cert reason, got %v", summary.Health.Reasons)
+	}
+}
+
 // TestDashboardHealth_InitContainerCrashloop verifies that a crash in an init
 // container is also detected.
 func TestDashboardHealth_InitContainerCrashloop(t *testing.T) {

--- a/backend/internal/k8s/resources/health.go
+++ b/backend/internal/k8s/resources/health.go
@@ -119,8 +119,12 @@ type HealthInputs struct {
 	CertsAvailable bool
 	// CertsUnavailableReason carries the skipped/unknown reason when !CertsAvailable.
 	CertsUnavailableReason string
-	CertWarning            int // certs in the warning expiry bucket
-	CertCritical           int // certs in the critical expiry bucket
+	// CertCritical is the count of certs in the critical expiry bucket
+	// (default ≤7 days, configurable via kubecenter.io/cert-critical-threshold-days).
+	// Only the critical bucket affects health — warning-bucket certs (default ≤30
+	// days) are still valid and intentionally do not degrade the cluster or deduct
+	// score; the cert observatory surfaces them for operators who want earlier notice.
+	CertCritical int
 
 	// --- Storage signal (flat deductions only; no signal score sub-weight) ---
 	StorageAvailable bool
@@ -377,11 +381,8 @@ func computeClusterHealth(in HealthInputs) ClusterHealth {
 		isDegraded = true
 		degradedReasons = append(degradedReasons, fmt.Sprintf("%d PVC(s) pending", in.PendingPVCs))
 	}
-	// cert expiry buckets
-	if in.CertsAvailable && in.CertWarning > 0 {
-		isDegraded = true
-		degradedReasons = append(degradedReasons, fmt.Sprintf("%d certificate(s) expiring soon (warning)", in.CertWarning))
-	}
+	// cert expiry — only the critical bucket (default ≤7 days) affects health;
+	// warning-bucket certs are still valid and do not degrade the cluster.
 	if in.CertsAvailable && in.CertCritical > 0 {
 		isDegraded = true
 		degradedReasons = append(degradedReasons, fmt.Sprintf("%d certificate(s) expiring soon (critical)", in.CertCritical))
@@ -463,14 +464,10 @@ func computeClusterHealth(in HealthInputs) ClusterHealth {
 		}
 	}
 
-	// Flat deductions (applied after weighted sum).
-	if in.CertsAvailable {
-		if in.CertWarning > 0 {
-			compositeScore -= 3
-		}
-		if in.CertCritical > 0 {
-			compositeScore -= 10
-		}
+	// Flat deductions (applied after weighted sum). Only critical-bucket certs
+	// deduct; warning-bucket certs are non-penalizing.
+	if in.CertsAvailable && in.CertCritical > 0 {
+		compositeScore -= 10
 	}
 	if in.StorageAvailable && in.PendingPVCs > 0 {
 		compositeScore -= 3

--- a/backend/internal/k8s/resources/health_test.go
+++ b/backend/internal/k8s/resources/health_test.go
@@ -29,7 +29,6 @@ func healthyInputs() HealthInputs {
 		AlertsActive:           0,
 		AlertsCritical:         0,
 		CertsAvailable:         true,
-		CertWarning:            0,
 		CertCritical:           0,
 		StorageAvailable:       true,
 		PendingPVCs:            0,
@@ -293,19 +292,6 @@ func TestComputeClusterHealth_Degraded_PendingPVC(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("want a pending PVC reason, got %v", h.Reasons)
-	}
-}
-
-// TestComputeClusterHealth_Degraded_CertWarning.
-func TestComputeClusterHealth_Degraded_CertWarning(t *testing.T) {
-	in := healthyInputs()
-	in.CertWarning = 1
-
-	h := computeClusterHealth(in)
-	assertNoNaN(t, h)
-
-	if h.Status != HealthStatusDegraded {
-		t.Errorf("want degraded, got %q", h.Status)
 	}
 }
 
@@ -613,7 +599,6 @@ func TestComputeClusterHealth_NaNGuard_AllZeros(t *testing.T) {
 		AlertsActive:           0,
 		AlertsCritical:         0,
 		CertsAvailable:         true,
-		CertWarning:            0,
 		CertCritical:           0,
 		StorageAvailable:       true,
 		PendingPVCs:            0,
@@ -717,7 +702,6 @@ func TestComputeClusterHealth_ReasonFormat_NoResourceNames(t *testing.T) {
 	in.EligiblePods = 20
 	in.PendingPVCs = 1
 	in.PDBViolations = 1
-	in.CertWarning = 1
 	in.CertCritical = 1
 	in.AlertsCritical = 1
 	in.AlertsActive = 3
@@ -740,7 +724,6 @@ func TestComputeClusterHealth_ScoreClamping_CannotGoBelowZero(t *testing.T) {
 	in.TotalNodes = 10
 	in.ReadyNodes = 2 // ~20% → node sub-score ≈ 20; also critical
 	in.PressureNodes = 10
-	in.CertWarning = 1   // −3
 	in.CertCritical = 1  // −10
 	in.PendingPVCs = 100 // −3
 	in.ControlPlane.SchedulerState = ComponentDown         // −10
@@ -902,7 +885,6 @@ func TestComputeClusterHealth_FullNaNSweep(t *testing.T) {
 		// many deductions stacked
 		func() HealthInputs {
 			in := healthyInputs()
-			in.CertWarning = 100
 			in.CertCritical = 100
 			in.PendingPVCs = 100
 			in.ControlPlane.SchedulerState = ComponentDown

--- a/plans/cluster-health-score.md
+++ b/plans/cluster-health-score.md
@@ -87,7 +87,7 @@ Evaluated top-down; first matching tier wins. "With data" means the signal resol
 |---|---|
 | `unknown` | nodes signal unavailable (RBAC-denied, cache unsynced, or 0 nodes visible with list permission) — nodes are the required backbone |
 | `critical` | node ready ratio < 2/3 with data; workload availability < 50% with data (progressing workloads excluded) |
-| `degraded` | any NotReady node; any node pressure condition (Memory/Disk/PID/NetworkUnavailable); workload availability < 95% (progressing workloads excluded); any crashloop/image-pull pod; PDB with `currentHealthy < desiredHealthy` whose workload is not progressing; pending PVC (excluding WaitForFirstConsumer awaiting a consumer); cert-manager warning or critical expiry bucket non-empty; any control-plane component scraped and down; any critical alert active |
+| `degraded` | any NotReady node; any node pressure condition (Memory/Disk/PID/NetworkUnavailable); workload availability < 95% (progressing workloads excluded); any crashloop/image-pull pod; PDB with `currentHealthy < desiredHealthy` whose workload is not progressing; pending PVC (excluding WaitForFirstConsumer awaiting a consumer); cert-manager critical expiry bucket non-empty (≤7d default; warning-bucket certs are still valid and do not degrade health); any control-plane component scraped and down; any critical alert active |
 | `healthy` | none of the above |
 
 The `degraded` tier is deliberately strict — a single crashloop or NotReady node shows yellow even on large clusters where something is almost always slightly broken. Yellow means "something needs attention"; the score number conveys magnitude.
@@ -103,7 +103,7 @@ Four weighted sub-scores, each 0–100, weights renormalized over signals that r
 - **Pods (0.20):** `100 − min(100, crashFraction × amplification)` where crashFraction = crashloop+imagepull pods over pods with `phase ∈ {Running, Pending}` and nil `deletionTimestamp` (excludes Succeeded/Failed/terminating — completed Jobs must not dilute, evicted leftovers must not depress).
 - **Alerts (0.10):** `100 − 10·critical − 3·(active − critical)`, clamped, heartbeat alerts (`Watchdog`, `DeadMansSwitch`) excluded. Counts are inherently absolute; the low weight bounds their influence.
 
-Flat deductions after the weighted sum, then clamp to [0, 100]: cert warning bucket −3, cert critical bucket −10, pending PVCs −3, and −10 per control-plane component scraped-and-down (etcd, scheduler, controller-manager each). Guard every division (0/0 → signal skipped, never NaN); `score` is null when status is `unknown`.
+Flat deductions after the weighted sum, then clamp to [0, 100]: cert critical bucket −10 (warning bucket is non-penalizing — certs 8–30 days out are still valid), pending PVCs −3, and −10 per control-plane component scraped-and-down (etcd, scheduler, controller-manager each). Guard every division (0/0 → signal skipped, never NaN); `score` is null when status is `unknown`.
 
 ### Wire shape (directional)
 


### PR DESCRIPTION
## Summary

Adjusts cluster-health cert weighting so that certificates expiring in the **warning** window (default 8–30 days) no longer degrade the cluster or deduct from the health score. Only the **critical** bucket — default ≤7 days, configurable per-cert via `kubecenter.io/cert-critical-threshold-days` — affects health.

### Why

A cert with 8–30 days of validity left is still valid; dinging the Overview ring that early creates standing yellow that operators learn to ignore. Health should react when a cert is genuinely close to expiry (7 days), which is exactly the existing critical-threshold default. Earlier notice is still available on the cert observatory page.

### Changes

- `health.go`: dropped the warning bucket from both the veto table (degraded trigger) and the flat score deduction; removed `CertWarning` from `HealthInputs`. Only `CertCritical` remains (−10, degraded).
- `dashboard.go`: stops feeding the adapter's warning count into health (the `ExpiringCounts` adapter is unchanged — it still returns both buckets for general use).
- Tests: removed the warning→degraded pure-function test; added dashboard regressions `TestDashboardHealth_CertWarningDoesNotDegrade` (warn=5/crit=0 → healthy, no cert reason) and `TestDashboardHealth_CertCriticalDegrades` (crit=1 → degraded with a critical reason).
- Plan doc: veto table + score section updated to match.

## Testing

`go vet ./... && go test ./...` — all backend packages pass.

## Post-Deploy Monitoring & Validation

- **Healthy signal:** a cluster whose only cert issue is warning-window expiry now renders a green ring; the cert observatory still lists those certs.
- **Failure signal:** ring still degrades when a cert crosses the 7-day critical threshold (or its per-cert override).
- **Rollback:** revert the commit — pure scoring-logic change, additive-safe, no migration.
- **Smoke test (homelab):** confirm the ring is green with current certs (which are in the warning window), and stays green until something reaches 7 days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)