### PR TITLE
fix(frontend): wizard SSR 500 — stop passing onClose function prop to islands

### DIFF
--- a/frontend/routes/backup/backups/new.tsx
+++ b/frontend/routes/backup/backups/new.tsx
@@ -2,11 +2,5 @@ import { define } from "@/utils.ts";
 import VeleroBackupWizard from "@/islands/VeleroBackupWizard.tsx";
 
 export default define.page(function NewBackupPage() {
-  return (
-    <VeleroBackupWizard
-      onClose={() => {
-        globalThis.location.href = "/backup/backups";
-      }}
-    />
-  );
+  return <VeleroBackupWizard />;
 });

--- a/frontend/routes/backup/restores/new.tsx
+++ b/frontend/routes/backup/restores/new.tsx
@@ -2,11 +2,5 @@ import { define } from "@/utils.ts";
 import VeleroRestoreWizard from "@/islands/VeleroRestoreWizard.tsx";
 
 export default define.page(function NewRestorePage() {
-  return (
-    <VeleroRestoreWizard
-      onClose={() => {
-        globalThis.location.href = "/backup/restores";
-      }}
-    />
-  );
+  return <VeleroRestoreWizard />;
 });

--- a/frontend/routes/backup/schedules/new.tsx
+++ b/frontend/routes/backup/schedules/new.tsx
@@ -2,11 +2,5 @@ import { define } from "@/utils.ts";
 import VeleroScheduleWizard from "@/islands/VeleroScheduleWizard.tsx";
 
 export default define.page(function NewSchedulePage() {
-  return (
-    <VeleroScheduleWizard
-      onClose={() => {
-        globalThis.location.href = "/backup/schedules";
-      }}
-    />
-  );
+  return <VeleroScheduleWizard />;
 });

--- a/frontend/routes/cluster/namespaces/new.tsx
+++ b/frontend/routes/cluster/namespaces/new.tsx
@@ -2,11 +2,5 @@ import { define } from "@/utils.ts";
 import NamespaceCreator from "@/islands/NamespaceCreator.tsx";
 
 export default define.page(function NewNamespacePage() {
-  return (
-    <NamespaceCreator
-      onClose={() => {
-        globalThis.location.href = "/cluster/namespaces";
-      }}
-    />
-  );
+  return <NamespaceCreator />;
 });

--- a/frontend/routes/config/configmaps/new.tsx
+++ b/frontend/routes/config/configmaps/new.tsx
@@ -2,11 +2,5 @@ import { define } from "@/utils.ts";
 import ConfigMapWizard from "@/islands/ConfigMapWizard.tsx";
 
 export default define.page(function NewConfigMapPage() {
-  return (
-    <ConfigMapWizard
-      onClose={() => {
-        globalThis.location.href = "/config/configmaps";
-      }}
-    />
-  );
+  return <ConfigMapWizard />;
 });

--- a/frontend/routes/config/namespace-limits/new.tsx
+++ b/frontend/routes/config/namespace-limits/new.tsx
@@ -2,11 +2,5 @@ import { define } from "@/utils.ts";
 import NamespaceLimitsWizard from "@/islands/NamespaceLimitsWizard.tsx";
 
 export default define.page(function NewNamespaceLimitsPage() {
-  return (
-    <NamespaceLimitsWizard
-      onClose={() => {
-        globalThis.location.href = "/config/namespace-limits";
-      }}
-    />
-  );
+  return <NamespaceLimitsWizard />;
 });

--- a/frontend/routes/config/secrets/new.tsx
+++ b/frontend/routes/config/secrets/new.tsx
@@ -2,11 +2,5 @@ import { define } from "@/utils.ts";
 import SecretWizard from "@/islands/SecretWizard.tsx";
 
 export default define.page(function NewSecretPage() {
-  return (
-    <SecretWizard
-      onClose={() => {
-        globalThis.location.href = "/config/secrets";
-      }}
-    />
-  );
+  return <SecretWizard />;
 });

--- a/frontend/routes/extensions/[group]/[resource]/new.tsx
+++ b/frontend/routes/extensions/[group]/[resource]/new.tsx
@@ -8,9 +8,6 @@ export default define.page(function NewCRDResourcePage(ctx) {
       group={group}
       resource={resource}
       mode="create"
-      onClose={() => {
-        globalThis.location.href = `/extensions/${group}/${resource}`;
-      }}
     />
   );
 });

