### PR TITLE
test(backend): fuzzing PR #3 — parsePHC, ParseMultiDoc, isPublicIP (Layer A breadth)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -22,6 +22,9 @@ jobs:
           - { pkg: ./internal/servicemesh/, target: FuzzParseMeshCompositeID }
           - { pkg: ./internal/server/, target: FuzzAuthzEnforcement }
           - { pkg: ./internal/k8s/resources/, target: FuzzMaskedSecret }
+          - { pkg: ./internal/auth/, target: FuzzParsePHC }
+          - { pkg: ./internal/yaml/, target: FuzzParseMultiDoc }
+          - { pkg: ./internal/wizard/, target: FuzzIsPublicIP }
     name: ${{ matrix.target }}
     defaults:
       run:

--- a/backend/internal/auth/phc_fuzz_test.go
+++ b/backend/internal/auth/phc_fuzz_test.go
@@ -1,0 +1,66 @@
+package auth
+
+import (
+	"strings"
+	"testing"
+)
+
+// FuzzParsePHC fuzzes the PHC-string parser used by Argon2id password
+// verification. parsePHC is called on persisted (attacker-influenced)
+// credential strings, so crash-safety on malformed input is the security
+// value. Oracle: parsePHC must never panic for any input string. A
+// returned error on malformed input is expected and correct — the test
+// asserts nothing about the error value. On the success branch (err==nil)
+// we sanity-check that salt and hash are non-nil to guard against a
+// silent empty-slice return that would let an attacker bypass verification.
+func FuzzParsePHC(f *testing.F) {
+	// Valid PHC string — real base64url (no padding) segments.
+	// Salt: 16 random bytes → base64.RawStdEncoding → "c2FsdHNhbHRzYWx0c2Fs"
+	// Hash: 32 random bytes → base64.RawStdEncoding → "aGFzaGhhc2hoYXNoaGFzaGhhc2hoYXNoaGFzaA"
+	f.Add("$argon2id$v=19$m=65536,t=3,p=4$c2FsdHNhbHRzYWx0c2Fs$aGFzaGhhc2hoYXNoaGFzaGhhc2hoYXNoaGFzaA")
+
+	// Truncated — missing everything after v=19.
+	f.Add("$argon2id$v=19$")
+
+	// Missing hash segment — valid params + salt but no trailing $<hash>.
+	f.Add("$argon2id$v=19$m=65536,t=3,p=4$c2FsdHNhbHRzYWx0c2Fs")
+
+	// Bad base64 in both salt and hash positions.
+	f.Add("$argon2id$v=19$m=1,t=1,p=1$!!!$@@@")
+
+	// Empty string.
+	f.Add("")
+
+	// Huge string (64 KB of '$' separators).
+	f.Add(strings.Repeat("$", 1<<16))
+
+	// Many '$' with otherwise plausible-looking content.
+	f.Add("$argon2id$v=19$m=1,t=1,p=1$" + strings.Repeat("aGk$", 50))
+
+	// Correct prefix but wrong algorithm name.
+	f.Add("$argon2i$v=19$m=65536,t=3,p=4$c2FsdHNhbHRzYWx0c2Fs$aGFzaGhhc2hoYXNoaGFzaGhhc2hoYXNoaGFzaA")
+
+	// Negative / zero parameters.
+	f.Add("$argon2id$v=19$m=0,t=0,p=0$c2FsdHNhbHRzYWx0c2Fs$aGFzaGhhc2hoYXNoaGFzaGhhc2hoYXNoaGFzaA")
+
+	// Version field overflow bait.
+	f.Add("$argon2id$v=99999999999999999999$m=65536,t=3,p=4$c2FsdA$aGFzaA")
+
+	// Null bytes embedded.
+	f.Add("$argon2id$v=19$m=65536,t=3,p=4$\x00\x00$\x00\x00")
+
+	f.Fuzz(func(t *testing.T, phc string) {
+		salt, hash, err := parsePHC(phc)
+		if err != nil {
+			// Malformed input → error is the expected, correct path.
+			return
+		}
+		// Success branch: sanity — neither slice should be nil.
+		if salt == nil {
+			t.Fatal("parsePHC returned nil salt with nil error")
+		}
+		if hash == nil {
+			t.Fatal("parsePHC returned nil hash with nil error")
+		}
+	})
+}

