### PR TITLE
test(backend): full-pipeline Secret-handler fuzz + kubernetes.Interface client seam

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -22,6 +22,7 @@ jobs:
           - { pkg: ./internal/servicemesh/, target: FuzzParseMeshCompositeID }
           - { pkg: ./internal/server/, target: FuzzAuthzEnforcement }
           - { pkg: ./internal/k8s/resources/, target: FuzzMaskedSecret }
+          - { pkg: ./internal/k8s/resources/, target: FuzzSecretPipeline }
           - { pkg: ./internal/auth/, target: FuzzParsePHC }
           - { pkg: ./internal/yaml/, target: FuzzParseMultiDoc }
           - { pkg: ./internal/wizard/, target: FuzzIsPublicIP }

--- a/backend/internal/auth/rbac.go
+++ b/backend/internal/auth/rbac.go
@@ -63,7 +63,7 @@ var trackedResources = map[string]bool{
 // RBACChecker queries Kubernetes RBAC permissions for users.
 type RBACChecker struct {
 	clientFactory interface {
-		ClientForUser(username string, groups []string) (*kubernetes.Clientset, error)
+		ClientForUser(username string, groups []string) (kubernetes.Interface, error)
 	}
 	mu     sync.Mutex
 	cache  map[string]rbacCacheEntry // keyed by username
@@ -72,7 +72,7 @@ type RBACChecker struct {
 
 // NewRBACChecker creates a new RBACChecker.
 func NewRBACChecker(clientFactory interface {
-	ClientForUser(username string, groups []string) (*kubernetes.Clientset, error)
+	ClientForUser(username string, groups []string) (kubernetes.Interface, error)
 }, logger *slog.Logger) *RBACChecker {
 	return &RBACChecker{
 		clientFactory: clientFactory,
@@ -174,7 +174,7 @@ func (rc *RBACChecker) GetSummary(ctx context.Context, user *User, namespaces []
 
 // getRulesForNamespace uses SelfSubjectRulesReview to get all permissions
 // in a single API call per namespace.
-func (rc *RBACChecker) getRulesForNamespace(ctx context.Context, cs *kubernetes.Clientset, namespace string) (map[string][]string, error) {
+func (rc *RBACChecker) getRulesForNamespace(ctx context.Context, cs kubernetes.Interface, namespace string) (map[string][]string, error) {
 	review := &authorizationv1.SelfSubjectRulesReview{
 		Spec: authorizationv1.SelfSubjectRulesReviewSpec{
 			Namespace: namespace,

--- a/backend/internal/auth/rbac_test.go
+++ b/backend/internal/auth/rbac_test.go
@@ -194,7 +194,7 @@ type fakeClientFactory struct {
 	callCount int
 }
 
-func (f *fakeClientFactory) ClientForUser(username string, groups []string) (*kubernetes.Clientset, error) {
+func (f *fakeClientFactory) ClientForUser(username string, groups []string) (kubernetes.Interface, error) {
 	f.mu.Lock()
 	f.callCount++
 	f.mu.Unlock()

--- a/backend/internal/certmanager/handler.go
+++ b/backend/internal/certmanager/handler.go
@@ -138,7 +138,7 @@ func (h *Handler) getImpersonatingClient(ctx context.Context, w http.ResponseWri
 
 // getTypedClient creates a typed Kubernetes clientset impersonating the user, routing to the
 // correct cluster via ClusterRouter. Returns (nil, false) and writes an error response on failure.
-func (h *Handler) getTypedClient(ctx context.Context, w http.ResponseWriter, clusterID string, user *auth.User) (*kubernetes.Clientset, bool) {
+func (h *Handler) getTypedClient(ctx context.Context, w http.ResponseWriter, clusterID string, user *auth.User) (kubernetes.Interface, bool) {
 	cs, err := h.ClusterRouter.ClientForCluster(ctx, clusterID, user.KubernetesUsername, user.KubernetesGroups)
 	if err != nil {
 		h.Logger.Error("failed to create typed client", "clusterID", clusterID, "error", err)

--- a/backend/internal/k8s/client.go
+++ b/backend/internal/k8s/client.go
@@ -38,18 +38,18 @@ type cachedDynClient struct {
 // ClientFactory creates Kubernetes clientsets, with impersonation support
 // and a cache to avoid repeated TLS handshakes.
 type ClientFactory struct {
-	baseConfig    *rest.Config
-	baseClientset *kubernetes.Clientset
-	cache         sync.Map // map[string]cachedClient — typed clientsets
-	dynCache      sync.Map // map[string]cachedDynClient — dynamic clients
-	baseDynClient dynamic.Interface
-	baseDynOnce   sync.Once
-	mapper        meta.RESTMapper
-	mapperOnce    sync.Once
+	baseConfig      *rest.Config
+	baseClientset   *kubernetes.Clientset
+	cache           sync.Map // map[string]cachedClient — typed clientsets
+	dynCache        sync.Map // map[string]cachedDynClient — dynamic clients
+	baseDynClient   dynamic.Interface
+	baseDynOnce     sync.Once
+	mapper          meta.RESTMapper
+	mapperOnce      sync.Once
 	clusterID       string
 	logger          *slog.Logger
-	testOverride    *kubernetes.Clientset // if set, ClientForUser returns this directly
-	testDynOverride dynamic.Interface     // if set, DynamicClientForUser returns this directly
+	testOverride    kubernetes.Interface // if set, ClientForUser returns this directly
+	testDynOverride dynamic.Interface    // if set, DynamicClientForUser returns this directly
 }
 
 // NewClientFactory creates a ClientFactory using in-cluster config with
@@ -127,7 +127,12 @@ func (f *ClientFactory) BaseDynamicClient() dynamic.Interface {
 
 // ClientForUser returns an impersonating clientset for the given user.
 // Results are cached for 5 minutes keyed by hash(username+groups).
-func (f *ClientFactory) ClientForUser(username string, groups []string) (*kubernetes.Clientset, error) {
+//
+// The return type is kubernetes.Interface (not the concrete *kubernetes.Clientset)
+// so callers and the whole typed-client spine can be driven by a fake clientset
+// in tests (e.g. the full-pipeline Secret-handler fuzz). Production always returns
+// a real *kubernetes.Clientset.
+func (f *ClientFactory) ClientForUser(username string, groups []string) (kubernetes.Interface, error) {
 	if f.testOverride != nil {
 		return f.testOverride, nil
 	}
@@ -245,14 +250,18 @@ func (f *ClientFactory) StartCacheSweeper(ctx context.Context) {
 	}()
 }
 
-// NewTestClientFactory returns a ClientFactory whose ClientForUser always
-// returns the given clientset, bypassing impersonation. For use in tests only.
-func NewTestClientFactory(cs *kubernetes.Clientset) *ClientFactory {
+// NewFakeClientFactory returns a ClientFactory whose ClientForUser always
+// returns the given kubernetes.Interface, bypassing impersonation. It accepts
+// any kubernetes.Interface (e.g. a *fake.Clientset), so the typed-client path
+// can be driven with seeded, adversarial objects. baseClientset is intentionally
+// left nil — callers that only exercise the impersonated ClientForUser path (the
+// Secret handlers) never touch it; a caller needing BaseClientset() / RESTMapper()
+// must use NewTestClientFactoryWithDynamic instead. For use in tests only.
+func NewFakeClientFactory(cs kubernetes.Interface) *ClientFactory {
 	return &ClientFactory{
-		baseClientset: cs,
-		clusterID:     "test",
-		logger:        slog.Default(),
-		testOverride:  cs,
+		clusterID:    "test",
+		logger:       slog.Default(),
+		testOverride: cs,
 	}
 }
 

--- a/backend/internal/k8s/client_test.go
+++ b/backend/internal/k8s/client_test.go
@@ -1,0 +1,30 @@
+package k8s
+
+import (
+	"testing"
+
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// TestNewFakeClientFactory verifies the test-injection seam: ClientForUser must
+// return the exact injected kubernetes.Interface (bypassing impersonation), and
+// baseClientset is intentionally nil. The nil-baseClientset contract is asserted
+// here so a future caller that reaches for BaseClientset() / RESTMapper() on a
+// fake-injected factory finds the constraint documented by a failing test rather
+// than a runtime nil dereference.
+func TestNewFakeClientFactory(t *testing.T) {
+	fakeCS := fake.NewSimpleClientset()
+	f := NewFakeClientFactory(fakeCS)
+
+	got, err := f.ClientForUser("alice", []string{"team"})
+	if err != nil {
+		t.Fatalf("ClientForUser returned error: %v", err)
+	}
+	if got != fakeCS {
+		t.Errorf("ClientForUser returned %v, want the injected fake %v", got, fakeCS)
+	}
+
+	if f.baseClientset != nil {
+		t.Error("NewFakeClientFactory must leave baseClientset nil (Secret handlers use only the impersonated path)")
+	}
+}

--- a/backend/internal/k8s/cluster_router.go
+++ b/backend/internal/k8s/cluster_router.go
@@ -44,8 +44,8 @@ type ClusterRouter struct {
 	// data through the cert-manager endpoints. Using a callback instead of
 	// a direct import keeps the k8s package free of upward dependencies on
 	// certmanager / eso / future cache-holding subsystems.
-	evictCBMu    sync.RWMutex
-	evictCBs     []func(clusterID string)
+	evictCBMu sync.RWMutex
+	evictCBs  []func(clusterID string)
 }
 
 // NewClusterRouter creates a ClusterRouter. clusterStore may be nil for
@@ -68,7 +68,7 @@ func NewClusterRouter(local *ClientFactory, cs *store.ClusterStore, encKey strin
 // cluster registry was configured, which mismatched AccessChecker's behavior
 // (it already hard-errored in the same scenario). Both layers now fail
 // closed in the safer direction.
-func (cr *ClusterRouter) ClientForCluster(ctx context.Context, clusterID, username string, groups []string) (*kubernetes.Clientset, error) {
+func (cr *ClusterRouter) ClientForCluster(ctx context.Context, clusterID, username string, groups []string) (kubernetes.Interface, error) {
 	if clusterID == "" || clusterID == "local" {
 		return cr.localFactory.ClientForUser(username, groups)
 	}
@@ -100,7 +100,7 @@ func (cr *ClusterRouter) DynamicClientForCluster(ctx context.Context, clusterID,
 type ClientPair struct {
 	ClusterID string
 	IsLocal   bool
-	Typed     *kubernetes.Clientset
+	Typed     kubernetes.Interface
 	Dynamic   dynamic.Interface
 }
 
@@ -258,7 +258,7 @@ func (cr *ClusterRouter) StartCacheSweeper(ctx context.Context) {
 	}()
 }
 
-func (cr *ClusterRouter) remoteTypedClient(ctx context.Context, clusterID, username string, groups []string) (*kubernetes.Clientset, error) {
+func (cr *ClusterRouter) remoteTypedClient(ctx context.Context, clusterID, username string, groups []string) (kubernetes.Interface, error) {
 	key := clusterID + "\x00" + cacheKey(username, groups)
 
 	// Check cache

--- a/backend/internal/k8s/resources/access.go
+++ b/backend/internal/k8s/resources/access.go
@@ -47,7 +47,7 @@ type AccessPredicate func(verb, apiGroup, resource, namespace string) bool
 
 type AccessChecker struct {
 	clientFactory interface {
-		ClientForUser(username string, groups []string) (*kubernetes.Clientset, error)
+		ClientForUser(username string, groups []string) (kubernetes.Interface, error)
 	}
 	// clusterRouter routes SAR clients to remote clusters when a non-local
 	// clusterID is supplied. nil is fine — callers always passing local
@@ -67,7 +67,7 @@ type AccessChecker struct {
 // non-local SARs once ClusterRouter is constructed (it depends on the cluster
 // store, which is built after the AccessChecker in main.go).
 func NewAccessChecker(clientFactory interface {
-	ClientForUser(username string, groups []string) (*kubernetes.Clientset, error)
+	ClientForUser(username string, groups []string) (kubernetes.Interface, error)
 }, logger *slog.Logger) *AccessChecker {
 	return &AccessChecker{
 		clientFactory: clientFactory,
@@ -255,7 +255,7 @@ func (ac *AccessChecker) CanAccessGroupResource(ctx context.Context, clusterID, 
 // clientForCluster picks the SAR-issuing clientset for the given cluster.
 // Local cluster ("", "local") routes through the local clientFactory;
 // non-local routes through clusterRouter. F#9 security audit 2026-05-22.
-func (ac *AccessChecker) clientForCluster(ctx context.Context, clusterID, username string, groups []string) (*kubernetes.Clientset, error) {
+func (ac *AccessChecker) clientForCluster(ctx context.Context, clusterID, username string, groups []string) (kubernetes.Interface, error) {
 	if k8s.IsLocalClusterID(clusterID) {
 		return ac.clientFactory.ClientForUser(username, groups)
 	}

--- a/backend/internal/k8s/resources/access_test.go
+++ b/backend/internal/k8s/resources/access_test.go
@@ -137,7 +137,7 @@ type countingFactory struct {
 	callCount int
 }
 
-func (f *countingFactory) ClientForUser(username string, groups []string) (*kubernetes.Clientset, error) {
+func (f *countingFactory) ClientForUser(username string, groups []string) (kubernetes.Interface, error) {
 	f.callCount++
 	return nil, nil
 }

--- a/backend/internal/k8s/resources/handler.go
+++ b/backend/internal/k8s/resources/handler.go
@@ -140,7 +140,7 @@ func requireUser(w http.ResponseWriter, r *http.Request) (*auth.User, bool) {
 
 // impersonatingClient returns a k8s clientset impersonating the authenticated user,
 // routed to the correct cluster based on the X-Cluster-ID request context.
-func (h *Handler) impersonatingClient(r *http.Request, user *auth.User) (*kubernetes.Clientset, error) {
+func (h *Handler) impersonatingClient(r *http.Request, user *auth.User) (kubernetes.Interface, error) {
 	clusterID := middleware.ClusterIDFromContext(r.Context())
 	return h.ClusterRouter.ClientForCluster(r.Context(), clusterID, user.KubernetesUsername, user.KubernetesGroups)
 }

--- a/backend/internal/k8s/resources/nodes.go
+++ b/backend/internal/k8s/resources/nodes.go
@@ -201,7 +201,7 @@ func isDaemonSetPod(pod *corev1.Pod) bool {
 	return false
 }
 
-func evictPod(ctx context.Context, cs *kubernetes.Clientset, pod *corev1.Pod) error {
+func evictPod(ctx context.Context, cs kubernetes.Interface, pod *corev1.Pod) error {
 	eviction := &policyv1.Eviction{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pod.Name,

--- a/backend/internal/k8s/resources/secret_pipeline_fuzz_test.go
+++ b/backend/internal/k8s/resources/secret_pipeline_fuzz_test.go
@@ -1,0 +1,175 @@
+package resources
+
+import (
+	"context"
+	"encoding/base64"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/kubecenter/kubecenter/internal/audit"
+	"github.com/kubecenter/kubecenter/internal/auth"
+	k8s "github.com/kubecenter/kubecenter/internal/k8s"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// pipelineSentinel is the plaintext seeded into every fuzzed Secret's Data,
+// StringData, and last-applied-configuration annotation. The leak oracle
+// asserts it NEVER survives a List/Get response — in plaintext (StringData,
+// annotation) OR base64 (the JSON encoding of the []byte Data values). It is
+// long and distinctive so a coverage-guided fuzzer (which has never seen these
+// bytes as input — the constant lives only in test code, never in a seed) will
+// not reproduce it in a non-masked field (name, key, annotation key) and cause
+// a false positive.
+const pipelineSentinel = "p1pel1ne-SENTINEL-must-never-leak-7f3a9c"
+
+// FuzzSecretPipeline drives the *full* Secret HTTP pipeline — handler →
+// ClusterRouter → ClientFactory(fake) → maskedSecret → JSON encode — rather
+// than the pure maskedSecret function alone (covered by FuzzMaskedSecret).
+// Secrets are fetched on-demand via the impersonated typed client (NOT the
+// informer cache), which is why this needs the ClientFactory → kubernetes.Interface
+// seam: a fake clientset seeded with adversarial Secrets is injected through it.
+//
+// Oracles:
+//   - A (crash-safety): no input — arbitrary keys, binary values, odd
+//     namespace/name/reveal-key — panics any of HandleListSecrets,
+//     HandleGetSecret, or HandleRevealSecret. A panic fails the fuzz.
+//   - D (secret-leak masking): the seeded sentinel never appears, plaintext or
+//     base64, in a List or Get response body. Reveal is the sanctioned
+//     plaintext path (explicit user action, audit-logged) and is therefore
+//     exempt from the leak oracle — crash-safety only.
+func FuzzSecretPipeline(f *testing.F) {
+	b64Sentinel := base64.StdEncoding.EncodeToString([]byte(pipelineSentinel))
+
+	// Seed corpus: realistic + adversarial "teeth". Every seed routes a Secret
+	// carrying the sentinel through the masking path, so each WOULD fail if
+	// maskedSecret stopped masking (verified by mutation).
+	f.Add("default", "db-creds", "password", []byte("hunter2"), "team", "password")
+	f.Add("", "", "", []byte(""), "", "")
+	f.Add("kube-system", "tls", "tls.crt", []byte{0x00, 0xFF, 0x1B, 0x0A}, "owner", "missing-key")
+	f.Add("ns", "big", "blob", []byte(strings.Repeat("A", 8192)), "ann", "blob")
+	// fuzzKey collides with the reserved sentinel key — exercise the guard.
+	f.Add("default", "creds", "__sentinel__", []byte("x"), "y", "__sentinel__")
+
+	f.Fuzz(func(t *testing.T, ns, name, fuzzKey string, fuzzVal []byte, annKey, revealKey string) {
+		// Normalize identity so List/Get actually hit the seeded Secret — an
+		// empty/invalid name would 404 and make the leak oracle vacuous (no
+		// teeth). The fuzzed ns/name still vary the stored object's identity.
+		if ns == "" {
+			ns = "default"
+		}
+		if name == "" {
+			name = "s"
+		}
+
+		secret := seedFuzzSecret(ns, name, fuzzKey, fuzzVal, annKey)
+		h := secretFuzzHandler(fake.NewSimpleClientset(secret))
+
+		assertNoLeak := func(op, body string) {
+			if strings.Contains(body, pipelineSentinel) {
+				t.Fatalf("%s leaked plaintext sentinel in response: %s", op, body)
+			}
+			if strings.Contains(body, b64Sentinel) {
+				t.Fatalf("%s leaked base64 sentinel in response: %s", op, body)
+			}
+		}
+
+		// List — both the namespace-scoped path (hits the secret) and the
+		// all-namespaces path (ns=""). Both must return 200 carrying the masked
+		// secret. Asserting the status keeps the leak oracle non-vacuous: a
+		// future regression that short-circuits to an empty error body (e.g. a
+		// 500 before maskedSecret runs) would otherwise satisfy assertNoLeak
+		// trivially. The namespaced list always contains the seeded secret, so
+		// masking is genuinely exercised regardless of the fake's cross-namespace
+		// listing behavior.
+		for _, listNS := range []string{ns, ""} {
+			rr := httptest.NewRecorder()
+			h.HandleListSecrets(rr, secretReq(map[string]string{"namespace": listNS}))
+			if rr.Code != http.StatusOK {
+				t.Fatalf("list (ns=%q) returned %d, want 200: %s", listNS, rr.Code, rr.Body.String())
+			}
+			assertNoLeak("list", rr.Body.String())
+		}
+
+		// Get the specific secret — must hit the seeded object (200) so the leak
+		// oracle exercises masking rather than passing on a 404 body.
+		{
+			rr := httptest.NewRecorder()
+			h.HandleGetSecret(rr, secretReq(map[string]string{"namespace": ns, "name": name}))
+			if rr.Code != http.StatusOK {
+				t.Fatalf("get (%s/%s) returned %d, want 200: %s", ns, name, rr.Code, rr.Body.String())
+			}
+			assertNoLeak("get", rr.Body.String())
+		}
+
+		// Reveal — crash-safety only; reveal deliberately returns the plaintext
+		// (base64-encoded) value, so the leak oracle does not apply.
+		{
+			rr := httptest.NewRecorder()
+			h.HandleRevealSecret(rr, secretReq(map[string]string{"namespace": ns, "name": name, "key": revealKey}))
+			_ = rr.Body.String()
+		}
+	})
+}
+
+// seedFuzzSecret builds a Secret whose sensitive fields all carry the sentinel
+// (so masking has something to erase) while keys, the extra annotation key, and
+// the secret's identity come from fuzz input. The non-sensitive "keep" annotation
+// holds a FIXED value, never the sentinel, so an un-stripped non-sensitive
+// annotation cannot itself trip the leak oracle.
+func seedFuzzSecret(ns, name, fuzzKey string, fuzzVal []byte, annKey string) *corev1.Secret {
+	const sentinelKey = "__sentinel__"
+	data := map[string][]byte{sentinelKey: []byte(pipelineSentinel)}
+	if fuzzKey != "" && fuzzKey != sentinelKey {
+		data[fuzzKey] = fuzzVal
+	}
+
+	annotations := map[string]string{
+		// MUST be stripped by masking — carries the sentinel via a kubectl manifest.
+		lastAppliedConfigAnnotation: `{"apiVersion":"v1","kind":"Secret","stringData":{"password":"` + pipelineSentinel + `"}}`,
+	}
+	if annKey != "" && annKey != lastAppliedConfigAnnotation {
+		annotations[annKey] = "non-sensitive-fixed"
+	}
+
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns, Annotations: annotations},
+		Data:       data,
+		StringData: map[string]string{"str-sentinel": pipelineSentinel},
+	}
+}
+
+// secretFuzzHandler builds a Handler whose typed-client path is routed to fakeCS
+// and whose RBAC gate trivially allows, so the fuzz reaches the masking path.
+func secretFuzzHandler(fakeCS *fake.Clientset) *Handler {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	factory := k8s.NewFakeClientFactory(fakeCS)
+	return &Handler{
+		ClusterRouter: k8s.NewClusterRouter(factory, nil, "", logger),
+		AccessChecker: NewAlwaysAllowAccessChecker(),
+		AuditLogger:   audit.NewSlogLogger(logger),
+		Logger:        logger,
+	}
+}
+
+// secretReq builds an authenticated request carrying the given chi URL params.
+func secretReq(params map[string]string) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/resources/secrets", nil)
+	user := &auth.User{
+		Username:           "admin",
+		KubernetesUsername: "admin",
+		KubernetesGroups:   []string{"system:masters"},
+	}
+	req = req.WithContext(auth.ContextWithUser(req.Context(), user))
+	rctx := chi.NewRouteContext()
+	for k, v := range params {
+		rctx.URLParams.Add(k, v)
+	}
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+}


### PR DESCRIPTION
## What & why

Closes the last open item from the backend-resilience fuzzing arc: **full-pipeline Secret-handler fuzzing**, which was blocked on a `ClientFactory → kubernetes.Interface` refactor.

`FuzzMaskedSecret` already covers the pure `maskedSecret` function. The remaining gap was driving the *actual* Secret HTTP handlers — which fetch on-demand via the impersonated typed client (not the informer cache) — against adversarial Secret data. That requires injecting a `fake.Clientset`, which the concrete `*kubernetes.Clientset` return type prevented.

## Changes

**1. Widen the typed-client spine `*kubernetes.Clientset → kubernetes.Interface`** (mechanical, compile-coupled):
`ClientForUser` + `testOverride`, `ClusterRouter.ClientForCluster` / `remoteTypedClient` / `ClientPair.Typed`, `Handler.impersonatingClient`, the `AccessChecker`/`RBACChecker` anon-interface decls + `clientForCluster`/`getRulesForNamespace`, `certmanager.getTypedClient`, `nodes.evictPod`, and the test fakes. New `NewFakeClientFactory(kubernetes.Interface)` injection seam. **Production behaviour is unchanged** — it still builds and returns a real impersonating clientset; only the static return type widened. The cache structs stay concrete.

**2. `FuzzSecretPipeline`** (`secret_pipeline_fuzz_test.go`, in-package): drives `HandleListSecrets`/`HandleGetSecret`/`HandleRevealSecret` via `httptest` with an allow-all `AccessChecker` + a fake-backed `ClusterRouter` seeded with adversarial Secrets.
- **Oracle A** — no panic on any keys / binary values / odd ns·name·reveal-key.
- **Oracle D** — a distinctive sentinel never survives List/Get responses, checked in **both** base64 (`Data []byte` JSON encoding) and plaintext (`StringData`, last-applied annotation) forms. `Reveal` is the sanctioned plaintext path → crash-safety only.
- +1 nightly `fuzz.yml` matrix row (covered by the existing shared `-list` drift guard).

## Verification

- `go build ./...`, `go vet ./...`, full `go test ./...` — all pass.
- `FuzzSecretPipeline`: 300k+ execs, 0 crashes/leaks.
- **Teeth verified by mutation:** stubbing `maskedSecret` to `return s` fails the fuzz on every seed, catching both the base64 `Data` leak and the plaintext `StringData`/annotation leak.

## Review (`/ce:review`, 8 reviewers)

No P0/P1 in new code; zero exploitable findings (security confirmed impersonation/RBAC unaffected and the inject seam is unreachable in production). Three corroborated fixes applied: assert HTTP 200 before the leak oracle (prevents vacuous pass), add `TestNewFakeClientFactory` documenting the nil-`baseClientset` contract, and delete dead `NewTestClientFactory` (0 callers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)