### PR TITLE
fix(frontend): bump vite to 7.3.5 to clear Trivy HIGH CVE-2026-53571

### DIFF
--- a/frontend/deno.json
+++ b/frontend/deno.json
@@ -20,6 +20,7 @@
     "fresh": "jsr:@fresh/core@^2.2.0",
     "fresh/runtime": "jsr:@fresh/core@^2.2.0/runtime",
     "@fresh/plugin-vite": "jsr:@fresh/plugin-vite@^1.0.0",
+    "vite": "npm:vite@^7.3.5",
     "preact": "npm:preact@^10.28.3",
     "preact/hooks": "npm:preact@^10.28.3/hooks",
     "@preact/signals": "npm:@preact/signals@^2.7.1",

--- a/frontend/deno.lock
+++ b/frontend/deno.lock
@@ -44,9 +44,9 @@
     "npm:@opentelemetry/api@^1.9.0": "1.9.1",
     "npm:@preact/signals@^2.5.1": "2.9.0_preact@10.29.1",
     "npm:@preact/signals@^2.7.1": "2.9.0_preact@10.29.1",
-    "npm:@prefresh/vite@^2.4.8": "2.4.12_preact@10.29.1_vite@7.3.2__yaml@2.8.3_yaml@2.8.3",
+    "npm:@prefresh/vite@^2.4.8": "2.4.12_preact@10.29.1_vite@7.3.5__yaml@2.8.3_yaml@2.8.3",
     "npm:@remix-run/node-fetch-server@0.12": "0.12.0",
-    "npm:@tailwindcss/vite@^4.1.10": "4.2.4_vite@7.3.2__yaml@2.8.3_yaml@2.8.3",
+    "npm:@tailwindcss/vite@^4.1.10": "4.2.4_vite@7.3.5__yaml@2.8.3_yaml@2.8.3",
     "npm:@types/babel__core@^7.20.5": "7.20.5",
     "npm:@xterm/addon-fit@0.10": "0.10.0_@xterm+xterm@5.5.0",
     "npm:@xterm/addon-web-links@0.11": "0.11.0_@xterm+xterm@5.5.0",
@@ -65,7 +65,8 @@
     "npm:preact@^10.29.1": "10.29.1",
     "npm:rollup@^4.55.1": "4.60.2",
     "npm:tailwindcss@^4.1.10": "4.2.4",
-    "npm:vite@^7.1.4": "7.3.2_yaml@2.8.3",
+    "npm:vite@^7.1.4": "7.3.5_yaml@2.8.3",
+    "npm:vite@^7.3.5": "7.3.5_yaml@2.8.3",
     "npm:yaml@^2.8.3": "2.8.3"
   },
   "jsr": {
@@ -130,7 +131,7 @@
         "npm:@remix-run/node-fetch-server",
         "npm:@types/babel__core",
         "npm:rollup",
-        "npm:vite"
+        "npm:vite@^7.1.4"
       ]
     },
     "@std/assert@1.0.19": {
@@ -923,7 +924,7 @@
     "@prefresh/utils@1.2.1": {
       "integrity": "sha512-vq/sIuN5nYfYzvyayXI4C2QkprfNaHUQ9ZX+3xLD8nL3rWyzpxOm1+K7RtMbhd+66QcaISViK7amjnheQ/4WZw=="
     },
-    "@prefresh/vite@2.4.12_preact@10.29.1_vite@7.3.2__yaml@2.8.3_yaml@2.8.3": {
+    "@prefresh/vite@2.4.12_preact@10.29.1_vite@7.3.5__yaml@2.8.3_yaml@2.8.3": {
       "integrity": "sha512-FY1fzXpUjiuosznMV0YM7XAOPZjB5FIdWS0W24+XnlxYkt9hNAwwsiKYn+cuTEoMtD/ZVazS5QVssBr9YhpCQA==",
       "dependencies": [
         "@babel/core",
@@ -1158,7 +1159,7 @@
         "@tailwindcss/oxide-win32-x64-msvc"
       ]
     },
-    "@tailwindcss/vite@4.2.4_vite@7.3.2__yaml@2.8.3_yaml@2.8.3": {
+    "@tailwindcss/vite@4.2.4_vite@7.3.5__yaml@2.8.3_yaml@2.8.3": {
       "integrity": "sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw==",
       "dependencies": [
         "@tailwindcss/node",
@@ -1613,8 +1614,8 @@
       ],
       "bin": true
     },
-    "vite@7.3.2_yaml@2.8.3": {
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+    "vite@7.3.5_yaml@2.8.3": {
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dependencies": [
         "esbuild@0.27.7",
         "fdir",
@@ -1669,6 +1670,7 @@
       "npm:postcss@^8.5.7",
       "npm:preact@^10.28.3",
       "npm:tailwindcss@^4.1.10",
+      "npm:vite@^7.3.5",
       "npm:yaml@^2.8.3"
     ],
     "packageJson": {


### PR DESCRIPTION
## Problem

The **CI Release** workflow on `main` ([run 27981913610](https://github.com/maulepilot117/k8sCenter/actions/runs/27981913610)) fails at the **Scan frontend image with Trivy** step. The frontend image bundles `vite@7.3.2`, which carries:

- **HIGH** `CVE-2026-53571` (fixed in 7.3.5)
- MEDIUM `CVE-2026-53632` (fixed in 7.3.5)

Trivy is configured with `severity: CRITICAL,HIGH` + `ignore-unfixed: true`, so the fixable HIGH trips the gate and the job exits 1 (blocking the backend image build + release).

This is the **only** HIGH/CRITICAL fixable Trivy finding in the image.

## Fix

`vite` was previously transitive (pulled by `@fresh/plugin-vite` under `^7.1.4`, locked to 7.3.2). This PR adds an explicit `vite` import pinned `^7.3.5` to raise the floor above the vulnerable version, and regenerates `deno.lock` (all 5 refs now resolve to 7.3.5). vite is already used directly by the `dev`/`build` tasks and the `vite/client` types, so a direct dependency entry is appropriate.

## Supply-chain cooldown

vite 7.3.5 was published 2026-06-01 — 21 days ago, well outside the 7-day cooldown.

## Verification

- `deno task check` (fmt + lint + check) passes repo-wide.
- Confirmed no remaining `vite@7.3.2` refs in the lockfile; 7.3.5 also clears the MEDIUM CVE.
- Note: a local `deno task build` failure exists (`monaco-editor` remote module → "Node built-in modules cannot be imported in the browser") but it is **pre-existing and environment-specific** — it reproduces identically on the original lockfile, and CI's Docker frontend build ("Build amd64 image for scanning") passes. Out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)