### PR TITLE
fix(monitoring): authenticate Grafana proxy via cookie so dashboards open in-browser

### DIFF
--- a/backend/internal/server/handle_auth.go
+++ b/backend/internal/server/handle_auth.go
@@ -415,6 +415,7 @@ func (s *Server) handleLogout(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.setRefreshCookie(w, "", -1)
+	s.setGrafanaProxyCookie(w, "", -1)
 
 	user, ok := auth.UserFromContext(r.Context())
 	if ok {

--- a/backend/internal/server/middleware/auth.go
+++ b/backend/internal/server/middleware/auth.go
@@ -40,6 +40,51 @@ func Auth(tm *auth.TokenManager) func(http.Handler) http.Handler {
 	}
 }
 
+// AuthCookieOrBearer returns middleware that validates a JWT access token taken
+// from EITHER the Authorization: Bearer header OR a named cookie (header wins
+// when both are present).
+//
+// This exists for browser-navigable, embeddable endpoints — specifically the
+// Grafana reverse-proxy. A Grafana dashboard is opened as a top-level
+// navigation / iframe and then pulls dozens of sub-resources (JS, CSS, API)
+// back through the same proxy path. None of those requests carry the
+// Authorization header the JS fetch client injects, so plain Bearer auth
+// (see Auth) makes the proxy unreachable from the browser. A path-scoped,
+// httpOnly cookie is sent automatically on every same-origin request to the
+// proxy path, authenticating the whole set. The cookie carries the same access
+// token used as a Bearer elsewhere — no additional privilege — and is set by
+// the auth handlers (see setGrafanaProxyCookie) scoped to the proxy path only.
+func AuthCookieOrBearer(tm *auth.TokenManager, cookieName string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var token string
+			if header := r.Header.Get("Authorization"); header != "" {
+				t, found := strings.CutPrefix(header, "Bearer ")
+				if !found || t == "" {
+					writeAuthError(w, http.StatusUnauthorized, "invalid authorization header format")
+					return
+				}
+				token = t
+			} else if c, err := r.Cookie(cookieName); err == nil && c.Value != "" {
+				token = c.Value
+			} else {
+				writeAuthError(w, http.StatusUnauthorized, "missing authorization")
+				return
+			}
+
+			claims, err := tm.ValidateAccessToken(token)
+			if err != nil {
+				writeAuthError(w, http.StatusUnauthorized, "invalid or expired token")
+				return
+			}
+
+			user := auth.UserFromClaims(claims)
+			ctx := auth.ContextWithUser(r.Context(), user)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
 // CSRF returns middleware that requires the X-Requested-With header on
 // state-changing requests (POST, PUT, PATCH, DELETE).
 // This prevents CSRF attacks since browsers won't add custom headers in cross-origin requests.

--- a/backend/internal/server/middleware/auth.go
+++ b/backend/internal/server/middleware/auth.go
@@ -27,17 +27,24 @@ func Auth(tm *auth.TokenManager) func(http.Handler) http.Handler {
 				return
 			}
 
-			claims, err := tm.ValidateAccessToken(token)
-			if err != nil {
-				writeAuthError(w, http.StatusUnauthorized, "invalid or expired token")
-				return
-			}
-
-			user := auth.UserFromClaims(claims)
-			ctx := auth.ContextWithUser(r.Context(), user)
-			next.ServeHTTP(w, r.WithContext(ctx))
+			validateAndInjectUser(tm, token, w, r, next)
 		})
 	}
+}
+
+// validateAndInjectUser validates an access token, places the resolved user in
+// the request context, and calls next — the shared tail of Auth and
+// AuthCookieOrBearer. On an invalid/expired token it writes a 401 and does not
+// call next.
+func validateAndInjectUser(tm *auth.TokenManager, token string, w http.ResponseWriter, r *http.Request, next http.Handler) {
+	claims, err := tm.ValidateAccessToken(token)
+	if err != nil {
+		writeAuthError(w, http.StatusUnauthorized, "invalid or expired token")
+		return
+	}
+	user := auth.UserFromClaims(claims)
+	ctx := auth.ContextWithUser(r.Context(), user)
+	next.ServeHTTP(w, r.WithContext(ctx))
 }
 
 // AuthCookieOrBearer returns middleware that validates a JWT access token taken
