### PR TITLE
fix(helm): provision Grafana dashboards independent of monitoring.deploy

### DIFF
--- a/helm/kubecenter/templates/monitoring/grafana-dashboards-cm.yaml
+++ b/helm/kubecenter/templates/monitoring/grafana-dashboards-cm.yaml
@@ -1,5 +1,11 @@
 {{- include "kubecenter.validatePlaceholders" . }}
-{{- if .Values.monitoring.deploy }}
+{{- /*
+  Dashboard provisioning is decoupled from monitoring.deploy: KubeCenter's own
+  dashboards are loaded by whatever Grafana sidecar is watching (the bundled
+  subchart's, or an external kube-prometheus-stack's when deploy=false). Gated
+  by its own opt-out flag so external-Grafana installs still get the dashboards.
+*/ -}}
+{{- if .Values.monitoring.grafana.provisionDashboards }}
 {{- range $path, $_ := .Files.Glob "dashboards/*.json" }}
 ---
 apiVersion: v1

--- a/helm/kubecenter/values-homelab.yaml.example
+++ b/helm/kubecenter/values-homelab.yaml.example
@@ -97,3 +97,32 @@ postgresql:
       enabled: false
     containerSecurityContext:
       enabled: false
+
+# Monitoring — homelab runs an EXTERNAL kube-prometheus-stack in the
+# `monitoring` namespace, so k8sCenter discovers it rather than deploying its
+# own. With deploy=false, set provisionDashboards=true (default) so k8sCenter's
+# dashboard ConfigMaps are still created — the external Grafana sidecar
+# (NAMESPACE=ALL, label grafana_dashboard=1) loads them. The viewer token lets
+# the backend list + proxy those dashboards (Grafana anonymous auth is off).
+#
+# Create the viewer token (one-time), keeping it out of shell history + git:
+#   1. Grafana → Administration → Service accounts → add `k8scenter-viewer`
+#      with the Viewer role → add a service account token.
+#   2. Put it straight into a Secret (do NOT paste it into values.yaml):
+#        $sec = Read-Host -AsSecureString "Paste glsa_ token"
+#        $TOK = [System.Net.NetworkCredential]::new('', $sec).Password
+#        kubectl -n <release-ns> create secret generic kubecenter-grafana-viewer `
+#          --from-literal=KUBECENTER_MONITORING_GRAFANAVIEWERTOKEN="$TOK" `
+#          --dry-run=client -o yaml | kubectl apply -f -
+#        Remove-Variable TOK, sec
+#   3. Reference it below so the wiring survives `helm upgrade`.
+monitoring:
+  deploy: false              # discover the external kube-prometheus-stack
+  grafana:
+    provisionDashboards: true # create dashboard ConfigMaps for the external sidecar
+    viewerTokenSecret:
+      name: kubecenter-grafana-viewer
+      key: KUBECENTER_MONITORING_GRAFANAVIEWERTOKEN
+    # provisioningTokenSecret left unset — dashboards come via the sidecar,
+    # not k8sCenter's API provisioning. The "provisioning disabled" startup
+    # WARN is expected and harmless in this topology.

--- a/helm/kubecenter/values.yaml
+++ b/helm/kubecenter/values.yaml
@@ -232,6 +232,12 @@ monitoring:
     url: ""              # Override auto-discovery
   grafana:
     url: ""              # Override auto-discovery
+    # Provision KubeCenter's own dashboards as sidecar ConfigMaps (labeled
+    # grafana_dashboard=1). Independent of monitoring.deploy: when you run an
+    # external kube-prometheus-stack (deploy=false), its Grafana sidecar still
+    # loads these so the KubeCenter dashboards appear. Set false to opt out
+    # (e.g. you manage dashboards yourself or have no Grafana sidecar).
+    provisionDashboards: true
     # WARNING: monitoring.grafana.apiToken is DEPRECATED and will be removed in
     # v2.0. The single-token form silently degrades to viewer-only mode —
     # dashboard provisioning is DISABLED when this field is set without the


### PR DESCRIPTION
## Problem

After #367 (which let dashboard *listing* use the viewer token), the Dashboards page was still empty on a homelab running an **external** kube-prometheus-stack with `monitoring.deploy: false`. Live evidence: **zero** `kubecenter`-tagged dashboard ConfigMaps existed in the cluster, even though the Grafana sidecar watches `NAMESPACE=ALL` for `grafana_dashboard=1`.

## Root cause

The dashboard ConfigMap template (`grafana-dashboards-cm.yaml`) was gated behind `monitoring.deploy`. With an external stack (`deploy=false`) and no provisioning token, **neither** provisioning path ran:
- Sidecar ConfigMaps — gated off by `monitoring.deploy=false`.
- API provisioning — disabled (no provisioning token).

So KubeCenter's dashboards never reached Grafana.

## Fix

Gate the dashboard ConfigMaps on a new `monitoring.grafana.provisionDashboards` flag (**default true**), decoupled from `monitoring.deploy`. Whatever Grafana sidecar is present — the bundled subchart's, or an external stack's watching all namespaces — now loads KubeCenter's dashboards.

The datasource ConfigMap stays gated on `monitoring.deploy` (don't add a duplicate Prometheus datasource to an external Grafana). The dashboards carry no explicit datasource, so they resolve to Grafana's default, which the external stack already provides.

## Verification

- `helm lint` — clean
- `helm template --set monitoring.deploy=false` — 7 dashboard ConfigMaps now render (previously 0)
- `--set monitoring.grafana.provisionDashboards=false` — renders nothing (opt-out works)
- datasource CM with `deploy=false` — still 0 (no duplicate datasource)

## Note — homelab still needs a viewer token

This makes the dashboards *exist* in Grafana. The backend also needs a Grafana **viewer token** to list/proxy them (anonymous auth is disabled on the homelab Grafana). That's deployment config (`monitoring.grafana.viewerTokenSecret`), tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