--- a/backend/internal/wizard/ssrf_fuzz_test.go
+++ b/backend/internal/wizard/ssrf_fuzz_test.go
@@ -14,7 +14,7 @@ var cgnatWizardNet = func() *net.IPNet {
 
 // FuzzIsPublicIP fuzzes the pure SSRF IP-classification core of validateHTTPSPublicURL.
 // Oracle (inverted from FuzzCheckIPNotPrivate): for any address the Go stdlib classifies
-// as loopback, private (RFC1918), link-local unicast or multicast, unspecified, multicast,
+// as loopback, private (RFC1918), link-local (unicast or multicast), multicast, unspecified,
 // or CGNAT (100.64.0.0/10), isPublicIP MUST return false. A regression that lets any of
 // these through is an SSRF hole. The must-reject set is a strict subset of what isPublicIP
 // actually claims to block — no false positives.

--- a/backend/internal/wizard/ssrf_fuzz_test.go
+++ b/backend/internal/wizard/ssrf_fuzz_test.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 )
 
-// cgnatWizardNet is the CGNAT block (RFC 6598, 100.64.0.0/10) mirrored from the
-// inline guard in isPublicIP so the oracle detects removal of that guard.
+// cgnatWizardNet is the CGNAT block (RFC 6598, 100.64.0.0/10) re-derived
+// independently of the bit-arithmetic guard in isPublicIP. An independent
+// re-derivation (rather than calling isPublicIP's own logic) lets the oracle
+// detect removal or drift of that guard instead of silently agreeing with it.
 var cgnatWizardNet = func() *net.IPNet {
 	_, n, _ := net.ParseCIDR("100.64.0.0/10")
 	return n
@@ -14,10 +16,10 @@ var cgnatWizardNet = func() *net.IPNet {
 
 // FuzzIsPublicIP fuzzes the pure SSRF IP-classification core of validateHTTPSPublicURL.
 // Oracle (inverted from FuzzCheckIPNotPrivate): for any address the Go stdlib classifies
-// as loopback, private (RFC1918), link-local (unicast or multicast), multicast, unspecified,
-// or CGNAT (100.64.0.0/10), isPublicIP MUST return false. A regression that lets any of
-// these through is an SSRF hole. The must-reject set is a strict subset of what isPublicIP
-// actually claims to block — no false positives.
+// as loopback, private (RFC1918), link-local unicast, multicast, or unspecified, or that
+// falls in CGNAT (100.64.0.0/10), isPublicIP MUST return false. A regression that lets any
+// of these through is an SSRF hole. The must-reject set mirrors isPublicIP's guards exactly
+// (cert_helpers.go) — no false positives.
 func FuzzIsPublicIP(f *testing.F) {
 	// 4-byte (IPv4) and 16-byte (IPv6) seeds spanning each blocked class.
 	f.Add([]byte{127, 0, 0, 1})       // loopback
@@ -39,12 +41,13 @@ func FuzzIsPublicIP(f *testing.F) {
 		}
 		ip := net.IP(raw)
 
-		// mustBeNonPublic mirrors the exact set of classes isPublicIP blocks.
-		// Every predicate here corresponds to a guard in isPublicIP's body.
+		// mustBeNonPublic mirrors the exact set of classes isPublicIP blocks
+		// (cert_helpers.go): loopback, RFC1918 private, link-local unicast,
+		// unspecified, multicast, and CGNAT. (Link-local multicast is a strict
+		// subset of IsMulticast, so it needs no separate term.)
 		mustBeNonPublic := ip.IsLoopback() ||
 			ip.IsPrivate() ||
 			ip.IsLinkLocalUnicast() ||
-			ip.IsLinkLocalMulticast() ||
 			ip.IsUnspecified() ||
 			ip.IsMulticast() ||
 			cgnatWizardNet.Contains(ip)

--- a/backend/internal/wizard/ssrf_fuzz_test.go
+++ b/backend/internal/wizard/ssrf_fuzz_test.go
@@ -1,0 +1,56 @@
+package wizard
+
+import (
+	"net"
+	"testing"
+)
+
+// cgnatWizardNet is the CGNAT block (RFC 6598, 100.64.0.0/10) mirrored from the
+// inline guard in isPublicIP so the oracle detects removal of that guard.
+var cgnatWizardNet = func() *net.IPNet {
+	_, n, _ := net.ParseCIDR("100.64.0.0/10")
+	return n
+}()
+
+// FuzzIsPublicIP fuzzes the pure SSRF IP-classification core of validateHTTPSPublicURL.
+// Oracle (inverted from FuzzCheckIPNotPrivate): for any address the Go stdlib classifies
+// as loopback, private (RFC1918), link-local unicast or multicast, unspecified, multicast,
+// or CGNAT (100.64.0.0/10), isPublicIP MUST return false. A regression that lets any of
+// these through is an SSRF hole. The must-reject set is a strict subset of what isPublicIP
+// actually claims to block — no false positives.
+func FuzzIsPublicIP(f *testing.F) {
+	// 4-byte (IPv4) and 16-byte (IPv6) seeds spanning each blocked class.
+	f.Add([]byte{127, 0, 0, 1})       // loopback
+	f.Add([]byte{10, 0, 0, 1})        // private (RFC1918 10/8)
+	f.Add([]byte{192, 168, 1, 1})     // private (RFC1918 192.168/16)
+	f.Add([]byte{169, 254, 169, 254}) // link-local unicast / cloud metadata (teeth)
+	f.Add([]byte{100, 64, 0, 1})      // CGNAT (teeth — no stdlib predicate covers this)
+	f.Add([]byte{0, 0, 0, 0})         // unspecified
+	f.Add([]byte{224, 0, 0, 1})       // multicast (224.0.0.0/4)
+	f.Add([]byte{8, 8, 8, 8})         // public (should return true)
+	f.Add(make([]byte, 16))           // IPv6 unspecified (::)
+	f.Add([]byte{1, 2, 3})            // malformed length — must be skipped
+
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		// Only 4- and 16-byte slices form a valid net.IP; others are not a
+		// meaningful SSRF input and are skipped.
+		if len(raw) != 4 && len(raw) != 16 {
+			return
+		}
+		ip := net.IP(raw)
+
+		// mustBeNonPublic mirrors the exact set of classes isPublicIP blocks.
+		// Every predicate here corresponds to a guard in isPublicIP's body.
+		mustBeNonPublic := ip.IsLoopback() ||
+			ip.IsPrivate() ||
+			ip.IsLinkLocalUnicast() ||
+			ip.IsLinkLocalMulticast() ||
+			ip.IsUnspecified() ||
+			ip.IsMulticast() ||
+			cgnatWizardNet.Contains(ip)
+
+		if mustBeNonPublic && isPublicIP(ip) {
+			t.Fatalf("SSRF hole: isPublicIP returned true (public) for blocked address %s", ip)
+		}
+	})
+}

--- a/backend/internal/yaml/parser_fuzz_test.go
+++ b/backend/internal/yaml/parser_fuzz_test.go
@@ -1,0 +1,45 @@
+package yaml
+
+import "testing"
+
+// FuzzParseMultiDoc verifies that ParseMultiDoc never panics on arbitrary
+// input bytes. A returned error is acceptable; a panic is not.
+func FuzzParseMultiDoc(f *testing.F) {
+	// Seed corpus -------------------------------------------------------
+
+	// Valid single-document
+	f.Add([]byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: x\n"))
+
+	// Valid multi-document
+	f.Add([]byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: a\n---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: b\n"))
+
+	// Empty body
+	f.Add([]byte{})
+
+	// YAML anchor/alias
+	f.Add([]byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: x\ndata:\n  a: &anchor 1\n  b: *anchor\n"))
+
+	// Deeply nested mapping (10 levels)
+	f.Add([]byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: deep\ndata:\n  a:\n    b:\n      c:\n        d:\n          e:\n            f:\n              g:\n                h:\n                  i:\n                    j: leaf\n"))
+
+	// Bare document separator only
+	f.Add([]byte("---\n"))
+
+	// Binary / non-UTF-8 bytes
+	f.Add([]byte{0x00, 0x01, 0x02, 0x03, 0xff, 0xfe, 0xfd})
+
+	// Very long scalar value (bounded to avoid artificial OOM in seeds)
+	longVal := make([]byte, 0, 256)
+	longVal = append(longVal, []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: x\ndata:\n  key: ")...)
+	for range 128 {
+		longVal = append(longVal, 'A')
+	}
+	longVal = append(longVal, '\n')
+	f.Add(longVal)
+
+	// Fuzz target -------------------------------------------------------
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// Oracle: must never panic. Error returns are fine.
+		_, _ = ParseMultiDoc(data)
+	})
+}


### PR DESCRIPTION
## Summary

PR #3 of the backend fuzzing initiative — Layer A breadth. Three pure-function fuzz targets mirroring PR #1. **Test files + CI only; no production code changed.** Follows PR #1 (`461209af`) and PR #2 (`6cf0febf`).

## Targets

| Target | Package | Oracle |
|---|---|---|
| `FuzzParsePHC` | `auth` | Crash-safety on malformed Argon2id PHC strings (attacker-controlled persisted hash); success branch asserts non-nil salt/hash. ~1.1M execs, no panic. |
| `FuzzParseMultiDoc` | `yaml` | Crash/OOM-safety on malformed multi-doc YAML (alias bombs, deep nesting, multi-doc, binary). ~953k execs; `MaxDocumentCount` + `CheckExpansionRatio` guards held. |
| `FuzzIsPublicIP` | `wizard` | SSRF: `isPublicIP` (the pure core of `validateHTTPSPublicURL`, distinct from `k8s.checkIPNotPrivate`) must return false for loopback/private/link-local/multicast/unspecified/CGNAT. ~1M execs, no SSRF hole. |

## Scope correction (vs. the original roadmap note)

The roadmap listed "the four other SSRF validators." The Phase-0 scan found that's partly stale:
- `validateSettingsURL` and `validateChannelURLs` **delegate** to `k8s.ValidateRemoteURL` — the *same* SSRF core PR #1 already fuzzed (`checkIPNotPrivate`); their unique logic is a trivial scheme check, and fuzzing them would trigger real DNS. **Excluded** (no new coverage).
- `validateVaultServerURL` is a one-line `https://` prefix check. **Excluded** (nothing to fuzz).
- `validateHTTPSPublicURL` *does* have its own pure core — `isPublicIP` — which **is** included.

`parsePHC` was promoted earlier per the PR #2 review's note that it's a high-value crash-safety target.

## Verification
- Repo-wide `go vet ./...` exit 0; `go test ./...` all green (seed corpora run here).
- Each target: 30s local live fuzz (~953k–1.1M execs), no failures.
- 3 new `fuzz.yml` matrix rows (existing `-list` guard + 5m budget + artifact-upload apply).
- Focused final review: Ready to merge — teeth confirmed (FuzzIsPublicIP's must-reject set verified line-by-line against `isPublicIP`).

## Follow-up (deferred)
- `unstructured` normalizer crash-safety (servicemesh/gateway/gitops/policy/velero) — distinct concern, best done with a shared "feed-arbitrary-unstructured, assert-no-panic" harness. Candidate for a PR #3b.
- Full-pipeline Secret-handler fuzzing (needs the `ClientFactory`→interface refactor).

> Pre-merge per repo policy: `/ce-review` + homelab smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)