--- a/frontend/routes/external-secrets/cluster-stores/new.tsx
+++ b/frontend/routes/external-secrets/cluster-stores/new.tsx
@@ -2,12 +2,5 @@ import { define } from "@/utils.ts";
 import SecretStoreWizard from "@/islands/SecretStoreWizard.tsx";
 
 export default define.page(function ClusterSecretStoreNewPage() {
-  return (
-    <SecretStoreWizard
-      scope="cluster"
-      onClose={() => {
-        globalThis.location.href = "/external-secrets/cluster-stores";
-      }}
-    />
-  );
+  return <SecretStoreWizard scope="cluster" />;
 });

--- a/frontend/routes/external-secrets/external-secrets/new.tsx
+++ b/frontend/routes/external-secrets/external-secrets/new.tsx
@@ -2,11 +2,5 @@ import { define } from "@/utils.ts";
 import ExternalSecretWizard from "@/islands/ExternalSecretWizard.tsx";
 
 export default define.page(function ExternalSecretNewPage() {
-  return (
-    <ExternalSecretWizard
-      onClose={() => {
-        globalThis.location.href = "/external-secrets/external-secrets";
-      }}
-    />
-  );
+  return <ExternalSecretWizard />;
 });

--- a/frontend/routes/external-secrets/stores/new.tsx
+++ b/frontend/routes/external-secrets/stores/new.tsx
@@ -2,12 +2,5 @@ import { define } from "@/utils.ts";
 import SecretStoreWizard from "@/islands/SecretStoreWizard.tsx";
 
 export default define.page(function SecretStoreNewPage() {
-  return (
-    <SecretStoreWizard
-      scope="namespaced"
-      onClose={() => {
-        globalThis.location.href = "/external-secrets/stores";
-      }}
-    />
-  );
+  return <SecretStoreWizard scope="namespaced" />;
 });

--- a/frontend/routes/networking/cilium-policies/new.tsx
+++ b/frontend/routes/networking/cilium-policies/new.tsx
@@ -2,11 +2,5 @@ import { define } from "@/utils.ts";
 import CiliumPolicyEditor from "@/islands/CiliumPolicyEditor.tsx";
 
 export default define.page(function NewCiliumPolicyPage() {
-  return (
-    <CiliumPolicyEditor
-      onClose={() => {
-        globalThis.location.href = "/networking/cilium-policies";
-      }}
-    />
-  );
+  return <CiliumPolicyEditor />;
 });

--- a/frontend/routes/networking/ingresses/new.tsx
+++ b/frontend/routes/networking/ingresses/new.tsx
@@ -2,11 +2,5 @@ import { define } from "@/utils.ts";
 import IngressWizard from "@/islands/IngressWizard.tsx";
 
 export default define.page(function NewIngressPage() {
-  return (
-    <IngressWizard
-      onClose={() => {
-        globalThis.location.href = "/networking/ingresses";
-      }}
-    />
-  );
+  return <IngressWizard />;
 });

--- a/frontend/routes/networking/networkpolicies/new.tsx
+++ b/frontend/routes/networking/networkpolicies/new.tsx
@@ -2,11 +2,5 @@ import { define } from "@/utils.ts";
 import NetworkPolicyWizard from "@/islands/NetworkPolicyWizard.tsx";
 
 export default define.page(function NewNetworkPolicyPage() {
-  return (
-    <NetworkPolicyWizard
-      onClose={() => {
-        globalThis.location.href = "/networking/networkpolicies";
-      }}
-    />
-  );
+  return <NetworkPolicyWizard />;
 });

--- a/frontend/routes/networking/services/new.tsx
+++ b/frontend/routes/networking/services/new.tsx
@@ -2,11 +2,5 @@ import { define } from "@/utils.ts";
 import ServiceWizard from "@/islands/ServiceWizard.tsx";
 
 export default define.page(function NewServicePage() {
-  return (
-    <ServiceWizard
-      onClose={() => {
-        globalThis.location.href = "/networking/services";
-      }}
-    />
-  );
+  return <ServiceWizard />;
 });

--- a/frontend/routes/rbac/clusterrolebindings/new.tsx
+++ b/frontend/routes/rbac/clusterrolebindings/new.tsx
@@ -5,9 +5,6 @@ export default define.page(function NewClusterRoleBindingPage() {
   return (
     <RoleBindingWizard
       clusterScoped
-      onClose={() => {
-        globalThis.location.href = "/rbac/clusterrolebindings";
-      }}
     />
   );
 });

--- a/frontend/routes/rbac/rolebindings/new.tsx
+++ b/frontend/routes/rbac/rolebindings/new.tsx
@@ -5,9 +5,6 @@ export default define.page(function NewRoleBindingPage() {
   return (
     <RoleBindingWizard
       clusterScoped={false}
-      onClose={() => {
-        globalThis.location.href = "/rbac/rolebindings";
-      }}
     />
   );
 });

