### PR TITLE
feat(frontend): show what's in violation on the compliance dashboard

### DIFF
--- a/frontend/islands/ComplianceDashboard.tsx
+++ b/frontend/islands/ComplianceDashboard.tsx
@@ -9,12 +9,27 @@ import { Spinner } from "@/components/ui/Spinner.tsx";
 import { Button } from "@/components/ui/Button.tsx";
 import WidgetShell from "@/components/ui/WidgetShell.tsx";
 import {
+  EngineBadge,
   SEVERITY_COLORS,
   SEVERITY_ORDER,
+  SeverityBadge,
 } from "@/components/ui/PolicyBadges.tsx";
-import type { ComplianceScore, SeverityCounts } from "@/lib/policy-types.ts";
+import type {
+  ComplianceScore,
+  NormalizedViolation,
+  SeverityCounts,
+} from "@/lib/policy-types.ts";
 import { scoreColor } from "@/lib/score-color.ts";
+import { resourceHref } from "@/lib/k8s-links.ts";
+import {
+  failingPolicies,
+  scopeViolations,
+  worstResources,
+} from "@/lib/compliance-violations.ts";
 import ComplianceTrendChart from "@/islands/ComplianceTrendChart.tsx";
+
+const TOP_POLICIES = 5;
+const TOP_RESOURCES = 8;
 
 function SeverityBar({
   label,
@@ -52,6 +67,7 @@ function SeverityBar({
 
 export default function ComplianceDashboard() {
   const scores = useSignal<ComplianceScore[]>([]);
+  const violations = useSignal<NormalizedViolation[]>([]);
   const loading = useSignal(true);
   const error = useSignal<string | null>(null);
   const refreshing = useSignal(false);
@@ -84,7 +100,22 @@ export default function ComplianceDashboard() {
     }
   }
 
-  // Refetch on mount and whenever the namespace picker changes.
+  // Violations power the "what's in violation" preview. Fetched once (the
+  // full RBAC-filtered list) and filtered client-side by the picker, so a
+  // namespace change needs no refetch. Failures here are non-fatal — the
+  // score is the primary content; the preview just stays empty.
+  async function fetchViolations() {
+    try {
+      const res = await apiGet<NormalizedViolation[]>(
+        "/v1/policies/violations",
+      );
+      violations.value = Array.isArray(res.data) ? res.data : [];
+    } catch {
+      // keep the page usable even if the violations list is unavailable
+    }
+  }
+
+  // Refetch the score on mount and whenever the namespace picker changes.
   useEffect(() => {
     if (!IS_BROWSER) return;
     fetchData().then(() => {
@@ -92,14 +123,24 @@ export default function ComplianceDashboard() {
     });
   }, [ns]);
 
-  useWsRefetch(fetchData, [
-    ["compliance-policyreports", "policyreports", ""],
-    ["compliance-clusterpolicyreports", "clusterpolicyreports", ""],
-  ], 5000);
+  // Load the violations list once on mount (filtered client-side by scope).
+  useEffect(() => {
+    if (!IS_BROWSER) return;
+    fetchViolations();
+  }, []);
+
+  useWsRefetch(
+    () => Promise.all([fetchData(), fetchViolations()]).then(() => {}),
+    [
+      ["compliance-policyreports", "policyreports", ""],
+      ["compliance-clusterpolicyreports", "clusterpolicyreports", ""],
+    ],
+    5000,
+  );
 
   async function handleRefresh() {
     refreshing.value = true;
-    await fetchData();
+    await Promise.all([fetchData(), fetchViolations()]);
     refreshing.value = false;
   }
 
@@ -113,6 +154,15 @@ export default function ComplianceDashboard() {
       s.scope === activeScope || (activeScope === "" && s.scope === "cluster")
     ) ?? scores.value[0];
   const scoped = ns !== "all";
+
+  // Derive the "what's in violation" preview from the full list, scoped the
+  // same way the score is (namespace-strict), so the two always agree.
+  const scopedViolations = scopeViolations(violations.value, ns);
+  const topPolicies = failingPolicies(scopedViolations, TOP_POLICIES);
+  const topResources = worstResources(scopedViolations, TOP_RESOURCES);
+  const violationsHref = scoped
+    ? `/security/violations?namespace=${encodeURIComponent(ns)}`
+    : "/security/violations";
 
   return (
     <div
@@ -246,6 +296,131 @@ export default function ComplianceDashboard() {
               </WidgetShell>
             </div>
           </div>
+
+          {/* What's in violation */}
+          {scopedViolations.length === 0
+            ? (
+              <WidgetShell title="Violations">
+                <p class="text-sm text-text-muted py-2">
+                  No active violations in{" "}
+                  {scoped ? `namespace "${ns}"` : "the cluster"}.
+                </p>
+              </WidgetShell>
+            )
+            : (
+              <div
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: "12px",
+                }}
+              >
+                <div
+                  style={{ display: "flex", flexWrap: "wrap", gap: "20px" }}
+                >
+                  {/* Failing policies — grouped by impact */}
+                  <div style={{ flex: "1 1 320px", minWidth: "300px" }}>
+                    <WidgetShell title="Failing Policies">
+                      <div class="space-y-2">
+                        {topPolicies.map((g) => (
+                          <div key={g.policy} class="flex items-center gap-3">
+                            <span
+                              style={{
+                                width: "6px",
+                                height: "6px",
+                                borderRadius: "50%",
+                                flexShrink: 0,
+                                background: SEVERITY_COLORS[g.severity] ??
+                                  "var(--text-muted)",
+                              }}
+                            />
+                            <span
+                              class="text-sm font-medium flex-1 truncate"
+                              style={{ color: "var(--text-primary)" }}
+                              title={g.policy}
+                            >
+                              {g.policy}
+                            </span>
+                            <SeverityBadge severity={g.severity} />
+                            <EngineBadge engine={g.engine} />
+                            <span class="text-xs text-text-muted w-24 text-right tabular-nums">
+                              {g.count}{" "}
+                              {g.count === 1 ? "resource" : "resources"}
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    </WidgetShell>
+                  </div>
+
+                  {/* Worst individual violating resources */}
+                  <div style={{ flex: "2 1 360px", minWidth: "320px" }}>
+                    <WidgetShell title="Worst Resources">
+                      <div class="space-y-2">
+                        {topResources.map((vio, i) => {
+                          const href = resourceHref(
+                            vio.kind,
+                            vio.namespace,
+                            vio.name,
+                          );
+                          const label = (
+                            <span
+                              class="font-mono text-xs font-medium"
+                              style={{
+                                color: href
+                                  ? "var(--accent)"
+                                  : "var(--text-primary)",
+                              }}
+                            >
+                              {vio.kind}/{vio.name}
+                            </span>
+                          );
+                          return (
+                            <div
+                              key={`${vio.kind}-${vio.namespace}-${vio.name}-${vio.policy}-${i}`}
+                              class="flex items-start gap-3"
+                            >
+                              <div class="flex-1 min-w-0">
+                                <div class="flex items-center gap-2 flex-wrap">
+                                  {href
+                                    ? (
+                                      <a href={href} class="hover:underline">
+                                        {label}
+                                      </a>
+                                    )
+                                    : label}
+                                  {vio.namespace && (
+                                    <span class="text-xs text-text-muted">
+                                      {vio.namespace}
+                                    </span>
+                                  )}
+                                  <SeverityBadge severity={vio.severity} />
+                                </div>
+                                <p
+                                  class="text-xs text-text-muted truncate"
+                                  title={vio.message}
+                                >
+                                  {vio.policy}
+                                  {vio.message ? ` — ${vio.message}` : ""}
+                                </p>
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </WidgetShell>
+                  </div>
+                </div>
+
+                <a
+                  href={violationsHref}
+                  class="text-sm hover:underline self-start"
+                  style={{ color: "var(--accent)" }}
+                >
+                  View all violations →
+                </a>
+              </div>
+            )}
 
           {/* Compliance trend chart */}
           <ComplianceTrendChart />

--- a/frontend/lib/compliance-violations.ts
+++ b/frontend/lib/compliance-violations.ts
@@ -1,0 +1,94 @@
+/**
+ * Pure derivations for the compliance dashboard's violations preview.
+ *
+ * The dashboard loads the full `/v1/policies/violations` list (same endpoint
+ * as the Violations browser) and derives two compact views from it:
+ *   - failingPolicies(): grouped "which policies are failing, by impact"
+ *   - worstResources(): the most severe individual violating resources
+ *
+ * Namespace scoping mirrors the backend `computeCompliance` semantics — a
+ * namespace view counts only violations whose namespace === scope — so the
+ * preview stays consistent with the score shown above it.
+ */
+import { SEVERITY_ORDER } from "@/lib/badge-colors.ts";
+import type { NormalizedViolation } from "@/lib/policy-types.ts";
+
+/** Lower rank = more severe. Unknown severities sort last. */
+export function severityRank(severity: string): number {
+  const i = (SEVERITY_ORDER as readonly string[]).indexOf(severity);
+  return i === -1 ? SEVERITY_ORDER.length : i;
+}
+
+/**
+ * Filter violations to the active namespace, matching the score's scoping.
+ * "all" (or empty) returns every violation unchanged.
+ */
+export function scopeViolations(
+  violations: NormalizedViolation[],
+  ns: string,
+): NormalizedViolation[] {
+  if (!ns || ns === "all") return violations;
+  return violations.filter((v) => v.namespace === ns);
+}
+
+/** One row of the "Failing Policies" summary. */
+export interface PolicyGroup {
+  policy: string;
+  severity: string;
+  engine: string;
+  blocking: boolean;
+  count: number;
+}
+
+/**
+ * Group violations by policy, counting offending resources. Sorted blocking
+ * (enforced) first, then by resource count desc, then policy name for
+ * stability. `severity` is the most severe seen across the group.
+ */
+export function failingPolicies(
+  violations: NormalizedViolation[],
+  limit: number,
+): PolicyGroup[] {
+  const groups = new Map<string, PolicyGroup>();
+  for (const v of violations) {
+    const existing = groups.get(v.policy);
+    if (existing) {
+      existing.count++;
+      existing.blocking = existing.blocking || v.blocking;
+      if (severityRank(v.severity) < severityRank(existing.severity)) {
+        existing.severity = v.severity;
+      }
+    } else {
+      groups.set(v.policy, {
+        policy: v.policy,
+        severity: v.severity,
+        engine: v.engine,
+        blocking: v.blocking,
+        count: 1,
+      });
+    }
+  }
+  return [...groups.values()]
+    .sort((a, b) =>
+      Number(b.blocking) - Number(a.blocking) ||
+      b.count - a.count ||
+      a.policy.localeCompare(b.policy)
+    )
+    .slice(0, limit);
+}
+
+/**
+ * Top-N individual violations, most severe first, blocking breaking ties.
+ * Does not mutate the input.
+ */
+export function worstResources(
+  violations: NormalizedViolation[],
+  limit: number,
+): NormalizedViolation[] {
+  return [...violations]
+    .sort((a, b) =>
+      severityRank(a.severity) - severityRank(b.severity) ||
+      Number(b.blocking) - Number(a.blocking)
+    )
+    .slice(0, limit);
+}

--- a/frontend/lib/compliance-violations_test.ts
+++ b/frontend/lib/compliance-violations_test.ts
@@ -1,0 +1,128 @@
+import { assertEquals } from "jsr:@std/assert@1";
+import {
+  failingPolicies,
+  scopeViolations,
+  severityRank,
+  worstResources,
+} from "./compliance-violations.ts";
+import type { NormalizedViolation } from "./policy-types.ts";
+
+function v(
+  partial: Partial<NormalizedViolation> & { policy: string; name: string },
+): NormalizedViolation {
+  return {
+    rule: "",
+    severity: "medium",
+    action: "denied",
+    message: "",
+    kind: "Pod",
+    engine: "kyverno",
+    blocking: false,
+    ...partial,
+  };
+}
+
+// --- severityRank ---
+
+Deno.test("severityRank: critical is most severe (lowest)", () => {
+  assertEquals(severityRank("critical") < severityRank("high"), true);
+  assertEquals(severityRank("high") < severityRank("low"), true);
+});
+
+Deno.test("severityRank: unknown sorts last", () => {
+  assertEquals(severityRank("bogus") > severityRank("low"), true);
+});
+
+// --- scopeViolations ---
+
+Deno.test("scopeViolations: 'all' returns everything", () => {
+  const list = [v({ policy: "a", name: "x", namespace: "ns1" })];
+  assertEquals(scopeViolations(list, "all").length, 1);
+});
+
+Deno.test("scopeViolations: filters strictly by namespace", () => {
+  const list = [
+    v({ policy: "a", name: "x", namespace: "ns1" }),
+    v({ policy: "a", name: "y", namespace: "ns2" }),
+    v({ policy: "a", name: "z", namespace: undefined }),
+  ];
+  const out = scopeViolations(list, "ns1");
+  assertEquals(out.length, 1);
+  assertEquals(out[0].name, "x");
+});
+
+// --- failingPolicies ---
+
+Deno.test("failingPolicies: groups by policy and counts resources", () => {
+  const list = [
+    v({ policy: "p1", name: "a" }),
+    v({ policy: "p1", name: "b" }),
+    v({ policy: "p2", name: "c" }),
+  ];
+  const out = failingPolicies(list, 5);
+  assertEquals(out.length, 2);
+  assertEquals(out[0].policy, "p1");
+  assertEquals(out[0].count, 2);
+});
+
+Deno.test("failingPolicies: blocking sorts before higher count", () => {
+  const list = [
+    v({ policy: "audit", name: "a" }),
+    v({ policy: "audit", name: "b" }),
+    v({ policy: "audit", name: "c" }),
+    v({ policy: "enforce", name: "d", blocking: true }),
+  ];
+  const out = failingPolicies(list, 5);
+  assertEquals(out[0].policy, "enforce");
+  assertEquals(out[0].blocking, true);
+});
+
+Deno.test("failingPolicies: keeps the most severe severity in a group", () => {
+  const list = [
+    v({ policy: "p1", name: "a", severity: "low" }),
+    v({ policy: "p1", name: "b", severity: "critical" }),
+  ];
+  const out = failingPolicies(list, 5);
+  assertEquals(out[0].severity, "critical");
+});
+
+Deno.test("failingPolicies: respects the limit", () => {
+  const list = [
+    v({ policy: "p1", name: "a" }),
+    v({ policy: "p2", name: "b" }),
+    v({ policy: "p3", name: "c" }),
+  ];
+  assertEquals(failingPolicies(list, 2).length, 2);
+});
+
+// --- worstResources ---
+
+Deno.test("worstResources: most severe first, does not mutate input", () => {
+  const list = [
+    v({ policy: "p", name: "low", severity: "low" }),
+    v({ policy: "p", name: "crit", severity: "critical" }),
+    v({ policy: "p", name: "med", severity: "medium" }),
+  ];
+  const out = worstResources(list, 10);
+  assertEquals(out.map((x) => x.name), ["crit", "med", "low"]);
+  // input order preserved (no in-place sort)
+  assertEquals(list.map((x) => x.name), ["low", "crit", "med"]);
+});
+
+Deno.test("worstResources: blocking breaks severity ties", () => {
+  const list = [
+    v({ policy: "p", name: "audit", severity: "high", blocking: false }),
+    v({ policy: "p", name: "enforce", severity: "high", blocking: true }),
+  ];
+  const out = worstResources(list, 10);
+  assertEquals(out[0].name, "enforce");
+});
+
+Deno.test("worstResources: respects the limit", () => {
+  const list = [
+    v({ policy: "p", name: "a", severity: "critical" }),
+    v({ policy: "p", name: "b", severity: "high" }),
+    v({ policy: "p", name: "c", severity: "low" }),
+  ];
+  assertEquals(worstResources(list, 2).length, 2);
+});


### PR DESCRIPTION
## What

The Compliance page (`/security/compliance`) previously showed only the score gauge and severity bars — no indication of **what** was actually in violation. This adds a namespace-scoped violations preview.

## UI

Two cards between the Severity Breakdown and the trend chart:

- **Failing Policies** — violations grouped by policy with severity + engine badges and the count of offending resources, sorted blocking (enforced) first, then by impact. Top 5.
- **Worst Resources** — the most severe individual violations, each `kind/name` linking to the resource detail, with policy + message. Top 8.
- **View all violations →** deep-links to `/security/violations` with the current namespace prefilled. A clean scope shows a "No active violations" note instead.

## How

- **No backend change.** Derived from the existing `GET /v1/policies/violations` list (same RBAC-filtered, WS-wired endpoint the Violations browser uses).
- Scoping mirrors backend `computeCompliance` (namespace-strict: `v.namespace === scope`), so the preview always agrees with the score above it.
- Violations are fetched **once** and filtered client-side, so namespace changes need no refetch. Fetch failures are **non-fatal** — the score stays usable and the preview just hides.
- Pure derivations extracted to `lib/compliance-violations.ts` (`scopeViolations` / `failingPolicies` / `worstResources` / `severityRank`) with full unit tests.

## Verification

- New `lib/compliance-violations_test.ts` — 11 tests, all pass.
- Full frontend lib suite — 50/50 pass.
- Repo-wide `deno task check` (fmt + lint + check) — exit 0.
- All UI reuses existing components (`PolicyBadges`, `WidgetShell`, `resourceHref`) and theme tokens — no new CSS.

Behavioral smoke test pending on homelab: confirm the cards populate and re-scope when switching namespaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)