@@ -72,15 +79,7 @@ func AuthCookieOrBearer(tm *auth.TokenManager, cookieName string) func(http.Hand
 				return
 			}
 
-			claims, err := tm.ValidateAccessToken(token)
-			if err != nil {
-				writeAuthError(w, http.StatusUnauthorized, "invalid or expired token")
-				return
-			}
-
-			user := auth.UserFromClaims(claims)
-			ctx := auth.ContextWithUser(r.Context(), user)
-			next.ServeHTTP(w, r.WithContext(ctx))
+			validateAndInjectUser(tm, token, w, r, next)
 		})
 	}
 }

--- a/backend/internal/server/middleware/auth_test.go
+++ b/backend/internal/server/middleware/auth_test.go
@@ -148,6 +148,34 @@ func TestAuthCookieOrBearer_AcceptsBearer(t *testing.T) {
 	}
 }
 
+func TestAuthCookieOrBearer_HeaderWinsOverInvalidCookie(t *testing.T) {
+	tm := auth.NewTokenManager([]byte("test-secret-key-32-bytes-long!!"))
+	user := &auth.User{ID: "u1", Username: "admin", Roles: []string{"admin"}}
+	token, _ := tm.IssueAccessToken(user)
+
+	var gotUser *auth.User
+	handler := AuthCookieOrBearer(tm, "grafana_proxy_token")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if u, ok := auth.UserFromContext(r.Context()); ok {
+			gotUser = u
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Valid Bearer header AND a junk cookie: header wins, request succeeds.
+	req := httptest.NewRequest("GET", "/api/v1/monitoring/grafana/proxy/d/abc/x", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "grafana_proxy_token", Value: "not-a-jwt"})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200 (header wins over invalid cookie), got %d", rec.Code)
+	}
+	if gotUser == nil || gotUser.Username != "admin" {
+		t.Fatalf("expected admin from bearer token, got %v", gotUser)
+	}
+}
+
 func TestAuthCookieOrBearer_RejectsNeither(t *testing.T) {
 	tm := auth.NewTokenManager([]byte("test-secret-key-32-bytes-long!!"))
 	handler := AuthCookieOrBearer(tm, "grafana_proxy_token")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/server/middleware/auth_test.go
+++ b/backend/internal/server/middleware/auth_test.go
@@ -99,6 +99,86 @@ func TestAuth_RejectsBadFormat(t *testing.T) {
 	}
 }
 
