### PR TITLE
fix(frontend): SSR boot crash — guard nav/theme localStorage with IS_BROWSER

### DIFF
--- a/frontend/lib/nav.ts
+++ b/frontend/lib/nav.ts
@@ -1,11 +1,16 @@
 // Shared signal for the collapsible secondary nav panel.
 // Mirrors the pattern used by lib/namespace.ts (selectedNamespace).
 import { signal } from "@preact/signals";
+import { IS_BROWSER } from "fresh/runtime";
 
 const STORAGE_KEY = "kc.navCollapsed";
 
+// IS_BROWSER (not `typeof localStorage`): Deno DEFINES localStorage during
+// SSR, but touching it on a read-only rootfs throws "Read-only file system
+// (os error 30)" and crashes the server on boot. IS_BROWSER is false during
+// SSR, so we never open the backing store there.
 function initial(): boolean {
-  if (typeof localStorage === "undefined") return false;
+  if (!IS_BROWSER) return false;
   return localStorage.getItem(STORAGE_KEY) === "1";
 }
 
@@ -14,7 +19,7 @@ export const navCollapsed = signal<boolean>(initial());
 
 export function toggleNav(): void {
   navCollapsed.value = !navCollapsed.value;
-  if (typeof localStorage !== "undefined") {
+  if (IS_BROWSER) {
     localStorage.setItem(STORAGE_KEY, navCollapsed.value ? "1" : "0");
   }
 }

--- a/frontend/lib/theme.ts
+++ b/frontend/lib/theme.ts
@@ -2,12 +2,17 @@
 // `initTheme()` in lib/themes.ts calls `applyTheme()` on TopBarV2 mount
 // so the persisted choice is applied at page load.
 import { signal } from "@preact/signals";
+import { IS_BROWSER } from "fresh/runtime";
 
 const STORAGE_KEY = "kc.theme";
 export type ThemeMode = "dark" | "light";
 
+// IS_BROWSER (not `typeof localStorage`): Deno DEFINES localStorage during
+// SSR, but touching it on a read-only rootfs throws "Read-only file system
+// (os error 30)" and crashes the server on boot. IS_BROWSER is false during
+// SSR, so we never open the backing store there.
 function initial(): ThemeMode {
-  if (typeof localStorage === "undefined") return "dark";
+  if (!IS_BROWSER) return "dark";
   return (localStorage.getItem(STORAGE_KEY) as ThemeMode) || "dark";
 }
 
@@ -23,7 +28,7 @@ export function applyTheme(): void {
 
 export function toggleTheme(): void {
   theme.value = theme.value === "light" ? "dark" : "light";
-  if (typeof localStorage !== "undefined") {
+  if (IS_BROWSER) {
     localStorage.setItem(STORAGE_KEY, theme.value);
   }
   applyTheme();


### PR DESCRIPTION
## Problem

The new frontend image (Liquid Glass) crash-loops on boot in the homelab deployment; ArgoCD shows `k8scenter` **Degraded** (new pod `CrashLoopBackOff`, old pod still serving):

```
error: Uncaught (in promise) Error: Read-only file system (os error 30)
  return localStorage.getItem(STORAGE_KEY) === "1";
    at initial (lib/nav.ts)
```

## Root cause

`lib/nav.ts` and `lib/theme.ts` (both new in the Liquid Glass refactor) guard `localStorage` with `typeof localStorage === "undefined"`. That's a Node-ism — **Deno defines `localStorage` during SSR**, so the guard never trips. Deno then tries to open its localStorage backing store on the container's **read-only rootfs** (Pod Security restricted → `readOnlyRootFilesystem`), throwing `os error 30` and killing the server before it serves. Both modules evaluate `signal(initial())` at module load, and `routes/_layout.tsx` imports them → every SSR crashes.

CI e2e missed it because it runs the frontend **without** the read-only-rootfs security context, where the localStorage write succeeds.

## Fix

Switch both modules to the `IS_BROWSER` guard already used by `lib/namespace.ts` and `lib/cluster.ts` (false during SSR → localStorage never touched on the server). Browser behavior unchanged. `deno task check` passes.

## After merge

CI Release builds + pushes a new frontend image; ArgoCD rolls it and the new pod should reach Ready, clearing the Degraded status and finally showing the Liquid Glass design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)