### PR TITLE
fix(reliability): shared recoverutil + sweep goroutine panic recovery (fast-follow C)

### DIFF
--- a/backend/internal/alerting/notifier.go
+++ b/backend/internal/alerting/notifier.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/kubecenter/kubecenter/internal/config"
+	"github.com/kubecenter/kubecenter/internal/recoverutil"
 )
 
 //go:embed templates/*.html
@@ -200,12 +201,16 @@ func (n *Notifier) Run(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case msg := <-n.queue:
-			if err := n.sendWithRetry(ctx, msg, 3); err != nil {
-				n.logger.Error("failed to send email after retries",
-					"error", err, "subject", msg.Subject)
-			}
+			recoverutil.Tick(ctx, n.logger, "alerting send email", func(ctx context.Context) {
+				if err := n.sendWithRetry(ctx, msg, 3); err != nil {
+					n.logger.Error("failed to send email after retries",
+						"error", err, "subject", msg.Subject)
+				}
+			})
 		case <-cleanupTicker.C:
-			n.cleanupCooldowns()
+			recoverutil.Tick(ctx, n.logger, "alerting cleanup cooldowns", func(_ context.Context) {
+				n.cleanupCooldowns()
+			})
 		}
 	}
 }

--- a/backend/internal/alerting/store.go
+++ b/backend/internal/alerting/store.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/kubecenter/kubecenter/internal/recoverutil"
 )
 
 // AlertEvent represents a single alert occurrence in the store.
@@ -265,15 +267,17 @@ func (s *MemoryStore) RunPruner(ctx context.Context, retentionDays int, logger *
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			cutoff := time.Now().UTC().AddDate(0, 0, -retentionDays)
-			pruned, err := s.Prune(ctx, cutoff)
-			if err != nil {
-				logger.Error("alert store prune failed", "error", err)
-				continue
-			}
-			if pruned > 0 {
-				logger.Info("alert store pruned", "removed", pruned, "retentionDays", retentionDays)
-			}
+			recoverutil.Tick(ctx, logger, "alerting store prune", func(ctx context.Context) {
+				cutoff := time.Now().UTC().AddDate(0, 0, -retentionDays)
+				pruned, err := s.Prune(ctx, cutoff)
+				if err != nil {
+					logger.Error("alert store prune failed", "error", err)
+					return
+				}
+				if pruned > 0 {
+					logger.Info("alert store pruned", "removed", pruned, "retentionDays", retentionDays)
+				}
+			})
 		}
 	}
 }

--- a/backend/internal/certmanager/handler.go
+++ b/backend/internal/certmanager/handler.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"runtime/debug"
 	"sort"
 	"sync"
 	"time"
@@ -25,6 +24,7 @@ import (
 	"github.com/kubecenter/kubecenter/internal/k8s"
 	"github.com/kubecenter/kubecenter/internal/k8s/resources"
 	"github.com/kubecenter/kubecenter/internal/notifications"
+	"github.com/kubecenter/kubecenter/internal/recoverutil"
 	"github.com/kubecenter/kubecenter/internal/server/middleware"
 )
 
@@ -229,29 +229,6 @@ func (h *Handler) getCached(ctx context.Context) (*cachedData, error) {
 	return result.(*cachedData), nil
 }
 
-// safeGo launches fn on the errgroup with panic recovery. A panic in an
-// errgroup worker goroutine is NOT caught by chi's recovery middleware — it
-// runs on a separate goroutine stack — and would terminate the whole process;
-// errgroup itself only propagates *returned* errors, never panics. Converting
-// a panic into an error lets g.Wait() surface it as an ordinary failure (a
-// graceful 500 on the request path, a skipped fill on the poller path) rather
-// than a crash. Mirrors the poller's runTickWithRecover defense for the
-// request-path fan-out that normalizes adversarial CRD data.
-func safeGo(g *errgroup.Group, logger *slog.Logger, label string, fn func() error) {
-	g.Go(func() (err error) {
-		defer func() {
-			if r := recover(); r != nil {
-				if logger != nil {
-					logger.Error("certmanager handler: errgroup worker panic recovered",
-						"worker", label, "panic", r, "stack", string(debug.Stack()))
-				}
-				err = fmt.Errorf("%s: recovered panic: %v", label, r)
-			}
-		}()
-		return fn()
-	})
-}
-
 func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error) {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
@@ -266,7 +243,7 @@ func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error)
 
 	g, gctx := errgroup.WithContext(ctx)
 