+func TestAuthCookieOrBearer_AcceptsCookie(t *testing.T) {
+	tm := auth.NewTokenManager([]byte("test-secret-key-32-bytes-long!!"))
+	user := &auth.User{ID: "u1", Username: "admin", Roles: []string{"admin"}}
+	token, err := tm.IssueAccessToken(user)
+	if err != nil {
+		t.Fatalf("IssueAccessToken failed: %v", err)
+	}
+
+	var gotUser *auth.User
+	handler := AuthCookieOrBearer(tm, "grafana_proxy_token")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if u, ok := auth.UserFromContext(r.Context()); ok {
+			gotUser = u
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Browser navigation: no Authorization header, token in cookie only.
+	req := httptest.NewRequest("GET", "/api/v1/monitoring/grafana/proxy/d/abc/x", nil)
+	req.AddCookie(&http.Cookie{Name: "grafana_proxy_token", Value: token})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200 with cookie auth, got %d", rec.Code)
+	}
+	if gotUser == nil || gotUser.Username != "admin" {
+		t.Fatalf("expected admin user in context, got %v", gotUser)
+	}
+}
+
+func TestAuthCookieOrBearer_AcceptsBearer(t *testing.T) {
+	tm := auth.NewTokenManager([]byte("test-secret-key-32-bytes-long!!"))
+	user := &auth.User{ID: "u1", Username: "admin", Roles: []string{"admin"}}
+	token, _ := tm.IssueAccessToken(user)
+
+	handler := AuthCookieOrBearer(tm, "grafana_proxy_token")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/api/v1/monitoring/grafana/proxy/d/abc/x", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200 with bearer auth, got %d", rec.Code)
+	}
+}
+
+func TestAuthCookieOrBearer_RejectsNeither(t *testing.T) {
+	tm := auth.NewTokenManager([]byte("test-secret-key-32-bytes-long!!"))
+	handler := AuthCookieOrBearer(tm, "grafana_proxy_token")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/api/v1/monitoring/grafana/proxy/d/abc/x", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 with no credential, got %d", rec.Code)
+	}
+}
+
+func TestAuthCookieOrBearer_RejectsInvalidCookie(t *testing.T) {
+	tm := auth.NewTokenManager([]byte("test-secret-key-32-bytes-long!!"))
+	handler := AuthCookieOrBearer(tm, "grafana_proxy_token")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/api/v1/monitoring/grafana/proxy/d/abc/x", nil)
+	req.AddCookie(&http.Cookie{Name: "grafana_proxy_token", Value: "not-a-jwt"})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 with invalid cookie, got %d", rec.Code)
+	}
+}
+
 func TestCSRF_BlocksStateChangingWithoutHeader(t *testing.T) {
 	handler := CSRF(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/backend/internal/server/monitoring_proxy_test.go
+++ b/backend/internal/server/monitoring_proxy_test.go
@@ -142,6 +142,80 @@ func TestGrafanaProxy_AdminGets200(t *testing.T) {
 	}
 }
 
+// loginCapture logs in and returns the grafana_proxy_token cookie set by the
+// login response (or nil if absent).
+func loginCapture(t *testing.T, srv *Server, username string, roles []string) *http.Cookie {
+	t.Helper()
+	if _, err := srv.LocalAuth.CreateUser(context.Background(), username, "password1234", roles, nil); err != nil {
+		t.Fatalf("CreateUser %s: %v", username, err)
+	}
+	body := `{"username":"` + username + `","password":"password1234"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Requested-With", "XMLHttpRequest")
+	w := httptest.NewRecorder()
+	srv.Router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("login %s failed: %d %s", username, w.Code, w.Body.String())
+	}
+	for _, c := range w.Result().Cookies() {
+		if c.Name == "grafana_proxy_token" {
+			return c
+		}
+	}
+	return nil
+}
+
+// TestGrafanaProxy_AdminCookieGets200 verifies the browser-navigation case: an
+// admin reaches the proxy with ONLY the path-scoped cookie (no Authorization
+// header), and that login sets the cookie scoped + hardened correctly.
+func TestGrafanaProxy_AdminCookieGets200(t *testing.T) {
+	srv := grafanaProxyTestServer(t)
+	cookie := loginCapture(t, srv, "admin-cookie", []string{"admin"})
+	if cookie == nil || cookie.Value == "" {
+		t.Fatal("login did not set grafana_proxy_token cookie")
+	}
+	if cookie.Path != "/api/v1/monitoring/grafana/proxy" {
+		t.Errorf("cookie path = %q, want /api/v1/monitoring/grafana/proxy", cookie.Path)
+	}
+	if !cookie.HttpOnly {
+		t.Error("grafana_proxy_token cookie must be HttpOnly")
+	}
+
+	// No Authorization header — cookie only, as a browser navigation sends.
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/monitoring/grafana/proxy/d/kubecenter-pods/overview", nil)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	srv.Router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("admin cookie GET grafana proxy: expected 200, got %d (body: %s)",
+			w.Code, w.Body.String())
+	}
+}
+
+// TestGrafanaProxy_NonAdminCookieGets403 verifies the admin gate still applies
+// on the cookie auth path.
+func TestGrafanaProxy_NonAdminCookieGets403(t *testing.T) {
+	srv := grafanaProxyTestServer(t)
+	cookie := loginCapture(t, srv, "viewer-cookie", []string{"viewer"})
+	if cookie == nil || cookie.Value == "" {
+		t.Fatal("login did not set grafana_proxy_token cookie")
+	}
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/monitoring/grafana/proxy/d/kubecenter-pods/overview", nil)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	srv.Router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("non-admin cookie GET grafana proxy: expected 403, got %d (body: %s)",
+			w.Code, w.Body.String())
+	}
+}
+
 // TestGrafanaProxy_PostReturns405 verifies that POST (not in Get/Head-only
 // registration) returns 405 Method Not Allowed from chi, regardless of user role.
 func TestGrafanaProxy_PostReturns405(t *testing.T) {

--- a/backend/internal/server/monitoring_proxy_test.go
+++ b/backend/internal/server/monitoring_proxy_test.go
@@ -181,6 +181,9 @@ func TestGrafanaProxy_AdminCookieGets200(t *testing.T) {
 	if !cookie.HttpOnly {
 		t.Error("grafana_proxy_token cookie must be HttpOnly")
 	}
+	if cookie.SameSite != http.SameSiteStrictMode {
+		t.Errorf("cookie SameSite = %v, want Strict (closes cross-site CSRF on the privileged proxy)", cookie.SameSite)
+	}
 
 	// No Authorization header — cookie only, as a browser navigation sends.
 	req := httptest.NewRequest(http.MethodGet,
@@ -192,6 +195,117 @@ func TestGrafanaProxy_AdminCookieGets200(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Errorf("admin cookie GET grafana proxy: expected 200, got %d (body: %s)",
 			w.Code, w.Body.String())
+	}
+}
+
+// loginAllCookies logs in (cookie mode) and returns all cookies the response set,
+// keyed by name.
+func loginAllCookies(t *testing.T, srv *Server, username string, roles []string) map[string]*http.Cookie {
+	t.Helper()
+	if _, err := srv.LocalAuth.CreateUser(context.Background(), username, "password1234", roles, nil); err != nil {
+		t.Fatalf("CreateUser %s: %v", username, err)
+	}
+	body := `{"username":"` + username + `","password":"password1234"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Requested-With", "XMLHttpRequest")
+	w := httptest.NewRecorder()
+	srv.Router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("login %s failed: %d %s", username, w.Code, w.Body.String())
+	}
+	out := map[string]*http.Cookie{}
+	for _, c := range w.Result().Cookies() {
+		out[c.Name] = c
+	}
+	return out
+}
+
+// TestGrafanaProxyCookie_SetOnRefresh verifies that a cookie-mode /auth/refresh
+// rotates grafana_proxy_token so a browser-loaded dashboard keeps working past
+// the access-token lifetime.
+func TestGrafanaProxyCookie_SetOnRefresh(t *testing.T) {
+	srv := grafanaProxyTestServer(t)
+	cookies := loginAllCookies(t, srv, "admin-refresh", []string{"admin"})
+	refresh := cookies["refresh_token"]
+	if refresh == nil {
+		t.Fatal("login did not set refresh_token cookie")
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/refresh", nil)
+	req.Header.Set("X-Requested-With", "XMLHttpRequest")
+	req.AddCookie(refresh)
+	w := httptest.NewRecorder()
+	srv.Router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("refresh failed: %d %s", w.Code, w.Body.String())
+	}
+
+	var got *http.Cookie
+	for _, c := range w.Result().Cookies() {
+		if c.Name == "grafana_proxy_token" {
+			got = c
+		}
+	}
+	if got == nil || got.Value == "" || got.MaxAge <= 0 {
+		t.Fatalf("refresh did not re-set grafana_proxy_token (got %+v)", got)
+	}
+}
+
+// TestGrafanaProxyCookie_ClearedOnLogout verifies logout expires the cookie.
+func TestGrafanaProxyCookie_ClearedOnLogout(t *testing.T) {
+	srv := grafanaProxyTestServer(t)
+	cookies := loginAllCookies(t, srv, "admin-logout", []string{"admin"})
+	refresh := cookies["refresh_token"]
+	if refresh == nil {
+		t.Fatal("login did not set refresh_token cookie")
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/logout", nil)
+	req.Header.Set("X-Requested-With", "XMLHttpRequest")
+	req.AddCookie(refresh)
+	w := httptest.NewRecorder()
+	srv.Router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("logout failed: %d %s", w.Code, w.Body.String())
+	}
+
+	var got *http.Cookie
+	for _, c := range w.Result().Cookies() {
+		if c.Name == "grafana_proxy_token" {
+			got = c
+		}
+	}
+	if got == nil || got.MaxAge >= 0 {
+		t.Fatalf("logout did not clear grafana_proxy_token (got %+v)", got)
+	}
+}
+
+// TestSetGrafanaProxyCookie_SecureFollowsDev verifies the Secure flag tracks
+// !Dev so production cookies are Secure and dev cookies work over plain HTTP.
+func TestSetGrafanaProxyCookie_SecureFollowsDev(t *testing.T) {
+	for _, tc := range []struct {
+		dev        bool
+		wantSecure bool
+	}{
+		{dev: false, wantSecure: true},
+		{dev: true, wantSecure: false},
+	} {
+		s := &Server{Config: &config.Config{Dev: tc.dev}}
+		w := httptest.NewRecorder()
+		s.setGrafanaProxyCookie(w, "token-value", 900)
+		var got *http.Cookie
+		for _, c := range w.Result().Cookies() {
+			if c.Name == "grafana_proxy_token" {
+				got = c
+			}
+		}
+		if got == nil {
+			t.Fatalf("dev=%v: cookie not set", tc.dev)
+		}
+		if got.Secure != tc.wantSecure {
+			t.Errorf("dev=%v: Secure = %v, want %v", tc.dev, got.Secure, tc.wantSecure)
+		}
 	}
 }
 

--- a/backend/internal/server/response.go
+++ b/backend/internal/server/response.go
@@ -46,15 +46,28 @@ func (s *Server) setRefreshCookie(w http.ResponseWriter, value string, maxAge in
 // proxy requests (not every API call), and read by middleware.AuthCookieOrBearer.
 const grafanaProxyCookieName = "grafana_proxy_token"
 
+// grafanaProxyPathPrefix is the proxy route path relative to the /api/v1 group.
+// Single source of truth shared by the cookie scope and the route registration
+// (registerGrafanaProxyRoute) so the two cannot drift — a mismatch would scope
+// the cookie to the wrong path and silently break browser-loaded dashboards.
+const grafanaProxyPathPrefix = "/monitoring/grafana/proxy"
+
 // grafanaProxyCookiePath scopes the cookie to the Grafana proxy subtree.
-const grafanaProxyCookiePath = "/api/v1/monitoring/grafana/proxy"
+const grafanaProxyCookiePath = "/api/v1" + grafanaProxyPathPrefix
 
 // setGrafanaProxyCookie sets (or clears, when value is empty) the path-scoped
-// httpOnly access-token cookie that lets browser navigations / iframes load the
-// proxied Grafana dashboard and its sub-resources — which cannot carry the
-// Authorization: Bearer header. SameSite=Lax so it is sent on top-level
-// navigations; the value is the same access token used as a Bearer elsewhere,
-// scoped to the proxy path and bounded to the access-token lifetime.
+// httpOnly access-token cookie that lets same-origin browser navigations /
+// iframes load the proxied Grafana dashboard and its sub-resources — which
+// cannot carry the Authorization: Bearer header. The value is the same access
+// token used as a Bearer elsewhere, scoped to the proxy path and bounded to the
+// access-token lifetime; it is set on every cookie-mode token issue (login,
+// refresh, OIDC web callback) and cleared on logout.
+//
+// SameSite=Strict (matching the refresh cookie): the dashboards page opens the
+// proxy as a SAME-ORIGIN top-level navigation (and any embed is same-origin),
+// both of which send Strict cookies — so the legitimate flow is unaffected,
+// while cross-site-initiated requests get no cookie, closing the CSRF surface
+// on this admin-gated, privileged-token-injecting proxy.
 func (s *Server) setGrafanaProxyCookie(w http.ResponseWriter, value string, maxAge int) {
 	http.SetCookie(w, &http.Cookie{
 		Name:     grafanaProxyCookieName,
@@ -62,7 +75,7 @@ func (s *Server) setGrafanaProxyCookie(w http.ResponseWriter, value string, maxA
 		Path:     grafanaProxyCookiePath,
 		HttpOnly: true,
 		Secure:   !s.Config.Dev,
-		SameSite: http.SameSiteLaxMode,
+		SameSite: http.SameSiteStrictMode,
 		MaxAge:   maxAge,
 	})
 }

--- a/backend/internal/server/response.go
+++ b/backend/internal/server/response.go
@@ -41,6 +41,32 @@ func (s *Server) setRefreshCookie(w http.ResponseWriter, value string, maxAge in
 	})
 }
 
+// grafanaProxyCookieName is the access-token cookie the Grafana reverse-proxy
+// authenticates with. It is scoped to the proxy path so it is sent ONLY on
+// proxy requests (not every API call), and read by middleware.AuthCookieOrBearer.
+const grafanaProxyCookieName = "grafana_proxy_token"
+
+// grafanaProxyCookiePath scopes the cookie to the Grafana proxy subtree.
+const grafanaProxyCookiePath = "/api/v1/monitoring/grafana/proxy"
+
+// setGrafanaProxyCookie sets (or clears, when value is empty) the path-scoped
+// httpOnly access-token cookie that lets browser navigations / iframes load the
+// proxied Grafana dashboard and its sub-resources — which cannot carry the
+// Authorization: Bearer header. SameSite=Lax so it is sent on top-level
+// navigations; the value is the same access token used as a Bearer elsewhere,
+// scoped to the proxy path and bounded to the access-token lifetime.
+func (s *Server) setGrafanaProxyCookie(w http.ResponseWriter, value string, maxAge int) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     grafanaProxyCookieName,
+		Value:    value,
+		Path:     grafanaProxyCookiePath,
+		HttpOnly: true,
+		Secure:   !s.Config.Dev,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   maxAge,
+	})
+}
+
 // newAuditEntry creates an audit entry pre-filled with common fields.
 //
 // SourceIP is set from r.RemoteAddr (which chi's RealIP may have rewritten