--- a/frontend/routes/scaling/hpas/new.tsx
+++ b/frontend/routes/scaling/hpas/new.tsx
@@ -2,11 +2,5 @@ import { define } from "@/utils.ts";
 import HPAWizard from "@/islands/HPAWizard.tsx";
 
 export default define.page(function NewHPAPage() {
-  return (
-    <HPAWizard
-      onClose={() => {
-        globalThis.location.href = "/scaling/hpas";
-      }}
-    />
-  );
+  return <HPAWizard />;
 });

--- a/frontend/routes/scaling/pdbs/new.tsx
+++ b/frontend/routes/scaling/pdbs/new.tsx
@@ -2,11 +2,5 @@ import { define } from "@/utils.ts";
 import PDBWizard from "@/islands/PDBWizard.tsx";
 
 export default define.page(function NewPDBPage() {
-  return (
-    <PDBWizard
-      onClose={() => {
-        globalThis.location.href = "/scaling/pdbs";
-      }}
-    />
-  );
+  return <PDBWizard />;
 });

--- a/frontend/routes/security/certificates/cluster-issuers/new.tsx
+++ b/frontend/routes/security/certificates/cluster-issuers/new.tsx
@@ -2,12 +2,5 @@ import { define } from "@/utils.ts";
 import IssuerWizard from "@/islands/IssuerWizard.tsx";
 
 export default define.page(function ClusterIssuerNewPage() {
-  return (
-    <IssuerWizard
-      scope="cluster"
-      onClose={() => {
-        globalThis.location.href = "/security/certificates/cluster-issuers";
-      }}
-    />
-  );
+  return <IssuerWizard scope="cluster" />;
 });

--- a/frontend/routes/security/certificates/issuers/new.tsx
+++ b/frontend/routes/security/certificates/issuers/new.tsx
@@ -2,12 +2,5 @@ import { define } from "@/utils.ts";
 import IssuerWizard from "@/islands/IssuerWizard.tsx";
 
 export default define.page(function IssuerNewPage() {
-  return (
-    <IssuerWizard
-      scope="namespaced"
-      onClose={() => {
-        globalThis.location.href = "/security/certificates/issuers";
-      }}
-    />
-  );
+  return <IssuerWizard scope="namespaced" />;
 });

--- a/frontend/routes/security/certificates/new.tsx
+++ b/frontend/routes/security/certificates/new.tsx
@@ -2,11 +2,5 @@ import { define } from "@/utils.ts";
 import CertificateWizard from "@/islands/CertificateWizard.tsx";
 
 export default define.page(function CertificateNewPage() {
-  return (
-    <CertificateWizard
-      onClose={() => {
-        globalThis.location.href = "/security/certificates";
-      }}
-    />
-  );
+  return <CertificateWizard />;
 });

--- a/frontend/routes/settings/users/new.tsx
+++ b/frontend/routes/settings/users/new.tsx
@@ -2,11 +2,5 @@ import { define } from "@/utils.ts";
 import UserWizard from "@/islands/UserWizard.tsx";
 
 export default define.page(function NewUserPage() {
-  return (
-    <UserWizard
-      onClose={() => {
-        globalThis.location.href = "/settings/users";
-      }}
-    />
-  );
+  return <UserWizard />;
 });

--- a/frontend/routes/storage/pvcs/new.tsx
+++ b/frontend/routes/storage/pvcs/new.tsx
@@ -2,11 +2,5 @@ import { define } from "@/utils.ts";
 import PVCWizard from "@/islands/PVCWizard.tsx";
 
 export default define.page(function NewPVCPage() {
-  return (
-    <PVCWizard
-      onClose={() => {
-        globalThis.location.href = "/storage/pvcs";
-      }}
-    />
-  );
+  return <PVCWizard />;
 });

--- a/frontend/routes/storage/snapshots/new.tsx
+++ b/frontend/routes/storage/snapshots/new.tsx
@@ -2,11 +2,5 @@ import { define } from "@/utils.ts";
 import SnapshotWizard from "@/islands/SnapshotWizard.tsx";
 
 export default define.page(function NewSnapshotPage() {
-  return (
-    <SnapshotWizard
-      onClose={() => {
-        globalThis.location.href = "/storage/snapshots";
-      }}
-    />
-  );
+  return <SnapshotWizard />;
 });

