### PR TITLE
fix(monitoring): list Grafana dashboards via viewer token, not provisioning token

### DIFF
--- a/backend/internal/monitoring/discovery.go
+++ b/backend/internal/monitoring/discovery.go
@@ -57,7 +57,7 @@ type Discoverer struct {
 	status                *MonitoringStatus
 	promClient            *PrometheusClient
 	grafProxy             http.Handler
-	grafClient            *GrafanaClient
+	grafClient            *GrafanaClient // read client (viewer token) — backs dashboard listing
 	dashboardsProvisioned bool
 	dashboardsProvCount   int
 }
@@ -115,7 +115,9 @@ func NewTestDiscoverer(status *MonitoringStatus, proxy http.Handler) *Discoverer
 	}
 }
 
-// GrafanaClient returns the cached Grafana API client, or nil.
+// GrafanaAPIClient returns the cached read-capable Grafana API client (carrying
+// the viewer token), or nil if Grafana is not discovered. Used for dashboard
+// listing — a read operation independent of the provisioning token.
 func (d *Discoverer) GrafanaAPIClient() *GrafanaClient {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
@@ -199,7 +201,6 @@ func (d *Discoverer) Discover(ctx context.Context) {
 	}
 
 	var grafProxy http.Handler
-	var grafClient *GrafanaClient
 	if grafURL != "" {
 		// Proxy is always created when Grafana is discovered — viewerToken is optional
 		// (it adds an Authorization header for Grafana instances that require auth)
@@ -209,12 +210,16 @@ func (d *Discoverer) Discover(ctx context.Context) {
 		} else {
 			grafProxy = proxy
 		}
-		// API client for dashboard provisioning requires the provisioning token
-		if provisioningToken != "" {
-			grafClient = NewGrafanaClient(grafURL, provisioningToken)
-		} else {
-			d.logger.Warn("grafana provisioning token not set — dashboard provisioning disabled")
-		}
+	}
+
+	// Read client backs dashboard listing (viewer token); provisioning client
+	// backs dashboard writes (provisioning token). Listing is a read operation
+	// and must not depend on the provisioning token — otherwise the dashboards
+	// page is empty in the common sidecar-provisioned deployment where only a
+	// viewer token is set.
+	grafReadClient, grafProvClient := buildGrafanaClients(grafURL, viewerToken, provisioningToken)
+	if grafURL != "" && grafProvClient == nil {
+		d.logger.Warn("grafana provisioning token not set — dashboard provisioning disabled")
 	}
 
 	// Provision dashboards once when Grafana is first discovered (or rediscovered)
@@ -223,12 +228,12 @@ func (d *Discoverer) Discover(ctx context.Context) {
 	lastCount := d.dashboardsProvCount
 	d.mu.RUnlock()
 
-	if grafClient == nil {
+	if grafProvClient == nil {
 		// Reset flag so we re-provision when Grafana comes back
 		alreadyProvisioned = false
 		lastCount = 0
 	} else if !alreadyProvisioned {
-		count, err := grafClient.ProvisionDashboards(ctx, d.logger)
+		count, err := grafProvClient.ProvisionDashboards(ctx, d.logger)
 		if err != nil {
 			d.logger.Error("dashboard provisioning failed", "error", err)
 			status.Dashboards = DashboardStatus{Error: err.Error()}
@@ -247,7 +252,7 @@ func (d *Discoverer) Discover(ctx context.Context) {
 	d.status = status
 	d.promClient = promClient
 	d.grafProxy = grafProxy
-	d.grafClient = grafClient
+	d.grafClient = grafReadClient
 	d.dashboardsProvisioned = alreadyProvisioned
 	d.dashboardsProvCount = lastCount
 	d.mu.Unlock()
@@ -257,6 +262,28 @@ func (d *Discoverer) Discover(ctx context.Context) {
 		"grafana", grafURL != "",
 		"operator", status.HasOperator,
 	)
+}
+
+// buildGrafanaClients constructs the Grafana API clients for a discovered
+// Grafana instance, separating read from write privileges:
+//
+//   - read: built whenever Grafana is discovered, carrying the viewer token
+//     (which may be empty for anonymous Grafana). Backs dashboard listing
+//     (GrafanaAPIClient → HandleDashboards), a read operation that must work
+//     regardless of whether dashboard provisioning is configured.
+//   - prov: built only when a provisioning token is set, carrying that token.
+//     Backs dashboard/folder writes (ProvisionDashboards).
+//
+// Returns (nil, nil) when Grafana is not discovered.
+func buildGrafanaClients(grafURL, viewerToken, provisioningToken string) (read, prov *GrafanaClient) {
+	if grafURL == "" {
+		return nil, nil
+	}
+	read = NewGrafanaClient(grafURL, viewerToken)
+	if provisioningToken != "" {
+		prov = NewGrafanaClient(grafURL, provisioningToken)
+	}
+	return read, prov
 }
 
 // checkOperatorCRDs checks whether Prometheus Operator CRDs are installed.

--- a/backend/internal/monitoring/grafana.go
+++ b/backend/internal/monitoring/grafana.go
@@ -109,7 +109,11 @@ func (g *GrafanaClient) SearchDashboards(ctx context.Context, tag string) ([]Das
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+g.token)
+	// Token is optional — anonymous Grafana serves search without auth, and an
+	// empty "Bearer " header is rejected by some Grafana configurations.
+	if g.token != "" {
+		req.Header.Set("Authorization", "Bearer "+g.token)
+	}
 
 	resp, err := g.httpClient.Do(req)
 	if err != nil {

--- a/backend/internal/monitoring/monitoring_test.go
+++ b/backend/internal/monitoring/monitoring_test.go
@@ -290,6 +290,38 @@ func TestHandleDashboards_NoGrafana(t *testing.T) {
 	}
 }
 
+// buildGrafanaClients must produce a read client (for dashboard listing)
+// independent of the provisioning token. Listing dashboards is a read
+// operation; gating it behind the provisioning token left the dashboards page
+// empty in the common sidecar-provisioned deployment where only a viewer token
+// is configured.
+func TestBuildGrafanaClients_ReadClientIndependentOfProvisioningToken(t *testing.T) {
+	read, prov := buildGrafanaClients("http://grafana.monitoring:80", "viewer-tok", "")
+	if read == nil {
+		t.Fatal("read client must be built for dashboard listing even without a provisioning token")
+	}
+	if prov != nil {
+		t.Error("provisioning client must be nil when no provisioning token is set")
+	}
+}
+
+func TestBuildGrafanaClients_BothTokens(t *testing.T) {
+	read, prov := buildGrafanaClients("http://grafana.monitoring:80", "viewer-tok", "prov-tok")
+	if read == nil {
+		t.Error("read client must be built when Grafana is discovered")
+	}
+	if prov == nil {
+		t.Error("provisioning client must be built when a provisioning token is set")
+	}
+}
+
+func TestBuildGrafanaClients_NoGrafana(t *testing.T) {
+	read, prov := buildGrafanaClients("", "viewer-tok", "prov-tok")
+	if read != nil || prov != nil {
+		t.Error("no clients should be built when Grafana is not discovered")
+	}
+}
+
 func TestHandleResourceDashboard_KnownKind(t *testing.T) {
 	d := &Discoverer{
 		status: &MonitoringStatus{Grafana: ComponentStatus{Available: true}},


### PR DESCRIPTION
## Problem

The Grafana **Dashboards** page (`/monitoring/dashboards`) was always empty — "No Dashboards Found" — even when dashboards existed in Grafana and the proxy worked.

## Root cause

`HandleDashboards` lists dashboards via `Discoverer.GrafanaAPIClient()`, which returned the cached `grafClient`. But `grafClient` was **only constructed when a provisioning token was configured** — a coupling introduced by the P1-3 viewer/provisioning token split (security audit 2026-05-22).

Listing dashboards is a **read** operation, yet it was gated behind the **write** credential. In the standard deployment — dashboards loaded by the Grafana sidecar from the chart's `helm/kubecenter/dashboards/*.json` ConfigMaps, with only a viewer token (or anonymous Grafana) and **no** provisioning token — `grafClient` was `nil`, so `/v1/monitoring/dashboards` always returned `[]`.

## Fix

- **`discovery.go`** — extracted `buildGrafanaClients(grafURL, viewerToken, provisioningToken)`: a **read** client (viewer token, built whenever Grafana is discovered) backs listing; a **provisioning** client (provisioning token, built only when set) backs writes. The cached client used by `GrafanaAPIClient()`/`HandleDashboards` is now the read client. The P1-3 read/write separation is preserved — listing never gains write access.
- **`grafana.go`** — `SearchDashboards` omits the `Authorization` header when no token is set, so anonymous Grafana isn't rejected by an empty `Bearer ` value.
- **`monitoring_test.go`** — 3 tests pinning the invariant (read client built independent of provisioning token; both built when both tokens set; neither built without Grafana).

## Verification

- `go test ./internal/monitoring/` — pass (incl. new tests)
- `go vet ./...` — clean (repo-wide)
- `go test ./...` — full backend suite green

Frontend untouched.

## Follow-up (out of scope)

Dashboard cards link to the admin-gated `/api/v1/monitoring/grafana/proxy/...`, so non-admins can now see the list but get 403 on click. Pre-existing behavior. Smoke test against homelab recommended before merge; if Grafana has anonymous read disabled, populate `monitoring.grafana.viewerTokenSecret`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