@@ -126,6 +152,10 @@ func (s *Server) issueTokenPairAt(w http.ResponseWriter, user *auth.User, cookie
 
 	if cookieMode {
 		s.setRefreshCookie(w, refreshToken, int(refreshLifetime.Seconds()))
+		// Path-scoped access-token cookie so browser-loaded Grafana proxy
+		// requests (which can't send the Bearer header) authenticate. Bounded
+		// to the access-token lifetime; refreshed on every /auth/refresh.
+		s.setGrafanaProxyCookie(w, accessToken, int(auth.AccessTokenLifetime.Seconds()))
 	}
 
 	return accessToken, refreshToken, nil

--- a/backend/internal/server/routes.go
+++ b/backend/internal/server/routes.go
@@ -97,6 +97,14 @@ func (s *Server) registerRoutes() {
 			r.With(middleware.RateLimit(webhookRL)).Post("/alerts/webhook", s.AlertingHandler.HandleWebhook)
 		}
 
+		// Grafana reverse-proxy — admin only, mounted OUTSIDE the Bearer-only
+		// authenticated group below. Authenticated via cookie OR bearer so
+		// browser navigations / iframes (which can't send the Authorization
+		// header) can load embedded dashboards and their sub-resources.
+		if s.MonitoringHandler != nil {
+			s.registerGrafanaProxyRoute(r)
+		}
+
 		// Authenticated routes — auth + CSRF enforced at the group level
 		r.Group(func(ar chi.Router) {
 			ar.Use(middleware.Auth(s.TokenManager))
@@ -341,6 +349,27 @@ func (s *Server) registerWizardRoutes(ar chi.Router) {
 	})
 }
 
+// registerGrafanaProxyRoute mounts the Grafana reverse-proxy with cookie-or-bearer
+// auth + admin gate, separate from the Bearer-only authenticated group. The
+// proxy is reached by browser navigations / iframes (the dashboards page opens
+// /monitoring/grafana/proxy/<d.url> in a new tab), which cannot carry the
+// Authorization header; the path-scoped grafana_proxy_token cookie authenticates
+// them and every sub-resource Grafana subsequently loads through the proxy.
+//
+// Method narrowing (Phase 2, F#25): only GET and HEAD are registered. Write
+// methods return 405 — write operations against Grafana must go through a typed,
+// audited handler, not the opaque proxy. Do not add PATCH/POST without a
+// security review.
+func (s *Server) registerGrafanaProxyRoute(r chi.Router) {
+	r.Group(func(gr chi.Router) {
+		gr.Use(middleware.AuthCookieOrBearer(s.TokenManager, grafanaProxyCookieName))
+		gr.Use(middleware.ClusterContext)
+		gr.Use(middleware.RequireAdmin)
+		gr.Get("/monitoring/grafana/proxy/*", s.MonitoringHandler.GrafanaProxy)
+		gr.Head("/monitoring/grafana/proxy/*", s.MonitoringHandler.GrafanaProxy)
+	})
+}
+
 func (s *Server) registerMonitoringRoutes(ar chi.Router) {
 	h := s.MonitoringHandler
 	ar.Route("/monitoring", func(mr chi.Router) {
@@ -357,20 +386,11 @@ func (s *Server) registerMonitoringRoutes(ar chi.Router) {
 		// Slug-based queries — authenticated non-admin users, RBAC-enforced per slug (P2-4).
 		mr.Get("/queries/*", h.HandleSlugQuery)
 
-		// Grafana reverse-proxy — admin only (viewer token injected server-side).
-		//
-		// Method narrowing (Phase 2, F#25): Only GET and HEAD are registered.
-		// POST / PUT / PATCH / DELETE now return 405 via chi's MethodNotAllowed
-		// handler. This is intentional — write operations against Grafana must
-		// go through a typed handler (HandleDashboards, etc.) where input is
-		// validated and audited, not through the opaque reverse-proxy.
-		// Removing a method here is a deliberate API contract change; do not
-		// re-add PATCH/POST without a security review.
-		mr.Route("/grafana/proxy", func(gr chi.Router) {
-			gr.Use(middleware.RequireAdmin)
-			gr.Get("/*", h.GrafanaProxy)
-			gr.Head("/*", h.GrafanaProxy)
-		})
+		// NOTE: the Grafana reverse-proxy (/monitoring/grafana/proxy/*) is
+		// deliberately NOT registered here. It is mounted in its own group
+		// (registerGrafanaProxyRoute) with cookie-or-bearer auth, because it is
+		// loaded by browser navigations / iframes that cannot send the
+		// Authorization header this group's Bearer-only Auth middleware requires.
 	})
 }
 

--- a/backend/internal/server/routes.go
+++ b/backend/internal/server/routes.go
@@ -365,8 +365,13 @@ func (s *Server) registerGrafanaProxyRoute(r chi.Router) {
 		gr.Use(middleware.AuthCookieOrBearer(s.TokenManager, grafanaProxyCookieName))
 		gr.Use(middleware.ClusterContext)
 		gr.Use(middleware.RequireAdmin)
-		gr.Get("/monitoring/grafana/proxy/*", s.MonitoringHandler.GrafanaProxy)
-		gr.Head("/monitoring/grafana/proxy/*", s.MonitoringHandler.GrafanaProxy)
+		// CSRF is inert for the GET/HEAD-only registration below, but kept for
+		// middleware-stack parity with the authenticated group: if a write verb
+		// is ever added here it is CSRF-protected by default rather than silently
+		// exposed (the method narrowing already 405s writes — defense in depth).
+		gr.Use(middleware.CSRF)
+		gr.Get(grafanaProxyPathPrefix+"/*", s.MonitoringHandler.GrafanaProxy)
+		gr.Head(grafanaProxyPathPrefix+"/*", s.MonitoringHandler.GrafanaProxy)
 	})
 }
 


