### PR TITLE
fix(frontend): resolve /rbac to security domain so secondary nav renders

### DIFF
--- a/frontend/lib/constants.ts
+++ b/frontend/lib/constants.ts
@@ -522,6 +522,7 @@ const _ALL_SECTIONS = [...DOMAIN_SECTIONS, SETTINGS_SECTION];
 export function getActiveDomain(path: string): string | null {
   // Explicit overrides for routes that don't share a domain's prefix.
   if (path.startsWith("/cluster")) return "overview";
+  if (path.startsWith("/rbac")) return "security";
   if (path.startsWith("/admin")) return "security";
   if (path.startsWith("/settings")) return "settings";
   if (path.startsWith("/scaling")) return "workloads";

--- a/frontend/lib/nav-domain_test.ts
+++ b/frontend/lib/nav-domain_test.ts
@@ -1,0 +1,36 @@
+import { assertEquals } from "jsr:@std/assert@1";
+import { getActiveDomain } from "./constants.ts";
+
+// The Security domain's routes are spread across three URL prefixes:
+// /rbac (Access Control + the landing page), /admin (webhooks), and
+// /security (Posture). getActiveDomain must resolve all of them to the
+// "security" domain so SecondaryNav renders the menu instead of an empty rail.
+
+Deno.test("getActiveDomain: /rbac/overview (security landing) -> security", () => {
+  assertEquals(getActiveDomain("/rbac/overview"), "security");
+});
+
+Deno.test("getActiveDomain: /rbac index -> security", () => {
+  assertEquals(getActiveDomain("/rbac"), "security");
+});
+
+Deno.test("getActiveDomain: /rbac/roles -> security", () => {
+  assertEquals(getActiveDomain("/rbac/roles"), "security");
+});
+
+Deno.test("getActiveDomain: /admin/validatingwebhooks -> security", () => {
+  assertEquals(getActiveDomain("/admin/validatingwebhooks"), "security");
+});
+
+Deno.test("getActiveDomain: /security/policies -> security", () => {
+  assertEquals(getActiveDomain("/security/policies"), "security");
+});
+
+// Regression guards for sibling domains that must NOT be swallowed.
+Deno.test("getActiveDomain: /workloads/pods -> workloads", () => {
+  assertEquals(getActiveDomain("/workloads/pods"), "workloads");
+});
+
+Deno.test("getActiveDomain: / -> overview", () => {
+  assertEquals(getActiveDomain("/"), "overview");
+});


### PR DESCRIPTION
## Problem

Clicking **Security** in the icon rail navigated to `/rbac/overview` and the secondary navigation panel rendered **empty** — no Access Control or Posture groups.

## Root cause

The Security domain's routes are spread across three URL prefixes:
- `/rbac` — Access Control items **and** the `/rbac/overview` landing page the IconRail links to
- `/admin` — webhooks
- `/security` — Posture

`getActiveDomain()` only resolved two of them: `/admin` via an explicit override, and `/security/*` via the `path.startsWith("/" + s.id)` shortcut. `/rbac/overview` and bare `/rbac` matched nothing — `overview` isn't a nav item, and `/rbac` isn't the domain id — so they fell through to `null`. `domainById(null)` is `undefined`, so `SecondaryNav` hit its no-groups branch and rendered an empty `<nav>`.

(`/rbac/roles`, `/rbac/rolebindings`, etc. already worked because they exactly match nav-item hrefs — only the landing page was broken.)

## Fix

One-line explicit override in `getActiveDomain()`, mirroring the existing `/admin → security` line:

```ts
if (path.startsWith("/rbac")) return "security";
```

## Tests

New `frontend/lib/nav-domain_test.ts` — captured the bug first (failing on `/rbac/overview` and `/rbac`), now covers all three security prefixes plus sibling-domain regression guards (`/workloads/pods`, `/`).

## Verification

- `deno test --allow-env lib/nav-domain_test.ts` — 7/7 pass
- Repo-wide `deno task check` (fmt + lint + check) — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)