### PR TITLE
Revert "chore(docker): bump denoland/deno to distroless-2.8.3 (#351)"

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,6 @@
 # Stage 1: Install dependencies and build (always on amd64 — Deno WASM loader
 # crashes under QEMU ARM64 emulation, but build output is arch-independent JS)
-FROM --platform=linux/amd64 denoland/deno:2.8.3 AS builder
+FROM --platform=linux/amd64 denoland/deno:2.8.2 AS builder
 
 WORKDIR /app
 
@@ -47,7 +47,7 @@ RUN find /app/node_modules -path '*/esbuild/bin/esbuild' -delete 2>/dev/null; \
 #     The sed substitution that updates the distroless dpkg status.d
 #     entry is now dynamic: extracts base + installed versions at
 #     build time.
-FROM denoland/deno:distroless-2.8.3 AS runtime-base
+FROM denoland/deno:distroless-2.8.2 AS runtime-base
 # debian:trixie (NOT -slim) — the slim variant ships
 # /etc/dpkg/dpkg.cfg.d/docker-clean which path-excludes /usr/share/doc/*,
 # stripping changelog.Debian.gz files. The 7-day cooldown gate below
@@ -121,7 +121,7 @@ RUN set -e && \
 
 # Stage 2: Production runtime (uses target platform — arm64 or amd64)
 # Use distroless variant to minimize OS-level CVEs (no shell, no package manager)
-FROM denoland/deno:distroless-2.8.3
+FROM denoland/deno:distroless-2.8.2
 
 # Overlay patched libraries (libssl3t64, libc6) and updated package metadata
 COPY --from=security-patch /patch/usr/lib/ /usr/lib/


### PR DESCRIPTION
Reverts #351.

## Why

The deno `distroless-2.8.3` base bump broke the **frontend Docker build** in CI Release, at the bespoke `security-patch` stage:

```
#18 libc6 2.41-12+deb13u3 uploaded 56 days ago — passes 7-day cooldown
ERROR: distroless base no longer contains libssl3t64 3.5.6-1~deb13u1 —
update the pin/sed to the base's new version, or drop libssl3t64 from the
security-patch stage if the base now ships >= 3.5.6-1~deb13u2
```

The 2.8.3 base already ships the patched `libssl3t64` (≥ deb13u2), so the stage's base-version assertion (`grep -q '3.5.6-1~deb13u1'`) trips and the build exits 1 — before the image is built/scanned/pushed.

Production was unaffected (the failed build never pushed; ArgoCD stayed on the healthy `sha-6c62adc0`), but `main`'s frontend release pipeline was left broken. This revert restores the known-good `distroless-2.8.2` Dockerfile.

## Follow-up

The deno 2.8.3 upgrade should be a deliberate PR that updates the `security-patch` stage — drop the now-obsolete `libssl3t64` patch (mirroring the prior #342 "drop obsolete libssl3t64 patch") and re-verify Trivy passes — rather than a blind base bump. Not suitable for an unattended dependabot merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)