### PR DESCRIPTION
## Problem

After #367 + #368 the Dashboards page lists dashboards, but **clicking a card** returns `401 missing authorization header`. The card opens `/api/v1/monitoring/grafana/proxy/<d.url>?kiosk=1` as a top-level browser navigation, which carries no `Authorization` header — that's only added by the JS fetch client (`lib/api.ts`). The proxy sat behind **Bearer-only** auth (`middleware.Auth`), so the navigation was rejected.

A query-param/Bearer token can't fix it either: once a Grafana page opens, it pulls **dozens of sub-resources** (JS, CSS, API) back through the same proxy path, and none of those browser-initiated requests can set a header. Only a **cookie** — sent automatically on every same-origin request to the path — can authenticate the whole set.

## Fix

Authenticate the proxy via a path-scoped, httpOnly access-token cookie, mirroring the existing `oidc_access_token` pattern (`handle_auth.go`).

- **`middleware.AuthCookieOrBearer`** — validates the JWT from the `Authorization: Bearer` header **or** a named cookie (header wins). 4 unit tests.
- **`setGrafanaProxyCookie`** — sets `grafana_proxy_token` on web login + refresh (**cookie-mode only**; body-mode/mobile untouched), cleared on logout:
  - `Path=/api/v1/monitoring/grafana/proxy` — sent **only** on proxy requests, not every API call
  - `HttpOnly`, `Secure` (non-dev), `SameSite=Lax` (sent on top-level navigations)
  - TTL = access-token lifetime (15m); refreshed on every `/auth/refresh`
  - Value is the **same** access token used as a Bearer elsewhere — no added privilege
