### PR TITLE
fix(certmanager): recover panics in poller + errgroup workers (ESO parity)

### DIFF
--- a/backend/internal/certmanager/handler.go
+++ b/backend/internal/certmanager/handler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"runtime/debug"
 	"sort"
 	"sync"
 	"time"
@@ -241,8 +242,8 @@ func safeGo(g *errgroup.Group, logger *slog.Logger, label string, fn func() erro
 		defer func() {
 			if r := recover(); r != nil {
 				if logger != nil {
-					logger.Error("certmanager: panic recovered in errgroup worker",
-						"worker", label, "panic", r)
+					logger.Error("certmanager handler: errgroup worker panic recovered",
+						"worker", label, "panic", r, "stack", string(debug.Stack()))
 				}
 				err = fmt.Errorf("%s: recovered panic: %v", label, r)
 			}
@@ -633,7 +634,7 @@ func (h *Handler) HandleGetCertificate(w http.ResponseWriter, r *http.Request) {
 	g, gCtx := errgroup.WithContext(ctx)
 
 	var crList *unstructured.UnstructuredList
-	g.Go(func() error {
+	safeGo(g, h.Logger, "list certificaterequests", func() error {
 		var fetchErr error
 		crList, fetchErr = dynClient.Resource(CertificateRequestGVR).Namespace(ns).List(gCtx, metav1.ListOptions{
 			LabelSelector: crSel,
@@ -642,14 +643,14 @@ func (h *Handler) HandleGetCertificate(w http.ResponseWriter, r *http.Request) {
 	})
 
 	var orderList *unstructured.UnstructuredList
-	g.Go(func() error {
+	safeGo(g, h.Logger, "list orders", func() error {
 		var fetchErr error
 		orderList, fetchErr = dynClient.Resource(OrderGVR).Namespace(ns).List(gCtx, metav1.ListOptions{})
 		return fetchErr
 	})
 
 	var challengeList *unstructured.UnstructuredList
-	g.Go(func() error {
+	safeGo(g, h.Logger, "list challenges", func() error {
 		var fetchErr error
 		challengeList, fetchErr = dynClient.Resource(ChallengeGVR).Namespace(ns).List(gCtx, metav1.ListOptions{})
 		return fetchErr

--- a/backend/internal/certmanager/handler.go
+++ b/backend/internal/certmanager/handler.go
@@ -228,6 +228,29 @@ func (h *Handler) getCached(ctx context.Context) (*cachedData, error) {
 	return result.(*cachedData), nil
 }
 
+// safeGo launches fn on the errgroup with panic recovery. A panic in an
+// errgroup worker goroutine is NOT caught by chi's recovery middleware — it
+// runs on a separate goroutine stack — and would terminate the whole process;
+// errgroup itself only propagates *returned* errors, never panics. Converting
+// a panic into an error lets g.Wait() surface it as an ordinary failure (a
+// graceful 500 on the request path, a skipped fill on the poller path) rather
+// than a crash. Mirrors the poller's runTickWithRecover defense for the
+// request-path fan-out that normalizes adversarial CRD data.
+func safeGo(g *errgroup.Group, logger *slog.Logger, label string, fn func() error) {
+	g.Go(func() (err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				if logger != nil {
+					logger.Error("certmanager: panic recovered in errgroup worker",
+						"worker", label, "panic", r)
+				}
+				err = fmt.Errorf("%s: recovered panic: %v", label, r)
+			}
+		}()
+		return fn()
+	})
+}
+
 func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error) {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
@@ -242,7 +265,7 @@ func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error)
 
 	g, gctx := errgroup.WithContext(ctx)
 
-	g.Go(func() error {
+	safeGo(g, h.Logger, "list certificates", func() error {
 		list, err := dynClient.Resource(CertificateGVR).Namespace("").List(gctx, metav1.ListOptions{})
 		if err != nil {
 			return fmt.Errorf("list certificates: %w", err)
@@ -258,7 +281,7 @@ func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error)
 		return nil
 	})
 
-	g.Go(func() error {
+	safeGo(g, h.Logger, "list issuers", func() error {
 		list, err := dynClient.Resource(IssuerGVR).Namespace("").List(gctx, metav1.ListOptions{})
 		if err != nil {
 			return fmt.Errorf("list issuers: %w", err)
@@ -270,7 +293,7 @@ func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error)
 		return nil
 	})
 
-	g.Go(func() error {
+	safeGo(g, h.Logger, "list clusterissuers", func() error {
 		list, err := dynClient.Resource(ClusterIssuerGVR).Namespace("").List(gctx, metav1.ListOptions{})
 		if err != nil {
 			return fmt.Errorf("list clusterissuers: %w", err)
@@ -404,7 +427,7 @@ func (h *Handler) fetchAllRemoteDirect(ctx context.Context, clusterID string, us
 
 	g, gctx := errgroup.WithContext(ctx)
 
-	g.Go(func() error {
+	safeGo(g, h.Logger, "list certificates", func() error {
 		list, err := dyn.Resource(CertificateGVR).Namespace("").List(gctx, metav1.ListOptions{})
 		if err != nil {
 			return fmt.Errorf("list certificates: %w", err)
@@ -420,7 +443,7 @@ func (h *Handler) fetchAllRemoteDirect(ctx context.Context, clusterID string, us
 		return nil
 	})
 
-	g.Go(func() error {
+	safeGo(g, h.Logger, "list issuers", func() error {
 		list, err := dyn.Resource(IssuerGVR).Namespace("").List(gctx, metav1.ListOptions{})
 		if err != nil {
 			return fmt.Errorf("list issuers: %w", err)
@@ -432,7 +455,7 @@ func (h *Handler) fetchAllRemoteDirect(ctx context.Context, clusterID string, us
 		return nil
 	})
 
-	g.Go(func() error {
+	safeGo(g, h.Logger, "list clusterissuers", func() error {
 		list, err := dyn.Resource(ClusterIssuerGVR).Namespace("").List(gctx, metav1.ListOptions{})
 		if err != nil {
 			return fmt.Errorf("list clusterissuers: %w", err)

--- a/backend/internal/certmanager/poller.go
+++ b/backend/internal/certmanager/poller.go
@@ -203,7 +203,7 @@ func (p *Poller) emit(ctx context.Context, rec emitRecord) {
 // Start runs the poller loop. It fires immediately, then on a 60-second ticker.
 // It blocks until ctx is cancelled.
 func (p *Poller) Start(ctx context.Context) {
-	p.tick(ctx)
+	p.runTickWithRecover(ctx)
 
 	ticker := time.NewTicker(60 * time.Second)
 	defer ticker.Stop()
@@ -213,9 +213,25 @@ func (p *Poller) Start(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			p.tick(ctx)
+			p.runTickWithRecover(ctx)
 		}
 	}
+}
+
+// runTickWithRecover wraps tick() with a defer recover() so a panic in a
+// normalizer or downstream dispatch doesn't unwind the poller goroutine.
+// The poller runs as a background goroutine OUTSIDE chi's panic-recovery
+// middleware, so an unrecovered panic here crashes the whole process and
+// silently halts certificate expiry monitoring. Recovering lets the next
+// ticker fire restart the cycle from a clean slate. Mirrors
+// externalsecrets.Poller.runTickWithRecover.
+func (p *Poller) runTickWithRecover(ctx context.Context) {
+	defer func() {
+		if r := recover(); r != nil {
+			p.logger.Error("certmanager poller: tick panic recovered", "panic", r)
+		}
+	}()
+	p.tick(ctx)
 }
 
 // tick performs one polling cycle: lists all Certificates and processes each one.

--- a/backend/internal/certmanager/poller.go
+++ b/backend/internal/certmanager/poller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -223,12 +224,16 @@ func (p *Poller) Start(ctx context.Context) {
 // The poller runs as a background goroutine OUTSIDE chi's panic-recovery
 // middleware, so an unrecovered panic here crashes the whole process and
 // silently halts certificate expiry monitoring. Recovering lets the next
-// ticker fire restart the cycle from a clean slate. Mirrors
+// ticker fire restart the cycle from a clean slate — a panic mid-cycle may
+// leave a few stale dedupe entries, but the next successful tick's prune
+// pass re-converges. The recovered panic is logged with its stack so the
+// offending object can still be traced. Mirrors
 // externalsecrets.Poller.runTickWithRecover.
 func (p *Poller) runTickWithRecover(ctx context.Context) {
 	defer func() {
-		if r := recover(); r != nil {
-			p.logger.Error("certmanager poller: tick panic recovered", "panic", r)
+		if r := recover(); r != nil && p.logger != nil {
+			p.logger.Error("certmanager poller: tick panic recovered",
+				"panic", r, "stack", string(debug.Stack()))
 		}
 	}()
 	p.tick(ctx)

--- a/backend/internal/certmanager/recover_test.go
+++ b/backend/internal/certmanager/recover_test.go
@@ -1,0 +1,80 @@
+package certmanager
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// TestPollerRunTickWithRecover_SwallowsPanic verifies that a panic inside a
+// poll cycle does not unwind the poller goroutine. newPollerForTest has a nil
+// Discoverer, so tick() panics on the first p.disc.IsAvailable() call. If
+// runTickWithRecover did not recover, this test binary would crash instead of
+// passing — that is the regression guard.
+func TestPollerRunTickWithRecover_SwallowsPanic(t *testing.T) {
+	p := newPollerForTest()
+	// Must return normally rather than crash the process.
+	p.runTickWithRecover(context.Background())
+}
+
+// TestSafeGo_PanicBecomesError verifies that a panic in an errgroup worker is
+// converted into a returned error (surfaced via g.Wait) rather than crashing
+// the process. errgroup itself only propagates returned errors, never panics.
+func TestSafeGo_PanicBecomesError(t *testing.T) {
+	g, _ := errgroup.WithContext(context.Background())
+	safeGo(g, slog.Default(), "boom worker", func() error {
+		panic("kaboom")
+	})
+	err := g.Wait()
+	if err == nil {
+		t.Fatal("expected safeGo to convert the panic into an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "boom worker") || !strings.Contains(err.Error(), "kaboom") {
+		t.Fatalf("error should name the worker and the panic value, got: %v", err)
+	}
+}
+
+// TestSafeGo_SuccessPassesThrough verifies the happy path is untouched.
+func TestSafeGo_SuccessPassesThrough(t *testing.T) {
+	g, _ := errgroup.WithContext(context.Background())
+	ran := false
+	safeGo(g, slog.Default(), "ok worker", func() error {
+		ran = true
+		return nil
+	})
+	if err := g.Wait(); err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	if !ran {
+		t.Fatal("fn was not executed")
+	}
+}
+
+// TestSafeGo_ErrorPassesThrough verifies a normal returned error is preserved
+// (not masked or rewrapped by the recovery shim).
+func TestSafeGo_ErrorPassesThrough(t *testing.T) {
+	g, _ := errgroup.WithContext(context.Background())
+	sentinel := errors.New("real failure")
+	safeGo(g, slog.Default(), "err worker", func() error {
+		return sentinel
+	})
+	if err := g.Wait(); !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel error to pass through, got: %v", err)
+	}
+}
+
+// TestSafeGo_NilLoggerNoPanic verifies the logger-nil guard: a panic must still
+// convert to an error without dereferencing a nil logger.
+func TestSafeGo_NilLoggerNoPanic(t *testing.T) {
+	g, _ := errgroup.WithContext(context.Background())
+	safeGo(g, nil, "nil-logger worker", func() error {
+		panic("still recovered")
+	})
+	if err := g.Wait(); err == nil {
+		t.Fatal("expected recovered panic to become an error even with a nil logger")
+	}
+}

--- a/backend/internal/certmanager/recover_test.go
+++ b/backend/internal/certmanager/recover_test.go
@@ -1,6 +1,7 @@
 package certmanager
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"log/slog"
@@ -10,15 +11,24 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// TestPollerRunTickWithRecover_SwallowsPanic verifies that a panic inside a
-// poll cycle does not unwind the poller goroutine. newPollerForTest has a nil
-// Discoverer, so tick() panics on the first p.disc.IsAvailable() call. If
-// runTickWithRecover did not recover, this test binary would crash instead of
-// passing — that is the regression guard.
-func TestPollerRunTickWithRecover_SwallowsPanic(t *testing.T) {
-	p := newPollerForTest()
-	// Must return normally rather than crash the process.
-	p.runTickWithRecover(context.Background())
+// TestPollerRunTickWithRecover_SwallowsPanicAndLogs verifies that a panic
+// inside a poll cycle does not unwind the poller goroutine AND that the
+// recovery actually fired. A nil Discoverer makes tick() panic on the first
+// p.disc.IsAvailable() call; runTickWithRecover must recover and emit its
+// error log. Asserting on the log line (not merely "did not crash") makes the
+// test fail loudly if the panic source ever disappears (e.g. a future nil-guard
+// on the disc chain) instead of passing vacuously.
+func TestPollerRunTickWithRecover_SwallowsPanicAndLogs(t *testing.T) {
+	var buf bytes.Buffer
+	p := &Poller{
+		logger: slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError})),
+		dedupe: make(map[string]threshold),
+		// disc is nil → tick() panics on p.disc.IsAvailable, exercising recover.
+	}
+	p.runTickWithRecover(context.Background()) // must return, not crash
+	if got := buf.String(); !strings.Contains(got, "tick panic recovered") {
+		t.Fatalf("expected recovery to log 'tick panic recovered' (proving the recover path fired); got: %q", got)
+	}
 }
 
 // TestSafeGo_PanicBecomesError verifies that a panic in an errgroup worker is
@@ -35,6 +45,20 @@ func TestSafeGo_PanicBecomesError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "boom worker") || !strings.Contains(err.Error(), "kaboom") {
 		t.Fatalf("error should name the worker and the panic value, got: %v", err)
+	}
+}
+
+// TestSafeGo_NonStringPanicBecomesError verifies a non-string panic value
+// (panic(42)) is still formatted into the returned error via %v. Guards against
+// a future switch to %s, which would render non-string values uselessly.
+func TestSafeGo_NonStringPanicBecomesError(t *testing.T) {
+	g, _ := errgroup.WithContext(context.Background())
+	safeGo(g, slog.Default(), "int worker", func() error {
+		panic(42)
+	})
+	err := g.Wait()
+	if err == nil || !strings.Contains(err.Error(), "42") || !strings.Contains(err.Error(), "int worker") {
+		t.Fatalf("expected non-string panic value and label in the error, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
Fast-follow A from the PR #3b (#373) review. Closes a pre-existing reliability gap the reviewers flagged: the certmanager expiry **poller** runs as a background goroutine outside chi's panic-recovery middleware, and the `fetchAll` / `fetchAllRemoteDirect` **errgroup workers** run on separate goroutine stacks chi also can't reach. A panic in any normalizer reached from these paths (on adversarial CRD data) would terminate the **whole process** and silently halt certificate expiry monitoring — a DoS vector from cluster data, not a graceful 500.

The normalizers are now fuzz-verified panic-free (#373), so this is **defense-in-depth** closing the structural gap, mirroring the existing `externalsecrets.Poller.runTickWithRecover` convention.

## Changes
- **`Poller.runTickWithRecover`** — wraps each `tick()` with `defer recover()` + `slog.Error`; the next ticker fire restarts from a clean slate. Used at both the immediate fire and every ticker tick in `Start`.
- **`safeGo`** — wraps errgroup workers so a panic converts to a returned error that `g.Wait()` surfaces as an ordinary failure (graceful 500 / skipped fill) instead of a crash. `errgroup` only propagates *returned* errors, never panics. Applied to the 6 normalizer-bearing workers in `fetchAll` + `fetchAllRemoteDirect`.

## Why both
A `recover()` on the poller goroutine does **not** protect errgroup child goroutines (different stacks). The poller wrap covers the poller's own stack (incl. the fallback direct-normalize path, `check`/`emit`/`ApplyThresholds`); `safeGo` covers the fan-out workers reached from both HTTP and poller via the shared cache. Both are independently necessary.

## Tests
- `TestPollerRunTickWithRecover_SwallowsPanic` — nil-disc deterministic panic in `tick()` is swallowed (the binary would crash otherwise).
- `TestSafeGo_*` — panic→error conversion, success/error pass-through, nil-logger tolerance.

Repo-wide `go vet`/`build`/`test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)