--- a/frontend/routes/workloads/cronjobs/new.tsx
+++ b/frontend/routes/workloads/cronjobs/new.tsx
@@ -2,11 +2,5 @@ import { define } from "@/utils.ts";
 import CronJobWizard from "@/islands/CronJobWizard.tsx";
 
 export default define.page(function NewCronJobPage() {
-  return (
-    <CronJobWizard
-      onClose={() => {
-        globalThis.location.href = "/workloads/cronjobs";
-      }}
-    />
-  );
+  return <CronJobWizard />;
 });

--- a/frontend/routes/workloads/daemonsets/new.tsx
+++ b/frontend/routes/workloads/daemonsets/new.tsx
@@ -2,11 +2,5 @@ import { define } from "@/utils.ts";
 import DaemonSetWizard from "@/islands/DaemonSetWizard.tsx";
 
 export default define.page(function NewDaemonSetPage() {
-  return (
-    <DaemonSetWizard
-      onClose={() => {
-        globalThis.location.href = "/workloads/daemonsets";
-      }}
-    />
-  );
+  return <DaemonSetWizard />;
 });

--- a/frontend/routes/workloads/deployments/new.tsx
+++ b/frontend/routes/workloads/deployments/new.tsx
@@ -2,11 +2,5 @@ import { define } from "@/utils.ts";
 import DeploymentWizard from "@/islands/DeploymentWizard.tsx";
 
 export default define.page(function NewDeploymentPage() {
-  return (
-    <DeploymentWizard
-      onClose={() => {
-        globalThis.location.href = "/workloads/deployments";
-      }}
-    />
-  );
+  return <DeploymentWizard />;
 });

--- a/frontend/routes/workloads/jobs/new.tsx
+++ b/frontend/routes/workloads/jobs/new.tsx
@@ -2,11 +2,5 @@ import { define } from "@/utils.ts";
 import JobWizard from "@/islands/JobWizard.tsx";
 
 export default define.page(function NewJobPage() {
-  return (
-    <JobWizard
-      onClose={() => {
-        globalThis.location.href = "/workloads/jobs";
-      }}
-    />
-  );
+  return <JobWizard />;
 });

--- a/frontend/routes/workloads/statefulsets/new.tsx
+++ b/frontend/routes/workloads/statefulsets/new.tsx
@@ -2,11 +2,5 @@ import { define } from "@/utils.ts";
 import StatefulSetWizard from "@/islands/StatefulSetWizard.tsx";
 
 export default define.page(function NewStatefulSetPage() {
-  return (
-    <StatefulSetWizard
-      onClose={() => {
-        globalThis.location.href = "/workloads/statefulsets";
-      }}
-    />
-  );
+  return <StatefulSetWizard />;
 });


### PR DESCRIPTION
## Problem

**Every wizard create route (`/…/new`) returns a 500** "Something went wrong" page on `main` — all 30 wizards are unusable, and the e2e `wizard-flows.spec.ts` suite fails on every wizard (timeout waiting for the name field). This affects all PRs against `main` (e.g. backend-only dependabot PRs also show red e2e).

## Root cause

Fresh serializes island props into the hydration payload, and **functions are not serializable**:

```
Error: Serializing functions is not supported.
  at FreshRuntimeScript (@fresh/core/.../runtime/server/preact_hooks.ts)
```

The Liquid Glass refactor (#353) added an `onClose={() => { globalThis.location.href = "…"; }}` **function** prop to all 30 `routes/**/new.tsx` files (before #353 they rendered `<XWizard />` with no props). Passing a function across the **server route → island** boundary throws during SSR, so the wizard never mounts.

Reproduced locally against the vite dev server: list pages = 200, every `/new` route = 500. Captured the stack by temporarily logging `error` in `routes/_error.tsx`.

## Fix

Remove the `onClose` prop from the 30 routes, reverting them to their pre-#353 shape (`<XWizard />`). This is safe because:

- Each wizard island already defaults `close` to `globalThis.history.back()` when `onClose` is `undefined` (verified all 27 route-target islands have the default), so standalone-route close still works.
- The islands **keep** accepting `onClose?` — dashboards/lists render the same wizards as in-island modals and pass a real close callback there. That path is client-side only and never serialized, so it is unaffected.
- Non-function props (`scope`, `clusterScoped`, `group`/`resource`/`mode`) are preserved.

## Verification

- Local vite dev server: all wizard `/new` routes now SSR to **200** (were 500); the `my-deployment` name input renders.
- `deno task check` (fmt + lint + check) passes repo-wide.

## Merge order note

This unblocks the e2e check on `main`. PR #357 (vite CVE / CI Release Trivy fix) will go green once this is on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)