- **`registerGrafanaProxyRoute`** — mounts the proxy in its own group **outside** the Bearer-only group, preserving the admin gate (`RequireAdmin`) and GET/HEAD-only narrowing (F#25). Removed from `registerMonitoringRoutes`.

## Security notes

- No privilege escalation: the cookie carries the existing access token, scoped to the proxy path, 15m TTL, HttpOnly (no JS access), Secure outside dev.
- CSRF: proxy is GET/HEAD-only and read-only (Grafana viewer) — an attacker forcing a dashboard view changes no state. SameSite=Lax further bounds cross-site sends.
- Admin gate unchanged and verified on both auth paths.

## Verification

- `go vet ./...` clean; `go test ./...` green (repo-wide).
- New/updated tests: cookie-only admin GET → 200; non-admin cookie → 403; Bearer still 200; POST → 405; cookie Path + HttpOnly asserted; 4 `AuthCookieOrBearer` unit tests.

## Notes

- No frontend change — the existing card link works once the browser holds the cookie. Existing logged-in sessions get it on next login/refresh.
- Caveat (accepted, per chosen approach): a dashboard tab left open beyond the 15m access-token TTL needs a refresh to keep loading sub-resources. A dedicated longer-lived proxy token was considered and deferred.

This is an auth/security change — recommend `/ce:review` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