-	safeGo(g, h.Logger, "list certificates", func() error {
+	recoverutil.Go(g, h.Logger, "list certificates", func() error {
 		list, err := dynClient.Resource(CertificateGVR).Namespace("").List(gctx, metav1.ListOptions{})
 		if err != nil {
 			return fmt.Errorf("list certificates: %w", err)
@@ -282,7 +259,7 @@ func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error)
 		return nil
 	})
 
-	safeGo(g, h.Logger, "list issuers", func() error {
+	recoverutil.Go(g, h.Logger, "list issuers", func() error {
 		list, err := dynClient.Resource(IssuerGVR).Namespace("").List(gctx, metav1.ListOptions{})
 		if err != nil {
 			return fmt.Errorf("list issuers: %w", err)
@@ -294,7 +271,7 @@ func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error)
 		return nil
 	})
 
-	safeGo(g, h.Logger, "list clusterissuers", func() error {
+	recoverutil.Go(g, h.Logger, "list clusterissuers", func() error {
 		list, err := dynClient.Resource(ClusterIssuerGVR).Namespace("").List(gctx, metav1.ListOptions{})
 		if err != nil {
 			return fmt.Errorf("list clusterissuers: %w", err)
@@ -428,7 +405,7 @@ func (h *Handler) fetchAllRemoteDirect(ctx context.Context, clusterID string, us
 
 	g, gctx := errgroup.WithContext(ctx)
 
-	safeGo(g, h.Logger, "list certificates", func() error {
+	recoverutil.Go(g, h.Logger, "list certificates", func() error {
 		list, err := dyn.Resource(CertificateGVR).Namespace("").List(gctx, metav1.ListOptions{})
 		if err != nil {
 			return fmt.Errorf("list certificates: %w", err)
@@ -444,7 +421,7 @@ func (h *Handler) fetchAllRemoteDirect(ctx context.Context, clusterID string, us
 		return nil
 	})
 
-	safeGo(g, h.Logger, "list issuers", func() error {
+	recoverutil.Go(g, h.Logger, "list issuers", func() error {
 		list, err := dyn.Resource(IssuerGVR).Namespace("").List(gctx, metav1.ListOptions{})
 		if err != nil {
 			return fmt.Errorf("list issuers: %w", err)
@@ -456,7 +433,7 @@ func (h *Handler) fetchAllRemoteDirect(ctx context.Context, clusterID string, us
 		return nil
 	})
 
-	safeGo(g, h.Logger, "list clusterissuers", func() error {
+	recoverutil.Go(g, h.Logger, "list clusterissuers", func() error {
 		list, err := dyn.Resource(ClusterIssuerGVR).Namespace("").List(gctx, metav1.ListOptions{})
 		if err != nil {
 			return fmt.Errorf("list clusterissuers: %w", err)
@@ -634,7 +611,7 @@ func (h *Handler) HandleGetCertificate(w http.ResponseWriter, r *http.Request) {
 	g, gCtx := errgroup.WithContext(ctx)
 
 	var crList *unstructured.UnstructuredList
-	safeGo(g, h.Logger, "list certificaterequests", func() error {
+	recoverutil.Go(g, h.Logger, "list certificaterequests", func() error {
 		var fetchErr error
 		crList, fetchErr = dynClient.Resource(CertificateRequestGVR).Namespace(ns).List(gCtx, metav1.ListOptions{
 			LabelSelector: crSel,
@@ -643,14 +620,14 @@ func (h *Handler) HandleGetCertificate(w http.ResponseWriter, r *http.Request) {
 	})
 
 	var orderList *unstructured.UnstructuredList
-	safeGo(g, h.Logger, "list orders", func() error {
+	recoverutil.Go(g, h.Logger, "list orders", func() error {
 		var fetchErr error
 		orderList, fetchErr = dynClient.Resource(OrderGVR).Namespace(ns).List(gCtx, metav1.ListOptions{})
 		return fetchErr
 	})
 
 	var challengeList *unstructured.UnstructuredList
-	safeGo(g, h.Logger, "list challenges", func() error {
+	recoverutil.Go(g, h.Logger, "list challenges", func() error {
 		var fetchErr error
 		challengeList, fetchErr = dynClient.Resource(ChallengeGVR).Namespace(ns).List(gCtx, metav1.ListOptions{})
 		return fetchErr

--- a/backend/internal/certmanager/handler.go
+++ b/backend/internal/certmanager/handler.go
@@ -243,7 +243,7 @@ func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error)
 
 	g, gctx := errgroup.WithContext(ctx)
 
-	recoverutil.Go(g, h.Logger, "list certificates", func() error {
+	recoverutil.Go(g, h.Logger, "certmanager list certificates", func() error {
 		list, err := dynClient.Resource(CertificateGVR).Namespace("").List(gctx, metav1.ListOptions{})
 		if err != nil {
 			return fmt.Errorf("list certificates: %w", err)
@@ -259,7 +259,7 @@ func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error)
 		return nil
 	})
 
-	recoverutil.Go(g, h.Logger, "list issuers", func() error {
+	recoverutil.Go(g, h.Logger, "certmanager list issuers", func() error {
 		list, err := dynClient.Resource(IssuerGVR).Namespace("").List(gctx, metav1.ListOptions{})
 		if err != nil {
 			return fmt.Errorf("list issuers: %w", err)
@@ -271,7 +271,7 @@ func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error)
 		return nil
 	})
 
-	recoverutil.Go(g, h.Logger, "list clusterissuers", func() error {
+	recoverutil.Go(g, h.Logger, "certmanager list clusterissuers", func() error {
 		list, err := dynClient.Resource(ClusterIssuerGVR).Namespace("").List(gctx, metav1.ListOptions{})
 		if err != nil {
 			return fmt.Errorf("list clusterissuers: %w", err)
@@ -405,7 +405,7 @@ func (h *Handler) fetchAllRemoteDirect(ctx context.Context, clusterID string, us
 
 	g, gctx := errgroup.WithContext(ctx)
 
-	recoverutil.Go(g, h.Logger, "list certificates", func() error {
+	recoverutil.Go(g, h.Logger, "certmanager remote list certificates", func() error {
 		list, err := dyn.Resource(CertificateGVR).Namespace("").List(gctx, metav1.ListOptions{})
 		if err != nil {
 			return fmt.Errorf("list certificates: %w", err)
@@ -421,7 +421,7 @@ func (h *Handler) fetchAllRemoteDirect(ctx context.Context, clusterID string, us
 		return nil
 	})
 
-	recoverutil.Go(g, h.Logger, "list issuers", func() error {
+	recoverutil.Go(g, h.Logger, "certmanager remote list issuers", func() error {
 		list, err := dyn.Resource(IssuerGVR).Namespace("").List(gctx, metav1.ListOptions{})
 		if err != nil {
 			return fmt.Errorf("list issuers: %w", err)
@@ -433,7 +433,7 @@ func (h *Handler) fetchAllRemoteDirect(ctx context.Context, clusterID string, us
 		return nil
 	})
 
-	recoverutil.Go(g, h.Logger, "list clusterissuers", func() error {
+	recoverutil.Go(g, h.Logger, "certmanager remote list clusterissuers", func() error {
 		list, err := dyn.Resource(ClusterIssuerGVR).Namespace("").List(gctx, metav1.ListOptions{})
 		if err != nil {
 			return fmt.Errorf("list clusterissuers: %w", err)
@@ -611,7 +611,7 @@ func (h *Handler) HandleGetCertificate(w http.ResponseWriter, r *http.Request) {
 	g, gCtx := errgroup.WithContext(ctx)
 
 	var crList *unstructured.UnstructuredList
-	recoverutil.Go(g, h.Logger, "list certificaterequests", func() error {
+	recoverutil.Go(g, h.Logger, "certmanager list certificaterequests", func() error {
 		var fetchErr error
 		crList, fetchErr = dynClient.Resource(CertificateRequestGVR).Namespace(ns).List(gCtx, metav1.ListOptions{
 			LabelSelector: crSel,
@@ -620,14 +620,14 @@ func (h *Handler) HandleGetCertificate(w http.ResponseWriter, r *http.Request) {
 	})
 
 	var orderList *unstructured.UnstructuredList
-	recoverutil.Go(g, h.Logger, "list orders", func() error {
+	recoverutil.Go(g, h.Logger, "certmanager list orders", func() error {
 		var fetchErr error
 		orderList, fetchErr = dynClient.Resource(OrderGVR).Namespace(ns).List(gCtx, metav1.ListOptions{})
 		return fetchErr
 	})
 
 	var challengeList *unstructured.UnstructuredList
-	recoverutil.Go(g, h.Logger, "list challenges", func() error {
+	recoverutil.Go(g, h.Logger, "certmanager list challenges", func() error {
 		var fetchErr error
 		challengeList, fetchErr = dynClient.Resource(ChallengeGVR).Namespace(ns).List(gCtx, metav1.ListOptions{})
 		return fetchErr

--- a/backend/internal/certmanager/poller.go
+++ b/backend/internal/certmanager/poller.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"runtime/debug"
 	"sync"
 	"time"
 
@@ -12,6 +11,7 @@ import (
 
 	"github.com/kubecenter/kubecenter/internal/k8s"
 	"github.com/kubecenter/kubecenter/internal/notifications"
+	"github.com/kubecenter/kubecenter/internal/recoverutil"
 )
 
 // threshold represents the expiry bucket for a certificate.
@@ -219,24 +219,17 @@ func (p *Poller) Start(ctx context.Context) {
 	}
 }
 
-// runTickWithRecover wraps tick() with a defer recover() so a panic in a
+// runTickWithRecover wraps tick() with panic recovery so a panic in a
 // normalizer or downstream dispatch doesn't unwind the poller goroutine.
 // The poller runs as a background goroutine OUTSIDE chi's panic-recovery
 // middleware, so an unrecovered panic here crashes the whole process and
 // silently halts certificate expiry monitoring. Recovering lets the next
 // ticker fire restart the cycle from a clean slate — a panic mid-cycle may
 // leave a few stale dedupe entries, but the next successful tick's prune
-// pass re-converges. The recovered panic is logged with its stack so the
-// offending object can still be traced. Mirrors
-// externalsecrets.Poller.runTickWithRecover.
+// pass re-converges. recoverutil.Tick logs the recovered panic with its
+// stack so the offending object can still be traced.
 func (p *Poller) runTickWithRecover(ctx context.Context) {
-	defer func() {
-		if r := recover(); r != nil && p.logger != nil {
-			p.logger.Error("certmanager poller: tick panic recovered",
-				"panic", r, "stack", string(debug.Stack()))
-		}
-	}()
-	p.tick(ctx)
+	recoverutil.Tick(ctx, p.logger, "certmanager poller tick", p.tick)
 }
 
 // tick performs one polling cycle: lists all Certificates and processes each one.

--- a/backend/internal/certmanager/recover_test.go
+++ b/backend/internal/certmanager/recover_test.go
@@ -3,21 +3,22 @@ package certmanager
 import (
 	"bytes"
 	"context"
-	"errors"
 	"log/slog"
 	"strings"
 	"testing"
-
-	"golang.org/x/sync/errgroup"
 )
 
 // TestPollerRunTickWithRecover_SwallowsPanicAndLogs verifies that a panic
 // inside a poll cycle does not unwind the poller goroutine AND that the
 // recovery actually fired. A nil Discoverer makes tick() panic on the first
-// p.disc.IsAvailable() call; runTickWithRecover must recover and emit its
-// error log. Asserting on the log line (not merely "did not crash") makes the
-// test fail loudly if the panic source ever disappears (e.g. a future nil-guard
-// on the disc chain) instead of passing vacuously.
+// p.disc.IsAvailable() call; runTickWithRecover (via recoverutil.Tick) must
+// recover and emit its error log. Asserting on the log line (not merely "did
+// not crash") makes the test fail loudly if the panic source ever disappears
+// (e.g. a future nil-guard on the disc chain) instead of passing vacuously.
+//
+// The generic recover wrappers themselves are unit-tested in
+// internal/recoverutil; this test guards the certmanager wiring + that the
+// poller passes a non-nil logger and a meaningful task label.
 func TestPollerRunTickWithRecover_SwallowsPanicAndLogs(t *testing.T) {
 	var buf bytes.Buffer
 	p := &Poller{
@@ -26,79 +27,8 @@ func TestPollerRunTickWithRecover_SwallowsPanicAndLogs(t *testing.T) {
 		// disc is nil → tick() panics on p.disc.IsAvailable, exercising recover.
 	}
 	p.runTickWithRecover(context.Background()) // must return, not crash
-	if got := buf.String(); !strings.Contains(got, "tick panic recovered") {
-		t.Fatalf("expected recovery to log 'tick panic recovered' (proving the recover path fired); got: %q", got)
-	}
-}
-
-// TestSafeGo_PanicBecomesError verifies that a panic in an errgroup worker is
-// converted into a returned error (surfaced via g.Wait) rather than crashing
-// the process. errgroup itself only propagates returned errors, never panics.
-func TestSafeGo_PanicBecomesError(t *testing.T) {
-	g, _ := errgroup.WithContext(context.Background())
-	safeGo(g, slog.Default(), "boom worker", func() error {
-		panic("kaboom")
-	})
-	err := g.Wait()
-	if err == nil {
-		t.Fatal("expected safeGo to convert the panic into an error, got nil")
-	}
-	if !strings.Contains(err.Error(), "boom worker") || !strings.Contains(err.Error(), "kaboom") {
-		t.Fatalf("error should name the worker and the panic value, got: %v", err)
-	}
-}
-
-// TestSafeGo_NonStringPanicBecomesError verifies a non-string panic value
-// (panic(42)) is still formatted into the returned error via %v. Guards against
-// a future switch to %s, which would render non-string values uselessly.
-func TestSafeGo_NonStringPanicBecomesError(t *testing.T) {
-	g, _ := errgroup.WithContext(context.Background())
-	safeGo(g, slog.Default(), "int worker", func() error {
-		panic(42)
-	})
-	err := g.Wait()
-	if err == nil || !strings.Contains(err.Error(), "42") || !strings.Contains(err.Error(), "int worker") {
-		t.Fatalf("expected non-string panic value and label in the error, got: %v", err)
-	}
-}
-
-// TestSafeGo_SuccessPassesThrough verifies the happy path is untouched.
-func TestSafeGo_SuccessPassesThrough(t *testing.T) {
-	g, _ := errgroup.WithContext(context.Background())
-	ran := false
-	safeGo(g, slog.Default(), "ok worker", func() error {
-		ran = true
-		return nil
-	})
-	if err := g.Wait(); err != nil {
-		t.Fatalf("expected nil error, got: %v", err)
-	}
-	if !ran {
-		t.Fatal("fn was not executed")
-	}
-}
-
-// TestSafeGo_ErrorPassesThrough verifies a normal returned error is preserved
-// (not masked or rewrapped by the recovery shim).
-func TestSafeGo_ErrorPassesThrough(t *testing.T) {
-	g, _ := errgroup.WithContext(context.Background())
-	sentinel := errors.New("real failure")
-	safeGo(g, slog.Default(), "err worker", func() error {
-		return sentinel
-	})
-	if err := g.Wait(); !errors.Is(err, sentinel) {
-		t.Fatalf("expected sentinel error to pass through, got: %v", err)
-	}
-}
-
-// TestSafeGo_NilLoggerNoPanic verifies the logger-nil guard: a panic must still
-// convert to an error without dereferencing a nil logger.
-func TestSafeGo_NilLoggerNoPanic(t *testing.T) {
-	g, _ := errgroup.WithContext(context.Background())
-	safeGo(g, nil, "nil-logger worker", func() error {
-		panic("still recovered")
-	})
-	if err := g.Wait(); err == nil {
-		t.Fatal("expected recovered panic to become an error even with a nil logger")
+	got := buf.String()
+	if !strings.Contains(got, "panic recovered") || !strings.Contains(got, "certmanager poller tick") {
+		t.Fatalf("expected recovery to log the poller task label and 'panic recovered' (proving the recover path fired); got: %q", got)
 	}
 }

--- a/backend/internal/externalsecrets/handler.go
+++ b/backend/internal/externalsecrets/handler.go
@@ -23,6 +23,7 @@ import (
 	"github.com/kubecenter/kubecenter/internal/k8s/resources"
 	"github.com/kubecenter/kubecenter/internal/monitoring"
 	"github.com/kubecenter/kubecenter/internal/notifications"
+	"github.com/kubecenter/kubecenter/internal/recoverutil"
 	"github.com/kubecenter/kubecenter/internal/server/middleware"
 )
 
@@ -377,7 +378,7 @@ func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error)
 
 	g, gctx := errgroup.WithContext(ctx)
 
-	g.Go(func() error {
+	recoverutil.Go(g, h.Logger, "list externalsecrets", func() error {
 		list, err := dynClient.Resource(ExternalSecretGVR).Namespace("").List(gctx, listOpts)
 		if err != nil {
 			h.Logger.Warn("list externalsecrets failed", "error", err)
@@ -391,7 +392,7 @@ func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error)
 		return nil
 	})
 
-	g.Go(func() error {
+	recoverutil.Go(g, h.Logger, "list clusterexternalsecrets", func() error {
 		list, err := dynClient.Resource(ClusterExternalSecretGVR).Namespace("").List(gctx, listOpts)
 		if err != nil {
 			h.Logger.Warn("list clusterexternalsecrets failed", "error", err)
@@ -405,7 +406,7 @@ func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error)
 		return nil
 	})
 
-	g.Go(func() error {
+	recoverutil.Go(g, h.Logger, "list secretstores", func() error {
 		list, err := dynClient.Resource(SecretStoreGVR).Namespace("").List(gctx, listOpts)
 		if err != nil {
 			h.Logger.Warn("list secretstores failed", "error", err)
@@ -419,7 +420,7 @@ func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error)
 		return nil
 	})
 
-	g.Go(func() error {
+	recoverutil.Go(g, h.Logger, "list clustersecretstores", func() error {
 		list, err := dynClient.Resource(ClusterSecretStoreGVR).Namespace("").List(gctx, listOpts)
 		if err != nil {
 			h.Logger.Warn("list clustersecretstores failed", "error", err)
@@ -433,7 +434,7 @@ func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error)
 		return nil
 	})
 
-	g.Go(func() error {
+	recoverutil.Go(g, h.Logger, "list pushsecrets", func() error {
 		list, err := dynClient.Resource(PushSecretGVR).Namespace("").List(gctx, listOpts)
 		if err != nil {
 			h.Logger.Warn("list pushsecrets failed", "error", err)

--- a/backend/internal/externalsecrets/handler.go
+++ b/backend/internal/externalsecrets/handler.go
@@ -378,7 +378,7 @@ func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error)
 
 	g, gctx := errgroup.WithContext(ctx)
 
-	recoverutil.Go(g, h.Logger, "list externalsecrets", func() error {
+	recoverutil.Go(g, h.Logger, "externalsecrets list externalsecrets", func() error {
 		list, err := dynClient.Resource(ExternalSecretGVR).Namespace("").List(gctx, listOpts)
 		if err != nil {
 			h.Logger.Warn("list externalsecrets failed", "error", err)
@@ -392,7 +392,7 @@ func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error)
 		return nil
 	})
 
-	recoverutil.Go(g, h.Logger, "list clusterexternalsecrets", func() error {
+	recoverutil.Go(g, h.Logger, "externalsecrets list clusterexternalsecrets", func() error {
 		list, err := dynClient.Resource(ClusterExternalSecretGVR).Namespace("").List(gctx, listOpts)
 		if err != nil {
 			h.Logger.Warn("list clusterexternalsecrets failed", "error", err)
@@ -406,7 +406,7 @@ func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error)
 		return nil
 	})
 
-	recoverutil.Go(g, h.Logger, "list secretstores", func() error {
+	recoverutil.Go(g, h.Logger, "externalsecrets list secretstores", func() error {
 		list, err := dynClient.Resource(SecretStoreGVR).Namespace("").List(gctx, listOpts)
 		if err != nil {
 			h.Logger.Warn("list secretstores failed", "error", err)
@@ -420,7 +420,7 @@ func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error)
 		return nil
 	})
 
-	recoverutil.Go(g, h.Logger, "list clustersecretstores", func() error {
+	recoverutil.Go(g, h.Logger, "externalsecrets list clustersecretstores", func() error {
 		list, err := dynClient.Resource(ClusterSecretStoreGVR).Namespace("").List(gctx, listOpts)
 		if err != nil {
 			h.Logger.Warn("list clustersecretstores failed", "error", err)
@@ -434,7 +434,7 @@ func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error)
 		return nil
 	})
 
-	recoverutil.Go(g, h.Logger, "list pushsecrets", func() error {
+	recoverutil.Go(g, h.Logger, "externalsecrets list pushsecrets", func() error {
 		list, err := dynClient.Resource(PushSecretGVR).Namespace("").List(gctx, listOpts)
 		if err != nil {
 			h.Logger.Warn("list pushsecrets failed", "error", err)
@@ -448,11 +448,31 @@ func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error)
 		return nil
 	})
 
-	// Per-CRD goroutines never return errors, so g.Wait() returns nil even
-	// when the parent ctx has been cancelled / timed out. Re-check the parent
-	// ctx explicitly: a cancelled fetch must NOT poison the cache with an
-	// empty snapshot for the next 30s.
-	_ = g.Wait()
+	// Per-CRD goroutines return nil on API errors (they call recordErr instead);
+	// they only return non-nil when recoverutil.Go recovers a panic. On panic,
+	// errgroup cancels gctx so the surviving workers call recordErr for their
+	// context-cancelled errors — but the panicking worker never calls recordErr,
+	// leaving its CRD slice nil without an errMap entry. Treat nil slices as
+	// fetch failures so the stale-cache preservation block below can restore
+	// last-known-good for the panicking CRD instead of caching an empty slice.
+	if werr := g.Wait(); werr != nil {
+		h.Logger.Warn("externalsecrets fetchAll worker error", "error", werr)
+		if externalSecrets == nil {
+			recordErr("externalsecrets", werr)
+		}
+		if clusterExternalSecrets == nil {
+			recordErr("clusterexternalsecrets", werr)
+		}
+		if stores == nil {
+			recordErr("secretstores", werr)
+		}
+		if clusterStores == nil {
+			recordErr("clustersecretstores", werr)
+		}
+		if pushSecrets == nil {
+			recordErr("pushsecrets", werr)
+		}
+	}
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}

--- a/backend/internal/externalsecrets/poller.go
+++ b/backend/internal/externalsecrets/poller.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/kubecenter/kubecenter/internal/k8s"
 	"github.com/kubecenter/kubecenter/internal/notifications"
+	"github.com/kubecenter/kubecenter/internal/recoverutil"
 	"github.com/kubecenter/kubecenter/internal/store"
 )
 
@@ -446,19 +447,13 @@ func (p *Poller) Start(ctx context.Context) {
 	}
 }
 
-// runTickWithRecover wraps tick() with a defer recover() so a panic in
+// runTickWithRecover wraps tick() with panic recovery so a panic in
 // dispatch (e.g., pgx pool exhaustion edge case, slog handler defect)
 // doesn't unwind the poller goroutine. The next ticker fire restarts the
-// tick from a clean slate.
+// tick from a clean slate. Delegates to recoverutil.Tick so the stack
+// trace is captured alongside the panic value.
 func (p *Poller) runTickWithRecover(ctx context.Context) {
-	defer func() {
-		if r := recover(); r != nil {
-			p.logger.Error("externalsecrets poller: tick panic recovered",
-				"panic", r,
-			)
-		}
-	}()
-	p.tick(ctx)
+	recoverutil.Tick(ctx, p.logger, "externalsecrets poller tick", p.tick)
 }
 
 // tick performs one polling cycle. Lists ExternalSecrets via the handler

--- a/backend/internal/gateway/handler.go
+++ b/backend/internal/gateway/handler.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kubecenter/kubecenter/internal/httputil"
 	"github.com/kubecenter/kubecenter/internal/k8s"
 	"github.com/kubecenter/kubecenter/internal/k8s/resources"
+	"github.com/kubecenter/kubecenter/internal/recoverutil"
 	"github.com/kubecenter/kubecenter/internal/server/middleware"
 )
 
@@ -47,8 +48,8 @@ type cachedData struct {
 	gatewayClasses []GatewayClassSummary
 	gateways       []GatewaySummary
 	httpRoutes     []HTTPRouteSummary
-	routes         []RouteSummary        // ALL non-HTTP routes (GRPC, TCP, TLS, UDP), differentiated by Kind
-	summary        GatewayAPISummary     // pre-computed unfiltered summary
+	routes         []RouteSummary    // ALL non-HTTP routes (GRPC, TCP, TLS, UDP), differentiated by Kind
+	summary        GatewayAPISummary // pre-computed unfiltered summary
 	fetchedAt      time.Time
 }
 
@@ -154,7 +155,7 @@ func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error)
 
 	g, gctx := errgroup.WithContext(ctx)
 
-	g.Go(func() error {
+	recoverutil.Go(g, h.Logger, "gateway fetch-gateway-classes", func() error {
 		list, err := dynClient.Resource(GatewayClassGVR).List(gctx, metav1.ListOptions{ResourceVersion: "0"})
 		if err != nil {
 			return fmt.Errorf("list gatewayclasses: %w", err)
@@ -166,7 +167,7 @@ func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error)
 		return nil
 	})
 
-	g.Go(func() error {
+	recoverutil.Go(g, h.Logger, "gateway fetch-gateways", func() error {
 		list, err := dynClient.Resource(GatewayGVR).Namespace("").List(gctx, metav1.ListOptions{ResourceVersion: "0"})
 		if err != nil {
 			return fmt.Errorf("list gateways: %w", err)
@@ -178,7 +179,7 @@ func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error)
 		return nil
 	})
 
-	g.Go(func() error {
+	recoverutil.Go(g, h.Logger, "gateway fetch-httproutes", func() error {
 		list, err := dynClient.Resource(HTTPRouteGVR).Namespace("").List(gctx, metav1.ListOptions{ResourceVersion: "0"})
 		if err != nil {
 			return fmt.Errorf("list httproutes: %w", err)
@@ -213,7 +214,7 @@ func (h *Handler) fetchAll(ctx context.Context, gen uint64) (*cachedData, error)
 		kindName := routeKindToKind[string(rk)]
 		capturedGVR := gvr
 		capturedKind := kindName
-		g2.Go(func() error {
+		recoverutil.Go(g2, h.Logger, "gateway fetch-route-"+capturedKind, func() error {
 			list, err := dynClient.Resource(capturedGVR).Namespace("").List(gctx2, metav1.ListOptions{})
 			if err != nil {
 				h.Logger.Debug("failed to list routes", "kind", capturedKind, "error", err)
@@ -691,14 +692,16 @@ func (h *Handler) resolveRouteRelationships(ctx context.Context, user *auth.User
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
-			sem <- struct{}{}
-			defer func() { <-sem }()
-			ref := &parentRefs[idx]
-			gwObj, err := dynClient.Resource(GatewayGVR).Namespace(ref.Namespace).Get(ctx, ref.Name, metav1.GetOptions{})
-			if err != nil {
-				return
-			}
-			ref.GatewayConditions = extractConditions(gwObj.Object, "status", "conditions")
+			recoverutil.Safe(h.Logger, "gateway resolve-parent-ref", func() {
+				sem <- struct{}{}
+				defer func() { <-sem }()
+				ref := &parentRefs[idx]
+				gwObj, err := dynClient.Resource(GatewayGVR).Namespace(ref.Namespace).Get(ctx, ref.Name, metav1.GetOptions{})
+				if err != nil {
+					return
+				}
+				ref.GatewayConditions = extractConditions(gwObj.Object, "status", "conditions")
+			})
 		}(i)
 	}
 
@@ -709,22 +712,24 @@ func (h *Handler) resolveRouteRelationships(ctx context.Context, user *auth.User
 				wg.Add(1)
 				go func(ruleIdx, backendIdx int) {
 					defer wg.Done()
-					sem <- struct{}{}
-					defer func() { <-sem }()
-					ref := &rules[ruleIdx].BackendRefs[backendIdx]
-					if ref.Kind != "Service" && ref.Kind != "" {
-						return
-					}
-					svcNs := ref.Namespace
-					if svcNs == "" {
-						if len(parentRefs) > 0 {
-							svcNs = parentRefs[0].Namespace
+					recoverutil.Safe(h.Logger, "gateway resolve-backend-ref", func() {
+						sem <- struct{}{}
+						defer func() { <-sem }()
+						ref := &rules[ruleIdx].BackendRefs[backendIdx]
+						if ref.Kind != "Service" && ref.Kind != "" {
+							return
 						}
-					}
-					_, err := cs.CoreV1().Services(svcNs).Get(ctx, ref.Name, metav1.GetOptions{})
-					if err == nil {
-						ref.Resolved = true
-					}
+						svcNs := ref.Namespace
+						if svcNs == "" {
+							if len(parentRefs) > 0 {
+								svcNs = parentRefs[0].Namespace
+							}
+						}
+						_, err := cs.CoreV1().Services(svcNs).Get(ctx, ref.Name, metav1.GetOptions{})
+						if err == nil {
+							ref.Resolved = true
+						}
+					})
 				}(ri, bi)
 			}
 		}
@@ -744,14 +749,16 @@ func (h *Handler) resolveParentGateways(ctx context.Context, dynClient dynamic.I
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
-			sem <- struct{}{}
-			defer func() { <-sem }()
-			ref := &parentRefs[idx]
-			gwObj, err := dynClient.Resource(GatewayGVR).Namespace(ref.Namespace).Get(ctx, ref.Name, metav1.GetOptions{})
-			if err != nil {
-				return
-			}
-			ref.GatewayConditions = extractConditions(gwObj.Object, "status", "conditions")
+			recoverutil.Safe(h.Logger, "gateway resolve-parent-gateway", func() {
+				sem <- struct{}{}
+				defer func() { <-sem }()
+				ref := &parentRefs[idx]
+				gwObj, err := dynClient.Resource(GatewayGVR).Namespace(ref.Namespace).Get(ctx, ref.Name, metav1.GetOptions{})
+				if err != nil {
+					return
+				}
+				ref.GatewayConditions = extractConditions(gwObj.Object, "status", "conditions")
+			})
 		}(i)
 	}
 	wg.Wait()
@@ -774,20 +781,22 @@ func (h *Handler) resolveBackendServices(ctx context.Context, user *auth.User, r
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
-			sem <- struct{}{}
-			defer func() { <-sem }()
-			ref := &refs[idx]
-			if ref.Kind != "Service" && ref.Kind != "" {
-				return
-			}
-			svcNs := ref.Namespace
-			if svcNs == "" {
-				svcNs = routeNs
-			}
-			_, svcErr := cs.CoreV1().Services(svcNs).Get(ctx, ref.Name, metav1.GetOptions{})
-			if svcErr == nil {
-				ref.Resolved = true
-			}
+			recoverutil.Safe(h.Logger, "gateway resolve-backend-service", func() {
+				sem <- struct{}{}
+				defer func() { <-sem }()
+				ref := &refs[idx]
+				if ref.Kind != "Service" && ref.Kind != "" {
+					return
+				}
+				svcNs := ref.Namespace
+				if svcNs == "" {
+					svcNs = routeNs
+				}
+				_, svcErr := cs.CoreV1().Services(svcNs).Get(ctx, ref.Name, metav1.GetOptions{})
+				if svcErr == nil {
+					ref.Resolved = true
+				}
+			})
 		}(i)
 	}
 	wg.Wait()

--- a/backend/internal/gitops/discovery.go
+++ b/backend/internal/gitops/discovery.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/kubecenter/kubecenter/internal/k8s"
+	"github.com/kubecenter/kubecenter/internal/recoverutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -56,7 +57,7 @@ func (d *GitOpsDiscoverer) Status() GitOpsStatus {
 
 // RunDiscoveryLoop runs discovery immediately, then every recheckInterval.
 func (d *GitOpsDiscoverer) RunDiscoveryLoop(ctx context.Context) {
-	d.Discover(ctx)
+	recoverutil.Tick(ctx, d.logger, "gitops discovery", d.Discover)
 
 	ticker := time.NewTicker(recheckInterval)
 	defer ticker.Stop()
@@ -66,7 +67,7 @@ func (d *GitOpsDiscoverer) RunDiscoveryLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			d.Discover(ctx)
+			recoverutil.Tick(ctx, d.logger, "gitops discovery", d.Discover)
 		}
 	}
 }

--- a/backend/internal/gitops/discovery.go
+++ b/backend/internal/gitops/discovery.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kubecenter/kubecenter/internal/k8s"
 	"github.com/kubecenter/kubecenter/internal/recoverutil"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/backend/internal/gitops/handler.go
+++ b/backend/internal/gitops/handler.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kubecenter/kubecenter/internal/k8s"
 	"github.com/kubecenter/kubecenter/internal/k8s/resources"
 	"github.com/kubecenter/kubecenter/internal/notifications"
+	"github.com/kubecenter/kubecenter/internal/recoverutil"
 	"github.com/kubecenter/kubecenter/internal/server/middleware"
 )
 
@@ -139,7 +140,9 @@ func (h *Handler) doFetch(ctx context.Context) (*cachedApps, error) {
 		go func() {
 			defer wg.Done()
 			var r fetchResult
-			r.apps, r.err = ListArgoApplications(ctx, dynClient)
+			recoverutil.Safe(h.Logger, "gitops argo-fetch", func() {
+				r.apps, r.err = ListArgoApplications(ctx, dynClient)
+			})
 			argoCh <- r
 		}()
 	} else {
@@ -151,27 +154,32 @@ func (h *Handler) doFetch(ctx context.Context) (*cachedApps, error) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			var ks, hr []NormalizedApp
-			var ksErr, hrErr error
-			var inner sync.WaitGroup
-			inner.Add(2)
-			go func() {
-				defer inner.Done()
-				ks, ksErr = ListFluxKustomizations(ctx, dynClient)
-			}()
-			go func() {
-				defer inner.Done()
-				hr, hrErr = ListFluxHelmReleases(ctx, dynClient)
-			}()
-			inner.Wait()
-
 			var r fetchResult
-			if ksErr != nil {
-				r.err = ksErr
-			} else if hrErr != nil {
-				r.err = hrErr
-			}
-			r.apps = append(ks, hr...)
+			recoverutil.Safe(h.Logger, "gitops flux-fetch", func() {
+				var ks, hr []NormalizedApp
+				var ksErr, hrErr error
+				var inner sync.WaitGroup
+				inner.Add(2)
+				go func() {
+					defer inner.Done()
+					recoverutil.Safe(h.Logger, "gitops flux-ks-fetch", func() {
+						ks, ksErr = ListFluxKustomizations(ctx, dynClient)
+					})
+				}()
+				go func() {
+					defer inner.Done()
+					recoverutil.Safe(h.Logger, "gitops flux-hr-fetch", func() {
+						hr, hrErr = ListFluxHelmReleases(ctx, dynClient)
+					})
+				}()
+				inner.Wait()
+				if ksErr != nil {
+					r.err = ksErr
+				} else if hrErr != nil {
+					r.err = hrErr
+				}
+				r.apps = append(ks, hr...)
+			})
 			fluxCh <- r
 		}()
 	} else {
@@ -455,11 +463,13 @@ func (h *Handler) invalidateCache() {
 	h.cacheGen++
 	h.cacheMu.Unlock()
 	if h.NotifService != nil {
-		go h.NotifService.Emit(context.Background(), notifications.Notification{
-			Source:   notifications.SourceGitOps,
-			Severity: notifications.SeverityInfo,
-			Title:    "GitOps sync status changed",
-			Message:  "A GitOps application sync status has changed. Check the GitOps dashboard for details.",
+		go recoverutil.Safe(h.Logger, "gitops notify", func() {
+			h.NotifService.Emit(context.Background(), notifications.Notification{
+				Source:   notifications.SourceGitOps,
+				Severity: notifications.SeverityInfo,
+				Title:    "GitOps sync status changed",
+				Message:  "A GitOps application sync status has changed. Check the GitOps dashboard for details.",
+			})
 		})
 	}
 }

--- a/backend/internal/k8s/cluster_prober.go
+++ b/backend/internal/k8s/cluster_prober.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
+	"github.com/kubecenter/kubecenter/internal/recoverutil"
 	"github.com/kubecenter/kubecenter/internal/store"
 )
 
@@ -81,7 +82,7 @@ func NewClusterProber(cs *store.ClusterStore, encKey string, onStatusChange Stat
 // Run starts the probing loop. Probes immediately on startup, then every 60s.
 // Blocks until ctx is cancelled.
 func (p *ClusterProber) Run(ctx context.Context) {
-	p.probeAll(ctx)
+	recoverutil.Tick(ctx, p.logger, "k8s cluster probe", p.probeAll)
 	ticker := time.NewTicker(60 * time.Second)
 	defer ticker.Stop()
 	for {
@@ -89,7 +90,7 @@ func (p *ClusterProber) Run(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			p.probeAll(ctx)
+			recoverutil.Tick(ctx, p.logger, "k8s cluster probe", p.probeAll)
 		}
 	}
 }

--- a/backend/internal/limits/checker.go
+++ b/backend/internal/limits/checker.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/kubecenter/kubecenter/internal/notifications"
+	"github.com/kubecenter/kubecenter/internal/recoverutil"
 )
 
 const (
@@ -68,7 +69,7 @@ func (c *Checker) run(ctx context.Context) {
 	defer c.wg.Done()
 
 	// Run initial check immediately
-	c.check(ctx)
+	recoverutil.Tick(ctx, c.logger, "limits quota check", c.check)
 
 	ticker := time.NewTicker(c.interval)
 	defer ticker.Stop()
@@ -80,7 +81,7 @@ func (c *Checker) run(ctx context.Context) {
 		case <-c.stopCh:
 			return
 		case <-ticker.C:
-			c.check(ctx)
+			recoverutil.Tick(ctx, c.logger, "limits quota check", c.check)
 		}
 	}
 }

--- a/backend/internal/loki/discovery.go
+++ b/backend/internal/loki/discovery.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kubecenter/kubecenter/internal/config"
 	"github.com/kubecenter/kubecenter/internal/k8s"
+	"github.com/kubecenter/kubecenter/internal/recoverutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -61,7 +62,7 @@ func (d *Discoverer) TenantID() string {
 // RunDiscoveryLoop runs the discovery sequence immediately and then every
 // recheckInterval until ctx is cancelled.
 func (d *Discoverer) RunDiscoveryLoop(ctx context.Context) {
-	d.Discover(ctx)
+	recoverutil.Tick(ctx, d.logger, "loki discovery", d.Discover)
 
 	ticker := time.NewTicker(recheckInterval)
 	defer ticker.Stop()
@@ -71,7 +72,7 @@ func (d *Discoverer) RunDiscoveryLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			d.Discover(ctx)
+			recoverutil.Tick(ctx, d.logger, "loki discovery", d.Discover)
 		}
 	}
 }

--- a/backend/internal/loki/discovery.go
+++ b/backend/internal/loki/discovery.go
@@ -7,10 +7,11 @@ import (
 	"sync"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/kubecenter/kubecenter/internal/config"
 	"github.com/kubecenter/kubecenter/internal/k8s"
 	"github.com/kubecenter/kubecenter/internal/recoverutil"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // recheckInterval is how often the discoverer re-probes the cluster for Loki.

--- a/backend/internal/monitoring/discovery.go
+++ b/backend/internal/monitoring/discovery.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kubecenter/kubecenter/internal/config"
 	"github.com/kubecenter/kubecenter/internal/k8s"
 	"github.com/kubecenter/kubecenter/internal/recoverutil"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/backend/internal/monitoring/discovery.go
+++ b/backend/internal/monitoring/discovery.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/kubecenter/kubecenter/internal/config"
 	"github.com/kubecenter/kubecenter/internal/k8s"
+	"github.com/kubecenter/kubecenter/internal/recoverutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -127,7 +128,7 @@ func (d *Discoverer) GrafanaAPIClient() *GrafanaClient {
 // RunDiscoveryLoop runs the discovery sequence immediately and then every
 // recheckInterval until ctx is cancelled.
 func (d *Discoverer) RunDiscoveryLoop(ctx context.Context) {
-	d.Discover(ctx)
+	recoverutil.Tick(ctx, d.logger, "monitoring discovery", d.Discover)
 
 	ticker := time.NewTicker(recheckInterval)
 	defer ticker.Stop()
@@ -137,7 +138,7 @@ func (d *Discoverer) RunDiscoveryLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			d.Discover(ctx)
+			recoverutil.Tick(ctx, d.logger, "monitoring discovery", d.Discover)
 		}
 	}
 }

--- a/backend/internal/monitoring/trends.go
+++ b/backend/internal/monitoring/trends.go
@@ -10,6 +10,7 @@ import (
 	"github.com/prometheus/common/model"
 
 	"github.com/kubecenter/kubecenter/internal/k8s/resources"
+	"github.com/kubecenter/kubecenter/internal/recoverutil"
 )
 
 // Dashboard trend window and resolution are chosen by the caller (the handler
@@ -85,11 +86,13 @@ func (a *UtilizationAdapter) DashboardTrends(ctx context.Context, window, step t
 	for i, q := range trendQueries {
 		go func(i int, query string) {
 			defer wg.Done()
-			val, _, err := pc.QueryRange(ctx, query, start, end, step)
-			if err != nil {
-				return // leave series[i] nil → empty slice in JSON
-			}
-			series[i] = parseMatrixSeries(val)
+			recoverutil.Safe(a.Discoverer.logger, "monitoring trends-query", func() {
+				val, _, err := pc.QueryRange(ctx, query, start, end, step)
+				if err != nil {
+					return // leave series[i] nil → empty slice in JSON
+				}
+				series[i] = parseMatrixSeries(val)
+			})
 		}(i, q.query)
 	}
 	wg.Wait()

--- a/backend/internal/networking/agent_exec.go
+++ b/backend/internal/networking/agent_exec.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/kubecenter/kubecenter/internal/audit"
 	"github.com/kubecenter/kubecenter/internal/k8s"
+	"github.com/kubecenter/kubecenter/internal/recoverutil"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/singleflight"
 	corev1 "k8s.io/api/core/v1"
@@ -131,12 +132,12 @@ func (c *CiliumAgentCollector) collect(ctx context.Context) (*agentCollectionRes
 	g.SetLimit(c.maxConcurrent)
 
 	for i, pod := range pods {
-		g.Go(func() error {
+		recoverutil.Go(g, c.logger, "networking agent-exec", func() error {
 			results[i] = c.execPod(gCtx, cs, pod)
 			return nil // errors captured per-node
 		})
 	}
-	_ = g.Wait() // always nil — per-node errors in results
+	_ = g.Wait() // nil unless a worker panics (panic logged by recoverutil); per-node errors in results
 
 	// Build result
 	partial := false

--- a/backend/internal/networking/handler.go
+++ b/backend/internal/networking/handler.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kubecenter/kubecenter/internal/audit"
 	"github.com/kubecenter/kubecenter/internal/httputil"
 	"github.com/kubecenter/kubecenter/internal/k8s"
+	"github.com/kubecenter/kubecenter/internal/recoverutil"
 	"github.com/kubecenter/kubecenter/internal/server/middleware"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -313,7 +314,7 @@ func (h *Handler) HandleUpdateCNIConfig(w http.ResponseWriter, r *http.Request) 
 	httputil.WriteData(w, config)
 
 	// Refresh cached CNI features asynchronously (non-blocking)
-	go h.Detector.Detect(context.Background())
+	go recoverutil.Safe(h.Logger, "networking detect", func() { h.Detector.Detect(context.Background()) })
 
 	// Invalidate all caches so next poll gets fresh data
 	h.InvalidateCaches()
@@ -654,19 +655,19 @@ func (h *Handler) fetchSubsystems(ctx context.Context) (*CiliumSubsystemsRespons
 	var agentErr error
 
 	g, gCtx := errgroup.WithContext(ctx)
-	g.Go(func() error {
+	recoverutil.Go(g, h.Logger, "networking fetch-cilium-nodes", func() error {
 		var err error
 		nodes, err = readCiliumNodes(gCtx, dynClient)
 		return err
 	})
-	g.Go(func() error {
+	recoverutil.Go(g, h.Logger, "networking fetch-endpoints", func() error {
 		var err error
 		endpoints, err = aggregateEndpoints(gCtx, dynClient)
 		return err
 	})
 	// Agent collection runs in parallel with CRD reads (opt-in, never fails the group)
 	if h.AgentCollector != nil {
-		g.Go(func() error {
+		recoverutil.Go(g, h.Logger, "networking fetch-agent", func() error {
 			agentResult, agentErr = h.AgentCollector.Collect(gCtx)
 			return nil // agent errors captured separately
 		})

--- a/backend/internal/notifications/service.go
+++ b/backend/internal/notifications/service.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/kubecenter/kubecenter/internal/recoverutil"
 	"github.com/kubecenter/kubecenter/internal/websocket"
 )
 
@@ -639,12 +640,14 @@ func (s *NotificationService) runRetention(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			count, err := s.store.PruneOlderThan(ctx, 90*24*time.Hour)
-			if err != nil {
-				s.logger.Error("prune notifications", "error", err)
-			} else if count > 0 {
-				s.logger.Info("pruned old notifications", "count", count)
-			}
+			recoverutil.Tick(ctx, s.logger, "notifications retention prune", func(ctx context.Context) {
+				count, err := s.store.PruneOlderThan(ctx, 90*24*time.Hour)
+				if err != nil {
+					s.logger.Error("prune notifications", "error", err)
+				} else if count > 0 {
+					s.logger.Info("pruned old notifications", "count", count)
+				}
+			})
 		}
 	}
 }

--- a/backend/internal/policy/discovery.go
+++ b/backend/internal/policy/discovery.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kubecenter/kubecenter/internal/k8s"
 	"github.com/kubecenter/kubecenter/internal/recoverutil"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/backend/internal/policy/discovery.go
+++ b/backend/internal/policy/discovery.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/kubecenter/kubecenter/internal/k8s"
+	"github.com/kubecenter/kubecenter/internal/recoverutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -68,7 +69,7 @@ func (d *PolicyDiscoverer) GatekeeperConstraintCRDs() []*k8s.CRDInfo {
 
 // RunDiscoveryLoop runs discovery immediately, then every recheckInterval.
 func (d *PolicyDiscoverer) RunDiscoveryLoop(ctx context.Context) {
-	d.Discover(ctx)
+	recoverutil.Tick(ctx, d.logger, "policy discovery", d.Discover)
 
 	ticker := time.NewTicker(recheckInterval)
 	defer ticker.Stop()
@@ -78,7 +79,7 @@ func (d *PolicyDiscoverer) RunDiscoveryLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			d.Discover(ctx)
+			recoverutil.Tick(ctx, d.logger, "policy discovery", d.Discover)
 		}
 	}
 }

--- a/backend/internal/policy/gatekeeper.go
+++ b/backend/internal/policy/gatekeeper.go
@@ -3,11 +3,14 @@ package policy
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/kubecenter/kubecenter/internal/k8s"
+	"github.com/kubecenter/kubecenter/internal/recoverutil"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -45,35 +48,40 @@ func listGatekeeperPoliciesAndViolations(ctx context.Context, dynClient dynamic.
 		wg.Add(1)
 		go func(c *k8s.CRDInfo) {
 			defer wg.Done()
+			// results is buffered at len(crds) and closed by the goroutine below after
+			// wg.Wait(); the range-reader terminates on close, so a missed send on
+			// panic does not deadlock. wg.Done() is kept outside Safe so the closer
+			// goroutine always sees the count reach zero.
+			recoverutil.Safe(slog.Default(), "policy normalize-gatekeeper", func() {
+				select {
+				case sem <- struct{}{}:
+					defer func() { <-sem }()
+				case <-ctx.Done():
+					return
+				}
 
-			select {
-			case sem <- struct{}{}:
-				defer func() { <-sem }()
-			case <-ctx.Done():
-				return
-			}
+				timeoutCtx, cancel := context.WithTimeout(ctx, constraintTimeout)
+				defer cancel()
 
-			timeoutCtx, cancel := context.WithTimeout(ctx, constraintTimeout)
-			defer cancel()
+				gvr := schema.GroupVersionResource{
+					Group:    "constraints.gatekeeper.sh",
+					Version:  c.Version,
+					Resource: c.Resource,
+				}
 
-			gvr := schema.GroupVersionResource{
-				Group:    "constraints.gatekeeper.sh",
-				Version:  c.Version,
-				Resource: c.Resource,
-			}
+				list, err := dynClient.Resource(gvr).List(timeoutCtx, metav1.ListOptions{})
+				if err != nil {
+					results <- constraintCRDResult{err: fmt.Errorf("listing %s: %w", c.Resource, err)}
+					return
+				}
 
-			list, err := dynClient.Resource(gvr).List(timeoutCtx, metav1.ListOptions{})
-			if err != nil {
-				results <- constraintCRDResult{err: fmt.Errorf("listing %s: %w", c.Resource, err)}
-				return
-			}
-
-			var r constraintCRDResult
-			for i := range list.Items {
-				r.policies = append(r.policies, NormalizeGatekeeperConstraint(&list.Items[i], c.Kind))
-				r.violations = append(r.violations, extractGatekeeperViolations(&list.Items[i], c.Kind)...)
-			}
-			results <- r
+				var r constraintCRDResult
+				for i := range list.Items {
+					r.policies = append(r.policies, NormalizeGatekeeperConstraint(&list.Items[i], c.Kind))
+					r.violations = append(r.violations, extractGatekeeperViolations(&list.Items[i], c.Kind)...)
+				}
+				results <- r
+			})
 		}(crd)
 	}
 

--- a/backend/internal/policy/handler.go
+++ b/backend/internal/policy/handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kubecenter/kubecenter/internal/k8s"
 	"github.com/kubecenter/kubecenter/internal/k8s/resources"
 	"github.com/kubecenter/kubecenter/internal/notifications"
+	"github.com/kubecenter/kubecenter/internal/recoverutil"
 	"github.com/kubecenter/kubecenter/internal/server/middleware"
 	"github.com/kubecenter/kubecenter/internal/store"
 )
@@ -93,11 +94,13 @@ func (h *Handler) InvalidateCache() {
 	h.cacheGen++
 	h.cacheMu.Unlock()
 	if h.NotifService != nil {
-		go h.NotifService.Emit(context.Background(), notifications.Notification{
-			Source:   notifications.SourcePolicy,
-			Severity: notifications.SeverityInfo,
-			Title:    "Policy engine change detected",
-			Message:  "Policy engine reported changes. Check the policy dashboard for details.",
+		go recoverutil.Safe(h.Logger, "policy notify", func() {
+			h.NotifService.Emit(context.Background(), notifications.Notification{
+				Source:   notifications.SourcePolicy,
+				Severity: notifications.SeverityInfo,
+				Title:    "Policy engine change detected",
+				Message:  "Policy engine reported changes. Check the policy dashboard for details.",
+			})
 		})
 	}
 }
@@ -133,10 +136,12 @@ func (h *Handler) doFetch(ctx context.Context) (*cachedPolicyData, error) {
 		go func() {
 			defer wg.Done()
 			var r fetchResult
-			r.policies, r.err = listKyvernoPolicies(ctx, dynClient)
-			if r.err == nil {
-				r.violations, r.err = listKyvernoViolations(ctx, dynClient)
-			}
+			recoverutil.Safe(h.Logger, "policy kyverno-fetch", func() {
+				r.policies, r.err = listKyvernoPolicies(ctx, dynClient)
+				if r.err == nil {
+					r.violations, r.err = listKyvernoViolations(ctx, dynClient)
+				}
+			})
 			kyvernoCh <- r
 		}()
 	} else {
@@ -148,9 +153,11 @@ func (h *Handler) doFetch(ctx context.Context) (*cachedPolicyData, error) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			constraintCRDs := h.Discoverer.GatekeeperConstraintCRDs()
 			var r fetchResult
-			r.policies, r.violations, r.err = listGatekeeperPoliciesAndViolations(ctx, dynClient, constraintCRDs)
+			recoverutil.Safe(h.Logger, "policy gatekeeper-fetch", func() {
+				constraintCRDs := h.Discoverer.GatekeeperConstraintCRDs()
+				r.policies, r.violations, r.err = listGatekeeperPoliciesAndViolations(ctx, dynClient, constraintCRDs)
+			})
 			gatekeeperCh <- r
 		}()
 	} else {

--- a/backend/internal/recoverutil/recoverutil.go
+++ b/backend/internal/recoverutil/recoverutil.go
@@ -42,6 +42,25 @@ func Go(g *errgroup.Group, logger *slog.Logger, label string, fn func() error) {
 	})
 }
 
+// Safe runs fn with panic recovery, for plain goroutines that are neither
+// errgroup workers nor ticker loops — bare `go func(){...}` fan-outs and
+// fire-and-forget `go method()` calls that run outside chi's recovery
+// middleware. A recovered panic is logged with its stack; fn's own cleanup
+// (e.g. a deferred wg.Done() registered by the caller before invoking Safe)
+// still runs. A nil logger is tolerated. Typical use:
+//
+//	go func(i int) { defer wg.Done(); recoverutil.Safe(logger, "label", func() { ... }) }(i)
+//	go recoverutil.Safe(logger, "notify", func() { svc.Emit(ctx, n) })
+func Safe(logger *slog.Logger, label string, fn func()) {
+	defer func() {
+		if r := recover(); r != nil && logger != nil {
+			logger.Error("goroutine panic recovered",
+				"task", label, "panic", r, "stack", string(debug.Stack()))
+		}
+	}()
+	fn()
+}
+
 // Tick runs fn(ctx) with panic recovery, for background ticker loops whose
 // goroutine has no surrounding recovery. A recovered panic is logged with its
 // stack so the offending input can be traced; the caller's loop continues to

--- a/backend/internal/recoverutil/recoverutil.go
+++ b/backend/internal/recoverutil/recoverutil.go
@@ -1,0 +1,58 @@
+// Package recoverutil provides panic-recovery wrappers for code that runs
+// OUTSIDE chi's HTTP panic-recovery middleware — background ticker loops and
+// errgroup worker goroutines. A panic on such a goroutine is not caught by the
+// request middleware (it runs on a separate stack) and would terminate the
+// whole process. These helpers turn that crash into a logged, recoverable
+// failure so adversarial cluster data degrades the affected feature instead of
+// taking down the server.
+//
+// Reference consumers: certmanager.Poller (Tick) + certmanager.Handler fetch
+// fan-outs (Go). Mirrors the convention first established by
+// externalsecrets.Poller.
+package recoverutil
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"runtime/debug"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// Go launches fn on the errgroup with panic recovery. A panic in an errgroup
+// worker goroutine is NOT caught by chi's recovery middleware (it runs on a
+// separate goroutine stack) and would terminate the process; errgroup itself
+// only propagates *returned* errors, never panics. A recovered panic is logged
+// with its stack and converted to an error so g.Wait() surfaces it as an
+// ordinary failure (a graceful 500 on a request path, a skipped fill on a
+// poller path) rather than a crash. A nil logger is tolerated.
+func Go(g *errgroup.Group, logger *slog.Logger, label string, fn func() error) {
+	g.Go(func() (err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				if logger != nil {
+					logger.Error("errgroup worker panic recovered",
+						"worker", label, "panic", r, "stack", string(debug.Stack()))
+				}
+				err = fmt.Errorf("%s: recovered panic: %v", label, r)
+			}
+		}()
+		return fn()
+	})
+}
+
+// Tick runs fn(ctx) with panic recovery, for background ticker loops whose
+// goroutine has no surrounding recovery. A recovered panic is logged with its
+// stack so the offending input can be traced; the caller's loop continues to
+// its next iteration rather than crashing the process. A nil logger is
+// tolerated (the panic is still swallowed).
+func Tick(ctx context.Context, logger *slog.Logger, label string, fn func(context.Context)) {
+	defer func() {
+		if r := recover(); r != nil && logger != nil {
+			logger.Error("background tick panic recovered",
+				"task", label, "panic", r, "stack", string(debug.Stack()))
+		}
+	}()
+	fn(ctx)
+}

--- a/backend/internal/recoverutil/recoverutil.go
+++ b/backend/internal/recoverutil/recoverutil.go
@@ -1,14 +1,20 @@
 // Package recoverutil provides panic-recovery wrappers for code that runs
-// OUTSIDE chi's HTTP panic-recovery middleware — background ticker loops and
-// errgroup worker goroutines. A panic on such a goroutine is not caught by the
-// request middleware (it runs on a separate stack) and would terminate the
-// whole process. These helpers turn that crash into a logged, recoverable
-// failure so adversarial cluster data degrades the affected feature instead of
-// taking down the server.
+// OUTSIDE chi's HTTP panic-recovery middleware — background ticker loops,
+// errgroup worker goroutines, and plain/fire-and-forget goroutines. A panic on
+// such a goroutine is not caught by the request middleware (it runs on a
+// separate stack) and would terminate the whole process. These helpers turn
+// that crash into a logged, recoverable failure so adversarial cluster data
+// degrades the affected feature instead of taking down the server.
 //
-// Reference consumers: certmanager.Poller (Tick) + certmanager.Handler fetch
-// fan-outs (Go). Mirrors the convention first established by
-// externalsecrets.Poller.
+// Pick the wrapper by goroutine shape:
+//   - Go   — errgroup worker (recover -> log -> return error for g.Wait).
+//   - Tick — background ticker-loop body (recover -> log -> loop continues).
+//   - Safe — plain `go func(){...}` / fire-and-forget (recover -> log).
+//
+// All three log the recovered panic with its stack under a stable "task" key,
+// so a single structured-log filter (task=<label>) catches every recoverutil
+// panic; the message string distinguishes the goroutine kind. A nil logger
+// falls back to slog.Default() — a recovered panic is never silently dropped.
 package recoverutil
 
 import (
@@ -20,21 +26,28 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// loggerOrDefault returns logger, or slog.Default() when logger is nil, so a
+// recovered panic is always recorded somewhere rather than silently discarded.
+func loggerOrDefault(logger *slog.Logger) *slog.Logger {
+	if logger == nil {
+		return slog.Default()
+	}
+	return logger
+}
+
 // Go launches fn on the errgroup with panic recovery. A panic in an errgroup
 // worker goroutine is NOT caught by chi's recovery middleware (it runs on a
 // separate goroutine stack) and would terminate the process; errgroup itself
 // only propagates *returned* errors, never panics. A recovered panic is logged
 // with its stack and converted to an error so g.Wait() surfaces it as an
 // ordinary failure (a graceful 500 on a request path, a skipped fill on a
-// poller path) rather than a crash. A nil logger is tolerated.
+// poller path) rather than a crash.
 func Go(g *errgroup.Group, logger *slog.Logger, label string, fn func() error) {
 	g.Go(func() (err error) {
 		defer func() {
 			if r := recover(); r != nil {
-				if logger != nil {
-					logger.Error("errgroup worker panic recovered",
-						"worker", label, "panic", r, "stack", string(debug.Stack()))
-				}
+				loggerOrDefault(logger).Error("errgroup worker panic recovered",
+					"task", label, "panic", r, "stack", string(debug.Stack()))
 				err = fmt.Errorf("%s: recovered panic: %v", label, r)
 			}
 		}()
@@ -47,14 +60,14 @@ func Go(g *errgroup.Group, logger *slog.Logger, label string, fn func() error) {
 // fire-and-forget `go method()` calls that run outside chi's recovery
 // middleware. A recovered panic is logged with its stack; fn's own cleanup
 // (e.g. a deferred wg.Done() registered by the caller before invoking Safe)
-// still runs. A nil logger is tolerated. Typical use:
+// still runs. Typical use:
 //
 //	go func(i int) { defer wg.Done(); recoverutil.Safe(logger, "label", func() { ... }) }(i)
 //	go recoverutil.Safe(logger, "notify", func() { svc.Emit(ctx, n) })
 func Safe(logger *slog.Logger, label string, fn func()) {
 	defer func() {
-		if r := recover(); r != nil && logger != nil {
-			logger.Error("goroutine panic recovered",
+		if r := recover(); r != nil {
+			loggerOrDefault(logger).Error("goroutine panic recovered",
 				"task", label, "panic", r, "stack", string(debug.Stack()))
 		}
 	}()
@@ -64,12 +77,11 @@ func Safe(logger *slog.Logger, label string, fn func()) {
 // Tick runs fn(ctx) with panic recovery, for background ticker loops whose
 // goroutine has no surrounding recovery. A recovered panic is logged with its
 // stack so the offending input can be traced; the caller's loop continues to
-// its next iteration rather than crashing the process. A nil logger is
-// tolerated (the panic is still swallowed).
+// its next iteration rather than crashing the process.
 func Tick(ctx context.Context, logger *slog.Logger, label string, fn func(context.Context)) {
 	defer func() {
-		if r := recover(); r != nil && logger != nil {
-			logger.Error("background tick panic recovered",
+		if r := recover(); r != nil {
+			loggerOrDefault(logger).Error("background tick panic recovered",
 				"task", label, "panic", r, "stack", string(debug.Stack()))
 		}
 	}()

--- a/backend/internal/recoverutil/recoverutil_test.go
+++ b/backend/internal/recoverutil/recoverutil_test.go
@@ -1,0 +1,117 @@
+package recoverutil
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// TestGo_PanicBecomesError verifies a panic in an errgroup worker is converted
+// into a returned error (surfaced via g.Wait) rather than crashing the process.
+func TestGo_PanicBecomesError(t *testing.T) {
+	g, _ := errgroup.WithContext(context.Background())
+	Go(g, slog.Default(), "boom worker", func() error {
+		panic("kaboom")
+	})
+	err := g.Wait()
+	if err == nil {
+		t.Fatal("expected Go to convert the panic into an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "boom worker") || !strings.Contains(err.Error(), "kaboom") {
+		t.Fatalf("error should name the worker and the panic value, got: %v", err)
+	}
+}
+
+// TestGo_NonStringPanicBecomesError verifies a non-string panic value
+// (panic(42)) is still formatted into the returned error via %v. Guards against
+// a future switch to %s, which would render non-string values uselessly.
+func TestGo_NonStringPanicBecomesError(t *testing.T) {
+	g, _ := errgroup.WithContext(context.Background())
+	Go(g, slog.Default(), "int worker", func() error {
+		panic(42)
+	})
+	err := g.Wait()
+	if err == nil || !strings.Contains(err.Error(), "42") || !strings.Contains(err.Error(), "int worker") {
+		t.Fatalf("expected non-string panic value and label in the error, got: %v", err)
+	}
+}
+
+// TestGo_SuccessPassesThrough verifies the happy path is untouched.
+func TestGo_SuccessPassesThrough(t *testing.T) {
+	g, _ := errgroup.WithContext(context.Background())
+	ran := false
+	Go(g, slog.Default(), "ok worker", func() error {
+		ran = true
+		return nil
+	})
+	if err := g.Wait(); err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	if !ran {
+		t.Fatal("fn was not executed")
+	}
+}
+
+// TestGo_ErrorPassesThrough verifies a normal returned error is preserved
+// (not masked or rewrapped by the recovery shim).
+func TestGo_ErrorPassesThrough(t *testing.T) {
+	g, _ := errgroup.WithContext(context.Background())
+	sentinel := errors.New("real failure")
+	Go(g, slog.Default(), "err worker", func() error {
+		return sentinel
+	})
+	if err := g.Wait(); !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel error to pass through, got: %v", err)
+	}
+}
+
+// TestGo_NilLoggerNoPanic verifies the logger-nil guard: a panic must still
+// convert to an error without dereferencing a nil logger.
+func TestGo_NilLoggerNoPanic(t *testing.T) {
+	g, _ := errgroup.WithContext(context.Background())
+	Go(g, nil, "nil-logger worker", func() error {
+		panic("still recovered")
+	})
+	if err := g.Wait(); err == nil {
+		t.Fatal("expected recovered panic to become an error even with a nil logger")
+	}
+}
+
+// TestTick_SwallowsPanicAndLogs verifies a panic inside the tick fn is
+// recovered and logged (the log line proves the recover path actually fired,
+// not merely that the process did not crash).
+func TestTick_SwallowsPanicAndLogs(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError}))
+	Tick(context.Background(), logger, "unit task", func(context.Context) {
+		panic("tick boom")
+	})
+	got := buf.String()
+	if !strings.Contains(got, "panic recovered") || !strings.Contains(got, "unit task") {
+		t.Fatalf("expected recovery to log the task label and 'panic recovered'; got: %q", got)
+	}
+}
+
+// TestTick_NilLoggerNoPanic verifies a nil logger is tolerated.
+func TestTick_NilLoggerNoPanic(t *testing.T) {
+	// Must not crash despite the nil logger.
+	Tick(context.Background(), nil, "nil-logger task", func(context.Context) {
+		panic("boom")
+	})
+}
+
+// TestTick_SuccessPassesThrough verifies the happy path runs fn normally.
+func TestTick_SuccessPassesThrough(t *testing.T) {
+	ran := false
+	Tick(context.Background(), slog.Default(), "ok task", func(context.Context) {
+		ran = true
+	})
+	if !ran {
+		t.Fatal("fn was not executed")
+	}
+}

--- a/backend/internal/recoverutil/recoverutil_test.go
+++ b/backend/internal/recoverutil/recoverutil_test.go
@@ -82,6 +82,34 @@ func TestGo_NilLoggerNoPanic(t *testing.T) {
 	}
 }
 
+// TestSafe_SwallowsPanicAndLogs verifies a panic inside a plain-goroutine fn
+// is recovered and logged (and does not crash the process).
+func TestSafe_SwallowsPanicAndLogs(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError}))
+	Safe(logger, "unit goroutine", func() {
+		panic("safe boom")
+	})
+	got := buf.String()
+	if !strings.Contains(got, "panic recovered") || !strings.Contains(got, "unit goroutine") {
+		t.Fatalf("expected recovery to log the task label and 'panic recovered'; got: %q", got)
+	}
+}
+
+// TestSafe_NilLoggerNoPanic verifies a nil logger is tolerated.
+func TestSafe_NilLoggerNoPanic(t *testing.T) {
+	Safe(nil, "nil-logger goroutine", func() { panic("boom") })
+}
+
+// TestSafe_SuccessRunsFn verifies the happy path executes fn.
+func TestSafe_SuccessRunsFn(t *testing.T) {
+	ran := false
+	Safe(slog.Default(), "ok goroutine", func() { ran = true })
+	if !ran {
+		t.Fatal("fn was not executed")
+	}
+}
+
 // TestTick_SwallowsPanicAndLogs verifies a panic inside the tick fn is
 // recovered and logged (the log line proves the recover path actually fired,
 // not merely that the process did not crash).

--- a/backend/internal/recoverutil/recoverutil_test.go
+++ b/backend/internal/recoverutil/recoverutil_test.go
@@ -91,12 +91,24 @@ func TestSafe_SwallowsPanicAndLogs(t *testing.T) {
 		panic("safe boom")
 	})
 	got := buf.String()
-	if !strings.Contains(got, "panic recovered") || !strings.Contains(got, "unit goroutine") {
-		t.Fatalf("expected recovery to log the task label and 'panic recovered'; got: %q", got)
+	if !strings.Contains(got, "panic recovered") || !strings.Contains(got, "unit goroutine") || !strings.Contains(got, "stack") {
+		t.Fatalf("expected recovery to log the task label, 'panic recovered', and a stack; got: %q", got)
 	}
 }
 
-// TestSafe_NilLoggerNoPanic verifies a nil logger is tolerated.
+// TestSafe_NonStringPanicLogs verifies a non-string panic value is formatted
+// into the log via %v (guards against a future switch to %s).
+func TestSafe_NonStringPanicLogs(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError}))
+	Safe(logger, "int goroutine", func() { panic(42) })
+	if got := buf.String(); !strings.Contains(got, "42") {
+		t.Fatalf("expected non-string panic value in the log; got: %q", got)
+	}
+}
+
+// TestSafe_NilLoggerNoPanic verifies a nil logger is tolerated (falls back to
+// slog.Default() — the panic is still recovered, never silently dropped).
 func TestSafe_NilLoggerNoPanic(t *testing.T) {
 	Safe(nil, "nil-logger goroutine", func() { panic("boom") })
 }
@@ -120,12 +132,24 @@ func TestTick_SwallowsPanicAndLogs(t *testing.T) {
 		panic("tick boom")
 	})
 	got := buf.String()
-	if !strings.Contains(got, "panic recovered") || !strings.Contains(got, "unit task") {
-		t.Fatalf("expected recovery to log the task label and 'panic recovered'; got: %q", got)
+	if !strings.Contains(got, "panic recovered") || !strings.Contains(got, "unit task") || !strings.Contains(got, "stack") {
+		t.Fatalf("expected recovery to log the task label, 'panic recovered', and a stack; got: %q", got)
 	}
 }
 
-// TestTick_NilLoggerNoPanic verifies a nil logger is tolerated.
+// TestTick_NonStringPanicLogs verifies a non-string panic value is formatted
+// into the log via %v.
+func TestTick_NonStringPanicLogs(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError}))
+	Tick(context.Background(), logger, "int task", func(context.Context) { panic(42) })
+	if got := buf.String(); !strings.Contains(got, "42") {
+		t.Fatalf("expected non-string panic value in the log; got: %q", got)
+	}
+}
+
+// TestTick_NilLoggerNoPanic verifies a nil logger is tolerated (falls back to
+// slog.Default()).
 func TestTick_NilLoggerNoPanic(t *testing.T) {
 	// Must not crash despite the nil logger.
 	Tick(context.Background(), nil, "nil-logger task", func(context.Context) {

--- a/backend/internal/scanning/discovery.go
+++ b/backend/internal/scanning/discovery.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/kubecenter/kubecenter/internal/k8s"
 	"github.com/kubecenter/kubecenter/internal/recoverutil"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/backend/internal/scanning/discovery.go
+++ b/backend/internal/scanning/discovery.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/kubecenter/kubecenter/internal/k8s"
+	"github.com/kubecenter/kubecenter/internal/recoverutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -42,7 +43,7 @@ func (d *ScannerDiscoverer) Status() ScannerStatus {
 
 // RunDiscoveryLoop runs discovery immediately, then every recheckInterval.
 func (d *ScannerDiscoverer) RunDiscoveryLoop(ctx context.Context) {
-	d.Discover(ctx)
+	recoverutil.Tick(ctx, d.logger, "scanning discovery", d.Discover)
 
 	ticker := time.NewTicker(recheckInterval)
 	defer ticker.Stop()
@@ -52,7 +53,7 @@ func (d *ScannerDiscoverer) RunDiscoveryLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			d.Discover(ctx)
+			recoverutil.Tick(ctx, d.logger, "scanning discovery", d.Discover)
 		}
 	}
 }

--- a/backend/internal/scanning/handler.go
+++ b/backend/internal/scanning/handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kubecenter/kubecenter/internal/k8s"
 	"github.com/kubecenter/kubecenter/internal/k8s/resources"
 	"github.com/kubecenter/kubecenter/internal/notifications"
+	"github.com/kubecenter/kubecenter/internal/recoverutil"
 	"github.com/kubecenter/kubecenter/internal/server/middleware"
 )
 
@@ -73,11 +74,13 @@ func (h *Handler) InvalidateCache() {
 	h.detailCache = make(map[string]*cachedDetailData)
 	h.cacheMu.Unlock()
 	if h.NotifService != nil {
-		go h.NotifService.Emit(context.Background(), notifications.Notification{
-			Source:   notifications.SourceScan,
-			Severity: notifications.SeverityInfo,
-			Title:    "Security scan results updated",
-			Message:  "New vulnerability scan results available. Check the security dashboard for details.",
+		go recoverutil.Safe(h.Logger, "scanning notify", func() {
+			h.NotifService.Emit(context.Background(), notifications.Notification{
+				Source:   notifications.SourceScan,
+				Severity: notifications.SeverityInfo,
+				Title:    "Security scan results updated",
+				Message:  "New vulnerability scan results available. Check the security dashboard for details.",
+			})
 		})
 	}
 }
@@ -124,7 +127,9 @@ func (h *Handler) doFetchNS(ctx context.Context, namespace string) (*cachedNSDat
 		go func() {
 			defer wg.Done()
 			var r fetchResult
-			r.vulns, r.err = ListTrivyVulnSummaries(ctx, dynClient, namespace)
+			recoverutil.Safe(h.Logger, "scanning trivy-fetch", func() {
+				r.vulns, r.err = ListTrivyVulnSummaries(ctx, dynClient, namespace)
+			})
 			trivyCh <- r
 		}()
 	} else {
@@ -136,7 +141,9 @@ func (h *Handler) doFetchNS(ctx context.Context, namespace string) (*cachedNSDat
 		go func() {
 			defer wg.Done()
 			var r fetchResult
-			r.vulns, r.err = ListKubescapeVulnSummaries(ctx, dynClient, namespace)
+			recoverutil.Safe(h.Logger, "scanning kubescape-fetch", func() {
+				r.vulns, r.err = ListKubescapeVulnSummaries(ctx, dynClient, namespace)
+			})
 			kubescapeCh <- r
 		}()
 	} else {

--- a/backend/internal/servicemesh/discovery.go
+++ b/backend/internal/servicemesh/discovery.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/kubecenter/kubecenter/internal/k8s"
+	"github.com/kubecenter/kubecenter/internal/recoverutil"
 )
 
 const (
@@ -105,7 +106,7 @@ func (d *Discoverer) SetOnChange(cb DiscoveryChangeCallback) {
 // Discoverer is purely lazy (probe-on-stale-read), which means a
 // post-startup mesh install isn't noticed until the next user request.
 func (d *Discoverer) RunDiscoveryLoop(ctx context.Context) {
-	d.Probe(ctx)
+	recoverutil.Tick(ctx, d.logger, "servicemesh discovery", func(ctx context.Context) { d.Probe(ctx) })
 	ticker := time.NewTicker(recheckInterval)
 	defer ticker.Stop()
 
@@ -114,7 +115,7 @@ func (d *Discoverer) RunDiscoveryLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			d.Probe(ctx)
+			recoverutil.Tick(ctx, d.logger, "servicemesh discovery", func(ctx context.Context) { d.Probe(ctx) })
 		}
 	}
 }

--- a/backend/internal/servicemesh/discovery.go
+++ b/backend/internal/servicemesh/discovery.go
@@ -106,6 +106,7 @@ func (d *Discoverer) SetOnChange(cb DiscoveryChangeCallback) {
 // Discoverer is purely lazy (probe-on-stale-read), which means a
 // post-startup mesh install isn't noticed until the next user request.
 func (d *Discoverer) RunDiscoveryLoop(ctx context.Context) {
+	// lambda required: Probe returns MeshStatus; Tick wants func(context.Context)
 	recoverutil.Tick(ctx, d.logger, "servicemesh discovery", func(ctx context.Context) { d.Probe(ctx) })
 	ticker := time.NewTicker(recheckInterval)
 	defer ticker.Stop()
@@ -115,6 +116,7 @@ func (d *Discoverer) RunDiscoveryLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
+			// lambda required: Probe returns MeshStatus; Tick wants func(context.Context)
 			recoverutil.Tick(ctx, d.logger, "servicemesh discovery", func(ctx context.Context) { d.Probe(ctx) })
 		}
 	}

--- a/backend/internal/servicemesh/handler.go
+++ b/backend/internal/servicemesh/handler.go
@@ -28,6 +28,7 @@ import (
 	"github.com/kubecenter/kubecenter/internal/k8s"
 	"github.com/kubecenter/kubecenter/internal/k8s/resources"
 	"github.com/kubecenter/kubecenter/internal/monitoring"
+	"github.com/kubecenter/kubecenter/internal/recoverutil"
 	"github.com/kubecenter/kubecenter/internal/server/middleware"
 )
 
@@ -195,12 +196,16 @@ func (h *Handler) doFetch(ctx context.Context) (*cachedMeshData, error) {
 
 	if status.Istio != nil && status.Istio.Installed {
 		wg.Go(func() {
-			istio = ListIstio(ctx, dynClient, "")
+			recoverutil.Safe(h.Logger, "servicemesh istio fetch", func() {
+				istio = ListIstio(ctx, dynClient, "")
+			})
 		})
 	}
 	if status.Linkerd != nil && status.Linkerd.Installed {
 		wg.Go(func() {
-			linkerd = ListLinkerd(ctx, dynClient, "")
+			recoverutil.Safe(h.Logger, "servicemesh linkerd fetch", func() {
+				linkerd = ListLinkerd(ctx, dynClient, "")
+			})
 		})
 	}
 	wg.Wait()

--- a/backend/internal/servicemesh/istio.go
+++ b/backend/internal/servicemesh/istio.go
@@ -9,6 +9,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
+
+	"github.com/kubecenter/kubecenter/internal/recoverutil"
 )
 
 const (
@@ -63,17 +65,19 @@ func ListIstio(ctx context.Context, dynClient dynamic.Interface, namespace strin
 		wg.Add(1)
 		go func(c istioCRD) {
 			defer wg.Done()
-			items, err := listCRD(ctx, dynClient, c.GVR, namespace, listOpts)
+			recoverutil.Safe(nil, "servicemesh istio list routes", func() {
+				items, err := listCRD(ctx, dynClient, c.GVR, namespace, listOpts)
 
-			mu.Lock()
-			defer mu.Unlock()
-			if err != nil {
-				result.Errors[c.Kind] = err.Error()
-				return
-			}
-			for i := range items {
-				result.Routes = append(result.Routes, normalizeIstioRoute(&items[i], c.Kind))
-			}
+				mu.Lock()
+				defer mu.Unlock()
+				if err != nil {
+					result.Errors[c.Kind] = err.Error()
+					return
+				}
+				for i := range items {
+					result.Routes = append(result.Routes, normalizeIstioRoute(&items[i], c.Kind))
+				}
+			})
 		}(c)
 	}
 
@@ -81,17 +85,19 @@ func ListIstio(ctx context.Context, dynClient dynamic.Interface, namespace strin
 		wg.Add(1)
 		go func(c istioCRD) {
 			defer wg.Done()
-			items, err := listCRD(ctx, dynClient, c.GVR, namespace, listOpts)
+			recoverutil.Safe(nil, "servicemesh istio list policies", func() {
+				items, err := listCRD(ctx, dynClient, c.GVR, namespace, listOpts)
 
-			mu.Lock()
-			defer mu.Unlock()
-			if err != nil {
-				result.Errors[c.Kind] = err.Error()
-				return
-			}
-			for i := range items {
-				result.Policies = append(result.Policies, normalizeIstioPolicy(&items[i], c.Kind))
-			}
+				mu.Lock()
+				defer mu.Unlock()
+				if err != nil {
+					result.Errors[c.Kind] = err.Error()
+					return
+				}
+				for i := range items {
+					result.Policies = append(result.Policies, normalizeIstioPolicy(&items[i], c.Kind))
+				}
+			})
 		}(c)
 	}
 

--- a/backend/internal/servicemesh/linkerd.go
+++ b/backend/internal/servicemesh/linkerd.go
@@ -7,6 +7,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
+
+	"github.com/kubecenter/kubecenter/internal/recoverutil"
 )
 
 // linkerdCRD bundles a GVR with the Kind name used for composite IDs and
@@ -58,17 +60,19 @@ func ListLinkerd(ctx context.Context, dynClient dynamic.Interface, namespace str
 		wg.Add(1)
 		go func(c linkerdCRD) {
 			defer wg.Done()
-			items, err := listCRD(ctx, dynClient, c.GVR, namespace, listOpts)
+			recoverutil.Safe(nil, "servicemesh linkerd list routes", func() {
+				items, err := listCRD(ctx, dynClient, c.GVR, namespace, listOpts)
 
-			mu.Lock()
-			defer mu.Unlock()
-			if err != nil {
-				result.Errors[c.Kind] = err.Error()
-				return
-			}
-			for i := range items {
-				result.Routes = append(result.Routes, normalizeLinkerdRoute(&items[i], c.Kind))
-			}
+				mu.Lock()
+				defer mu.Unlock()
+				if err != nil {
+					result.Errors[c.Kind] = err.Error()
+					return
+				}
+				for i := range items {
+					result.Routes = append(result.Routes, normalizeLinkerdRoute(&items[i], c.Kind))
+				}
+			})
 		}(c)
 	}
 
@@ -76,17 +80,19 @@ func ListLinkerd(ctx context.Context, dynClient dynamic.Interface, namespace str
 		wg.Add(1)
 		go func(c linkerdCRD) {
 			defer wg.Done()
-			items, err := listCRD(ctx, dynClient, c.GVR, namespace, listOpts)
+			recoverutil.Safe(nil, "servicemesh linkerd list policies", func() {
+				items, err := listCRD(ctx, dynClient, c.GVR, namespace, listOpts)
 
-			mu.Lock()
-			defer mu.Unlock()
-			if err != nil {
-				result.Errors[c.Kind] = err.Error()
-				return
-			}
-			for i := range items {
-				result.Policies = append(result.Policies, normalizeLinkerdPolicy(&items[i], c.Kind))
-			}
+				mu.Lock()
+				defer mu.Unlock()
+				if err != nil {
+					result.Errors[c.Kind] = err.Error()
+					return
+				}
+				for i := range items {
+					result.Policies = append(result.Policies, normalizeLinkerdPolicy(&items[i], c.Kind))
+				}
+			})
 		}(c)
 	}
 

--- a/backend/internal/servicemesh/metrics.go
+++ b/backend/internal/servicemesh/metrics.go
@@ -9,6 +9,7 @@ import (
 	"github.com/prometheus/common/model"
 
 	"github.com/kubecenter/kubecenter/internal/monitoring"
+	"github.com/kubecenter/kubecenter/internal/recoverutil"
 )
 
 // promQueryTimeout bounds every PromQL query originating from this
@@ -230,13 +231,22 @@ func goldenSignalsForService(ctx context.Context, pc *monitoring.PrometheusClien
 
 	for name, q := range rendered {
 		go func(name, q string) {
-			val, _, qerr := pc.Query(queryCtx, q, now)
-			if qerr != nil {
-				outcomes <- outcome{name: name, err: qerr}
-				return
-			}
-			scalar, ok := firstScalarValue(val)
-			outcomes <- outcome{name: name, value: scalar, ok: ok}
+			// Defer the channel send OUTSIDE Safe so a panic in the query/parse
+			// path still delivers one item to outcomes, preserving the invariant
+			// that the consumer receives exactly len(rendered) items. Without
+			// this, a panic would swallow the send and deadlock the consumer.
+			o := outcome{name: name}
+			defer func() { outcomes <- o }()
+			recoverutil.Safe(nil, "servicemesh golden signals query", func() {
+				val, _, qerr := pc.Query(queryCtx, q, now)
+				if qerr != nil {
+					o.err = qerr
+					return
+				}
+				scalar, ok := firstScalarValue(val)
+				o.value = scalar
+				o.ok = ok
+			})
 		}(name, q)
 	}
 

--- a/backend/internal/velero/handler.go
+++ b/backend/internal/velero/handler.go
@@ -1018,7 +1018,7 @@ func (h *Handler) doFetchAll(ctx context.Context, gen uint64) (*cachedVeleroData
 
 	g, gctx := errgroup.WithContext(ctx)
 
-	recoverutil.Go(g, h.Logger, "list backups", func() error {
+	recoverutil.Go(g, h.Logger, "velero list backups", func() error {
 		list, err := dynClient.Resource(BackupGVR).Namespace("").List(gctx, metav1.ListOptions{})
 		if err != nil {
 			return err
@@ -1030,7 +1030,7 @@ func (h *Handler) doFetchAll(ctx context.Context, gen uint64) (*cachedVeleroData
 		return nil
 	})
 
-	recoverutil.Go(g, h.Logger, "list restores", func() error {
+	recoverutil.Go(g, h.Logger, "velero list restores", func() error {
 		list, err := dynClient.Resource(RestoreGVR).Namespace("").List(gctx, metav1.ListOptions{})
 		if err != nil {
 			return err
@@ -1042,7 +1042,7 @@ func (h *Handler) doFetchAll(ctx context.Context, gen uint64) (*cachedVeleroData
 		return nil
 	})
 
-	recoverutil.Go(g, h.Logger, "list schedules", func() error {
+	recoverutil.Go(g, h.Logger, "velero list schedules", func() error {
 		list, err := dynClient.Resource(ScheduleGVR).Namespace("").List(gctx, metav1.ListOptions{})
 		if err != nil {
 			return err
@@ -1054,7 +1054,7 @@ func (h *Handler) doFetchAll(ctx context.Context, gen uint64) (*cachedVeleroData
 		return nil
 	})
 
-	recoverutil.Go(g, h.Logger, "list backup storage locations", func() error {
+	recoverutil.Go(g, h.Logger, "velero list backup storage locations", func() error {
 		list, err := dynClient.Resource(BackupStorageLocationGVR).Namespace("").List(gctx, metav1.ListOptions{})
 		if err != nil {
 			return err
@@ -1066,7 +1066,7 @@ func (h *Handler) doFetchAll(ctx context.Context, gen uint64) (*cachedVeleroData
 		return nil
 	})
 
-	recoverutil.Go(g, h.Logger, "list volume snapshot locations", func() error {
+	recoverutil.Go(g, h.Logger, "velero list volume snapshot locations", func() error {
 		list, err := dynClient.Resource(VolumeSnapshotLocationGVR).Namespace("").List(gctx, metav1.ListOptions{})
 		if err != nil {
 			return err

--- a/backend/internal/velero/handler.go
+++ b/backend/internal/velero/handler.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kubecenter/kubecenter/internal/k8s"
 	"github.com/kubecenter/kubecenter/internal/k8s/resources"
 	"github.com/kubecenter/kubecenter/internal/notifications"
+	"github.com/kubecenter/kubecenter/internal/recoverutil"
 	"github.com/kubecenter/kubecenter/internal/server/middleware"
 )
 
@@ -84,11 +85,13 @@ func (h *Handler) InvalidateCache() {
 	h.cacheMu.Unlock()
 
 	if h.NotifService != nil {
-		go h.NotifService.Emit(context.Background(), notifications.Notification{
-			Source:   notifications.SourceVelero,
-			Severity: notifications.SeverityInfo,
-			Title:    "Velero data updated",
-			Message:  "Backup or restore data has changed",
+		go recoverutil.Safe(h.Logger, "velero notify", func() {
+			h.NotifService.Emit(context.Background(), notifications.Notification{
+				Source:   notifications.SourceVelero,
+				Severity: notifications.SeverityInfo,
+				Title:    "Velero data updated",
+				Message:  "Backup or restore data has changed",
+			})
 		})
 	}
 }
@@ -1015,7 +1018,7 @@ func (h *Handler) doFetchAll(ctx context.Context, gen uint64) (*cachedVeleroData
 
 	g, gctx := errgroup.WithContext(ctx)
 
-	g.Go(func() error {
+	recoverutil.Go(g, h.Logger, "list backups", func() error {
 		list, err := dynClient.Resource(BackupGVR).Namespace("").List(gctx, metav1.ListOptions{})
 		if err != nil {
 			return err
@@ -1027,7 +1030,7 @@ func (h *Handler) doFetchAll(ctx context.Context, gen uint64) (*cachedVeleroData
 		return nil
 	})
 
-	g.Go(func() error {
+	recoverutil.Go(g, h.Logger, "list restores", func() error {
 		list, err := dynClient.Resource(RestoreGVR).Namespace("").List(gctx, metav1.ListOptions{})
 		if err != nil {
 			return err
@@ -1039,7 +1042,7 @@ func (h *Handler) doFetchAll(ctx context.Context, gen uint64) (*cachedVeleroData
 		return nil
 	})
 
-	g.Go(func() error {
+	recoverutil.Go(g, h.Logger, "list schedules", func() error {
 		list, err := dynClient.Resource(ScheduleGVR).Namespace("").List(gctx, metav1.ListOptions{})
 		if err != nil {
 			return err
@@ -1051,7 +1054,7 @@ func (h *Handler) doFetchAll(ctx context.Context, gen uint64) (*cachedVeleroData
 		return nil
 	})
 
-	g.Go(func() error {
+	recoverutil.Go(g, h.Logger, "list backup storage locations", func() error {
 		list, err := dynClient.Resource(BackupStorageLocationGVR).Namespace("").List(gctx, metav1.ListOptions{})
 		if err != nil {
 			return err
@@ -1063,7 +1066,7 @@ func (h *Handler) doFetchAll(ctx context.Context, gen uint64) (*cachedVeleroData
 		return nil
 	})
 
-	g.Go(func() error {
+	recoverutil.Go(g, h.Logger, "list volume snapshot locations", func() error {
 		list, err := dynClient.Resource(VolumeSnapshotLocationGVR).Namespace("").List(gctx, metav1.ListOptions{})
 		if err != nil {
 			return err


### PR DESCRIPTION
## Summary
Fast-follow C from the #374 review: extract certmanager's goroutine panic-recovery helpers into a shared `internal/recoverutil` package, then sweep the same unrecovered-goroutine gap across the backend. A panic on a goroutine that runs **outside chi's recovery middleware** (errgroup workers, background ticker loops, bare/fire-and-forget goroutines) crashes the *whole process*; these helpers turn that into a logged, recoverable failure.

## `internal/recoverutil` (new, centrally unit-tested)
- `Go(g, logger, label, fn)` — errgroup workers: recover → log w/ stack → return error for `g.Wait`.
- `Tick(ctx, logger, label, fn)` — background ticker loops: recover → log → continue.
- `Safe(logger, label, fn)` — plain/fire-and-forget goroutines: recover → log.

## Phase 1 — extract + migrate the reference
certmanager migrated onto recoverutil (local `safeGo`/`runTickWithRecover` removed; behavior unchanged).

## Phase 2 — sweep
**Real process-crash-from-cluster-data gaps** (normalize/parse inside a goroutine):
- `externalsecrets/handler.go` (5 errgroup workers), `velero/handler.go` (5 workers + fire-and-forget `Emit`), `gateway/handler.go` (errgroup workers + 4 bare `go func` route resolvers, semaphore pairing preserved), `networking/handler.go` (3 workers + fire-and-forget `Detect`).

**Defense-in-depth** on List-only background loops (no current data-panic path, but an unrecovered panic still crashes the process): `k8s/cluster_prober`, `limits/checker`, `alerting/notifier` + store pruner, `notifications` retention, and the 6 `RunDiscoveryLoop`s (scanning, loki, policy, monitoring, gitops, servicemesh).

Validation note: the original review named ~10 pollers as gaps; verification found they're List-only (no in-goroutine parse), so those are insurance, not fixes — the genuine data-reachable gaps are the 4 handlers.

Behavior unchanged on happy paths. Repo-wide `go vet`/`build`/`test` green; existing package tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)