### PR TITLE
fix(ci): gate Trivy release scans on CRITICAL,HIGH only

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -135,12 +135,20 @@ jobs:
         # without blocking. Accepted residual findings belong in
         # .trivyignore (created on demand when the first allowlisted
         # CVE shows up) — the audit's "reviewed allowlists" guidance.
+        #
+        # limit-severities-for-sarif=true is REQUIRED: without it the
+        # action builds the SARIF report with ALL severities, which also
+        # drops the severity filter for exit-code — so the build would
+        # fail on fixable LOW/MEDIUM CVEs, not just CRITICAL/HIGH,
+        # contradicting the policy above. With it, both the SARIF and the
+        # exit-code honour severity=CRITICAL,HIGH.
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
         with:
           image-ref: k8scenter-backend:scan
           format: sarif
           output: trivy-backend.sarif
           severity: CRITICAL,HIGH
+          limit-severities-for-sarif: true
           ignore-unfixed: true
           exit-code: "1"
           trivyignores: ".trivyignore"
@@ -228,6 +236,7 @@ jobs:
           format: sarif
           output: trivy-frontend.sarif
           severity: CRITICAL,HIGH
+          limit-severities-for-sarif: true
           ignore-unfixed: true
           exit-code: "1"
           trivyignores: ".trivyignore"


### PR DESCRIPTION
## Problem

The **CI Release** stayed red even after #357 cleared the HIGH `vite` CVE. The frontend Trivy step fails with `exit code 1` while GitHub code-scanning shows **only LOW** findings remaining (`esbuild` GHSA-g7r4-m6w7-qqqr, `@babel/core` CVE-2026-49356).

## Root cause

Both release Trivy steps use `format: sarif` + `severity: CRITICAL,HIGH` + `exit-code: 1`, but **don't** set `limit-severities-for-sarif`. With that unset, `aquasecurity/trivy-action` builds the SARIF report with **all severities** (you can see `Building SARIF report with all severities` in the log) and drops the `--severity` filter — which also makes `exit-code: 1` trigger on **any** severity, including fixable LOW/MEDIUM. That contradicts the step's own documented policy ("fails the workflow on any fixable critical/high").

So the LOW esbuild/babel CVEs were enough to fail the release; the HIGH vite CVE was just the first thing the earlier diagnosis surfaced.

## Fix

Add `limit-severities-for-sarif: true` to both the backend and frontend scan steps. Now the SARIF report **and** the exit-code honour `severity: CRITICAL,HIGH`. Releases block only on fixable CRITICAL/HIGH CVEs (the intent); LOW/MEDIUM advisories no longer gate the build and can be handled via normal dependency bumps.

Note: the actual Trivy release scan only runs on push to `main` (not on PRs), so this is verified by watching the CI Release run after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)